### PR TITLE
Add maven settings.xml config to java.mdx

### DIFF
--- a/content/docs/references/clients/java.mdx
+++ b/content/docs/references/clients/java.mdx
@@ -33,15 +33,32 @@ with your idl to produce a Java compatible client.
 <repositories>
   <repository>
       <id>gpr-sava</id>
-      <name>sava-software</name>
+      <name>sava</name>
       <url>https://maven.pkg.github.com/sava-software/sava</url>
   </repository>
   <repository>
       <id>gpr-json-iterator</id>
-      <name>comodal</name>
+      <name>json-iterator</name>
       <url>https://maven.pkg.github.com/comodal/json-iterator</url>
   </repository>
 </repositories>
+```
+
+```xml  title="settings.xml"
+<settings>
+  <servers>
+    <server>
+        <id>gpr-sava</id>
+        <username>GITHUB_USERNAME</username>
+        <password>GITHUB_PERSONAL_ACCESS_TOKEN</password>
+    </server>
+    <server>
+        <id>gpr-json-iterator</id>
+        <username>GITHUB_USERNAME</username>
+        <password>GITHUB_PERSONAL_ACCESS_TOKEN</password>
+    </server>
+  </servers>
+</settings>
 ```
 
 ### Gradle


### PR DESCRIPTION
### Problem

Maven docs for the Sava SDK were missing configuration needed to authenticate to the libraries hosted on github package repository.


### Summary of Changes

Added example settings.xml file documentation.

