### PR TITLE
Remove alias config causing all Nextjs App directory paths to error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -113,12 +113,6 @@ const moduleExports = () => {
       );
       imageLoaderRule.exclude = /\.inline\.svg$/;
 
-      // Alias configuration
-      config.resolve.alias = {
-        ...config.resolve.alias,
-        react: path.resolve(__dirname, "node_modules/react"),
-      };
-
       return config;
     },
 

--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,6 @@ const withBundleAnalyzer = require("@next/bundle-analyzer");
 const { i18n } = require("./next-i18next.config");
 const rewritesAndRedirectsJson = require("./rewrites-redirects.json");
 const { builder } = require("@builder.io/sdk");
-const path = require("path");
 
 const securityHeaders = [
   {


### PR DESCRIPTION
Alias results in nextjs app dir paths to throw `TypeError: Cannot read properties of null (reading 'useContext')`
![CleanShot 2024-08-02 at 13 26 33@2x](https://github.com/user-attachments/assets/c32864b4-6cbb-4429-bead-2043f4d8682f)

Removing following code from next.config.js fixes issue

```ts
      // Alias configuration
      config.resolve.alias = {
        ...config.resolve.alias,
        react: path.resolve(__dirname, "node_modules/react"),
      };
```
![CleanShot 2024-08-02 at 13 27 39@2x](https://github.com/user-attachments/assets/6a8453fb-d0aa-4da2-b606-f55e0a31b124)

Code was added in [this PR](https://github.com/solana-foundation/solana-com-legacy/pull/1337). Solana-com seems to run fine with it removed.