### PR TITLE
Added a guide on Core NFTs

### DIFF
--- a/content/courses/tokens-and-nfts/meta.json
+++ b/content/courses/tokens-and-nfts/meta.json
@@ -3,6 +3,6 @@
     "token-program",
     "token-program-advanced",
     "nfts-with-metaplex",
-    "nft-with-metaplex-core"
+    "nfts-with-metaplex-core"
   ]
 }

--- a/content/courses/tokens-and-nfts/meta.json
+++ b/content/courses/tokens-and-nfts/meta.json
@@ -1,3 +1,8 @@
 {
-  "pages": ["token-program", "token-program-advanced", "nfts-with-metaplex", "nft-with-metaplex-core"]
+  "pages": [
+    "token-program",
+    "token-program-advanced",
+    "nfts-with-metaplex",
+    "nft-with-metaplex-core"
+  ]
 }

--- a/content/courses/tokens-and-nfts/meta.json
+++ b/content/courses/tokens-and-nfts/meta.json
@@ -1,3 +1,3 @@
 {
-  "pages": ["token-program", "token-program-advanced", "nfts-with-metaplex"]
+  "pages": ["token-program", "token-program-advanced", "nfts-with-metaplex", "nft-with-metaplex-core"]
 }

--- a/content/courses/tokens-and-nfts/nfts-with-metaplex-core.mdx
+++ b/content/courses/tokens-and-nfts/nfts-with-metaplex-core.mdx
@@ -1,102 +1,124 @@
 ---
-title: Create Solana NFTs With Metaplex
+title: Create Solana NFTs With Metaplex Core
 objectives:
   - Explain NFTs and how they're represented on the Solana network
-  - Explain the role of the Metaplex Token Metadata program
-  - Create and update NFTs using the Metaplex JS SDK
+  - Explain Collections and how do they differ between the Core Program and the
+    Token Metadata Program
+  - Explain the role of the Metaplex Core program
+  - Create and update a Collection using the Metaplex JS SDK
+  - Create and update Assets using the Metaplex JS SDK
 description:
-  "How to create NFTs in TypeScript with Metaplex Metadata program and Irys
+  "How to create NFTs in TypeScript with Metaplex Core program and Irys
   permanent storage service."
+tags:
+  - quickstart
+  - metaplex
+  - typescript
+keywords:
+  - typescript
+  - npm
+  - yarn
+  - package
+  - tutorial
+  - digital assets
+  - intro to solana nfts
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
 ---
 
 ### Summary
 
