### PR TITLE
Update SVG config

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -109,7 +109,7 @@ const nextConfig = {
 
   webpack(config) {
     config.module.rules.push({
-      test: /\.svg$/,
+      test: /\.inline\.svg$/,
       use: {
         loader: "@svgr/webpack",
         options: {
@@ -128,6 +128,11 @@ const nextConfig = {
           },
         },
       },
+    });
+
+    config.module.rules.push({
+      test: /(?<!inline)\.svg$/,
+      type: "asset",
     });
 
     return config;


### PR DESCRIPTION
### Problem
With merging #71, we lost support for both inline SVGs and regular image SVGs

### Summary of Changes
Update Webpack config to handle both inline SVGs and regular image SVGs
https://react-svgr.com/docs/webpack/
