### PR TITLE
feat: support strings in tabs `items`

### DIFF
--- a/src/components/shared/MarkdownRenderer/components/MarkdownTabs.tsx
+++ b/src/components/shared/MarkdownRenderer/components/MarkdownTabs.tsx
@@ -10,7 +10,7 @@ import styles from "./MarkdownTabs.module.scss";
 
 interface MarkdownTabsProps {
   children: ReactNode;
-  items?: string[];
+  items?: string[] | string;
   defaultIndex?: number;
   groupId?: string;
   persist?: boolean;
@@ -27,7 +27,12 @@ export function MarkdownTabs({
   persist = false,
   ...props
 }: MarkdownTabsProps) {
-  const values = useMemo(() => items.map((item) => toValue(item)), [items]);
+  const labels: string[] = useMemo(() => {
+    if (typeof items == "string")
+      return items.split(",").map((item) => item.trim());
+    else return items;
+  }, []);
+  const values = useMemo(() => labels.map((item) => toValue(item)), [labels]);
   const [value, setValue] = useState(values[defaultIndex]);
 
   useLayoutEffect(() => {
@@ -75,7 +80,7 @@ export function MarkdownTabs({
               v === value ? styles["active"] : ""
             }`}
           >
-            {items[i]}
+            {labels[i]}
           </TabsPrimitive.Trigger>
         ))}
       </TabsPrimitive.List>


### PR DESCRIPTION
added support for passing a string value for the `items` inside the `Tabs` component

this will allow passing a comma-separated list of the tab labels within dev content files

note: this is to support fixing the render errors with several open issues in the dev-content repo: https://github.com/solana-foundation/developer-content/issues/455
these issues are being caused by crowdin altering the content files in an odd way, specifically when an MDX component has an attribute with an array value, crowdin prepends a `\` in front of the components opening tag. breaking the parser....