### PR TITLE
fix: 🐛 fixes typo in intro-to-anchor

### DIFF
--- a/content/courses/onchain-development/intro-to-anchor.mdx
+++ b/content/courses/onchain-development/intro-to-anchor.mdx
@@ -397,7 +397,7 @@ As an example, let's look at `AccountStruct` used by the `account_name` of
 pub struct InstructionAccounts {
     #[account(init,
         payer = user,
-        space = DISCRIMINATOR + AnchorStruct::INIT_SPACE
+        space = DISCRIMINATOR + AccountStruct::INIT_SPACE
     )]
     pub account_name: Account<'info, AccountStruct>,
     ...


### PR DESCRIPTION
### Problem

A typo at https://github.com/solana-foundation/solana-com/blob/58f9caf2c89d8ea238f193437bb5e24c9e739f6d/content/courses/onchain-development/intro-to-anchor.mdx?plain=1#L400

### Summary of Changes

Should be `AccountStruct` insted.
