### PR TITLE
developer header updates

### DIFF
--- a/public/locales/ar/common.json
+++ b/public/locales/ar/common.json
@@ -791,6 +791,10 @@
           "title": "وثائق مكتبة برامج سولانا",
           "description": "الوثائق الرسمية لمكتبة برامج سولانا."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "المصادر",
           "description": "أدوات تطوير واسعة للبناء على سولانا."

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -791,6 +791,10 @@
           "title": "Solana Program Library Dokumentation",
           "description": "Offizielle Dokumentation für die Solana Program Library."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Ressourcen",
           "description": "Umfassende Entwicklerwerkzeuge für die Entwicklung auf Solana."

--- a/public/locales/el/common.json
+++ b/public/locales/el/common.json
@@ -791,6 +791,10 @@
           "title": "Τεκμηρίωση Βιβλιοθήκης Προγραμμάτων Solana",
           "description": "Επίσημη τεκμηρίωση της Βιβλιοθήκης Προγραμμάτων Solana."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Πόροι",
           "description": "Εκτεταμένα εργαλεία προγραμματιστών για τη δημιουργία στο Solana."

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -791,9 +791,17 @@
           "title": "Solana Program Library Documentation",
           "description": "Official docs the Solana Program Library."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Resources",
           "description": "Extensive developer tooling for building on Solana."
+        },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
         },
         "courses": {
           "title": "Courses",
@@ -810,7 +818,7 @@
         "hello-world": "Hello World",
         "bootcamp": "Bootcamp",
         "evm-to-svm": "EVM to SVM",
-        "local-setup": "Local Setup"
+        "local-setup": "Installation"
       }
     },
     "solutions": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -791,6 +791,10 @@
           "title": "Documentación de la Biblioteca de Programas de Solana",
           "description": "Documentos oficiales de la Biblioteca de Programas de Solana."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Recursos",
           "description": "Amplio conjunto de herramientas para desarrolladores para construir en Solana."

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -791,6 +791,10 @@
           "title": "Solana-ohjelmakirjaston dokumentaatio",
           "description": "Viralliset dokumentit Solana-ohjelmakirjastolle."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Resurssit",
           "description": "Laajat kehittäjätyökalut Solanalle rakentamiseen."

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -791,6 +791,10 @@
           "title": "Documentation de la bibliothèque de programmes Solana",
           "description": "Documentation officielle de la bibliothèque de programmes Solana."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Ressources",
           "description": "Outils de développement étendus pour construire sur Solana."

--- a/public/locales/hi/common.json
+++ b/public/locales/hi/common.json
@@ -791,6 +791,10 @@
           "title": "सोलाना प्रोग्राम लाइब्रेरी दस्तावेज़ीकरण",
           "description": "सोलाना प्रोग्राम लाइब्रेरी के लिए आधिकारिक दस्तावेज़।"
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "संसाधन",
           "description": "सोलाना पर निर्माण के लिए व्यापक डेवलपर टूलिंग।"

--- a/public/locales/id/common.json
+++ b/public/locales/id/common.json
@@ -791,6 +791,10 @@
           "title": "Dokumentasi Perpustakaan Program Solana",
           "description": "Dokumentasi resmi Perpustakaan Program Solana."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Sumber Daya",
           "description": "Alat pengembang yang luas untuk membangun di Solana."

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -791,6 +791,10 @@
           "title": "Documentazione della Solana Program Library",
           "description": "Documentazione ufficiale della Solana Program Library."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Risorse",
           "description": "Strumenti estesi per sviluppatori per costruire su Solana."

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -791,6 +791,10 @@
           "title": "Solanaプログラムライブラリドキュメント",
           "description": "Solanaプログラムライブラリの公式ドキュメント。"
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "リソース",
           "description": "Solana上での開発のための広範な開発者ツール。"

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -791,6 +791,10 @@
           "title": "솔라나 프로그램 라이브러리 문서",
           "description": "솔라나 프로그램 라이브러리의 공식 문서."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "자원",
           "description": "솔라나에서 빌드하기 위한 광범위한 개발자 도구."

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -791,6 +791,10 @@
           "title": "Solana Programma Bibliotheek Documentatie",
           "description": "Officiële documentatie van de Solana Programma Bibliotheek."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Middelen",
           "description": "Uitgebreide ontwikkelaarstools voor het bouwen op Solana."

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -791,6 +791,10 @@
           "title": "Dokumentacja Biblioteki Programów Solany",
           "description": "Oficjalna dokumentacja Biblioteki Programów Solany."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Zasoby",
           "description": "Obszerne narzędzia dla deweloperów do budowania na Solanie."

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -791,6 +791,10 @@
           "title": "Documentação da Biblioteca de Programas Solana",
           "description": "Documentação oficial da Biblioteca de Programas Solana."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Recursos",
           "description": "Ferramentas extensivas para desenvolvedores construírem na Solana."

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -791,6 +791,10 @@
           "title": "Документация библиотеки программ Solana",
           "description": "Официальная документация библиотеки программ Solana."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Ресурсы",
           "description": "Обширные инструменты для разработчиков для создания на Solana."

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -791,6 +791,10 @@
           "title": "Solana Program Kütüphanesi Belgeleri",
           "description": "Solana Program Kütüphanesi için resmi belgeler."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Kaynaklar",
           "description": "Solana üzerinde inşa etmek için kapsamlı geliştirici araçları."

