### PR TITLE
removed file metadata tag from codeblock filename regex

### DIFF
--- a/src/utils/markdown.ts
+++ b/src/utils/markdown.ts
@@ -45,7 +45,7 @@ export async function serializeMarkdown(
   }
 }
 
-const CODE_BLOCK_FILENAME_REGEX = /(name|file|filename)="?([^"\s]*)"?/;
+const CODE_BLOCK_FILENAME_REGEX = /(name|filename)="?([^"\s]*)"?/;
 // const CODE_BLOCK_SHOW_LINE_NUMBERS_REGEX = /showLineNumbers=?(true|false)?/;
 
 function visit(node: any, tagNames: any, handler: any) {


### PR DESCRIPTION
[This cookbook page ](https://solana.com/developers/cookbook/wallets/check-publickey) has filepath instead of name, I added file as filepath in metadata of codeblock to import files but it is getting rendered in the codeblock while can be ignored for now.

![Screenshot 2024-11-12 at 4 43 07 PM](https://github.com/user-attachments/assets/38b05704-af6a-4d04-95fb-9d2e06b80e4a)