### PR TITLE
Remove invalid search params

### DIFF
--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,6 +1,7 @@
 import createMiddleware from "next-intl/middleware";
 import { routing } from "@/i18n/routing";
 import { NextResponse } from "next/server";
+import { locales } from "@/i18n/config.cjs";
 
 const handleI18nRouting = createMiddleware(routing);
 
@@ -10,6 +11,17 @@ export default async function middleware(req) {
       `${req.nextUrl.origin + req.nextUrl.pathname.toLowerCase()}`,
     );
   }
+
+  const localeParam = req.nextUrl?.searchParams?.get("locale");
+  if (localeParam && !locales.includes(localeParam)) {
+    // An invalid locale search param means that the pages router was trying
+    // to do a soft navigation and matched the route pages/[locale]/[...slug]
+    // the right route will be resolved after the middleware adds the right locale prefix
+    // we can safely remove the locale and slug params to avoid poluting the URL
+    req.nextUrl.searchParams.delete("locale");
+    req.nextUrl.searchParams.delete("slug");
+  }
+
   return handleI18nRouting(req);
 }
 


### PR DESCRIPTION
### Problem

During client-side navigation nextjs thinks that href="solutions/token-extensions" should go to the catch-all "[locale]/[...slug].js" so it sends the URL params "locale=solutions&slug=token-extensions"

### Summary of Changes

Remove the locale and slug params in the middleware. We only do it when the locale param isn't a valid locale, just to be extra safe.