### PR TITLE
docs: update json-structures page

### DIFF
--- a/content/docs/rpc/json-structures.mdx
+++ b/content/docs/rpc/json-structures.mdx
@@ -19,14 +19,48 @@ Transactions are quite different from those on other blockchains. Be sure to
 review [Anatomy of a Transaction](/docs/core/transactions) to learn about
 transactions on Solana.
 
+### JSON
+
 The JSON structure of a transaction is defined as follows:
 
-- `signatures: <array[string]>` - A list of base-58 encoded signatures applied
-  to the transaction. The list is always of length
-  `message.header.numRequiredSignatures` and not empty. The signature at index
-  `i` corresponds to the public key at index `i` in `message.accountKeys`. The
-  first one is used as the
-  [transaction id](/docs/terminology#transaction-id).
+<Accordions>
+<Accordion title="Reference">
+
+```shell
+"transaction": {
+  "message": {
+    "accountKeys": [
+      "EF3cbGuhJus5mCdGZkVz7GQce7QHbswBhZu6fmK9zkCR",
+      "4LAyP5B5jNyNm7Ar2dG8sNipEiwTMEyCHd1iCHhhXYkY",
+      "11111111111111111111111111111111"
+    ],
+    "header": {
+      "numReadonlySignedAccounts": 0,
+      "numReadonlyUnsignedAccounts": 1,
+      "numRequiredSignatures": 1
+    },
+    "instructions": [
+      {
+        "accounts": [
+          0,
+          1
+        ],
+        "data": "3Bxs411Dtc7pkFQj",
+        "programIdIndex": 2,
+        "stackHeight": null
+      }
+    ],
+    "recentBlockhash": "6pw7JBwq9tb5GHiBQgVY6RAp5otbouwYvEc1kbbxKFec"
+  },
+  "signatures": [
+    "2M8mvwhtxyz3vAokXESVeR9FQ4t9QQxF5ek6ENNBBHVkW5XyZvJVK5MQej5ccwTZH6iWBJJoZ2CcizBs89pvpPBh"
+  ]
+}
+```
+
+</Accordion>
+</Accordions>
+
 - `message: <object>` - Defines the content of the transaction.
   - `accountKeys: <array[string]>` - List of base-58 encoded public keys used by
     the transaction, including by the instructions and for signatures. The first
@@ -66,6 +100,87 @@ The JSON structure of a transaction is defined as follows:
       addresses of writable accounts from a lookup table.
     - `readonlyIndexes: <array[number]>` - List of indices used to load
       addresses of readonly accounts from a lookup table.
+- `signatures: <array[string]>` - A list of base-58 encoded signatures applied
+  to the transaction. The list is always of length
+  `message.header.numRequiredSignatures` and not empty. The signature at index
+  `i` corresponds to the public key at index `i` in `message.accountKeys`. The
+  first one is used as the
+  [transaction id](/docs/terminology#transaction-id).
+
+### JSON Parsed
+
+The JSON parsed structure of a transaction follows a similar structure to the regular JSON format, with additional parsing of account and instruction information:
+
+<Accordions>
+<Accordion title="Reference">
+
+```shell
+"transaction": {
+  "message": {
+    "accountKeys": [
+      {
+        "pubkey": "EF3cbGuhJus5mCdGZkVz7GQce7QHbswBhZu6fmK9zkCR",
+        "signer": true,
+        "source": "transaction",
+        "writable": true
+      },
+      {
+        "pubkey": "4LAyP5B5jNyNm7Ar2dG8sNipEiwTMEyCHd1iCHhhXYkY",
+        "signer": false,
+        "source": "transaction",
+        "writable": true
+      },
+      {
+        "pubkey": "11111111111111111111111111111111",
+        "signer": false,
+        "source": "transaction",
+        "writable": false
+      }
+    ],
+    "instructions": [
+      {
+        "parsed": {
+          "info": {
+            "destination": "4LAyP5B5jNyNm7Ar2dG8sNipEiwTMEyCHd1iCHhhXYkY",
+            "lamports": 100000000,
+            "source": "EF3cbGuhJus5mCdGZkVz7GQce7QHbswBhZu6fmK9zkCR"
+          },
+          "type": "transfer"
+        },
+        "program": "system",
+        "programId": "11111111111111111111111111111111",
+        "stackHeight": null
+      }
+    ],
+    "recentBlockhash": "6pw7JBwq9tb5GHiBQgVY6RAp5otbouwYvEc1kbbxKFec"
+  },
+  "signatures": [
+    "2M8mvwhtxyz3vAokXESVeR9FQ4t9QQxF5ek6ENNBBHVkW5XyZvJVK5MQej5ccwTZH6iWBJJoZ2CcizBs89pvpPBh"
+  ]
+}
+```
+
+</Accordion>
+</Accordions>
+
+- `message: <object>` - Defines the content of the transaction.
+  - `accountKeys: <array[object]>` - List of account information used by the transaction.
+    - `pubkey: <string>` - The base-58 encoded public key of the account.
+    - `signer: <boolean>` - Indicates if the account is a required transaction signer.
+    - `writable: <boolean>` - Indicates if the account is writable.
+    - `source: <string>` - Source of the account (transaction or lookup table).
+  - `recentBlockhash: <string>` - A base-58 encoded hash of a recent block in
+    the ledger used to prevent transaction duplication and to give transactions
+    lifetimes.
+  - `instructions: <array[object]>` - List of parsed program instructions.
+    - `program: <string>` - The name of the program being called.
+    - `programId: <string>` - The base-58 encoded public key of the program.
+    - `stackHeight: <number|null>` - The stack height of the instruction.
+    - `parsed: <object>` - Program-specific parsed data.
+      - `type: <string>` - The type of instruction (e.g., "transfer").
+      - `info: <object>` - Parsed instruction information specific to the program and instruction type.
+- `signatures: <array[string]>` - A list of base-58 encoded signatures applied
+  to the transaction.
 
 ## Inner Instructions
 
@@ -77,6 +192,80 @@ of processing.
 
 The JSON structure of inner instructions is defined as a list of objects in the
 following structure:
+
+<Accordions>
+<Accordion title="Reference">
+
+```shell
+"innerInstructions": [
+  {
+    "index": 0,
+    "instructions": [
+      {
+        "accounts": [
+          0,
+          1,
+          2
+        ],
+        "data": "WPNHsFPyEMr",
+        "programIdIndex": 3,
+        "stackHeight": 2
+      },
+      {
+        "accounts": [
+          0,
+          1
+        ],
+        "data": "11111dBUPbGETd4QtNMQVg8HqgcZtKy6DcJm6R4TZufJkuhkDS47VsauCCGhLf2xrm5BQ",
+        "programIdIndex": 2,
+        "stackHeight": 3
+      }
+    ]
+  }
+]
+```
+
+Reference transaction:
+
+```shell
+"transaction": {
+  "message": {
+    "accountKeys": [
+      "4kh6HxYZiAebF8HWLsUWod2EaQQ6iWHpHYCz8UcmFbM1",
+      "Bpo7aaM9kqfCjM6JgZCSdev7HsaUFj51mBPPEhQcDpUR",
+      "11111111111111111111111111111111",
+      "8HupNBr7SBhBLcBsLhbtes3tCarBm6Bvpqp5AfVjHuj8",
+      "GENmb1D59wqCKRwujq4PJ8461EccQ5srLHrXyXp4HMTH"
+    ],
+    "header": {
+      "numReadonlySignedAccounts": 0,
+      "numReadonlyUnsignedAccounts": 3,
+      "numRequiredSignatures": 2
+    },
+    "instructions": [
+      {
+        "accounts": [
+          0,
+          1,
+          2,
+          3
+        ],
+        "data": "H2ot5wbZsmL",
+        "programIdIndex": 4,
+        "stackHeight": null
+      }
+    ],
+    "recentBlockhash": "28CroH2jyCaCFF6ssyUK989zBZY6dBxnUNU9A4oPUbER"
+  },
+  "signatures": [
+    "4i4EuRQ1sNzKWEBYwg28VAMkQbaAeHyRRwu1tQRksowtQhGRJtgaHXpDAhBfpYZnVodGoQYwiUiB5yBRDoWbZ7VH",
+    "2dipFcFF4CvwtbCFbRdctQmyzAYcq8RWrLryZErbKPhnriCJ6wDmKfJoSJfDjFNzUEcJDKkfasS2pcjvGEUjdYN6"
+  ]
+}
+```
+
+</Accordion>
+</Accordions>
 
 - `index: number` - Index of the transaction instruction from which the inner
   instruction(s) originated
@@ -90,6 +279,124 @@ following structure:
   - `data: <string>` - The program input data encoded in a base-58 string.
 
 ## Token Balances
+
+<Accordions>
+<Accordion title="Reference">
+
+```shell
+"postTokenBalances": [
+  {
+    "accountIndex": 1,
+    "mint": "6HvU8PbqP3nZLkFF59rr2zkTHqetPLgb6NnxKZLHQxNp",
+    "owner": "DKypunNAGLPGBj3SocY8fF4ZrnDNVTf6QcUyW4trvkB",
+    "programId": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+    "uiTokenAmount": {
+      "amount": "0",
+      "decimals": 2,
+      "uiAmount": null,
+      "uiAmountString": "0"
+    }
+  },
+  {
+    "accountIndex": 2,
+    "mint": "6HvU8PbqP3nZLkFF59rr2zkTHqetPLgb6NnxKZLHQxNp",
+    "owner": "8xm9beCpBH7SgqRz1mKua7KJF52whAVCiDEV1qREGHNV",
+    "programId": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+    "uiTokenAmount": {
+      "amount": "100",
+      "decimals": 2,
+      "uiAmount": 1.0,
+      "uiAmountString": "1"
+    }
+  }
+],
+
+"preTokenBalances": [
+  {
+    "accountIndex": 1,
+    "mint": "6HvU8PbqP3nZLkFF59rr2zkTHqetPLgb6NnxKZLHQxNp",
+    "owner": "DKypunNAGLPGBj3SocY8fF4ZrnDNVTf6QcUyW4trvkB",
+    "programId": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+    "uiTokenAmount": {
+      "amount": "100",
+      "decimals": 2,
+      "uiAmount": 1.0,
+      "uiAmountString": "1"
+    }
+  },
+  {
+    "accountIndex": 2,
+    "mint": "6HvU8PbqP3nZLkFF59rr2zkTHqetPLgb6NnxKZLHQxNp",
+    "owner": "8xm9beCpBH7SgqRz1mKua7KJF52whAVCiDEV1qREGHNV",
+    "programId": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+    "uiTokenAmount": {
+      "amount": "0",
+      "decimals": 2,
+      "uiAmount": null,
+      "uiAmountString": "0"
+    }
+  }
+]
+```
+
+Reference transaction:
+
+```shell
+"transaction": {
+  "message": {
+    "accountKeys": [
+      {
+        "pubkey": "DKypunNAGLPGBj3SocY8fF4ZrnDNVTf6QcUyW4trvkB",
+        "signer": true,
+        "source": "transaction",
+        "writable": true
+      },
+      {
+        "pubkey": "39nzuQ2WYHf231DJRPt1TLfaXSWXEKYGcqP3NQf6zK7G",
+        "signer": false,
+        "source": "transaction",
+        "writable": true
+      },
+      {
+        "pubkey": "DtCPWGmvCTov7CNmNTx8AFe3SEFSxgy265kZawv8SVL3",
+        "signer": false,
+        "source": "transaction",
+        "writable": true
+      },
+      {
+        "pubkey": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+        "signer": false,
+        "source": "transaction",
+        "writable": false
+      }
+    ],
+    "addressTableLookups": [],
+    "instructions": [
+      {
+        "parsed": {
+          "info": {
+            "amount": "100",
+            "authority": "DKypunNAGLPGBj3SocY8fF4ZrnDNVTf6QcUyW4trvkB",
+            "destination": "DtCPWGmvCTov7CNmNTx8AFe3SEFSxgy265kZawv8SVL3",
+            "source": "39nzuQ2WYHf231DJRPt1TLfaXSWXEKYGcqP3NQf6zK7G"
+          },
+          "type": "transfer"
+        },
+        "program": "spl-token",
+        "programId": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+        "stackHeight": null
+      }
+    ],
+    "recentBlockhash": "42mjf871LtzDK8NVZUAht1xBoCvNMagQGSM7BnFWZD6M"
+  },
+  "signatures": [
+    "5ZQqsF4tTFJDR5vuNJxejtw2GMc8KEtnPXnQjwhGzAtdbPTKtrLfPkFAbBTyPjZSVB3CbR5BiP5S8zAfZNtuwh88"
+  ]
+}
+```
+
+</Accordion>
+</Accordions>
 
 The JSON structure of token balances is defined as a list of objects in the
 following structure:


### PR DESCRIPTION
### Problem

- json-structures page does not mention `jsonParsed` encoding format

### Summary of Changes

- add JSON Parsed section
- add reference snippets for each section

Fixes #

https://github.com/solana-foundation/solana-com/issues/171