### PR TITLE
chore: add java, go, and python SDK pages

### DIFF
--- a/content/docs/clients/go.mdx
+++ b/content/docs/clients/go.mdx
@@ -1,0 +1,24 @@
+---
+title: Go SDK
+description:
+  Learn how to interact with Solana using the Go sdk
+  (gagliardetto/solana-go).
+h1: Go SDK for Solana
+---
+
+There's a [Go sdk](https://sava.software/welcome) that supports most functions 
+to interact with Solana. If you're using Anchor for your Solana programs, you 
+will be able to use 
+[anchor-go](https://github.com/gagliardetto/anchor-go) with your idl 
+to produce a Golang compatible client.
+
+## Installation
+
+```bash  title="Terminal"
+go get github.com/gagliardetto/solana-go@v1.12.0
+```
+
+## More Documentation
+
+Please visit the [Go SDK documentation](https://github.com/gagliardetto/solana-go?tab=readme-ov-file#installation) 
+for more information on using this Go SDK with Solana.

--- a/content/docs/clients/java.mdx
+++ b/content/docs/clients/java.mdx
@@ -1,0 +1,76 @@
+---
+title: Java SDK
+description:
+  Learn how to interact with Solana using the Java sdk
+  (sava-software/sava).
+h1: Java SDK for Solana
+---
+
+There's a [Java sdk](https://sava.software/welcome) built by 
+[Sava Engineering](https://sava.engineering/) that supports most functions to 
+interact with Solana. If you're using Anchor for your Solana programs, you will 
+be able to use [anchor-src-gen](https://sava.software/utilities/anchor-src-gen) 
+with your idl to produce a Java compatible client.
+
+## Installation
+
+### Maven
+
+```xml  title="pom.xml"
+<dependencies>
+    <dependency>
+        <groupId>software.sava</groupId>
+        <artifactId>sava-core</artifactId>
+        <version>VERSION</version>
+    </dependency>
+    <dependency>
+        <groupId>software.sava</groupId>
+        <artifactId>sava-rpc</artifactId>
+        <version>VERSION</version>
+    </dependency>
+</dependencies>
+
+<repositories>
+  <repository>
+      <id>gpr-sava</id>
+      <name>sava-software</name>
+      <url>https://maven.pkg.github.com/sava-software/sava</url>
+  </repository>
+  <repository>
+      <id>gpr-json-iterator</id>
+      <name>comodal</name>
+      <url>https://maven.pkg.github.com/comodal/json-iterator</url>
+  </repository>
+</repositories>
+```
+
+### Gradle
+
+```bash  title="build.gradle"
+repositories {
+  maven {
+    url = "https://maven.pkg.github.com/sava-software/sava"
+    credentials {
+      username = GITHUB_USERNAME
+      password = GITHUB_PERSONAL_ACCESS_TOKEN
+    }
+  }
+  maven {
+    url = "https://maven.pkg.github.com/comodal/json-iterator"
+    credentials {
+      username = GITHUB_USERNAME
+      password = GITHUB_PERSONAL_ACCESS_TOKEN
+    }
+  }
+}
+
+dependencies {
+  implementation "software.sava:sava-core:$VERSION"
+  implementation "software.sava:sava-rpc:$VERSION"
+}
+```
+
+## More Documentation
+
+Please visit the [Sava Software documentation](https://sava.software/welcome) 
+for more information on using this Java SDK with Solana.

--- a/content/docs/clients/meta.json
+++ b/content/docs/clients/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Solana SDKs",
-  "pages": ["rust", "javascript"],
+  "pages": ["rust", "javascript", "go", "python", "java"],
   "defaultOpen": true
 }

--- a/content/docs/clients/python.mdx
+++ b/content/docs/clients/python.mdx
@@ -1,0 +1,25 @@
+---
+title: Python SDK
+description:
+  Learn how to interact with Solana using the Python sdk
+  (michaelhly/solana-py).
+h1: Python SDK for Solana
+---
+
+There's a [Python sdk](https://github.com/michaelhly/solana-py) that supports most functions 
+to interact with Solana. If you're using Anchor for your Solana programs, you 
+will be able to use 
+[anchor-py](https://github.com/kevinheavey/anchorpy) with your idl 
+to produce a Python compatible client.
+
+## Installation
+
+```bash  title="Terminal"
+pip install solders
+pip install solana
+```
+
+## More Documentation
+
+Please visit the [Python SDK documentation](https://github.com/michaelhly/solana-py?tab=readme-ov-file#general-usage) 
+for more information on using this Python SDK with Solana.


### PR DESCRIPTION
Adding some additional SDK pages for the major SDKs. Mostly for CTA and to help people find them.