### PR TITLE
docs: remove locale from giscus to prevent duplicate discussions

### DIFF
--- a/src/app/[locale]/developers/cookbook/cookbook.tsx
+++ b/src/app/[locale]/developers/cookbook/cookbook.tsx
@@ -25,6 +25,7 @@ export function CookbookPage({
       hideTableOfContents={true}
       pageTree={cookbookSource.pageTree[locale]}
       href={page.url}
+      locale={locale}
     >
       <MDX components={mdxComponents} />
     </DocsPage>

--- a/src/app/[locale]/docs/(main)/docs.tsx
+++ b/src/app/[locale]/docs/(main)/docs.tsx
@@ -26,6 +26,7 @@ export function MainDocsPage({
       pageTree={docsSource.pageTree[locale]}
       href={page.url}
       lastModified={page.data.lastModified}
+      locale={locale}
     >
       <MDX components={mdxComponents} />
     </DocsPage>

--- a/src/app/[locale]/docs/rpc/rpc.tsx
+++ b/src/app/[locale]/docs/rpc/rpc.tsx
@@ -41,6 +41,7 @@ export async function RpcDocsPage({
       hideTableOfContents={page.data.hideTableOfContents}
       pageTree={docsSource.pageTree[locale]}
       href={page.url}
+      locale={locale}
     >
       <MDX components={{ ...mdxComponents, ...rpcMDXComponents }} />
     </DocsPage>

--- a/src/app/components/giscus.tsx
+++ b/src/app/components/giscus.tsx
@@ -8,7 +8,6 @@ interface GiscusWidgetProps {
 }
 
 export default function GiscusWidget({ discussionKey }: GiscusWidgetProps) {
-  console.log("discussionKey", discussionKey);
   const { resolvedTheme } = useTheme();
   return (
     <Giscus
@@ -17,7 +16,8 @@ export default function GiscusWidget({ discussionKey }: GiscusWidgetProps) {
       repoId="R_kgDON1vT5w"
       category="Announcements"
       categoryId="DIC_kwDON1vT584CmvXl"
-      mapping="pathname"
+      mapping="specific"
+      term={discussionKey}
       inputPosition="top"
       loading="lazy"
       strict="1"


### PR DESCRIPTION
### Problem

Giscus would create discussion for each locale for each page.

![CleanShot 2025-02-09 at 12 10 30@2x](https://github.com/user-attachments/assets/bc273dae-d05c-4bb4-bc29-a9ccf8596f8d)



### Summary of Changes

remove locale from giscus key used to map page to [discussion](https://github.com/solana-developers/docs-feedback/discussions)