### PR TITLE
Add `/content` folder to Crowdin

### DIFF
--- a/content/docs/intro/wallets.es.mdx
+++ b/content/docs/intro/wallets.es.mdx
@@ -1,0 +1,60 @@
+---
+title: Wallets
+h1: Guía de Wallets de Solana
+---
+
+Este documento describe las diferentes opciones de wallet disponibles para los usuarios de Solana que quieren ser capaces de enviar, recibir y interactuar con SOL tokens en la blockchain de Solana.
+
+## ¿Qué es una Wallet?
+
+Una wallet de criptomonedas es un dispositivo o aplicación que almacena una colección de claves y
+puede ser utilizada para enviar, recibir y rastrear la propiedad de criptomonedas. Las wallets pueden tomar muchas formas. Una wallet puede ser un directorio o archivo en el sistema de archivos de tu computadora, un trozo de papel, o un dispositivo especializado llamado _hardware
+wallet_. También hay aplicaciones y programas informáticos para teléfonos inteligentes que
+proporcionan una forma de usuario para crear y gestionar wallets.
+
+### Keypair
+
+Un [_keypair_](/docs/terminology#keypair) es una clave secreta generada de forma segura
+y su clave pública derivada. Una clave secreta y su clave pública correspondiente son
+juntos conocidos como un _keypair_. Una wallet contiene una colección de una o más
+keypairs y proporciona algún medio para interactuar con ellas.
+
+### Clave pública
+
+La [_clave pública_](/docs/terminology#public-key-pubkey) (comúnmente abreviada
+a _pubkey_) se conoce como la dirección de recepción de la wallet o simplemente su
+_dirección_. La dirección de la wallet **puede ser compartida y mostrada libremente**. Cuando
+otra parte está a punto de enviar una cierta cantidad de criptomonedas a una wallet,
+necesitan conocer la dirección de recepción de la wallet. Dependiendo de la implementación de la blockchain, la dirección también puede ser utilizada para ver cierta información sobre una
+wallet, como ver el saldo, pero no tiene la capacidad de cambiar nada sobre
+la wallet o retirar ninguna criptomoneda.
+
+### Clave secreta
+
+La [_clave secreta_](/docs/terminology#private-key) (también conocida como
+_clave privada_) es necesaria para firmar digitalmente cualquier transacción para
+enviar criptomonedas a otra dirección o para hacer cualquier cambio en la wallet. La
+clave secreta **nunca debe ser compartida**. Si alguien accede a la clave secreta
+de una wallet, pueden retirar todas las criptomonedas que contiene. Si la clave secreta
+de una wallet se pierde, cualquier criptomoneda que se haya enviado a la dirección
+de esa wallet se perderá permanentemente.
+
+## Seguridad
+
+Diferentes soluciones de wallet ofrecen diferentes enfoques para la seguridad de las claves,
+interactuar con las claves y firmar transacciones para usar/gastar las criptomonedas.
+Algunas son más fáciles de usar que otras. Algunas almacenan y respaldan las claves secretas más
+seguramente. Solana soporta varios tipos de wallets para que puedas elegir el equilibrio correcto
+de seguridad y conveniencia.
+
+**Si quieres ser capaz de recibir SOL tokens en la blockchain de Solana, primero necesitarás crear una wallet.**
+
+## Wallets soportados
+
+Varias wallets basadas en navegadores y aplicaciones móviles soportan Solana. Encuentra algunas opciones
+que podrían ser adecuadas para ti en la página [Solana Wallets](/wallets).
+
+Para usuarios avanzados o desarrolladores, las
+[wallets de línea de comandos](https://docs.anza.xyz/cli/wallets) pueden ser más
+adecuadas, ya que las nuevas funciones en la blockchain de Solana siempre serán soportadas
+en la línea de comandos antes de ser integradas en soluciones de terceros.

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -29,4 +29,12 @@ files: [
       #
       "translation": "/public/locales/%two_letters_code%/common.json",
     },
+    {
+      "source": "/content/**/*.mdx",
+      "translation": "/content/**/%file_name%.%two_letters_code%.mdx",
+    },
+    {
+      "source": "/content/**/meta.json",
+      "translation": "/content/**/%file_name%.%two_letters_code%.json",
+    },
   ]

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -29,12 +29,20 @@ files: [
       #
       "translation": "/public/locales/%two_letters_code%/common.json",
     },
+    # {
+    #   "source": "/content/**/*.mdx",
+    #   "translation": "/content/**/%file_name%.%two_letters_code%.mdx",
+    # },
+    # {
+    #   "source": "/content/**/meta.json",
+    #   "translation": "/content/**/%file_name%.%two_letters_code%.json",
+    # },
     {
-      "source": "/content/**/*.mdx",
-      "translation": "/content/**/%file_name%.%two_letters_code%.mdx",
+      "source": "/content/docs/intro/**/*.mdx",
+      "translation": "/content/docs/intro/**/%file_name%.%two_letters_code%.mdx",
     },
     {
-      "source": "/content/**/meta.json",
-      "translation": "/content/**/%file_name%.%two_letters_code%.json",
+      "source": "/content/docs/intro/**/meta.json",
+      "translation": "/content/docs/intro/**/%file_name%.%two_letters_code%.json",
     },
   ]


### PR DESCRIPTION
### Problem

Recently migrated content files aren't managed by Crowdin.

### Summary of Changes

Added new sources to `crowdin.yml`

---

This is what I think we need based on the [docs](https://support.crowdin.com/developer/configuration-file/). Since there's no way to test this before committing, maybe we should try using a subfolder first instead of the entire `/content` folder, something like `/content/docs/intro`.

One concern I have is how Crowdin handles translated files once they're committed. It’s unclear if it will ignore files like `/content/index.es.mdx` or mistakenly treat them as sources.