### PR TITLE
`new_readonly` is not not writable account

### DIFF
--- a/content/guides/getstarted/how-to-cpi.mdx
+++ b/content/guides/getstarted/how-to-cpi.mdx
@@ -257,5 +257,5 @@ When building an instruction in Rust, use the following syntax to specify the
 AccountMeta::new(account1_pubkey, true),           // writable, signer
 AccountMeta::new(account2_pubkey, false),          // writable, not signer
 AccountMeta::new_readonly(account3_pubkey, false), // not writable, not signer
-AccountMeta::new_readonly(account4_pubkey, true),  // writable, signer
+AccountMeta::new_readonly(account4_pubkey, true),  // not writable, signer
 ```


### PR DESCRIPTION
### Problem

Went through https://solana.com/developers/guides/getstarted/how-to-cpi

and found out that docs states:

```
AccountMeta::new_readonly(account4_pubkey, true),  // writable, signer
```

and by definition of `readonly` account cannot be writable

### Summary of Changes

renamed comment from `// writable, signer` to `// not writable, signer`

Fixes #