### PR TITLE
docs: revert install page changes

### DIFF
--- a/content/docs/intro/installation.mdx
+++ b/content/docs/intro/installation.mdx
@@ -15,28 +15,24 @@ development.
 On Mac and Linux, run this single command to install all dependencies.
 
 ```shell title="Terminal"
-curl --proto '=https' --tlsv1.2 -sSfL https://raw.githubusercontent.com/solana-foundation/mucho/master/install.sh | bash
+curl --proto '=https' --tlsv1.2 -sSfL https://raw.githubusercontent.com/solana-developers/solana-install/main/install.sh | bash
 ```
 
-The command above uses [`mucho`](https://github.com/solana-foundation/mucho) to
-install the core Solana development tools.
-
-<Callout>
-  Windows users: Install WSL (see [Install
-  Dependencies](#install-dependencies)), then run the command above in the
+<Callout type="warn">
+  Windows Users: You must first install WSL (see [Install
+  Dependencies](#install-dependencies)). Then run the command above in the
   Ubuntu (Linux) terminal.
 </Callout>
 
 After installation, you should see output similar to the following:
 
-```shell
-✔ mucho 0.6.0 installed
-ℹ rust 1.84.1 is already installed
-ℹ solana 2.1.1 is already installed
-ℹ avm 0.30.1 is already installed
-ℹ anchor 0.30.1 is already installed
-ℹ solana-verify 0.4.1 is already installed
-ℹ yarn 1.22.1 is already installed
+```
+Installed Versions:
+Rust: rustc 1.85.0 (4d91de4e4 2025-02-17)
+Solana CLI: solana-cli 2.1.14 (src:3ad46824; feat:3271415109, client:Agave)
+Anchor CLI: anchor-cli 0.30.1
+Node.js: v23.8.0
+Yarn: 1.22.1
 ```
 
 If the quick installation command above doesn't work, please refer to the


### PR DESCRIPTION
- revert because mucho doesn't install required linux dependencies
![CleanShot 2025-02-25 at 00 47 15@2x](https://github.com/user-attachments/assets/b4b2e0f4-f512-439c-b111-1fc2f36a5646)