### PR TITLE
Update Config for RichTextQuote and update solana-lib version to 2.39.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@mdx-js/react": "^3.0.1",
     "@shikijs/transformers": "^1.6.0",
     "@sindresorhus/slugify": "^2.2.1",
-    "@solana-foundation/solana-lib": "^2.38.3",
+    "@solana-foundation/solana-lib": "^2.39.0",
     "@typeform/embed": "^4.4.0",
     "bootstrap": "^5.3.3",
     "cheerio": "^1.0.0-rc.12",

--- a/src/utils/builderConfigs.js
+++ b/src/utils/builderConfigs.js
@@ -1760,10 +1760,10 @@ export const RichTextQuoteConfig = {
   inputs: [
     {
       name: "quote",
-      type: "text",
+      type: "richText",
       localized: true,
       defaultValue:
-        "xNFTs take a radically practical approach to solving two of web3’s main problems today, decentralization and distribution, with profound implications.",
+        "<p>xNFTs take a radically practical approach to solving two of web3’s main problems today, decentralization and distribution, with profound implications.</p>",
     },
     {
       name: "author",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1512,10 +1512,10 @@
   dependencies:
     escape-string-regexp "^5.0.0"
 
-"@solana-foundation/solana-lib@^2.38.3":
-  version "2.38.3"
-  resolved "https://registry.yarnpkg.com/@solana-foundation/solana-lib/-/solana-lib-2.38.3.tgz#5bfd50136af812bd5ce257c132ad69391b7d7ef8"
-  integrity sha512-jsxTyadn0zgOVv940Em2EikSaXH8igk12OzRSxhT6wejcbeombZAG+PP9yZ9K9NYf66AnpoK924zCPBH9pjYQQ==
+"@solana-foundation/solana-lib@^2.39.0":
+  version "2.39.0"
+  resolved "https://registry.yarnpkg.com/@solana-foundation/solana-lib/-/solana-lib-2.39.0.tgz#4767cb6c07be0df0394a0c2e35525edf4dda7f04"
+  integrity sha512-PNAGugODDpmrEMTFCzYgoaVLScTYKDwwLFFS8EpoXWIOzzb/3HX8Z5f3BeaWdpbk5joTTlAMpDKlkAiJe1OqEA==
   dependencies:
     "@radix-ui/react-tooltip" "^1.0.6"
     "@types/react-slick" "^0.23.13"


### PR DESCRIPTION
- Switches the field type of `quote` from `text` to `richText` to give more control over the look of the text.
- Updates solana-lib to `2.39.0` to pull updates to the RichTextQuote component so it uses `HtmlParser` to render the rich text