### PR TITLE
docs: move exchange page from docs to guides

### DIFF
--- a/content/docs/more/meta.json
+++ b/content/docs/more/meta.json
@@ -1,5 +1,0 @@
-{
-  "title": "More Information",
-  "pages": ["exchange"],
-  "defaultOpen": true
-}

--- a/content/guides/advanced/exchange.mdx
+++ b/content/guides/advanced/exchange.mdx
@@ -1,5 +1,8 @@
 ---
 title: Add Solana to Your Exchange
+description:
+  Learn how to integrate Solana into your exchange with this guide covering node
+  setup and implementation details for deposits and withdrawals.
 ---
 
 This guide describes how to add Solana's native token SOL to your cryptocurrency
@@ -96,8 +99,8 @@ versions include incompatible protocol changes, which necessitate timely
 software update to avoid errors in processing blocks.
 
 Our official release announcements for all kinds of releases (normal and
-security) are communicated via a [discord](/discord) channel
-called `#mb-announcement` (`mb` stands for `mainnet-beta`).
+security) are communicated via a [discord](/discord) channel called
+`#mb-announcement` (`mb` stands for `mainnet-beta`).
 
 Like staked validators, we expect any exchange-operated validators to be updated
 at your earliest convenience within a business day or two after a normal release
@@ -232,8 +235,8 @@ block and inspect for addresses of interest, using the JSON-RPC service of your
 Solana API node.
 
 - To identify which blocks are available, send a
-  [`getBlocks`](/docs/rpc/http/getblocks) request, passing the last block
-  you have already processed as the start-slot parameter:
+  [`getBlocks`](/docs/rpc/http/getblocks) request, passing the last block you
+  have already processed as the start-slot parameter:
 
 ```shell
 curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d '{
@@ -590,8 +593,8 @@ off to the cluster using the JSON-RPC
 #### Transaction Confirmations & Finality
 
 Get the status of a batch of transactions using the
-[`getSignatureStatuses`](/docs/rpc/http/getsignaturestatuses) JSON-RPC
-endpoint. The `confirmations` field reports how many
+[`getSignatureStatuses`](/docs/rpc/http/getsignaturestatuses) JSON-RPC endpoint.
+The `confirmations` field reports how many
 [confirmed blocks](/docs/terminology#confirmed-block) have elapsed since the
 transaction was processed. If `confirmations: null`, it is
 [finalized](/docs/terminology#finality).
@@ -772,11 +775,10 @@ validator has included such transactions in their block because they chose other
 transactions with higher economic value. Valid Transactions on Solana may be
 delayed or dropped if Prioritization Fees are not implemented properly.
 
-[Prioritization Fees](/docs/terminology#prioritization-fee) are additional
-fees that can be added on top of the
-[base Transaction Fee](/docs/core/fees#transaction-fees) to ensure
-transaction inclusion within blocks and in these situations and help ensure
-deliverability.
+[Prioritization Fees](/docs/terminology#prioritization-fee) are additional fees
+that can be added on top of the
+[base Transaction Fee](/docs/core/fees#transaction-fees) to ensure transaction
+inclusion within blocks and in these situations and help ensure deliverability.
 
 These priority fees are added to transaction by adding a special Compute Budget
 instruction that sets the desired priority fee to be paid.
@@ -975,8 +977,8 @@ accounts do not:
    deposited. Token accounts can be created explicitly with the
    `spl-token create-account` command, or implicitly by the
    `spl-token transfer --fund-recipient ...` command.
-1. SPL Token accounts must remain [rent-exempt](/docs/core/fees#rent-exempt)
-   for the duration of their existence and therefore require a small amount of
+1. SPL Token accounts must remain [rent-exempt](/docs/core/fees#rent-exempt) for
+   the duration of their existence and therefore require a small amount of
    native SOL tokens be deposited at account creation. For SPL Token accounts,
    this amount is 0.00203928 SOL (2,039,280 lamports).
 

--- a/content/guides/advanced/meta.json
+++ b/content/guides/advanced/meta.json
@@ -8,6 +8,7 @@
     "introduction-to-durable-nonces",
     "stake-weighted-qos",
     "testing-with-jest-and-bankrun",
-    "verified-builds"
+    "verified-builds",
+    "exchange"
   ]
 }

--- a/rewrites-redirects.mjs
+++ b/rewrites-redirects.mjs
@@ -685,5 +685,9 @@ export default {
       source: "/developers/guides/immutable-owner",
       destination: "/developers/guides/token-extensions/immutable-owner",
     },
+    {
+      source: "/docs/more/exchange",
+      destination: "/developers/guides/advanced/exchange",
+    },
   ],
 };

--- a/source.config.ts
+++ b/source.config.ts
@@ -1,4 +1,4 @@
-import { defineDocs } from "fumadocs-mdx/config";
+import { defineConfig, defineDocs } from "fumadocs-mdx/config";
 import { z } from "zod";
 
 const schema = z.custom<{
@@ -45,3 +45,7 @@ const guidesData = defineDocs({
 
 export const guides = guidesData.docs;
 export const guidesMeta = guidesData.meta;
+
+export default defineConfig({
+  lastModifiedTime: "git",
+});

--- a/src/app/[locale]/docs/(main)/docs.tsx
+++ b/src/app/[locale]/docs/(main)/docs.tsx
@@ -25,6 +25,7 @@ export function MainDocsPage({
       hideTableOfContents={page.data.hideTableOfContents}
       pageTree={docsSource.pageTree[locale]}
       href={page.url}
+      lastModified={page.data.lastModified}
     >
       <MDX components={mdxComponents} />
     </DocsPage>

--- a/src/app/components/docs-page.tsx
+++ b/src/app/components/docs-page.tsx
@@ -19,6 +19,7 @@ export function DocsPage(props: {
   title: string;
   pageTree?: any;
   href: string;
+  lastModified?: Date;
 }) {
   const path = props.filePath;
   const href = `https://github.com/solana-foundation/solana-com/blob/main/content/docs/${path.startsWith("/") ? path.slice(1) : path}`;
@@ -46,6 +47,7 @@ export function DocsPage(props: {
       footer={{
         component: <Footer pageUrl={props.href} pageTree={props.pageTree} />,
       }}
+      lastUpdate={props.lastModified}
     >
       <DocsTitle className="text-fd-accent-foreground text-4xl md:text-5xl">
         {props.title}


### PR DESCRIPTION
### Summary of Changes

- Move "Add Solana to your Exchange" page out of /docs into a page on /guides
- Enable [lastModifiedTime](https://fumadocs.vercel.app/docs/mdx/last-modified) for /docs to display "Last updated on Date" at bottom of page