### PR TITLE
Add cta to AI guide

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -18,7 +18,8 @@
     "description": "Solana is a blockchain with low costs, high speeds, minimal energy impact, and easy user experience. AI could reduce that friction even further, opening up the power of decentralization to millions of people.",
     "hero": {
       "title": "<colored>AI</colored> innovation at the speed of Solana",
-      "point-3": "An ecosystem of builders at intersection of AI + Web3"
+      "point-3": "An ecosystem of builders at intersection of AI + Web3",
+      "cta": "See AI tools on Solana"
     },
     "why-ai": {
       "caption": "Why AI on the Blockchain?",

--- a/src/components/ai/AiHero.jsx
+++ b/src/components/ai/AiHero.jsx
@@ -1,6 +1,7 @@
 import classNames from "classnames";
 import Image from "next/image";
 import { Trans, useTranslation } from "next-i18next";
+import Button from "@/components/shared/Button";
 import bgSmall from "../../../assets/ai/hero-bg-small.png";
 import bgLarge from "../../../assets/ai/hero-bg-large.png";
 
@@ -28,8 +29,16 @@ export default function AiHero() {
             />
           </h1>
           <div className={classNames("w-lg-75", styles["hero__points"])}>
-            <div>{t("ai.hero.point-3")}</div>
+            <p className="mb-0">{t("ai.hero.point-3")}</p>
           </div>
+          <Button
+            newTab
+            size="large"
+            to="/developers/guides/getstarted/intro-to-ai"
+            variant="secondary"
+          >
+            {t("ai.hero.cta")}
+          </Button>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Problem
Missing CTA in the hero section


### Summary of Changes
Add proper CTA to the AI guide `developers/guides/getstarted/intro-to-ai`