### PR TITLE
fix(courses): fix inaccessible link in `Course/program-optimization/program-architecture`

### DIFF
--- a/content/courses/program-optimization/program-architecture.mdx
+++ b/content/courses/program-optimization/program-architecture.mdx
@@ -122,7 +122,7 @@ Be careful with small number types, though. You can quickly run into unexpected
 behavior due to overflow. For example, a u8 type that is iteratively incremented
 will reach 255 and then go back to 0 instead of 256. For more real-world
 context, look up the
-**[Y2K bug](https://www.nationalgeographic.org/encyclopedia/Y2K-bug/#:~:text=As%20the%20year%202000%20approached%2C%20computer%20programmers%20realized%20that%20computers,would%20be%20damaged%20or%20flawed.).**
+**[Y2K bug](https://education.nationalgeographic.org/resource/Y2K-bug/)**.
 
 If you want to read more about Anchor sizes, take a look at
 [Sec3's blog post about it](https://www.sec3.dev/blog/all-about-anchor-account-size)
@@ -583,7 +583,7 @@ Memory used to grow is already zero-initialized upon program entrypoint and
 re-zeroing it wastes compute units. If within the same call a program reallocs
 from larger to smaller and back to larger again the new space could contain
 stale data. Pass `true` for `zero_init` in this case, otherwise compute units
-will be wasted re-zero-initializing. 
+will be wasted re-zero-initializing.
 
 </Callout>
 
@@ -597,7 +597,7 @@ and expected growth patterns.
 - The payer of the transaction is responsible for providing the additional
   lamports.
 - Consider the cost implications of frequent resizing in your program design.
-  
+
 
 </Callout>
 
@@ -1329,7 +1329,7 @@ treasury for each.
 The `treasury` is a signer on the instruction. This is to make sure whoever is
 creating the game has the private keys to the `treasury`. This is a design
 decision rather than "the right way." Ultimately, it's a security measure to
-ensure the game master will be able to retrieve their funds. 
+ensure the game master will be able to retrieve their funds.
 
 </Callout>
 


### PR DESCRIPTION
### Problem

In the source page of `Course/program-optimization/program-architecture`, the link referring to "Y2K-bug" is broken.

### Summary of Changes

fix(courses): fix inaccessible link

Fixes #