### PR TITLE
Github footer now directs to this website's git

### DIFF
--- a/rewrites-redirects.json
+++ b/rewrites-redirects.json
@@ -9,7 +9,7 @@
   "redirects": [
     { "source": "/reddit", "destination": "https://reddit.com/r/solana" },
     { "source": "/telegram", "destination": "https://t.me/solana" },
-    { "source": "/github", "destination": "https://github.com/solana-labs" },
+    { "source": "/github", "destination": "https://github.com/solana-foundation/solana-com" },
     { "source": "/twitter", "destination": "https://twitter.com/solana" },
     {
       "source": "/youtube",


### PR DESCRIPTION
The footer button for github was directing to /solana-labs. I'm assuming that was a legacy from when labs owned the site and client. Now that this site is owned by a different repo, I think it should be pointed there so contributors know where to go.

There's also an argument for a github link to direct to a protocol client repo, but that should live somewhere else because that's 3 different repos at this point.