### PR TITLE
Fix: Use correct cargo command for building Solana program  The `carg…

### DIFF
--- a/content/docs/programs/deploying.mdx
+++ b/content/docs/programs/deploying.mdx
@@ -228,7 +228,7 @@ These references can be looked up in the ELF dump to identify the offending
 instruction and its context.
 
 ```shell
-cargo build-bpf --dump
+cargo build-sbf --dump
 ```
 
 The file will be output to `/target/deploy/your_program-dump.txt`.


### PR DESCRIPTION
### Problem
The `cargo build-bpf --dump` command is incorrect. 
The correct command is `cargo build-sbf --dump`. 

### Summary of Changes
Use correct cargo command for generating ELF information