### PR TITLE
show locale in markdown render errors

### DIFF
--- a/src/pages/developers/cookbook/[[...slug]].tsx
+++ b/src/pages/developers/cookbook/[[...slug]].tsx
@@ -48,7 +48,10 @@ export async function getStaticProps({ params, locale }) {
   if (!!redirect) return redirect;
 
   // serialize the content via mdx
-  const source = await serializeMarkdown(record.body, record?.id);
+  const source = await serializeMarkdown(
+    record.body,
+    `${locale}-${record?.id}`,
+  );
 
   // load the nav data
   const navData = await ContentApi.getNavForGroup("cookbook", locale);

--- a/src/pages/developers/courses/[course]/[lesson]/index.tsx
+++ b/src/pages/developers/courses/[course]/[lesson]/index.tsx
@@ -108,7 +108,10 @@ export async function getStaticProps({ params, locale }) {
   if (!!redirect) return redirect;
 
   // serialize the content via mdx
-  const source = await serializeMarkdown(record.body || "", record?.id);
+  const source = await serializeMarkdown(
+    record.body || "",
+    `${locale}-${record?.id}`,
+  );
 
   return {
     props: {

--- a/src/pages/developers/guides/[...slug].tsx
+++ b/src/pages/developers/guides/[...slug].tsx
@@ -101,7 +101,10 @@ export async function getStaticProps({ params, locale }) {
   if (!!redirect) return redirect;
 
   // serialize the content via mdx
-  const source = await serializeMarkdown(record.body || "", record?.id);
+  const source = await serializeMarkdown(
+    record.body || "",
+    `${locale}-${record?.id}`,
+  );
 
   return {
     props: {

--- a/src/pages/developers/resources/[...slug].jsx
+++ b/src/pages/developers/resources/[...slug].jsx
@@ -96,7 +96,10 @@ export async function getStaticProps({ params, locale }) {
   if (!!redirect) return redirect;
 
   // serialize the content via mdx
-  const source = await serializeMarkdown(record.body || "", record?.id);
+  const source = await serializeMarkdown(
+    record.body || "",
+    `${locale}-${record?.id}`,
+  );
 
   return {
     props: {

--- a/src/pages/docs/[[...slug]].tsx
+++ b/src/pages/docs/[[...slug]].tsx
@@ -180,7 +180,10 @@ export async function getStaticProps({ params, locale }) {
   if (!!redirect) return redirect;
 
   // serialize the content via mdx
-  const source = await serializeMarkdown(record.body, record?.id);
+  const source = await serializeMarkdown(
+    record.body,
+    `${locale}-${record?.id}`,
+  );
 
   // load the nav data
   const navData = await ContentApi.getNavForGroup("docs", locale);

--- a/src/pages/docs/rpc/[[...slug]].tsx
+++ b/src/pages/docs/rpc/[[...slug]].tsx
@@ -236,7 +236,10 @@ export async function getStaticProps({ params, locale }) {
   if (!!redirect) return redirect;
 
   // serialize the content via mdx
-  const source = await serializeMarkdown(record.body, record?.id);
+  const source = await serializeMarkdown(
+    record.body,
+    `${locale}-${record?.id}`,
+  );
 
   // load the nav data
   const navData = await ContentApi.getNavForGroup("docs/rpc", locale);

--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -34,7 +34,7 @@ export async function serializeMarkdown(
       },
     });
   } catch (err) {
-    console.error("[serializeMarkdown]", docKey);
+    console.error("[ERROR] [serializeMarkdown]", docKey);
     console.error(err);
     return await serialize(
       "There was an unknown error while processing the markdown content. \n\n" +


### PR DESCRIPTION
when a markdown render error occurs, it does not display which locale had an issue

updated the github issue link to include the locale for easier troubleshooting