-- **Non-Fungible Tokens (NFTs)** are SPL Tokens with an associated metadata
-  account, 0 decimals, and a maximum supply of 1
-- **Metadata** attaches additional properties to token mints (both NFTs and
-  regular tokens). For NFTs, metadata includes the token name and a link to an
-  offchain JSON file. This JSON file contains links to artwork and other media
-  files, any special traits the NFT has, and more.
-- The **Metaplex Token Metadata** program is an onchain program that attaches
-  metadata to a token mint. We can interact with the Token Metadata program
-  using the
-  [Token Metadata package](https://developers.metaplex.com/token-metadata) via
-  Umi, a tool made by Metaplex for working with onchain programs.
+- **Non-Fungible Tokens (NFTs)** are onchain digital assets. They are
+  indivisible, meaning they cannot be split into fractional parts, and unique.
+- **Metadata** attaches additional properties to Assets and Collection. Metadata
+  includes the token name and a link to an offchain JSON file. This JSON file
+  contains links to artwork and other media files, any special traits the NFT
+  has, and more.
+- The [Metaplex Core Program](https://developers.metaplex.com/core) is an
+  onchain program that sheds the complexity and technical debt of previous
+  standards and provides a clean and simple core spec for digital assets using a
+  single account design
 
 ### Lesson
 
-Solana Non-Fungible Tokens (NFTs) are SPL tokens created using the Token
-program. These tokens, however, also have an additional metadata account
-associated with each token mint.
+In this lesson, we'll explore how Core Assets are represented and demonstrate
+how to create and update them using the mpl-core SDK.
 
-In this lesson, we'll cover the basics of how NFTs are represented on Solana,
-how to create and update them using the `mpl-token-metadata` npm module.
+Solana Non-Fungible Tokens (NFTs) were commonly represented as SPL tokens with
+an additional metadata account associated with each token mint and created using
+both the Token Program and the Metaplex Token Metadata Program.
+
+However, with the introduction of the new Metaplex Core Program, NFTs have their
+own program and standard that leverage a single account design and has a
+flexible plugin system that that enables developers to natively modify asset
+behavior and functionality
+
+In this lesson, we'll explore how Core Assets are represented and demonstrate
+how to create and update them using the `mpl-core` SDK.
 
 #### NFTs on Solana
 
-An NFT is a standard token from the Token Program with the following
-characteristics:
+All NFTs characteristics were previously achievable with a combination of the
+SPL Token Program and the Metaplex Token Metadata Program by setting the
+following boundaries:
 
-1. Has 0 decimals, so it cannot be divided into parts
-2. Comes from a token mint with a supply of 1, so only 1 of these tokens exists
-3. Comes from a token mint whose authority is set to `null` (to ensure that the
-   supply never changes)
-4. Has an associated account that stores **metadata** - things like a name,
-   symbol, images, etc.
+1. 0 decimals, so it cannot be divided into parts.
+2. Supply of 1, so only 1 of these tokens exists.
+3. No mint authority to ensure that the supply never changes.
+4. Additional accounts including, Metadata, Master Edition and Token Record to
+   store addotional information like name, uri, ... and inform that the previous
+   boundaries are enforced.
 
-While the first three points can be achieved with the SPL Token Program, the
-associated metadata requires an additional program. This is the **Metadata
-program**.
+This came with a big overhead and lots of inefficiencies for a market as big as
+NFTs and Digital Asset in general.
 
-#### The Metaplex Token Metadata program
+Thanks to the **Metaplex Core Program**, all this characteristics are now
+included at the protocol level!
 
-The most popular way Solana NFTs have been created is by using the
-[Metaplex Token Metadata](https://developers.metaplex.com/token-metadata)
-program.
+#### The Metaplex Core program
 
-![Metadata](/assets/courses/unboxed/solana-nft-metaplex-metadata.png)
+The [Metaplex Core Program](https://developers.metaplex.com/core) is the newest
+NFT Digital Asset standard from Metaplex
 
-- When creating an NFT, the Token Metadata program creates an **onchain
-  metadata** account using a Program Derived Address (PDA) with the token mint
-  as a seed. This allows the metadata account for any NFT to be located
-  deterministically using the address of the token mint. The onchain metadata
-  contains a URI field that points to an offchain `.json` file.
-
-- The **offchain metadata** in the JSON file stores the link to the media
-  (images, videos, 3D files) of the NFT, any traits the NFT may have, and
-  additional metadata (see
-  [this example JSON file](https://lsc6xffbdvalb5dvymf5gwjpeou7rr2btkoltutn5ij5irlpg3wa.arweave.net/XIXrlKEdQLD0dcML01kvI6n4x0GanLnSbeoT1EVvNuw)).
-  Permanent data storage systems such as Arweave are often used to store the
-  offchain component of NFT metadata.
+- Unlike the Token Metadata Program, Collections are separate accounts with a
+  distinct data model from the Assets accounts. They store only
+  collection-specific metadata, such as the collection name and collection
+  image.
+- Assets are now a single account model and design that don't rely on additional
+  accounts such as Associated Token Accounts or Metadata Accounts. Instead, when
+  a Core Assets is created, the Metaplex Core Program stores the ownership and
+  metadata directly on the Asset.
+- Both Assets and Collections can integrate with lifecycle events such as
+  creation, transfer, and burning, enabling custom behaviors through Plugins.
+  For instance, plugins allow features like royalty enforcement or on-chain
+  attributes to be added with a single instruction, eliminating the need for
+  extra code.
 
 In the following sections, we'll cover the basics of using the
-`metaplex-foundation/token-metadata` plugin with Umi to prepare assets, create
-NFTs, update NFTs, and associate an NFT with a broader collection. For more
-information on `metaplex-foundation/token-metadata` see the
-[developer docs for Token Metadata](https://developers.metaplex.com/token-metadata).
+`metaplex-foundation/mpl-core` SDK with Umi to prepare off-chain metadata,
+create and update Assets, and add them into a collection. For more information
+about `metaplex-foundation/mpl-core` visit the
+[Metaplex Developer Docs](https://developers.metaplex.com/core).
 
-<Callout type="info">
+#### Umi
 
-[Metaplex Core](https://developers.metaplex.com/core), is an NFT standard from Metaplex where asset details such as the owner, name, uri e.t.c are stored on a single account. However, the most common style of NFT is still by making a Solana
-SPL token with some Metadata attached via the Metaplex Metadata program, so
-that's what we'll be using in this tutorial.
+Umi is a framework built by Metaplex that can register JS/TS clients built with
+Kinobi/Codama that interact with on-chain programs. While it can interface with
+clients from various programs, it's most commonly used with all the Metaplex
+programs.
 
-</Callout>
+**Note**: Umi uses different implementation types for common web3.js functions
+and concepts, such as Keypairs, PublicKeys, and Connections. Fortunately, it's
+easy to convert between web3.js and Umi equivalents.
 
-#### UMI instance
+For more deetails, visit the
+[Metaplex Developer Docs](https://developers.metaplex.com/umi).
 
-Umi is a framework for making JS/TS clients for onchain programs, that was
-created by Metaplex. Umi can create JS/TS clients for many programs, but in
-practice, it's most commonly used to communicate to the Token Metadata program.
+#### Installing and setting up Umi
 
-Note that Umi has different implementations for many concepts than web3.js,
-including Keypairs, PublicKeys, and Connections. However, it is easy to convert
-from web3.js versions of these items to the Umi equivalents.
-
-#### Installation and setting up Umi
-
-First we create a new Umi instance. We can do this by either providing our own
-RPC endpoint, or use the public facing Solana endpoints provided by the
+First, create a new Umi instance. We can do this by either providing our own RPC
+endpoint, or use the public facing Solana endpoints provided by the
 `clusterApiUrl` method.
 
 ```typescript
@@ -106,19 +128,18 @@ import { clusterApiUrl } from "@solana/web3.js";
 const umi = createUmi(clusterApiUrl("devnet"));
 ```
 
-Finally, we pass in the identity for our Umi instance (this is the keypair that
-will be used to sign transactions) and the plugins that we will use, in our
-case, this is the `metaplex-foundation/mpl-token-metadata`.
+Next, set the identity for your Umi instance (the keypair what will be used to
+sign transactions) and load the necessary plugins, in this case, the `mplCore`
+plugin.
 
 ```typescript
-import { mplTokenMetadata } from "@metaplex-foundation/mpl-token-metadata";
+import { mplCore } from "@metaplex-foundation/mpl-core";
 import { keypairIdentity } from "@metaplex-foundation/umi";
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
 import { getKeypairFromFile } from "@solana-developers/helpers";
 import { promises as fs } from "fs";
-import { clusterApiUrl } from "@solana/web3.js";
 
-const umi = createUmi(clusterApiUrl("devnet"));
+const umi = createUmi("https://api.devnet.solana.com").use(mplCore());
 
 // load keypair from local file system
 // See https://github.com/solana-developers/helpers?tab=readme-ov-file#get-a-keypair-from-a-keypair-file
@@ -128,17 +149,16 @@ const localKeypair = await getKeypairFromFile();
 const umiKeypair = umi.eddsa.createKeypairFromSecretKey(localKeypair.secretKey);
 
 // load the MPL metadata program plugin and assign a signer to our umi instance
-umi.use(keypairIdentity(umiKeypair)).use(mplTokenMetadata());
+umi.use(keypairIdentity(umiKeypair));
 ```
 
-#### Uploading assets
+#### Uploading images
 
-Before creating an NFT, you must prepare and upload any assets you plan to
-associate with the NFT. While this doesn't have to be an image, most NFTs have
-an image associated with them.
+Before creating an Asset, you must prepare and upload any assets you plan to
+associate with it such as images, animation files, and off chain metadata.
 
-Preparing and uploading an image involves converting the image to a buffer,
-converting the file to a
+Preparing and uploading an image involves converting to a buffer first. You can
+convert the file to a
 [generic file](https://developers.metaplex.com/umi/storage#generic-files) using
 the `createGenericFile()` function and finally uploading it to the designated
 Storage Driver.
@@ -150,7 +170,7 @@ computer.
 In action, uploading an image named `random-image.png` from your computer would
 take the following steps:
 
-1. Reading the file using `readFile` into a buffer.
+1. Reading the file using `fs.readFile()` into a buffer.
 
 2. Creating a generic file type with the files MIME Type from the buffer and
    filePath.
@@ -158,6 +178,12 @@ take the following steps:
 3. Uploading file to designated storage provider.
 
 ```typescript
+// Add an uploader to your umi instance. In this case we're going to use Irys
+import { irysUploader } from "@metaplex-foundation/umi-uploader-irys";
+
+// ...create Umi as shown before
+umi.use(irysUploader());
+
 let filePath = "random-image.png";
 
 const buffer = await fs.readFile(filePath);
@@ -168,202 +194,231 @@ let file = createGenericFile(buffer, filePath, {
 const [image] = await umi.uploader.upload([file]);
 ```
 
-The function's return value will be the URI where the image was stored.
+The function will return the uri where the image is stored.
 
-#### Upload metadata
+#### Uploading the metadata
 
-After uploading an image, it's time to upload the offchain JSON metadata using
-the `uploadJson()` method. This will return a URI where the JSON metadata is
+After uploading the image, it's time to upload the offchain JSON metadata using
+the `uploadJson()` method. This will return a uri where the JSON metadata is
 stored.
 
 Remember, the offchain portion of the metadata includes things like the image
-URI as well as additional information like the name and description of the NFT.
-While you can technically include anything you'd like in this JSON object, in
-most cases, you should follow the
-[NFT standard](https://developers.metaplex.com/token-metadata/token-standard#the-non-fungible-standard)
-to ensure compatibility with wallets, programs, and applications.
+uri we just generated as well as additional information like the name and
+description of the Asset. While you can technically include anything you'd like
+in this JSON object, in most cases, you should follow the
+[standard JSON schema](https://developers.metaplex.com/core/json-schema) for
+Core to ensure compatibility with wallets, programs, and applications.
 
 To create the metadata, use the `uploadJson()` method provided by the SDK. This
-method accepts a metadata object and returns a URI that points to the uploaded
+method accepts a metadata object and returns a uri that points to the uploaded
 metadata.
 
 ```typescript
-const uri = await umi.uploader.uploadJson({
-  name,
-  description,
-  image,
-});
+const metadata = {
+  name: "My NFT",
+  description: "This is an NFT on Solana",
+  image, // Uri of the Image
+  external_url: "https://example.com",
+  properties: {
+    files: [
+      {
+        uri: image,
+        type: "image/jpeg",
+      },
+    ],
+    category: "image",
+  },
+};
+
+const uri = await umi.uploader.uploadJson(metadata);
 ```
 
-#### Create the NFT
+Now that you know how to create the metadata for your Collections and Assets,
+remember to modify the values as you see fit and use the response to fill out
+the `uri` field.
 
-After uploading the NFT's metadata, you can finally create the NFT on the
-network. The `mplTokenMetadata` plugin we added earlier provides the required
-helpers to create an NFT or any other token with minimal configuration. The
-helper `createNft` method will create the mint account, token account, metadata
-account, and master edition account for you. The data provided to this method
-will represent the onchain portion of the NFT metadata. You can explore the SDK
-to see all the other input optionally supplied to this method.
+#### Creating the Collection
+
+Once you have uploaded the appropiate files to respresent your Core Collection
+(image, metadata.json) you can finally create the Core Collection itself.
+
+The `createCollection` method allows you to create a collection with the
+provided data
 
 ```typescript
-const { signature, result } = await createNft(umi, {
-  mint,
-  name: "My NFT",
-  uri,
-  updateAuthority: umi.identity.publicKey,
-  sellerFeeBasisPoints: percentAmount(0),
+const collection = generateSigner(umi);
+console.log("\nCollection Address: ", collection.publicKey.toString());
+
+const { signature, result } = await createCollection(umi, {
+  collection,
+  name: "My Collection",
+  uri: collectionUri,
 }).sendAndConfirm(umi, { send: { commitment: "finalized" } });
 ```
 
 The `sendAndConfirm` method is what takes care of signing our transaction and
-sending it. It also provides other options to set pre-flight checks and our
-desired commitment for the transaction, which defaults to `confirmed` if not
-provided.
+sending it. It also provides available options such as setting pre-flight checks
+and our desired commitment level for the transaction, which defaults to
+`confirmed` if not provided.
 
 This method returns an object containing the transaction signature and a result.
 The result object contains the outcome of our transaction. If successful, the
 `err` inside this will be set to null otherwise it'll contain the error for the
 failed transaction.
 
-By default, the SDK sets the `isMutable` property to true, allowing for updates
-to be made to the NFT's metadata. However, you can choose to set `isMutable` to
-false, making the NFT's metadata immutable.
-
-#### Update the NFT
-
-If you've left `isMutable` as true, you may update your NFT's metadata.
-
-The SDK's `updateV1` method allows you to update both the onchain and offchain
-portions of the NFT's metadata. To update the offchain metadata, you'll need to
-repeat the steps of uploading a new image and metadata URI (as outlined in the
-previous steps), then provide the new metadata URI to this method. This will
-change the URI that the onchain metadata points to, effectively updating the
-offchain metadata as well.
+By default, the SDK sets the `payer` and the `updateAuthority` property
+respecitvely using the payer and signer identity of the Umi instance we created
+previously like this:
 
 ```typescript
-const nft = await fetchMetadataFromSeeds(umi, { mintAddress });
-
-await updateV1(umi, {
-  mint,
-  authority: umi.identity,
-  data: {
-    ...nft,
-    sellerFeeBasisPoints: 0,
-    name: "Updated Name",
-  },
-  primarySaleHappened: true,
-  isMutable: true,
-}).sendAndConfirm(umi);
-```
-
-Note that any fields you don't include in the call to `updateV1` will stay the
-same, by design.
-
-#### Add the NFT to a collection
-
-A
-[Certified Collection](https://developers.metaplex.com/token-metadata/collections)
-is an NFT that individual NFTs can belong to. Think of a large NFT collection
-like Solana Monkey Business. If you look at an individual NFT's
-[Metadata](https://explorer.solana.com/address/C18YQWbfwjpCMeCm2MPGTgfcxGeEDPvNaGpVjwYv33q1/metadata)
-you will see a `collection` field with a `key` that points to the
-`Certified Collection`
-[NFT](https://explorer.solana.com/address/SMBH3wF6baUj6JWtzYvqcKuj2XCKWDqQxzspY12xPND/).
-Simply put, NFTs that are part of a collection are associated with another NFT
-that represents the collection itself.
-
-Certified collections are important because they mean the collection owner has
-verified that each NFT actually belongs to the collection!
-
-To add an NFT to a collection, first, the Collection NFT has to be created. The
-process is the same as before, except you'll include one additional field on our
-NFT Metadata: `isCollection`. This field tells the token program that this NFT
-is a Collection NFT.
-
-```typescript
-const collectionMint = generateSigner(umi);
-
-await createNft(umi, {
-  mint: collectionMint,
-  name: `My Collection`,
-  uri,
-  sellerFeeBasisPoints: percentAmount(0),
-  isCollection: true,
-}).sendAndConfirm(umi);
-```
-
-To mint an NFT into this collection, the
-[Collection type](https://mpl-token-metadata-js-docs.vercel.app/types/Collection.html)
-which has two fields, the address of the `collectionMint` generated above and
-the verified field.
-
-```typescript
-const { signature, result } = await createNft(umi, {
-  mint,
-  name: "My NFT",
-  uri,
+const { signature, result } = await createCollection(umi, {
+  ...createCollectionArgs,
+  payer: umi.payer.publickey,
   updateAuthority: umi.identity.publicKey,
-  sellerFeeBasisPoints: percentAmount(0),
-  collection: { key: collectionMint.publicKey, verified: false },
 }).sendAndConfirm(umi, { send: { commitment: "finalized" } });
 ```
 
-When you checkout the metadata on your newly created NFT, you should now see a
-`collection` field like so:
+#### Creating the Asset
 
-```json
-"collection":{
-  "verified": false,
-  "key": "SMBH3wF6baUj6JWtzYvqcKuj2XCKWDqQxzspY12xPND"
-}
-```
-
-The last thing you need to do is verify the NFT. This effectively just flips the
-`verified` field above to true, but it's incredibly important. This is what lets
-consuming programs and apps, including wallets and art marketplaces, know that
-your NFT is in fact part of the collection - because the Collection's owner has
-signed a transaction making the NFT a member of that collection. You can do this
-using the `verifyCollectionV1` function:
+The `create` method allows you to create a new Asset similarly to how is done
+for Collections
 
 ```typescript
-const metadata = findMetadataPda(umi, { mint: mint.publicKey });
+const asset = generateSigner(umi);
+console.log("\nAsset Address: ", asset.publicKey.toString());
 
-await verifyCollectionV1(umi, {
-  metadata,
-  collectionMint,
-  authority: umi.identity,
-}).sendAndConfirm(umi);
+const { signature, result } = await create(umi, {
+  asset,
+  name: "My Asset",
+  uri: assetUri,
+}).sendAndConfirm(umi, { send: { commitment: "finalized" } });
 ```
+
+For this method there are two additional optional fields:
+
+- the `owner` field that if not supplied will default to the signer identity of
+  the Umi instance like this:
+
+```typescript
+const { signature, result } = await create(umi, {
+  ...createArgs,
+  owner: umi.identity.publicKey,
+}).sendAndConfirm(umi, { send: { commitment: "finalized" } });
+```
+
+- the `collection` field is only needed when we want to add the asset to a
+  collection
+
+```typescript
+const asset = generateSigner(umi);
+const collection = await fetchCollection(
+  umi,
+  publicKey("CORE_COLLECTION_ADDRESS"),
+);
+
+const { signature, result } = await create(umi, {
+  asset,
+  collection,
+  name: "My Asset",
+  uri: assetUri,
+}).sendAndConfirm(umi, { send: { commitment: "finalized" } });
+```
+
+**Note**: once you add an Asset to a Collection you'll need to pass in a
+`CollectionV1` object in the collection field (can be obtained by using the
+`fetchCollection()` function) of subsequent instructions. Leaving the collection
+field empty will cause invalidations during transactions causing them to fail.
+
+#### Updating the Asset & Collection
+
+The following steps works for both Assets and Collection, the only difference
+will be employing the `update` method for Assets and the `updateCollection`
+method for Collections
+
+The `update` method allows you to update all the fields present in the account
+like `collection`, `name`, `updateAuthority` and the `uri`
+
+```typescript
+const asset = await fetchAsset(umi, publickey("CORE_ASSET_ADDRESS"));
+const collection = await fetchCollection(umi, publicKey("CORE_ASSET_ADDRESS"));
+
+const { signature, result } = await update(umi, {
+  asset,
+  collection,
+  name: 'My new NFT'
+  uri: newAssetUri
+  newCollection: publicKey("NEW_CORE_COLLECTION_ADDRESS")
+}).sendAndConfirm(umi, { send: { commitment: "finalized" } });
+```
+
+When we add an Asset to a Collection, to not waste any additional bytes, the
+collection gets stored in the `updateAuthority` field of the asset. So if you
+want to change the collection address for the asset, you can update the
+`updateAuthority` field of the `update` function, instead of using the
+`newCollection` field, like this:
+
+```typescript
+const asset = await fetchAsset(umi, publickey("CORE_ASSET_ADDRESS"));
+const collection = await fetchCollection(umi, publicKey("CORE_ASSET_ADDRESS"));
+
+const { signature, result } = await update(umi, {
+  asset,
+  collection,
+  newUpdateAuthority: updateAuthority("Collection", [
+    publicKey("NEW_CORE_COLLECTION_ADDRESS"),
+  ]),
+}).sendAndConfirm(umi, { send: { commitment: "finalized" } });
+```
+
+**Note**: We can use the same method to add the Asset to a Collection if it
+isn't part of a collection currently.
+
+A noted difference from the `token-metadata` program is that it not impossible
+to create an immutable `Asset` using the `create` method. The only way to make
+an asset immutable is to change the `updateAuthority` to `None` in a futher
+update.
+
+```typescript
+const asset = await fetchAsset(umi, publickey("CORE_ASSET_ADDRESS"));
+const collection = await fetchCollection(umi, publicKey("CORE_ASSET_ADDRESS"));
+
+const { signature, result } = await update(umi, {
+  asset,
+  collection,
+  newUpdateAuthority: updateAuthority("None"),
+}).sendAndConfirm(umi, { send: { commitment: "finalized" } });
+```
+
+**Note**: any fields you don't include in the call to `updateV1` will stay the
+same, by design.
 
 ### Lab
 
-In this lab, we'll go through the steps to create an NFT using the Metaplex Umi
-framework, update the NFT's metadata after the fact, and then associate the NFT
-with a collection. By the end, you will have a basic understanding of how to use
-the Metaplex Umi and the mplTokenMetadata library to interact with NFTs on
-Solana.
+In this lab, we'll go through the steps to create a Core Asset using the
+Metaplex Umi framework, add the Asset to the Collection and update its metadata
+in subsequent transactions. By the end, you will have a basic understanding of
+how to use the Metaplex Umi and the `mpl-core` SDK to interact with digital
+assets on Solana.
 
-#### Part 1: Creating an NFT collection
+#### Part 1: Creating an Core collection
 
 To begin, make a new folder and install the relevant dependencies:
 
 ```bash
-npm i @solana/web3.js@1 @solana-developers/helpers@2 @metaplex-foundation/mpl-token-metadata @metaplex-foundation/umi-bundle-defaults @metaplex-foundation/umi-uploader-irys esrun
+npm i @solana/web3.js npm i @solana/web3.js npm i @solana-developers/helpers npm i @metaplex-foundation/mpl-core npm i @metaplex-foundation/umi-bundle-defaults npm i @metaplex-foundation/umi-uploader-irys npm i --save-dev esrun
 ```
 
-Then create a file called `create-metaplex-nft-collection.ts`, and add our
+Then create a file called `create-metaplex-core-collection.ts`, and add our
 imports:
 
 ```typescript
-import {
-  createNft,
-  mplTokenMetadata,
-} from "@metaplex-foundation/mpl-token-metadata";
+import { createCollection, mplCore } from "@metaplex-foundation/mpl-core";
 import {
   createGenericFile,
   generateSigner,
   keypairIdentity,
   percentAmount,
+  sol,
 } from "@metaplex-foundation/umi";
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
 import { irysUploader } from "@metaplex-foundation/umi-uploader-irys";
@@ -384,6 +439,7 @@ Connect to devnet, load a user and Airdrop some SOL if needed:
 const connection = new Connection(clusterApiUrl("devnet"));
 
 // load keypair from local file system
+// See https://github.com/solana-developers/helpers?tab=readme-ov-file#get-a-keypair-from-a-keypair-file
 // assumes that the keypair is already generated using `solana-keygen new`
 const user = await getKeypairFromFile();
 
@@ -397,47 +453,40 @@ await airdropIfRequired(
 console.log("Loaded user:", user.publicKey.toBase58());
 ```
 
-Create a new Umi instance, assign it the loaded keypair, load the
-`mplTokenMetadata` to interact with the metadata program and `irysUploader` to
-upload our files.
+Create a new Umi instance, assign it the loaded keypair, load the `mplCore` to
+interact with the metadata program and `irysUploader` to upload our files.
 
 ```typescript
-const umi = createUmi(connection);
-
-// load keypair from local file system
-// See https://github.com/solana-developers/helpers?tab=readme-ov-file#get-a-keypair-from-a-keypair-file
-const user = await getKeypairFromFile();
+// create a new connection to Solana's devnet cluster
+const umi = createUmi(connection).use(mplCore()).use(irysUploader());
 
 // convert to umi compatible keypair
 const umiKeypair = umi.eddsa.createKeypairFromSecretKey(user.secretKey);
 
 // assigns a signer to our umi instance, and loads the MPL metadata program and Irys uploader plugins.
-umi
-  .use(keypairIdentity(umiKeypair))
-  .use(mplTokenMetadata())
-  .use(irysUploader());
+umi.use(keypairIdentity(umiKeypair));
 ```
 
-Download the image assets the collection image from the links below and save
-them inside your working directory,
+Download the assets and collection image from the links below and save them
+inside your working directory:
 
-1. collection image:
+1. Collection image:
    https://github.com/solana-developers/professional-education/blob/main/labs/metaplex-umi/collection.png
 
-2. NFT image:
+2. Asset image:
    https://github.com/solana-developers/professional-education/blob/main/labs/metaplex-umi/nft.png
 
-We will use these images as our collection and nft cover images respectively.
+We will use these images as our collection and asset cover images respectively.
 
-We will use Irys as our storage provider, and Metaplex conveniently ships the
-`umi-uploader-irys` plugin we can use to upload our files. The plugin, also
-takes care of storage fees so that we don't have to worry about making this on
-our own.
+We will use Irys as our storage provider that Metaplex conveniently supports
+through the `umi-uploader-irys` plugin, we can use that to upload our files. The
+plugin, also takes care of sending the right amount of lamports for storage fees
+so we don't have to worry about making this on our own.
 
 Upload the offchain metadata to Irys:
 
 ```typescript
-const collectionImagePath = path.resolve(__dirname, "collection.png");
+const collectionImagePath = "collection.png";
 
 const buffer = await fs.readFile(collectionImagePath);
 let file = createGenericFile(buffer, collectionImagePath, {
@@ -446,39 +495,43 @@ let file = createGenericFile(buffer, collectionImagePath, {
 const [image] = await umi.uploader.upload([file]);
 console.log("image uri:", image);
 
-// upload offchain json to Arweave using irys
-const uri = await umi.uploader.uploadJson({
+const metadata = {
   name: "My Collection",
-  symbol: "MC",
   description: "My Collection description",
   image,
-});
+  external_url: "https://example.com",
+  properties: {
+    files: [
+      {
+        uri: image,
+        type: "image/jpeg",
+      },
+    ],
+    category: "image",
+  },
+};
+
+// upload offchain json to Arweave using irys
+const uri = await umi.uploader.uploadJson(metadata);
 console.log("Collection offchain metadata URI:", uri);
 ```
 
-Then actually make the collection:
+Then actually create the collection:
 
 ```typescript
 // generate mint keypair
-const collectionMint = generateSigner(umi);
+const collection = generateSigner(umi);
 
-// create and mint NFT
-await createNft(umi, {
-  mint: collectionMint,
+// create and mint a Collection
+await createCollection(umi, {
+  collection,
   name: "My Collection",
   uri,
-  updateAuthority: umi.identity.publicKey,
-  sellerFeeBasisPoints: percentAmount(0),
-  isCollection: true,
 }).sendAndConfirm(umi, { send: { commitment: "finalized" } });
 
-let explorerLink = getExplorerLink(
-  "address",
-  collectionMint.publicKey,
-  "devnet",
-);
-console.log(`Collection NFT:  ${explorerLink}`);
-console.log(`Collection NFT address is:`, collectionMint.publicKey);
+let explorerLink = getExplorerLink("address", collection.publicKey, "devnet");
+console.log(`Collection: ${explorerLink}`);
+console.log(`Collection address is:  ${collection.publicKey}`);
 console.log("✅ Finished successfully!");
 ```
 
@@ -486,54 +539,47 @@ We advise using [esrun](https://www.npmjs.com/package/esrun) to run the scripts
 because it allows you to use top level await without having to wrap your code
 inside asynchronous function.
 
-Run the `create-metaplex-nft-collection.ts` script
+Run the `create-metaplex-core-collection.ts` script
 
 ```
-npx esrun create-metaplex-nft-collection.ts
+npx esrun create-metaplex-core-collection.ts
 ```
 
 The output should look like this:
 
 ```
-% npx esrun create-metaplex-nft-collection.ts
-
-Loaded user: 4kg8oh3jdNtn7j2wcS7TrUua31AgbLzDVkBZgTAe44aF
-image uri: https://arweave.net/XWpt7HDOFC0wJQcQWgP9n_cxHS0qQik9-27CAAaGP6E
-Collection offchain metadata URI: https://arweave.net/atIf58t3FHa3heoOtNqPkVvEGC_9WzAduY0GQE-LnFI
-Collection NFT:  https://explorer.solana.com/address/D2zi1QQmtZR5fk7wpA1Fmf6hTY2xy8xVMyNgfq6LsKy1?cluster=devnet
-Collection NFT address is: D2zi1QQmtZR5fk7wpA1Fmf6hTY2xy8xVMyNgfq6LsKy1
+% npx esrun create-metaplex-core-collection.ts
+Loaded user: 2YkGRHjwD3jqcu4ie6pL9Axpdx5AKa6KDyj8bF473Vk5
+image uri: https://arweave.net/EBRzcUrhbiTfSnx2oD1SZacGMbq2WeFtLUWSD5tAuP7
+Collection offchain metadata URI: https://gateway.irys.xyz/HTK7UZsUqiVcnZ9ez2eNKPQLiU3Xg1hyic1ghwj6gXXE
+Collection: https://explorer.solana.com/address/ACJgjrstigNsgukPuZWZay1L2DXeJPwTn6EyxB5hwWrK?cluster=devnet
+Collection address is:  ACJgjrstigNsgukPuZWZay1L2DXeJPwTn6EyxB5hwWrK
 ✅ Finished successfully!
 ```
 
-Congratulations! You've created a Metaplex Collection. Check this out on Solana
-Explorer using the URL above which should resemble
+Congratulations! You've created a Metaplex Core Collection. Check this out on
+Solana Explorer using the URL above!
 
-![Solana Explorer with details about created collection](/assets/courses/unboxed/solana-explorer-metaplex-collection.png)
+Keep the Collection addres since we're going to use it in the next step.
 
-If you have any trouble, try and fix it yourself, but if you need to you can
-also check out the
-[solution code](https://github.com/solana-developers/professional-education/blob/main/labs/metaplex-umi/create-collection.ts).
+#### 2. Creating a Core Asset and adding it to the Collection
 
-We'll use the collection NFT address in the next step.
+We'll now create a Core Asset that's a member of the Collection we just Created.
 
-#### 2. Creating a Metaplex NFT inside the collection
-
-We'll now make a Metaplex NFT that's a member of the collection we just made.
-Make a new file called `create-metaplex-nft.ts`. The setup for this will look
-the same as the previous file, with slightly different imports:
+Start by creating a new file called `create-metaplex-core-asset.ts`. The setup
+for this will look the same as the previous file, with slightly different
+imports:
 
 ```typescript
 import {
-  createNft,
-  findMetadataPda,
-  mplTokenMetadata,
-  verifyCollectionV1,
-} from "@metaplex-foundation/mpl-token-metadata";
+  mplCore,
+  create,
+  fetchCollection,
+} from "@metaplex-foundation/mpl-core";
 import {
   createGenericFile,
   generateSigner,
   keypairIdentity,
-  percentAmount,
   publicKey as UMIPublicKey,
 } from "@metaplex-foundation/umi";
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
@@ -546,6 +592,7 @@ import {
 import { clusterApiUrl, Connection, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import { promises as fs } from "fs";
 import * as path from "path";
+
 // create a new connection to Solana's devnet cluster
 const connection = new Connection(clusterApiUrl("devnet"));
 
@@ -561,41 +608,22 @@ await airdropIfRequired(
   0.1 * LAMPORTS_PER_SOL,
 );
 
-const umi = createUmi(connection);
+const umi = createUmi(connection).use(mplCore()).use(irysUploader());
 
 // convert to umi compatible keypair
 const umiKeypair = umi.eddsa.createKeypairFromSecretKey(user.secretKey);
 
-// load our plugins and signer
-umi
-  .use(keypairIdentity(umiKeypair))
-  .use(mplTokenMetadata())
-  .use(irysUploader());
-```
-
-Now let's tell Metaplex our collection, and the NFT we want to make:
-
-```typescript
-// Substitute in your collection NFT address from create-metaplex-nft-collection.ts
-const collectionNftAddress = UMIPublicKey("YOUR_COLLECTION_NFT_ADDRESS_HERE");
-
-// example data and metadata for our NFT
-const nftData = {
-  name: "My NFT",
-  symbol: "MN",
-  description: "My NFT Description",
-  sellerFeeBasisPoints: 0,
-  imageFile: "nft.png",
-};
+// assigns a signer to our umi instance, and loads the MPL metadata program and Irys uploader plugins.
+umi.use(keypairIdentity(umiKeypair));
 ```
 
 We can then put out files into Irys:
 
 ```typescript
-const NFTImagePath = path.resolve(__dirname, "nft.png");
+const assetImagePath = "asset.png";
 
-const buffer = await fs.readFile(NFTImagePath);
-let file = createGenericFile(buffer, NFTImagePath, {
+const buffer = await fs.readFile(assetImagePath);
+let file = createGenericFile(buffer, assetImagePath, {
   contentType: "image/png",
 });
 
@@ -603,167 +631,88 @@ let file = createGenericFile(buffer, NFTImagePath, {
 const [image] = await umi.uploader.upload([file]);
 console.log("image uri:", image);
 
-// upload offchain json using irys and get metadata uri
-const uri = await umi.uploader.uploadJson({
-  name: "My NFT",
-  symbol: "MN",
-  description: "My NFT Description",
+const metadata = {
+  name: "My Asset",
+  description: "My Asset Description",
   image,
-});
-console.log("NFT offchain metadata URI:", uri);
+  external_url: "https://example.com",
+  attributes: [
+    {
+      trait_type: "trait1",
+      value: "value1",
+    },
+    {
+      trait_type: "trait2",
+      value: "value2",
+    },
+  ],
+  properties: {
+    files: [
+      {
+        uri: image,
+        type: "image/jpeg",
+      },
+    ],
+    category: "image",
+  },
+};
+
+// upload offchain json using irys and get metadata uri
+const uri = await umi.uploader.uploadJson(metadata);
+console.log("Asset offchain metadata URI:", uri);
 ```
 
-And then create an NFT using the URI from the metadata:
+Then we create an Asset and we add it to the Collection we just created:
 
 ```typescript
-// generate mint keypair
-const mint = generateSigner(umi);
+// Substitute in your collection NFT address from create-metaplex-nft-collection.ts
+const collection = await fetchCollection(
+  umi,
+  UMIPublicKey("YOUR_COLLECTION_ADDRESS_HERE"),
+);
+const asset = generateSigner(umi);
 
 // create and mint NFT
-await createNft(umi, {
-  mint,
-  name: "My NFT",
-  symbol: "MN",
+await create(umi, {
+  asset,
+  collection,
+  name: "My Asset",
   uri,
-  updateAuthority: umi.identity.publicKey,
-  sellerFeeBasisPoints: percentAmount(0),
-  collection: {
-    key: collectionAddress,
-    verified: false,
-  },
 }).sendAndConfirm(umi, { send: { commitment: "finalized" } });
 
-let explorerLink = getExplorerLink("address", mint.publicKey, "devnet");
-console.log(`Token Mint:  ${explorerLink}`);
+let explorerLink = getExplorerLink("address", asset.publicKey, "devnet");
+console.log(`Asset: ${explorerLink}`);
+console.log(`Asset address: ${asset.publicKey}`);
 ```
 
-Run `npx esrun create-metaplex-nft.ts`. If all goes well, you will see the
+Run `npx esrun create-metaplex-core-asset`. If all goes well, you will see the
 following:
 
 ```
-% npx esrun create-metaplex-nft.ts
-
-Loaded user: 4kg8oh3jdNtn7j2wcS7TrUua31AgbLzDVkBZgTAe44aF
-image uri: https://arweave.net/XgTss3uKlddlMFjRTIvDiDLBv6Pptm-Vx9mz6Oe5f-o
-NFT offchain metadata URI: https://arweave.net/PK3Url31k4BYNvYOgTuYgWuCLrNjl5BrrF5lbY9miR8
-Token Mint:  https://explorer.solana.com/address/CymscdAwuTRjCz1ezsNZa15MnwGNrxhGUEToLFcyijMT?cluster=devnet
-Created NFT address is CymscdAwuTRjCz1ezsNZa15MnwGNrxhGUEToLFcyijMT
+% npx esrun create-metaplex-core-asset
+Loaded user: 2YkGRHjwD3jqcu4ie6pL9Axpdx5AKa6KDyj8bF473Vk5
+image uri: https://arweave.net/79wKgR6VAuS3RfneBCNx3RMxzhAPUdqBaK4Ah4KQuWAr
+Asset offchain metadata URI: https://gateway.irys.xyz/7F7YdG9mGFXaq51qPbog5QmymovansiipABtM2nDNLAV
+Asset: https://explorer.solana.com/address/BXfRBtgVRmEnwQaLqCAproeuSMNdkgWYptHvjvHekHht?cluster=devnet
+Asset address: BXfRBtgVRmEnwQaLqCAproeuSMNdkgWYptHvjvHekHht
 ✅ Finished successfully!
 ```
 
-Inspect your NFT at the address given! If you have any trouble, try and fix it
-yourself, but if you need to you can also check out the
-[solution code](https://github.com/solana-developers/professional-education/blob/main/labs/metaplex-umi/create-nft.ts).
-
-You should have something similar to this image on your explorer page
-![Solana Explorer with details about created NFT](/assets/courses/unboxed/solana-explorer-metaplex-nft.png)
-
-Finally, let's verify our mint as being part of our collection. This makes it so
-the `verified` field in the onchain metadata is set to `true`, so consuming
-programs and apps can know for sure that the NFT in fact belongs to the
-collection.
-
-Create a new file `verify-metaplex-nft.ts`, import the required libraries and
-instantiate a new umi Instance.
-
-```typescript
-import {
-  findMetadataPda,
-  mplTokenMetadata,
-  verifyCollectionV1,
-} from "@metaplex-foundation/mpl-token-metadata";
-import {
-  keypairIdentity,
-  publicKey as UMIPublicKey,
-} from "@metaplex-foundation/umi";
-import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";
-import { irysUploader } from "@metaplex-foundation/umi-uploader-irys";
-import {
-  airdropIfRequired,
-  getExplorerLink,
-  getKeypairFromFile,
-} from "@solana-developers/helpers";
-import { clusterApiUrl, Connection, LAMPORTS_PER_SOL } from "@solana/web3.js";
-
-// create a new connection to Solana's devnet cluster
-const connection = new Connection(clusterApiUrl("devnet"));
-
-// load keypair from local file system
-// assumes that the keypair is already generated using `solana-keygen new`
-const user = await getKeypairFromFile();
-console.log("Loaded user:", user.publicKey.toBase58());
-
-await airdropIfRequired(
-  connection,
-  user.publicKey,
-  1 * LAMPORTS_PER_SOL,
-  0.1 * LAMPORTS_PER_SOL,
-);
-
-const umi = createUmi(connection);
-
-// Substitute in your collection NFT address from create-metaplex-nft-collection.ts
-const collectionAddress = UMIPublicKey("");
-
-// Substitute in your NFT address from create-metaplex-nft.ts
-const nftAddress = UMIPublicKey("");
-```
-
-Verifying an NFT will require you to have the `collectionAddress` you used
-created in the creation of a collection stage, and we will use the
-`verifyCollectionV1` method.
-
-```typescript
-// Verify our collection as a Certified Collection
-// See https://developers.metaplex.com/token-metadata/collections
-const metadata = findMetadataPda(umi, { mint: nftAddress });
-await verifyCollectionV1(umi, {
-  metadata,
-  collectionMint: collectionAddress,
-  authority: umi.identity,
-}).sendAndConfirm(umi);
-
-let explorerLink = getExplorerLink("address", nftAddress, "devnet");
-console.log(`verified collection:  ${explorerLink}`);
-console.log("✅ Finished successfully!");
-```
-
-Run `npx esrun verify-metaplex-nft.ts`. If all goes well, you will see the
-following:
-
-```
-% npx esrun create-metaplex-nft.ts
-
-Loaded user: 4kg8oh3jdNtn7j2wcS7TrUua31AgbLzDVkBZgTAe44aF
-verified collection: https://explorer.solana.com/address/CymscdAwuTRjCz1ezsNZa15MnwGNrxhGUEToLFcyijMT?cluster=devnet
-✅ Finished successfully!
-```
-
-Inspect your verified NFT at the address given! If you have any trouble, try and
-fix it yourself, but if you need to you can also check out the
-[solution code](https://github.com/solana-developers/professional-education/blob/main/labs/metaplex-umi/verify-nft.ts).
-
-The verified flag on your NFT should now be set to `1` -> `true` showing that
-it's verified. To confirm this, look under the metadata tab on the Solana
-Explorer to confirm that your NFT is verified as part of the collection.
-
-![Solana Explorer with details about created NFT](/assets/courses/unboxed/solana-explorer-verified-nft.png)
-
-Remember the NFT address, we'll use it in the next step.
+Inspect your Asset at the address given to confirm that the asset has been
+minted!
 
 #### 3. Update the NFT
 
-Create a new file, called `update-metaplex-nft.ts`. The imports will be similar
-to our previous files:
+Create a new file, called `update-metaplex-core-asset.ts`. The imports will be
+similar to our previous files:
 
 ```typescript
 import {
-  createNft,
-  fetchMetadataFromSeeds,
-  updateV1,
-  findMetadataPda,
-  mplTokenMetadata,
-} from "@metaplex-foundation/mpl-token-metadata";
+  mplCore,
+  update,
+  fetchAsset,
+  fetchCollection,
+} from "@metaplex-foundation/mpl-core";
 import {
   createGenericFile,
   generateSigner,
@@ -786,6 +735,7 @@ import * as path from "path";
 const connection = new Connection(clusterApiUrl("devnet"));
 
 // load keypair from local file system
+// See https://github.com/solana-developers/helpers?tab=readme-ov-file#get-a-keypair-from-a-keypair-file
 // assumes that the keypair is already generated using `solana-keygen new`
 const user = await getKeypairFromFile();
 console.log("Loaded user:", user.publicKey.toBase58());
@@ -797,43 +747,24 @@ await airdropIfRequired(
   0.1 * LAMPORTS_PER_SOL,
 );
 
-const umi = createUmi(connection);
+// create a new connection to Solana's devnet cluster
+const umi = createUmi(connection).use(mplCore()).use(irysUploader());
 
 // convert to umi compatible keypair
 const umiKeypair = umi.eddsa.createKeypairFromSecretKey(user.secretKey);
 
-// load our plugins and signer
-umi
-  .use(keypairIdentity(umiKeypair))
-  .use(mplTokenMetadata())
-  .use(irysUploader());
+// assigns a signer to our umi instance, and loads the MPL metadata program and Irys uploader plugins.
+umi.use(keypairIdentity(umiKeypair));
 ```
 
-Let's load our NFT, specifying the address from the previous example, and set up
-what we'd like to update:
+Fetch both Asset and Collection, using the address from the previous example and
+try to update the uri and the name of the Asset:
 
 ```typescript
-// Load the NFT using the mint address
-const mint = UMIPublicKey("YOUR_NFT_ADDRESS_HERE");
-const asset = await fetchDigitalAsset(umi, mint);
+const assetImagePath = "asset.png";
 
-// example data for updating an existing NFT
-const updatedNftData = {
-  name: "Updated Asset",
-  symbol: "UPDATED",
-  description: "Updated Description",
-  sellerFeeBasisPoints: 0,
-  imageFile: "nft.png",
-};
-```
-
-We can then use Metaplex to update our NFT:
-
-```typescript
-const NFTImagePath = path.resolve(__dirname, "nft.png");
-
-const buffer = await fs.readFile(NFTImagePath);
-let file = createGenericFile(buffer, NFTImagePath, {
+const buffer = await fs.readFile(assetImagePath);
+let file = createGenericFile(buffer, assetImagePath, {
   contentType: "image/png",
 });
 
@@ -841,58 +772,71 @@ let file = createGenericFile(buffer, NFTImagePath, {
 const [image] = await umi.uploader.upload([file]);
 console.log("image uri:", image);
 
-// upload updated offchain json using irys and get metadata uri
-const uri = await umi.uploader.uploadJson({
-  name: "Updated ",
-  symbol: "UPDATED",
-  description: "Updated Description",
+const metadata = {
+  name: "My Updated Asset",
+  description: "My Updated Asset Description",
   image,
-});
-console.log("NFT offchain metadata URI:", uri);
-
-// Load the NFT using the mint address
-const mint = UMIPublicKey("Zxd9TmtBHQNti6tJxtx1AKYJFykNUwJL4rth441CjRd");
-const nft = await fetchMetadataFromSeeds(umi, { mint });
-
-await updateV1(umi, {
-  mint,
-  authority: umi.identity,
-  data: {
-    ...nft,
-    sellerFeeBasisPoints: 0,
-    name: "Updated Asset",
+  external_url: "https://example.com",
+  attributes: [
+    {
+      trait_type: "trait1",
+      value: "value1",
+    },
+    {
+      trait_type: "trait2",
+      value: "value2",
+    },
+  ],
+  properties: {
+    files: [
+      {
+        uri: image,
+        type: "image/jpeg",
+      },
+    ],
+    category: "image",
   },
-  primarySaleHappened: true,
-  isMutable: true,
+};
+
+// upload offchain json using irys and get metadata uri
+const uri = await umi.uploader.uploadJson(metadata);
+console.log("Asset offchain metadata URI:", uri);
+
+// Fetch the accounts using the address
+const asset = await fetchAsset(umi, UMIPublicKey("YOUR_ASSET_ADDRESS_HERE"));
+const collection = await fetchCollection(
+  umi,
+  UMIPublicKey("YOUR_COLLECTION_ADDRESS_HERE"),
+);
+
+await update(umi, {
+  asset,
+  collection,
+  name: "My Updated Asset",
+  uri,
 }).sendAndConfirm(umi);
 
-let explorerLink = getExplorerLink("address", mint, "devnet");
-console.log(`NFT updated with new metadata URI: ${explorerLink}`);
+let explorerLink = getExplorerLink("address", asset.publicKey, "devnet");
+console.log(`Asset updated with new metadata URI: ${explorerLink}`);
 
 console.log("✅ Finished successfully!");
 ```
 
-Run `npx esrun update-metaplex-nft.ts`. You should see something like:
+Run `npx esrun update-metaplex-core-asset.ts`. You should see something like:
 
-```bash
-% npx esrun update-metaplex-nft.ts
-
-Loaded user: 4kg8oh3jdNtn7j2wcS7TrUua31AgbLzDVkBZgTAe44aF
-image uri: https://arweave.net/dboiAebucLGhprtknDQnp-yMj348cpJF4aQul406odg
-NFT offchain metadata URI: https://arweave.net/XEjo-44GHRFNOEtPUdDsQlW5z1Gtpk2Wv0HvR8ll1Bw
-NFT updated with new metadata URI: https://explorer.solana.com/address/Zxd9TmtBHQNti6tJxtx1AKYJFykNUwJL4rth441CjRd?cluster=devnet
+```
+% npx esrun update-metaplex-core-asset.ts
+Loaded user: 2YkGRHjwD3jqcu4ie6pL9Axpdx5AKa6KDyj8bF473Vk5
+image uri: https://arweave.net/DtdF6YbCbSV6y5eeet6Hk2oJq2afFwKzZmrLpfFkyLym
+Asset offchain metadata URI: https://gateway.irys.xyz/DQysfQZ9CuGveSYDWKZwhjUX7VnRSzfaPtvojo44rhJw
+Asset updated with new metadata URI: https://explorer.solana.com/address/BXfRBtgVRmEnwQaLqCAproeuSMNdkgWYptHvjvHekHht?cluster=devnet
 ✅ Finished successfully!
 ```
 
-Inspect the updated NFT on Solana Explorer! Just like previously, if you have
-any issues, you should fix them yourself, but if needed the
-[solution code](https://github.com/solana-developers/professional-education/blob/main/labs/metaplex-umi/update-nft.ts)
-is available.
+Inspect the updated NFT on Solana Explorer!
 
-![Solana Explorer with details about the updated NFT](/assets/courses/unboxed/solana-explorer-with-updated-NFT.png)
-
-Congratulations! You've successfully learned how to use the Metaplex SDK to
-create, update, and verify NFTs as part of a collection. That's everything you
+Congratulations! You've successfully learned how to use the Metaplex mpl-core
+SDK to create, update, and add an Asset to a Collection. That's everything you
 need to build out your own collection for just about any use case. You could
 build a new event ticketing platform, revamp a retail business membership
 program, or even digitize your school's student ID system. The possibilities are
@@ -902,16 +846,12 @@ endless!
 
 The steps covered above for creating an NFT would be incredibly tedious to
 execute for thousands of NFTs in one go. Many providers, including Metaplex,
-MagicEden, and Tensor have so-called 'fair launch' tools that take care of
+Magic Eden, and Tensor have so-called 'fair launch' tools that take care of
 minting large quantities of NFTs and ensuring they are sold within the
-parameters set by their creators. Dive into one of these fair launch platforms
-and create an NFT. This hands-on experience will not only reinforce your
-understanding of the tools but also boost your confidence in your ability to use
-them effectively in the future.
+parameters set by their creators. Dive into how Metaplex support fair launches
+through [Candy Machine](https://developers.metaplex.com/core-candy-machine)!
 
-<Callout type="info" title="Completed the lab?">
-
+<Callout type="success" title="Completed the lab?">
 Push your code to GitHub and
-[tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=296745ac-503c-4b14-b3a6-b51c5004c165)!
-
+[tell us what you thought of this lesson](https://form.typeform.com/to/IPH0UGz7#answers-lesson=296745ac-503c-4b14-b3a6-b51c5004c165)! // TODO
 </Callout>

--- a/content/courses/tokens-and-nfts/nfts-with-metaplex-core.mdx
+++ b/content/courses/tokens-and-nfts/nfts-with-metaplex-core.mdx
@@ -77,9 +77,10 @@ information on `metaplex-foundation/token-metadata` see the
 
 <Callout type="info">
 
-[Metaplex Core](https://developers.metaplex.com/core), is the Digital Asset NFT 
-standard from Metaplex where asset details such as the owner, name, uri e.t.c are 
-stored on a single account. You can read a more detailed guide [here](/content/courses/tokens-and-nfts/nfts-with-metaplex-core.md)
+[Metaplex Core](https://developers.metaplex.com/core), is an NFT standard from Metaplex where asset details such as the owner, name, uri e.t.c are stored on a single account. However, the most common style of NFT is still by making a Solana
+SPL token with some Metadata attached via the Metaplex Metadata program, so
+that's what we'll be using in this tutorial.
+
 </Callout>
 
 #### UMI instance


### PR DESCRIPTION
**Note**: I added this PR on the developer repo before it got migrated to solana-com after talking with the Devrel team about creating a new guide on Core NFTs since the current one on NFT is quite outdated 

### Problem

There wasn't any guides and courses on how to use the new Core NFT standard from Metaplex

### Summary of Changes

Added the nfts-with-metaplex-core course at content/courses/tokens-and-nfts/nfts-with-metaplex-core.md with all the information about the new standard + the Lab with a full code example that is ready to use (respecting the same layout and style from the old course on token metadata NFTs)

Changed the callout at nfts-with-metaplex in content/courses/tokens-and-nfts/nfts-with-metaplex.md to link the new guide when talking about the new standard