### PR TITLE
docs: fix go sdk link

### DIFF
--- a/content/docs/clients/go.mdx
+++ b/content/docs/clients/go.mdx
@@ -6,7 +6,7 @@ description:
 h1: Go SDK for Solana
 ---
 
-There's a [Go SDK](https://sava.software/welcome) that supports most functions 
+There's a [Go SDK](https://github.com/gagliardetto/solana-go) that supports most functions 
 to interact with Solana. If you're using Anchor for your Solana programs, you 
 will be able to use 
 [anchor-go](https://github.com/gagliardetto/anchor-go) with your idl 


### PR DESCRIPTION


### Problem
The provided Go SDK link was incorrectly pointing to the Java SDK.


### Summary of Changes
Change the link.


Fixes #