### PR TITLE
docs: fix link to example rust program

### DIFF
--- a/content/docs/programs/rust/program-structure.mdx
+++ b/content/docs/programs/rust/program-structure.mdx
@@ -24,7 +24,7 @@ follow a common pattern:
 - `error.rs`: Defines custom errors that the program can return.
 
 You can find examples in the
-[Solana Program Library](https://github.com/solana-labs/solana-program-library/tree/master/token/program/src).
+[Solana Program Library](https://github.com/solana-program/token/tree/main/program/src).
 
 ## Example Program
 


### PR DESCRIPTION
### Problem
the Rust Program docs (https://github.com/solana-foundation/solana-com/blob/main/content/docs/programs/rust/program-structure.mdx) have an example that points to a deprecated repo


### Summary of Changes
change the URL for the example repo from 
https://github.com/solana-labs/solana-program-library/tree/master/token/program/src
to
https://github.com/solana-program/token/tree/main/program/src


Fixes #