### PR TITLE
MarkdownTabs - font size

### DIFF
--- a/src/components/shared/MarkdownRenderer/components/MarkdownTabs.module.scss
+++ b/src/components/shared/MarkdownRenderer/components/MarkdownTabs.module.scss
@@ -20,7 +20,7 @@
 
 .markdown-tabs-trigger {
   padding: 0.5rem 1rem;
-  font-size: 0.875rem;
+  font-size: 1rem;
   font-weight: 500;
   color: var(--tabs-text-color);
   background-color: transparent;
@@ -44,7 +44,7 @@
 .markdown-tabs-content {
   padding-left: 1rem;
   padding-right: 1rem;
-  font-size: 1rem;
+  font-size: 1.2rem;
 }
 
 :global(.light) .markdown-tabs {


### PR DESCRIPTION
## Problem

the markdown tab content's font is too small and hard to read

## Changes

- boosted the font size