### PR TITLE
replace try_to_vec with try_to_vec_with_schema

### DIFF
--- a/content/guides/getstarted/intro-to-native-rust.mdx
+++ b/content/guides/getstarted/intro-to-native-rust.mdx
@@ -26,7 +26,7 @@ program. Here is the program on
 [Solana Playground](https://beta.solpg.io/661058a6cffcf4b13384d02a).
 
 ```rust title="lib.rs"
-use borsh::{BorshDeserialize, BorshSerialize};
+use borsh::{try_to_vec_with_schema, BorshDeserialize, BorshSchema, BorshSerialize};
 use solana_program::{
     account_info::{next_account_info, AccountInfo},
     entrypoint,
@@ -64,7 +64,7 @@ pub fn process_initialize(
     let system_program = next_account_info(accounts_iter)?;
 
     let account_data = NewAccount { data };
-    let size = account_data.try_to_vec()?.len();
+    let size = try_to_vec_with_schema(&account_data)?.len();
     let lamports = (Rent::get()?).minimum_balance(size);
 
     invoke(
@@ -88,7 +88,7 @@ pub enum Instructions {
     Initialize { data: u64 },
 }
 
-#[derive(BorshSerialize, BorshDeserialize, Debug)]
+#[derive(BorshSerialize, BorshDeserialize, Debug, BorshSchema)]
 pub struct NewAccount {
     pub data: u64,
 }


### PR DESCRIPTION
### Problem
In `borsh` v1.5.5 the `try_to_vec` method is no longer provided by `BorshSerialize`. Instead we can use `try_to_vec_with_schema` by deriving `BorshSchema` on the struct.

### Summary of Changes
- Replaced `try_to_vec` with `try_to_vec_with_schema`
- Added`#[derive(BorshSchema)]` on `NewAccount` struct

