### PR TITLE
Fix courses link

### DIFF
--- a/src/components/header/HeaderListBuild.js
+++ b/src/components/header/HeaderListBuild.js
@@ -46,7 +46,7 @@ const HeaderListBuild = () => {
             {t("nav.developers.items.resources.description")}
           </Link>
           <Link
-            to="/developers#courses"
+            to="/developers/courses"
             className="nav-link nav-link--secondary"
             activeClassName="active"
           >


### PR DESCRIPTION
Currently goes to `/developers#courses`, but courses are on `/developers/courses`