--- a/public/locales/uk/common.json
+++ b/public/locales/uk/common.json
@@ -791,6 +791,10 @@
           "title": "Документація бібліотеки програм Solana",
           "description": "Офіційна документація бібліотеки програм Solana."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Ресурси",
           "description": "Широкий набір інструментів для розробників для створення на Solana."

--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -791,6 +791,10 @@
           "title": "Tài liệu Thư viện Chương trình Solana",
           "description": "Tài liệu chính thức của Thư viện Chương trình Solana."
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "Tài nguyên",
           "description": "Công cụ phát triển phong phú để xây dựng trên Solana."

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -791,6 +791,10 @@
           "title": "Solana 程序库文档",
           "description": "Solana 程序库的官方文档。"
         },
+        "cookbook": {
+          "title": "Cookbook",
+          "description": "Snippets and copyable example code for Solana applications."
+        },
         "resources": {
           "title": "资源",
           "description": "用于在 Solana 上构建的广泛开发工具。"

--- a/src/components/header/HeaderListBuild.js
+++ b/src/components/header/HeaderListBuild.js
@@ -36,16 +36,6 @@ const HeaderListBuild = () => {
             {t("nav.developers.items.docs.description")}
           </Link>
           <Link
-            to="/developers/resources"
-            className="nav-link nav-link--secondary"
-            activeClassName="active"
-          >
-            <strong className="d-block text-white">
-              {t("nav.developers.items.resources.title")}
-            </strong>
-            {t("nav.developers.items.resources.description")}
-          </Link>
-          <Link
             to="/developers/courses"
             className="nav-link nav-link--secondary"
             activeClassName="active"
@@ -54,6 +44,16 @@ const HeaderListBuild = () => {
               {t("nav.developers.items.courses.title")}
             </strong>
             {t("nav.developers.items.courses.description")}
+          </Link>
+          <Link
+            to="/developers/resources"
+            className="nav-link nav-link--secondary"
+            activeClassName="active"
+          >
+            <strong className="d-block text-white">
+              {t("nav.developers.items.resources.title")}
+            </strong>
+            {t("nav.developers.items.resources.description")}
           </Link>
         </div>
       </div>
@@ -74,7 +74,7 @@ const HeaderListBuild = () => {
             {t("nav.developers.tutorials.hello-world")}
           </Link>
           <Link
-            to="/developers/guides/getstarted/setup-local-development"
+            to="/docs/intro/installation"
             className="nav-link nav-link--secondary text-white d-block text-white fw-bold"
             activeClassName="active font-weight-bold"
           >

--- a/src/components/header/HeaderListBuild.js
+++ b/src/components/header/HeaderListBuild.js
@@ -46,6 +46,16 @@ const HeaderListBuild = () => {
             {t("nav.developers.items.courses.description")}
           </Link>
           <Link
+            to="/developers/cookbook"
+            className="nav-link nav-link--secondary"
+            activeClassName="active"
+          >
+            <strong className="d-block text-white">
+              {t("nav.developers.items.cookbook.title")}
+            </strong>
+            {t("nav.developers.items.cookbook.description")}
+          </Link>
+          <Link
             to="/developers/resources"
             className="nav-link nav-link--secondary"
             activeClassName="active"


### PR DESCRIPTION
## Summary of changes

- add [Solana Cookbook](https://solana.com/developers/cookbook) to the header
- reorder header links
- update the link and label for the installation page (the older guide page was migrated into the docs and already redirects to the installation page)