### PR TITLE
Builder API updates

### DIFF
--- a/src/lib/builder/page/api.js
+++ b/src/lib/builder/page/api.js
@@ -5,35 +5,68 @@ builder.init(PAGE_BUILDER_CONFIG.apiKey);
 builder.apiVersion = "v3";
 Builder.isStatic = true;
 
+const withTimeout = (promise, ms) =>
+  Promise.race([
+    promise,
+    new Promise((_, reject) =>
+      setTimeout(
+        () => reject(new Error(`Builder.io request timeout after ${ms}ms`)),
+        ms,
+      ),
+    ),
+  ]);
+
 export async function getAllPagesWithSlug() {
-  return builder.getAll(PAGE_BUILDER_CONFIG.pagesModel, {
-    options: { noTargeting: true },
-    apiKey: PAGE_BUILDER_CONFIG.apiKey,
-    fields: "data",
-  });
+  try {
+    return await withTimeout(
+      builder.getAll(PAGE_BUILDER_CONFIG.pagesModel, {
+        options: {
+          noTargeting: true,
+          cache: "force-cache",
+        },
+        apiKey: PAGE_BUILDER_CONFIG.apiKey,
+        fields: "data",
+      }),
+      5000,
+    );
+  } catch (error) {
+    console.error("[getAllPagesWithSlug] Error:", error.message);
+    return [];
+  }
 }
 
 export async function getPage(slug, locale) {
-  const slugs = slug === "/" ? "/" : { $in: [slug, `/${slug}`] };
+  try {
+    const slugs = slug === "/" ? "/" : { $in: [slug, `/${slug}`] };
 
-  let page = await builder
-    .get(PAGE_BUILDER_CONFIG.pagesModel, {
-      includeRefs: true,
-      staleCacheSeconds: 20,
-      userAttributes: {
-        urlPath: slug,
-        locale,
-      },
-      options: {
-        locale: locale,
-      },
-      query: {
-        data: {
-          slug: slugs,
-        },
-      },
-    })
-    .toPromise();
+    const page = await withTimeout(
+      builder
+        .get(PAGE_BUILDER_CONFIG.pagesModel, {
+          includeRefs: true,
+          staleCacheSeconds: 60,
+          userAttributes: {
+            urlPath: slug,
+            locale,
+          },
+          options: {
+            locale: locale,
+            noTargeting: true,
+          },
+          query: {
+            "data.slug": slugs,
+          },
+        })
+        .toPromise(),
+      8000,
+    );
 
-  return page || null;
+    return page || null;
+  } catch (error) {
+    console.error("[getPage] Error:", {
+      slug,
+      locale,
+      error: error.message,
+    });
+    return null;
+  }
 }

--- a/src/pages/[...slug].js
+++ b/src/pages/[...slug].js
@@ -28,10 +28,13 @@ const Page = ({ page, builderLocale }) => {
       />
       <Layout>
         <BuilderComponent
-          options={{ includeRefs: true }}
           model={PAGE_BUILDER_CONFIG.pagesModel}
           content={page}
           locale={builderLocale || "Default"}
+          options={{
+            includeRefs: true,
+            noTraverse: true,
+          }}
         />
         <ModalLauncher />
       </Layout>
@@ -40,18 +43,31 @@ const Page = ({ page, builderLocale }) => {
 };
 
 export async function getStaticPaths() {
-  const allPages = await getAllPagesWithSlug();
+  try {
+    const allPages = await getAllPagesWithSlug();
 
-  const slugs = await allPages
-    ?.map((page) => {
-      return page.data.slug[0] === "/" ? page.data.slug : `/${page.data.slug}`;
-    })
-    .filter((slug) => slug !== "/");
+    const slugs = await allPages
+      ?.map((page) => {
+        return page.data.slug[0] === "/"
+          ? page.data.slug
+          : `/${page.data.slug}`;
+      })
+      .filter((slug) => slug !== "/");
 
-  return {
-    paths: [...slugs] || [],
-    fallback: "blocking",
-  };
+    return {
+      paths: [...slugs] || [],
+      fallback: "blocking",
+    };
+  } catch (error) {
+    console.error("[getStaticPaths] Error:", {
+      message: error.message,
+      stack: error.stack,
+    });
+    return {
+      paths: [],
+      fallback: "blocking",
+    };
+  }
 }
 
 export const getStaticProps = async ({ locale, params }) => {


### PR DESCRIPTION
Update Builder API calls logic to avoid hanging requests that consume Vercel function resources:

- More aggressive Builder.io caching with force-cache
- Fail faster (5s for `getAllPagesWithSlug`, 8s for `getPage`)
- More reliable error handling