### PR TITLE
Update docs links

### DIFF
--- a/src/components/validators/ValidatorsFAQ.js
+++ b/src/components/validators/ValidatorsFAQ.js
@@ -31,10 +31,10 @@ const ValidatorsFAQ = () => {
                         ),
                         discordlink: <Link href="/discord" />,
                         requirementslink: (
-                          <Link href="https://docs.solanalabs.com/operations/requirements" />
+                          <Link href="https://docs.anza.xyz/operations/requirements" />
                         ),
                         economicslink: (
-                          <Link href="https://docs.solana.com/cluster/economics" />
+                          <Link href="https://docs.anza.xyz/implemented-proposals/ed_overview/" />
                         ),
                         stakinglink: <Link href="/docs/economics/staking" />,
                         programlink: (

--- a/src/components/validators/ValidatorsGettingStarted.js
+++ b/src/components/validators/ValidatorsGettingStarted.js
@@ -46,7 +46,7 @@ const ValidatorsGettingStarted = () => {
               </p>
             </div>
             <Button
-              to="https://docs.solanalabs.com/operations"
+              to="https://docs.anza.xyz/operations"
               newTab
               aria-label="Solana Docs"
               variant="none"

--- a/src/components/validators/ValidatorsHero.js
+++ b/src/components/validators/ValidatorsHero.js
@@ -25,7 +25,7 @@ const ValidatorsHero = forwardRef((props, ref) => {
           <p className="regular hero-text">{t("validators.sub-header")}</p>
           <div className="hero-buttons">
             <Button
-              to="https://docs.solanalabs.com/operations"
+              to="https://docs.anza.xyz/operations"
               newTab
               aria-label="Read about becoming a Validator"
               className="d-inline-block mt-2 mt-md-4 me-sm-2 lift"


### PR DESCRIPTION
### Problem
docs.solanalabs.com redirects to docs.anza.xyz now


### Summary of Changes
This PR updates some docs.solanalabs.com docs links to point to their equivalent docs.anza.xyz pages.