### PR TITLE
Add skip_untranslated_files to crowdin config

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -40,9 +40,11 @@ files: [
     {
       "source": "/content/docs/intro/**/*.mdx",
       "translation": "/content/docs/intro/**/%file_name%.%two_letters_code%.mdx",
+      "skip_untranslated_files": true,
     },
     {
       "source": "/content/docs/intro/**/meta.json",
       "translation": "/content/docs/intro/**/%file_name%.%two_letters_code%.json",
+      "skip_untranslated_files": true,
     },
   ]


### PR DESCRIPTION
### Problem

Crowdin GitHub integration pushes translation files even when they are 0% translated. See #162.

### Summary of Changes

Add `skip_untranslated_files` to the `/content` folder file groups. 

Not sure if it's going to work since this setting isn't mentioned in the [configuration file docs](https://support.crowdin.com/developer/configuration-file/), but it's in the [CLI docs](https://crowdin.github.io/crowdin-cli/advanced#configure-export-options-for-each-file-group). 