### PR TITLE
Reintroduce revalidate gradually

### DIFF
--- a/src/pages/developers/cookbook/[[...slug]].tsx
+++ b/src/pages/developers/cookbook/[[...slug]].tsx
@@ -63,7 +63,7 @@ export async function getStaticProps({ params, locale }) {
       source,
       navData,
     },
-    // revalidate: 60,
+    revalidate: 60,
   };
 }
 

--- a/src/pages/developers/courses/[course]/[lesson]/index.tsx
+++ b/src/pages/developers/courses/[course]/[lesson]/index.tsx
@@ -119,6 +119,6 @@ export async function getStaticProps({ params, locale }) {
       record,
       source,
     },
-    // revalidate: 60,
+    revalidate: 60,
   };
 }

--- a/src/pages/developers/courses/[course]/index.tsx
+++ b/src/pages/developers/courses/[course]/index.tsx
@@ -94,7 +94,7 @@ export async function getStaticProps({
       lessons,
       // source,
     },
-    // revalidate: 60,
+    revalidate: 60,
   };
 }
 

--- a/src/pages/developers/courses/index.tsx
+++ b/src/pages/developers/courses/index.tsx
@@ -34,7 +34,7 @@ export async function getStaticProps({ locale }) {
       records,
       featured,
     },
-    // revalidate: 60,
+    revalidate: 60,
   };
 }
 

--- a/src/pages/developers/guides/[...slug].tsx
+++ b/src/pages/developers/guides/[...slug].tsx
@@ -112,6 +112,6 @@ export async function getStaticProps({ params, locale }) {
       record,
       source,
     },
-    // revalidate: 60,
+    revalidate: 60,
   };
 }

--- a/src/pages/developers/guides/index.jsx
+++ b/src/pages/developers/guides/index.jsx
@@ -28,7 +28,7 @@ export async function getStaticProps({ locale }) {
       records,
       featured,
     },
-    // revalidate: 60,
+    revalidate: 60,
   };
 }
 

--- a/src/pages/developers/resources/[...slug].jsx
+++ b/src/pages/developers/resources/[...slug].jsx
@@ -107,6 +107,6 @@ export async function getStaticProps({ params, locale }) {
       record,
       source,
     },
-    // revalidate: 60,
+    revalidate: 60,
   };
 }

--- a/src/pages/developers/resources/index.jsx
+++ b/src/pages/developers/resources/index.jsx
@@ -26,7 +26,7 @@ export async function getStaticProps({ locale }) {
       records,
       featured,
     },
-    // revalidate: 60,
+    revalidate: 60,
   };
 }
 

--- a/src/pages/docs/rpc/[[...slug]].tsx
+++ b/src/pages/docs/rpc/[[...slug]].tsx
@@ -252,6 +252,6 @@ export async function getStaticProps({ params, locale }) {
       source,
       navData,
     },
-    // revalidate: 60,
+    revalidate: 60,
   };
 }


### PR DESCRIPTION
### Problem
Some pages using `revalidate` were randomly returning 404 after a while


### Summary of Changes
Now that we updated to nextjs ^15, and updated node v. to 22 in Vercel, I will monitor and expecting to get rid of this annoying issue.