### PR TITLE
Avoid the horizontal scroll visible on Firefox 

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -3,7 +3,11 @@ import { getPage } from "@/lib/builder/page/api";
 import Page from "./[...slug]";
 
 export default function Home(props) {
-  return <Page {...props} />;
+  return (
+    <div className="overflow-hidden">
+      <Page {...props} />
+    </div>
+  );
 }
 
 export const getStaticProps = async ({ locale }) => {


### PR DESCRIPTION
### Problem
https://github.com/solana-foundation/solana-com/issues/148


### Summary of Changes
Avoid the horizontal scroll visible on Firefox desktop - clip the overflow visible due to the hero absolute positioned elements.


Fixes #148