### PR TITLE
fix: changelog description

### DIFF
--- a/src/components/developers/sections/DevelopersDocumentsSection/DevelopersChangelog.jsx
+++ b/src/components/developers/sections/DevelopersDocumentsSection/DevelopersChangelog.jsx
@@ -14,7 +14,14 @@ export default function DevelopersChangelog({ latestVideo }) {
     <div className={styles["changelog"]}>
       <h3 className={styles["changelog__title"]}>Solana Changelog</h3>
       <p className={styles["changelog__description"]}>
-        {truncateTextByWord(latestVideo.snippet?.description, 240, "...")}
+        {truncateTextByWord(
+          (
+            latestVideo.snippet?.description ||
+            "Latest changes for the Solana blockchain"
+          ).split("---")[0],
+          160,
+          "...",
+        )}
       </p>
       <Button
         to={`https://www.youtube.com/watch?v=${latestVideo.snippet.resourceId.videoId}&list=${latestVideo.snippet.playlistId}`}


### PR DESCRIPTION
updated the changelog description parser to handle no description and splitting based on the video description containing `---` as a separator

for future changelog video descriptions (and several past ones), we will start adding a summary paragraph at the top followed by a `---` separator so solana-com can better display

note: for other descriptions without this separator, similar video description behavior as before will occur, but just a little shorter

Fixes: #61