### PR TITLE
Fix incorrect CLI command in intro-to-anchor-frontend.mdx

### DIFF
--- a/content/courses/onchain-development/intro-to-anchor-frontend.mdx
+++ b/content/courses/onchain-development/intro-to-anchor-frontend.mdx
@@ -572,7 +572,7 @@ Once you have the starter code, take a look around. Install the dependencies
 with `npm install` and then run the app with `npm run dev`.
 
 This project is a simple Next.js application, created using
-`npx create-nextjs-dapp`
+`npx create-next-app`
 
 The `idl.json` file for the Counter program, and the `Initialize` and
 `Increment` components we'll be building throughout this lab.

--- a/content/courses/onchain-development/intro-to-anchor-frontend.mdx
+++ b/content/courses/onchain-development/intro-to-anchor-frontend.mdx
@@ -572,7 +572,7 @@ Once you have the starter code, take a look around. Install the dependencies
 with `npm install` and then run the app with `npm run dev`.
 
 This project is a simple Next.js application, created using
-`npx create-next-dapp`
+`npx create-nextjs-dapp`
 
 The `idl.json` file for the Counter program, and the `Initialize` and
 `Increment` components we'll be building throughout this lab.


### PR DESCRIPTION
Updated incorrect CLI command from create-next-dapp to create-nextjs-dapp in intro-to-anchor-frontend.mdx to match the actual command.

### Problem
![image](https://github.com/user-attachments/assets/934103bc-540c-4a87-9b52-370552bf84ba)
![image](https://github.com/user-attachments/assets/021209e1-fb1c-409a-84fa-d36041483edd)
The Solana documentation incorrectly states that the command to create a Next.js dApp is `create-next-dapp`. However, running this command does not work.

The correct command is `create-nextjs-dapp`, as shown in the actual output.

![image](https://github.com/user-attachments/assets/b28b1668-f48d-4fc0-ab5f-ea8ebf7cdc14)
![image](https://github.com/user-attachments/assets/70e5c773-5e87-4b5f-8cd8-350a6028bc35)



cause actual command to create nextjs dapp is `create-nextjs-dapp` 

- Updated intro-to-anchor-frontend.mdx to replace `create-next-dapp` with `create-nextjs-dapp`.

- Ensured the correct CLI command is documented to prevent confusion for developers.


### Summary of Changes



Fixes #
https://solana.com/developers/courses/onchain-development/intro-to-anchor-frontend#lab