### PR TITLE
Add support for Builder symbols preview

### DIFF
--- a/src/pages/edit-symbol.js
+++ b/src/pages/edit-symbol.js
@@ -1,0 +1,13 @@
+// Integrating Builder Symbols
+// https://www.builder.io/c/docs/integrate-symbols
+
+import { builder, BuilderComponent } from "@builder.io/react";
+import { PAGE_BUILDER_CONFIG } from "@/lib/builder/page/constants";
+import customComponentsRegistration from "../utils/customComponentGenerator";
+
+builder.init(PAGE_BUILDER_CONFIG.apiKey);
+customComponentsRegistration();
+
+export default function Page() {
+  return <BuilderComponent model="symbol" />;
+}


### PR DESCRIPTION
Add support for Builder symbols preview to reuse content across CMS pages and sections.