### PR TITLE
docs: create separate page for toolkit, and remove course and guide from secondary nav

### DIFF
--- a/content/docs/toolkit/index.mdx
+++ b/content/docs/toolkit/index.mdx
@@ -23,8 +23,8 @@ keywords:
   - solana foundry
 ---
 
-> This is a beta version of the [Solana Toolkit](/docs/toolkit/), and is
-> still a WIP. Please post all feedback as a GitHub issue
+> This is a beta version of the [Solana Toolkit](/docs/toolkit/), and is still a
+> WIP. Please post all feedback as a GitHub issue
 > [here](https://github.com/solana-foundation/developer-content/issues/new?title=%5Btoolkit%5D%20).
 
 The Solana Program development toolkit is published as the

--- a/content/docs/toolkit/projects/meta.json
+++ b/content/docs/toolkit/projects/meta.json
@@ -8,5 +8,6 @@
     "mobile-app",
     "existing-project",
     "project-layout"
-  ]
+  ],
+  "defaultOpen": true
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -575,7 +575,8 @@
       "guides": "Guides",
       "terminology": "Terminology",
       "courses": "Courses",
-      "cookbook": "Cookbook"
+      "cookbook": "Cookbook",
+      "toolkit": "Toolkit"
     }
   },
   "environment": {
@@ -801,6 +802,10 @@
         "hackathon": {
           "title": "Hackathon",
           "description": "Kickstart your crypto journey."
+        },
+        "api": {
+          "title": "RPC API",
+          "description": "Solana RPC API reference documentation."
         }
       },
       "tutorials": {

--- a/src/app/[locale]/docs/toolkit/[[...slug]]/page.tsx
+++ b/src/app/[locale]/docs/toolkit/[[...slug]]/page.tsx
@@ -1,0 +1,48 @@
+import { docsSource } from "@/app/sources/docs";
+import { DocsPage } from "@/app/components/docs-page";
+import { mdxComponents } from "@/app/mdx-components";
+import { getMdxMetadata } from "@/app/metadata";
+import { notFound } from "next/navigation";
+import { toStaticParams } from "@/app/sources/utils";
+
+type Props = {
+  params: Promise<{ slug?: string[]; locale: string }>;
+};
+
+export default async function Page(props: Props) {
+  const { slug, locale } = await props.params;
+  const page = docsSource.getPage(["toolkit", ...(slug || [])], locale);
+  if (!page) notFound();
+
+  const { body: MDX, toc } = await page.data.load();
+
+  return (
+    <DocsPage
+      toc={toc}
+      full={page.data.full}
+      title={page.data.h1 || page.data.title}
+      filePath={page.file.path}
+      hideTableOfContents={page.data.hideTableOfContents}
+      pageTree={docsSource.pageTree[locale]}
+      href={page.url}
+      locale={locale}
+    >
+      <MDX components={mdxComponents} />
+    </DocsPage>
+  );
+}
+
+export async function generateStaticParams() {
+  const params = toStaticParams(docsSource)
+    .filter((param) => param.slug[0] === "toolkit")
+    .map((param) => ({ slug: param.slug.slice(1) }));
+
+  return [{ slug: [] }, ...params.filter((param) => param.slug.length > 0)];
+}
+
+export async function generateMetadata(props: Props) {
+  const { slug, locale } = await props.params;
+  const page = docsSource.getPage(["toolkit", ...(slug || [])], locale);
+  if (!page) notFound();
+  return getMdxMetadata(page);
+}

--- a/src/app/[locale]/docs/toolkit/layout.tsx
+++ b/src/app/[locale]/docs/toolkit/layout.tsx
@@ -11,15 +11,12 @@ export default async function Layout({
 }) {
   const { locale } = await params;
   const tree = docsSource.pageTree[locale];
-  const pageTree = {
-    ...tree,
-    children: tree.children.filter(
-      (child) =>
-        typeof child.name !== "string" ||
-        (!child.name.startsWith("Solana RPC Methods") &&
-          !child.name.startsWith("The Solana Toolkit")),
-    ),
-  };
+  const toolkitFolder = tree.children.find(
+    (child) =>
+      typeof child.name === "string" &&
+      child.name.startsWith("The Solana Toolkit"),
+  );
+  const pageTree = { ...tree, children: [toolkitFolder] };
   return (
     <DocsLayout tree={pageTree} locale={locale}>
       {children}

--- a/src/components/developers/DevelopersNav/DevelopersNav.jsx
+++ b/src/components/developers/DevelopersNav/DevelopersNav.jsx
@@ -4,7 +4,6 @@ import DocsIcon from "@@/public/src/img/developers/docs.inline.svg";
 import RpcApiIcon from "@@/public/src/img/developers/api.inline.svg";
 import CookbookIcon from "@@/public/src/img/developers/cookbook.inline.svg";
 import GuidesIcon from "@@/public/src/img/developers/guides.inline.svg";
-import CoursesIcon from "@@/public/src/img/developers/courses.inline.svg";
 import StackExchangeIcon from "@@/assets/developers/stackexchange.inline.svg";
 import { useTranslation } from "next-i18next";
 
@@ -41,23 +40,11 @@ export default function DevelopersNav({ containerClassName }) {
                 {t("developers.nav.cookbook")}
               </span>
             </Link>
-            <Link
-              partiallyActive
-              to="/developers/courses"
-              activeClassName="active"
-            >
-              <CoursesIcon height="16" width="16" className="me-2" />
-              <span className="align-middle">
-                {t("developers.nav.courses")}
-              </span>
-            </Link>
-            <Link
-              partiallyActive
-              to="/developers/guides"
-              activeClassName="active"
-            >
+            <Link partiallyActive to="/docs/toolkit" activeClassName="active">
               <GuidesIcon height="16" width="16" className="me-2" />
-              <span className="align-middle">{t("developers.nav.guides")}</span>
+              <span className="align-middle">
+                {t("developers.nav.toolkit")}
+              </span>
             </Link>
             <Link
               href="https://solana.stackexchange.com/"

--- a/src/components/header/HeaderListBuild.js
+++ b/src/components/header/HeaderListBuild.js
@@ -17,7 +17,6 @@ const HeaderListBuild = () => {
           <Link
             to="/docs"
             className="nav-link nav-link--secondary"
-            partiallyActive
             activeClassName="active"
           >
             <strong className="d-block text-white">
@@ -26,14 +25,14 @@ const HeaderListBuild = () => {
             {t("nav.developers.items.docs.description")}
           </Link>
           <Link
-            to="/developers/courses"
+            to="/docs/rpc"
             className="nav-link nav-link--secondary"
             activeClassName="active"
           >
             <strong className="d-block text-white">
-              {t("nav.developers.items.courses.title")}
+              {t("nav.developers.items.api.title")}
             </strong>
-            {t("nav.developers.items.courses.description")}
+            {t("nav.developers.items.api.description")}
           </Link>
           <Link
             to="/developers/cookbook"


### PR DESCRIPTION
- Remove course and guides from secondary nav to minimize traffic due to amount of outdated content. Pages still accessible and linked to on /developers landing page
- Create separate page for Solana Toolkit and added link to secondary nav to try to drive more traffic to it while separating it from core /docs content