### PR TITLE
Fix SEO and i18n for some /developers pages

### DIFF
--- a/src/app/[locale]/developers/courses/[course]/[lesson]/page.tsx
+++ b/src/app/[locale]/developers/courses/[course]/[lesson]/page.tsx
@@ -4,6 +4,7 @@ import { mdxComponents } from "@/app/mdx-components";
 import { BlogPage } from "@/app/components/blog-page";
 import { getAlternates } from "@/i18n/routing";
 import { getUrlWithoutLocale } from "@/app/sources/utils";
+import { ResolvingMetadata } from "next";
 
 type Props = {
   params: Promise<{ course: string; lesson: string; locale: string }>;
@@ -54,17 +55,28 @@ export async function generateStaticParams() {
   });
 }
 
-export async function generateMetadata(props: {
-  params: Promise<{ course: string; lesson: string; locale: string }>;
-}) {
+export async function generateMetadata(
+  props: {
+    params: Promise<{
+      course: string;
+      lesson: string;
+      locale: string;
+    }>;
+  },
+  parent: ResolvingMetadata,
+) {
   const { course, lesson, locale } = await props.params;
   const page = coursesSource.getPage([course, lesson], locale);
   if (!page) notFound();
   const url = getUrlWithoutLocale(page);
+
+  const { openGraph } = await parent;
+
   return {
     title: page.data.seoTitle || page.data.h1 || page.data.title,
     description: page.data.description,
     openGraph: {
+      ...openGraph,
       images: `/opengraph${url}`,
     },
     alternates: getAlternates(url, locale),

--- a/src/app/[locale]/developers/courses/[course]/page.tsx
+++ b/src/app/[locale]/developers/courses/[course]/page.tsx
@@ -4,6 +4,7 @@ import Curriculum from "./curriculum";
 import { notFound } from "next/navigation";
 import { getAlternates } from "@/i18n/routing";
 import { getUrlWithoutLocale, toUrlWithoutLocale } from "@/app/sources/utils";
+import { ResolvingMetadata } from "next";
 
 type Props = {
   params: Promise<{ course: string; locale: string }>;
@@ -46,17 +47,22 @@ export async function generateStaticParams() {
   return slugs.map((slug: string) => ({ course: slug }));
 }
 
-export async function generateMetadata(props: Props) {
+export async function generateMetadata(
+  props: Props,
+  parent: ResolvingMetadata,
+) {
   const { course, locale } = await props.params;
   const page = coursesSource.getPage([course]);
   if (!page) notFound();
 
   const url = getUrlWithoutLocale(page);
+  const { openGraph } = await parent;
 
   return {
     title: page.data.seoTitle || page.data.h1 || page.data.title,
     description: page.data.description,
     openGraph: {
+      ...openGraph,
       images: `/opengraph${url}`,
     },
     alternates: getAlternates(url, locale),

--- a/src/app/[locale]/developers/courses/page.tsx
+++ b/src/app/[locale]/developers/courses/page.tsx
@@ -4,6 +4,7 @@ import Courses from "./courses-index";
 import { DefaultCard } from "@solana-foundation/solana-lib/dist/components/CardDeck/DefaultCard/defaultCard";
 import { getAlternates } from "@/i18n/routing";
 import { toUrlWithoutLocale } from "@/app/sources/utils";
+import { serverTranslation } from "@/i18n/translation";
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -42,10 +43,15 @@ export default async function Page(props: Props) {
 
 export async function generateMetadata(props: Props) {
   const { locale } = await props.params;
+  const { t } = await serverTranslation(locale);
+
   return {
-    title: "Developer Courses",
-    description:
-      "Learn Solana development with developer guides, from beginner to advanced. JavaScript, TypeScript, Rust, and more.",
+    title: t("developers.courses.title"),
+    description: t("developers.courses.seo-description"),
+    openGraph: {
+      title: t("developers.courses.title"),
+      description: t("developers.courses.seo-description"),
+    },
     alternates: getAlternates("/developers/courses", locale),
   };
 }

--- a/src/app/[locale]/developers/courses/page.tsx
+++ b/src/app/[locale]/developers/courses/page.tsx
@@ -5,6 +5,7 @@ import { DefaultCard } from "@solana-foundation/solana-lib/dist/components/CardD
 import { getAlternates } from "@/i18n/routing";
 import { toUrlWithoutLocale } from "@/app/sources/utils";
 import { serverTranslation } from "@/i18n/translation";
+import { ResolvingMetadata } from "next";
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -41,14 +42,19 @@ export default async function Page(props: Props) {
   return <Courses courseCards={courseCards} />;
 }
 
-export async function generateMetadata(props: Props) {
+export async function generateMetadata(
+  props: Props,
+  parent: ResolvingMetadata,
+) {
   const { locale } = await props.params;
   const { t } = await serverTranslation(locale);
+  const { openGraph } = await parent;
 
   return {
     title: t("developers.courses.title"),
     description: t("developers.courses.seo-description"),
     openGraph: {
+      ...openGraph,
       title: t("developers.courses.title"),
       description: t("developers.courses.seo-description"),
     },

--- a/src/app/[locale]/developers/guides/[...slugs]/page.tsx
+++ b/src/app/[locale]/developers/guides/[...slugs]/page.tsx
@@ -4,6 +4,7 @@ import { mdxComponents } from "@/app/mdx-components";
 import { BlogPage } from "@/app/components/blog-page";
 import { getAlternates } from "@/i18n/routing";
 import { getUrlWithoutLocale, toStaticParams } from "@/app/sources/utils";
+import { ResolvingMetadata } from "next";
 
 type Props = {
   params: Promise<{ slugs: string[]; locale: string }>;
@@ -37,16 +38,21 @@ export async function generateStaticParams() {
   return params.map((p) => ({ slugs: p.slug }));
 }
 
-export async function generateMetadata(props: Props) {
+export async function generateMetadata(
+  props: Props,
+  parent: ResolvingMetadata,
+) {
   const { slugs, locale } = await props.params;
   const page = guidesSource.getPage(slugs, locale);
   if (!page) notFound();
   const url = getUrlWithoutLocale(page);
+  const { openGraph } = await parent;
 
   return {
     title: page.data.seoTitle || page.data.h1 || page.data.title,
     description: page.data.description,
     openGraph: {
+      ...openGraph,
       images: `/opengraph${url}`,
     },
     alternates: getAlternates(url, locale),

--- a/src/app/[locale]/developers/guides/page.tsx
+++ b/src/app/[locale]/developers/guides/page.tsx
@@ -1,6 +1,7 @@
 import { getGuides } from "@/app/sources/guides";
 import { GuidesIndex } from "./guides";
 import { getAlternates } from "@/i18n/routing";
+import { serverTranslation } from "@/i18n/translation";
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -19,10 +20,15 @@ export default async function Page(props: Props) {
 
 export async function generateMetadata(props: Props) {
   const { locale } = await props.params;
+  const { t } = await serverTranslation(locale);
+
   return {
-    title: "Developer Guides",
-    description:
-      "Learn Solana development with developer guides, from beginner to advanced. JavaScript, TypeScript, Rust, and more.",
+    title: t("developers.guides.title"),
+    description: t("developers.guides.seo-description"),
+    openGraph: {
+      title: t("developers.guides.title"),
+      description: t("developers.guides.seo-description"),
+    },
     alternates: getAlternates("/developers/guides", locale),
   };
 }

--- a/src/app/[locale]/developers/guides/page.tsx
+++ b/src/app/[locale]/developers/guides/page.tsx
@@ -2,6 +2,7 @@ import { getGuides } from "@/app/sources/guides";
 import { GuidesIndex } from "./guides";
 import { getAlternates } from "@/i18n/routing";
 import { serverTranslation } from "@/i18n/translation";
+import { ResolvingMetadata } from "next";
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -18,14 +19,19 @@ export default async function Page(props: Props) {
   );
 }
 
-export async function generateMetadata(props: Props) {
+export async function generateMetadata(
+  props: Props,
+  parent: ResolvingMetadata,
+) {
   const { locale } = await props.params;
   const { t } = await serverTranslation(locale);
+  const { openGraph } = await parent;
 
   return {
     title: t("developers.guides.title"),
     description: t("developers.guides.seo-description"),
     openGraph: {
+      ...openGraph,
       title: t("developers.guides.title"),
       description: t("developers.guides.seo-description"),
     },

--- a/src/app/[locale]/developers/page.tsx
+++ b/src/app/[locale]/developers/page.tsx
@@ -55,6 +55,7 @@ export async function generateMetadata(
   const { locale } = await params;
   const { t } = await serverTranslation(locale);
   const { openGraph } = await parent;
+
   return {
     title: t("developers.title"),
     description: t("developers.description"),

--- a/src/app/[locale]/developers/resources/page.tsx
+++ b/src/app/[locale]/developers/resources/page.tsx
@@ -2,6 +2,11 @@ import { resources } from "@/app/sources/resources";
 import { ResourcesIndex } from "./resources";
 import { getAlternates } from "@/i18n/routing";
 import { serverTranslation } from "@/i18n/translation";
+import { ResolvingMetadata } from "next";
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
 
 export default function Page() {
   const featured = resources
@@ -14,16 +19,19 @@ export default function Page() {
   );
 }
 
-export async function generateMetadata(props: {
-  params: Promise<{ locale: string }>;
-}) {
+export async function generateMetadata(
+  props: Props,
+  parent: ResolvingMetadata,
+) {
   const { locale } = await props.params;
   const { t } = await serverTranslation(locale);
+  const { openGraph } = await parent;
 
   return {
     title: t("developers.resources-page.title"),
     description: t("developers.resources-page.seo-description"),
     openGraph: {
+      ...openGraph,
       title: t("developers.resources-page.title"),
       description: t("developers.resources-page.seo-description"),
     },

--- a/src/app/[locale]/developers/resources/page.tsx
+++ b/src/app/[locale]/developers/resources/page.tsx
@@ -1,7 +1,7 @@
 import { resources } from "@/app/sources/resources";
 import { ResourcesIndex } from "./resources";
 import { getAlternates } from "@/i18n/routing";
-
+import { serverTranslation } from "@/i18n/translation";
 export default function Page() {
   const featured = resources
     .filter((record: any) => record.featured)
@@ -17,10 +17,15 @@ export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await props.params;
+  const { t } = await serverTranslation(locale);
+
   return {
-    title: "Developer Resources",
-    description:
-      "Discover developer resources for the Solana ecosystem. Documentation, tooling, frameworks, sdks, and more.",
+    title: t("developers.resources-page.title"),
+    description: t("developers.resources-page.seo-description"),
+    openGraph: {
+      title: t("developers.resources-page.title"),
+      description: t("developers.resources-page.seo-description"),
+    },
     alternates: getAlternates("/developers/resources", locale),
   };
 }

--- a/src/app/[locale]/developers/resources/page.tsx
+++ b/src/app/[locale]/developers/resources/page.tsx
@@ -2,6 +2,7 @@ import { resources } from "@/app/sources/resources";
 import { ResourcesIndex } from "./resources";
 import { getAlternates } from "@/i18n/routing";
 import { serverTranslation } from "@/i18n/translation";
+
 export default function Page() {
   const featured = resources
     .filter((record: any) => record.featured)


### PR DESCRIPTION
### Problem
Related #111 

### Summary of Changes
- Localize some missing titles and descriptions
- Update the OGP title and description fields for `/developers/courses`, `/developers/guides` and `/developers/resources`. Previously the OGP fields were set to global site title and description.

<img width="2458" alt="image" src="https://github.com/user-attachments/assets/6efe2ee7-8bcf-48d4-a0ca-f46c5846deab" />
