### PR TITLE
Add redirect for install page from /guide to /docs

### DIFF
--- a/rewrites-redirects.json
+++ b/rewrites-redirects.json
@@ -107,6 +107,10 @@
     {
       "source": "/meta",
       "destination": "/"
+    },
+    {
+      "source": "/developers/guides/getstarted/setup-local-development",
+      "destination": "/docs/intro/installation"
     }
   ]
 }


### PR DESCRIPTION
`/developers/guides/getstarted/setup-local-development` was removed and replaced with `/docs/intro/installation`

Adding redirect on solana-com repo due to limitation to `altRoutes` frontmatter on developer-content repo.