### PR TITLE
Fix opengraph metadata

### DIFF
--- a/src/app/[locale]/developers/cookbook/cookbook.tsx
+++ b/src/app/[locale]/developers/cookbook/cookbook.tsx
@@ -2,8 +2,7 @@ import { cookbookSource } from "@/app/sources/cookbook";
 import { DocsPage } from "@/app/components/docs-page";
 import { notFound } from "next/navigation";
 import { mdxComponents } from "@/app/mdx-components";
-import { getAlternates } from "@/i18n/routing";
-import { getUrlWithoutLocale } from "@/app/sources/utils";
+import { getMdxMetadata } from "@/app/metadata";
 
 export function CookbookPage({
   slug,
@@ -35,14 +34,5 @@ export function CookbookPage({
 export function getMetadataFromSlug(slug: string[], locale: string) {
   const page = cookbookSource.getPage(slug, locale);
   if (!page) notFound();
-  const url = getUrlWithoutLocale(page);
-
-  return {
-    title: page.data.seoTitle || page.data.h1 || page.data.title,
-    description: page.data.description,
-    openGraph: {
-      images: `/opengraph${url}`,
-    },
-    alternates: getAlternates(url, locale),
-  };
+  return getMdxMetadata(page);
 }

--- a/src/app/[locale]/developers/courses/[course]/[lesson]/page.tsx
+++ b/src/app/[locale]/developers/courses/[course]/[lesson]/page.tsx
@@ -2,8 +2,7 @@ import { coursesSource } from "@/app/sources/courses";
 import { notFound } from "next/navigation";
 import { mdxComponents } from "@/app/mdx-components";
 import { BlogPage } from "@/app/components/blog-page";
-import { getAlternates } from "@/i18n/routing";
-import { getUrlWithoutLocale } from "@/app/sources/utils";
+import { getMdxMetadata } from "@/app/metadata";
 
 type Props = {
   params: Promise<{ course: string; lesson: string; locale: string }>;
@@ -60,13 +59,5 @@ export async function generateMetadata(props: {
   const { course, lesson, locale } = await props.params;
   const page = coursesSource.getPage([course, lesson], locale);
   if (!page) notFound();
-  const url = getUrlWithoutLocale(page);
-  return {
-    title: page.data.seoTitle || page.data.h1 || page.data.title,
-    description: page.data.description,
-    openGraph: {
-      images: `/opengraph${url}`,
-    },
-    alternates: getAlternates(url, locale),
-  };
+  return getMdxMetadata(page);
 }

--- a/src/app/[locale]/developers/courses/[course]/page.tsx
+++ b/src/app/[locale]/developers/courses/[course]/page.tsx
@@ -2,8 +2,8 @@ import { coursesSource } from "@/app/sources/courses";
 import { authors } from "@/app/sources/authors";
 import Curriculum from "./curriculum";
 import { notFound } from "next/navigation";
-import { getAlternates } from "@/i18n/routing";
-import { getUrlWithoutLocale, toUrlWithoutLocale } from "@/app/sources/utils";
+import { getMdxMetadata } from "@/app/metadata";
+import { toUrlWithoutLocale } from "@/app/sources/utils";
 
 type Props = {
   params: Promise<{ course: string; locale: string }>;
@@ -48,17 +48,7 @@ export async function generateStaticParams() {
 
 export async function generateMetadata(props: Props) {
   const { course, locale } = await props.params;
-  const page = coursesSource.getPage([course]);
+  const page = coursesSource.getPage([course], locale);
   if (!page) notFound();
-
-  const url = getUrlWithoutLocale(page);
-
-  return {
-    title: page.data.seoTitle || page.data.h1 || page.data.title,
-    description: page.data.description,
-    openGraph: {
-      images: `/opengraph${url}`,
-    },
-    alternates: getAlternates(url, locale),
-  };
+  return getMdxMetadata(page);
 }

--- a/src/app/[locale]/developers/courses/page.tsx
+++ b/src/app/[locale]/developers/courses/page.tsx
@@ -2,8 +2,8 @@ import { coursesSource } from "@/app/sources/courses";
 import Courses from "./courses-index";
 
 import { DefaultCard } from "@solana-foundation/solana-lib/dist/components/CardDeck/DefaultCard/defaultCard";
-import { getAlternates } from "@/i18n/routing";
 import { toUrlWithoutLocale } from "@/app/sources/utils";
+import { getIndexMetadata } from "@/app/metadata";
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -42,10 +42,10 @@ export default async function Page(props: Props) {
 
 export async function generateMetadata(props: Props) {
   const { locale } = await props.params;
-  return {
-    title: "Developer Courses",
-    description:
-      "Learn Solana development with developer guides, from beginner to advanced. JavaScript, TypeScript, Rust, and more.",
-    alternates: getAlternates("/developers/courses", locale),
-  };
+  return await getIndexMetadata({
+    titleKey: "developers.courses.title",
+    descriptionKey: "developers.courses.seo-description",
+    path: "/developers/courses",
+    locale,
+  });
 }

--- a/src/app/[locale]/developers/guides/[...slugs]/page.tsx
+++ b/src/app/[locale]/developers/guides/[...slugs]/page.tsx
@@ -2,8 +2,8 @@ import { guidesSource } from "@/app/sources/guides";
 import { notFound } from "next/navigation";
 import { mdxComponents } from "@/app/mdx-components";
 import { BlogPage } from "@/app/components/blog-page";
-import { getAlternates } from "@/i18n/routing";
-import { getUrlWithoutLocale, toStaticParams } from "@/app/sources/utils";
+import { toStaticParams } from "@/app/sources/utils";
+import { getMdxMetadata } from "@/app/metadata";
 
 type Props = {
   params: Promise<{ slugs: string[]; locale: string }>;
@@ -41,14 +41,5 @@ export async function generateMetadata(props: Props) {
   const { slugs, locale } = await props.params;
   const page = guidesSource.getPage(slugs, locale);
   if (!page) notFound();
-  const url = getUrlWithoutLocale(page);
-
-  return {
-    title: page.data.seoTitle || page.data.h1 || page.data.title,
-    description: page.data.description,
-    openGraph: {
-      images: `/opengraph${url}`,
-    },
-    alternates: getAlternates(url, locale),
-  };
+  return getMdxMetadata(page);
 }

--- a/src/app/[locale]/developers/guides/page.tsx
+++ b/src/app/[locale]/developers/guides/page.tsx
@@ -1,6 +1,6 @@
 import { getGuides } from "@/app/sources/guides";
 import { GuidesIndex } from "./guides";
-import { getAlternates } from "@/i18n/routing";
+import { getIndexMetadata } from "@/app/metadata";
 
 type Props = {
   params: Promise<{ locale: string }>;
@@ -19,10 +19,10 @@ export default async function Page(props: Props) {
 
 export async function generateMetadata(props: Props) {
   const { locale } = await props.params;
-  return {
-    title: "Developer Guides",
-    description:
-      "Learn Solana development with developer guides, from beginner to advanced. JavaScript, TypeScript, Rust, and more.",
-    alternates: getAlternates("/developers/guides", locale),
-  };
+  return await getIndexMetadata({
+    titleKey: "developers.guides.title",
+    descriptionKey: "developers.guides.seo-description",
+    path: "/developers/guides",
+    locale,
+  });
 }

--- a/src/app/[locale]/developers/page.tsx
+++ b/src/app/[locale]/developers/page.tsx
@@ -3,9 +3,7 @@ import { YT_PLAYLIST_CHANGELOG } from "@/constants/developerContentConfig";
 import { getYTVideos } from "@/utils/followerFunctions";
 import { resources } from "@/app/sources/resources";
 import { getGuides } from "@/app/sources/guides";
-import { serverTranslation } from "@/i18n/translation";
-import { ResolvingMetadata } from "next";
-import { getAlternates } from "@/i18n/routing";
+import { getIndexMetadata } from "@/app/metadata";
 
 type Props = { params: Promise<{ locale: string }> };
 
@@ -48,21 +46,12 @@ async function getResources() {
   return resources.filter((r) => r.featured).slice(0, 6);
 }
 
-export async function generateMetadata(
-  { params }: Props,
-  parent: ResolvingMetadata,
-) {
+export async function generateMetadata({ params }: Props) {
   const { locale } = await params;
-  const { t } = await serverTranslation(locale);
-  const { openGraph } = await parent;
-  return {
-    title: t("developers.title"),
-    description: t("developers.description"),
-    openGraph: {
-      ...openGraph,
-      title: t("developers.title"),
-      description: t("developers.description"),
-    },
-    alternates: getAlternates("/developers", locale),
-  };
+  return await getIndexMetadata({
+    titleKey: "developers.title",
+    descriptionKey: "developers.description",
+    path: "/developers",
+    locale,
+  });
 }

--- a/src/app/[locale]/developers/resources/page.tsx
+++ b/src/app/[locale]/developers/resources/page.tsx
@@ -1,6 +1,6 @@
 import { resources } from "@/app/sources/resources";
 import { ResourcesIndex } from "./resources";
-import { getAlternates } from "@/i18n/routing";
+import { getIndexMetadata } from "@/app/metadata";
 
 export default function Page() {
   const featured = resources
@@ -17,10 +17,10 @@ export async function generateMetadata(props: {
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await props.params;
-  return {
-    title: "Developer Resources",
-    description:
-      "Discover developer resources for the Solana ecosystem. Documentation, tooling, frameworks, sdks, and more.",
-    alternates: getAlternates("/developers/resources", locale),
-  };
+  return await getIndexMetadata({
+    titleKey: "developers.resources-page.title",
+    descriptionKey: "developers.resources-page.seo-description",
+    path: "/developers/resources",
+    locale,
+  });
 }

--- a/src/app/[locale]/docs/(main)/docs.tsx
+++ b/src/app/[locale]/docs/(main)/docs.tsx
@@ -2,8 +2,7 @@ import { docsSource } from "@/app/sources/docs";
 import { DocsPage } from "@/app/components/docs-page";
 import { notFound } from "next/navigation";
 import { mdxComponents } from "@/app/mdx-components";
-import { getAlternates } from "@/i18n/routing";
-import { getUrlWithoutLocale } from "@/app/sources/utils";
+import { getMdxMetadata } from "@/app/metadata";
 
 export function MainDocsPage({
   slug,
@@ -35,15 +34,5 @@ export function MainDocsPage({
 export function getMetadataFromSlug(slug: string[], locale: string) {
   const page = docsSource.getPage(slug, locale);
   if (!page) notFound();
-
-  const url = getUrlWithoutLocale(page);
-
-  return {
-    title: page.data.seoTitle || page.data.h1 || page.data.title,
-    description: page.data.description,
-    openGraph: {
-      images: `/opengraph/developers${url}`,
-    },
-    alternates: getAlternates(url, locale),
-  };
+  return getMdxMetadata(page);
 }

--- a/src/app/[locale]/docs/rpc/rpc.tsx
+++ b/src/app/[locale]/docs/rpc/rpc.tsx
@@ -10,8 +10,7 @@ import {
 } from "@/components/shared/MarkdownRenderer/DocSideBySide";
 import { DocsPage } from "@/app/components/docs-page";
 import { mdxComponents } from "@/app/mdx-components";
-import { getAlternates } from "@/i18n/routing";
-import { getUrlWithoutLocale } from "@/app/sources/utils";
+import { getMdxMetadata } from "@/app/metadata";
 
 const rpcMDXComponents = {
   DocSideBySide,
@@ -51,15 +50,5 @@ export async function RpcDocsPage({
 export function getMetadataFromSlug(slug: string[], locale: string) {
   const page = docsSource.getPage(slug, locale);
   if (!page) notFound();
-
-  const url = getUrlWithoutLocale(page);
-
-  return {
-    title: page.data.seoTitle || page.data.h1 || page.data.title,
-    description: page.data.description,
-    openGraph: {
-      images: `/opengraph/developers${url}`,
-    },
-    alternates: getAlternates(url, locale),
-  };
+  return getMdxMetadata(page);
 }

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -11,6 +11,7 @@ import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { staticLocales } from "@/i18n/config.cjs";
 import { Metadata } from "next";
+import { getBaseMetadata } from "@/app/metadata";
 
 const namespaces = ["common"];
 
@@ -62,46 +63,5 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
-  const { siteMetadata, siteUrl } = config;
-  return {
-    other: {
-      "docsearch:language": locale,
-      language: locale,
-    },
-    title: {
-      template: "%s | Solana",
-      default: siteMetadata.title,
-    },
-    description: siteMetadata.description,
-    openGraph: {
-      description: siteMetadata.description,
-      type: "website",
-      images: [siteMetadata.socialShare],
-      locale,
-    },
-    twitter: {
-      card: "summary_large_image",
-      creator: siteMetadata.author,
-    },
-    robots: "index, follow",
-    manifest: "/site.webmanifest",
-    metadataBase: new URL(siteUrl),
-    icons: [
-      {
-        url: "/favicon.png",
-        rel: "icon",
-        type: "image/png",
-      },
-      {
-        url: "/favicon.svg",
-        rel: "icon",
-        type: "image/svg+xml",
-      },
-      {
-        url: "/apple-touch-icon.png",
-        rel: "apple-touch-icon",
-        sizes: "180x180",
-      },
-    ],
-  };
+  return getBaseMetadata(locale);
 }

--- a/src/app/metadata.ts
+++ b/src/app/metadata.ts
@@ -1,0 +1,85 @@
+import { config } from "@/config";
+import { getUrlWithoutLocale } from "@/app/sources/utils";
+import { getAlternates } from "@/i18n/routing";
+import { serverTranslation } from "@/i18n/translation";
+
+export function getBaseMetadata(locale: string) {
+  const { siteMetadata, siteUrl } = config;
+  return {
+    other: {
+      "docsearch:language": locale,
+      language: locale,
+    },
+    title: {
+      template: "%s | Solana",
+      default: siteMetadata.title,
+    },
+    description: siteMetadata.description,
+    openGraph: {
+      type: "website",
+      images: [siteMetadata.socialShare],
+      locale,
+    },
+    twitter: {
+      card: "summary_large_image",
+      creator: siteMetadata.author,
+    },
+    robots: "index, follow",
+    manifest: "/site.webmanifest",
+    metadataBase: new URL(siteUrl),
+    icons: [
+      {
+        url: "/favicon.png",
+        rel: "icon",
+        type: "image/png",
+      },
+      {
+        url: "/favicon.svg",
+        rel: "icon",
+        type: "image/svg+xml",
+      },
+      {
+        url: "/apple-touch-icon.png",
+        rel: "apple-touch-icon",
+        sizes: "180x180",
+      },
+    ],
+  };
+}
+
+export async function getIndexMetadata({
+  titleKey,
+  descriptionKey,
+  locale,
+  path,
+}) {
+  const { t } = await serverTranslation(locale);
+  return {
+    title: t(titleKey),
+    description: t(descriptionKey),
+    alternates: getAlternates(path, locale),
+  };
+}
+
+export function getMdxMetadata(page) {
+  const url = getUrlWithoutLocale(page);
+  const title = page.data.seoTitle || page.data.h1 || page.data.title;
+  const description = page.data.description;
+  const { openGraph } = getBaseMetadata(page.locale);
+
+  const imagePrefix = url?.startsWith("/docs")
+    ? "/opengraph/developers"
+    : "/opengraph";
+
+  return {
+    title,
+    description,
+    alternates: getAlternates(url, page.locale),
+    openGraph: {
+      ...openGraph,
+      images: [imagePrefix + url],
+      title,
+      description,
+    },
+  };
+}

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -41,6 +41,19 @@ export function pathsWithLocales<T>(paths: { params: T }[]) {
   );
 }
 
+export function getMetadata(
+  title: string,
+  description: string,
+  path: string,
+  locale: string,
+) {
+  return {
+    title: title,
+    description: description,
+    alternates: getAlternates(path, locale),
+  };
+}
+
 export function getAlternates(path: string, locale: string) {
   const languages = {
     "x-default": `/${path}`,

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -41,19 +41,6 @@ export function pathsWithLocales<T>(paths: { params: T }[]) {
   );
 }
 
-export function getMetadata(
-  title: string,
-  description: string,
-  path: string,
-  locale: string,
-) {
-  return {
-    title: title,
-    description: description,
-    alternates: getAlternates(path, locale),
-  };
-}
-
 export function getAlternates(path: string, locale: string) {
   const languages = {
     "x-default": `/${path}`,


### PR DESCRIPTION
### Problem

- some pages had wrong opengraph description
- some pages were missing translated metadata

### Summary of Changes

- refactor metadata generation in app router to avoid repetition
- add missing metadata translations
- remove root layout opengraph description to avoid overriding pages' opengraph
