### PR TITLE
Fix: courses heading page light mode fixed

### DIFF
--- a/src/components/developers/sections/DevelopersHeroSection/DevelopersHeroSection.module.scss
+++ b/src/components/developers/sections/DevelopersHeroSection/DevelopersHeroSection.module.scss
@@ -2,6 +2,10 @@
   width: 100%;
   display: flex;
 
+  h1 {
+    color: var(--body-text);
+  }
+
   &__image {
     width: 100%;
     margin-top: -60%;


### PR DESCRIPTION
### Problem
Courses page heading was not displaying in light mode due to incorrect font color used


### Summary of Changes
corrected the font color in light mode 

### Screenshots

![image](https://github.com/user-attachments/assets/c71c54f7-a390-4e61-a2d5-ebb8504cc5c7)





Fixes #128