### PR TITLE
docs: reduce docs sidebar padding

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -96,6 +96,11 @@
   mask-image: none !important;
 }
 
+.fumadocs #nd-sidebar :is(a, button) {
+  padding-top: 0.4rem !important;
+  padding-bottom: 0.4rem !important;
+}
+
 .scrollbar-thin {
   scrollbar-width: thin;
   scrollbar-color: transparent transparent;


### PR DESCRIPTION
Reduce docs sidebar padding because items seem too spaced out due to increasing font size from defaults