### PR TITLE
[cookbook] verify signer and address

### DIFF
--- a/content/cookbook/wallets/check-publickey.mdx
+++ b/content/cookbook/wallets/check-publickey.mdx
@@ -10,12 +10,10 @@ have a private key associated with them. You can check this by looking to see if
 the public key lies on the ed25519 curve. Only public keys that lie on the curve
 can be controlled by users with wallets.
 
-<Tabs groupId="language" items={['web3.js v2', 'web3.js v1']}>
+<CodeTabs storage="cookbook">
 
-<Tab value="web3.js v2">
-
-```typescript
-import { isAddress } from "@solana/web3.js";
+```typescript !! title="gill"
+import { isAddress } from "gill";
 
 // Note that generateKeyPair() will always give a public key that is valid for users
 
@@ -36,10 +34,7 @@ const errorPubkey = "testPubkey";
 console.log("Invalid Address: ", isAddress(errorPubkey));
 ```
 
-</Tab>
-<Tab value="web3.js v1">
-
-```typescript
+```typescript !! title="web3.js"
 import { PublicKey } from "@solana/web3.js";
 
 // Note that Keypair.generate() will always give a public key that is valid for users
@@ -62,5 +57,4 @@ const errorPubkey = new PublicKey("testPubkey");
 console.log(PublicKey.isOnCurve(errorPubkey.toBytes()));
 ```
 
-</Tab>
-</Tabs>
+</CodeTabs>

--- a/content/cookbook/wallets/verify-keypair.mdx
+++ b/content/cookbook/wallets/verify-keypair.mdx
@@ -1,12 +1,33 @@
 ---
 title: How to Verify a Keypair
-description: "Learn how to verify keypairs on Solana."
+description:
+  "Learn how to verify keypairs on Solana match a given public address."
 ---
 
 If you are given a keypair, you can verify whether or not the secret matches the
-given public key
+given public key:
 
-```typescript title="verify-keypair.ts"
+<CodeTabs storage="cookbook">
+
+```typescript !! title="gill"
+import { createKeyPairSignerFromBytes, address } from "gill";
+
+const publicKey = address("24PNhTaNtomHhoy3fTRaMhAFCRj4uHqhZEEoWrKDbR5p");
+
+const keypairBytes = new Uint8Array([
+  174, 47, 154, 16, 202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56,
+  222, 53, 138, 189, 224, 216, 117, 173, 10, 149, 53, 45, 73, 251, 237, 246, 15,
+  185, 186, 82, 177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240, 121, 121,
+  35, 172, 247, 68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135,
+]);
+
+const signer = await createKeyPairSignerFromBytes(keypairBytes);
+
+console.log(signer.address === publicKey);
+// output: true
+```
+
+```typescript !! title="web3.js"
 import { Keypair, PublicKey } from "@solana/web3.js";
 
 const publicKey = new PublicKey("24PNhTaNtomHhoy3fTRaMhAFCRj4uHqhZEEoWrKDbR5p");
@@ -23,3 +44,5 @@ const keypair = Keypair.fromSecretKey(
 console.log(keypair.publicKey.toBase58() === publicKey.toBase58());
 // output: true
 ```
+
+</CodeTabs>


### PR DESCRIPTION
### Summary of Changes

- added cookbook snippets for verifying a signer/address using the new javascript client
- update "validate pubkey" to use CodeTabs