### PR TITLE
docs: fix docs secondary nav UI bug

### DIFF
--- a/content/docs/references/feature-gates/meta.json
+++ b/content/docs/references/feature-gates/meta.json
@@ -4,5 +4,5 @@
     "tsynmcspg4xficj1v3tdb4c7crmr5tsbhlz4sf7rrna",
     "b7h2caeia4zfcpe3qcgmqbiwibtwrdbrbsj1dy6ktxbq"
   ],
-  "defaultOpen": true
+  "defaultOpen": false
 }

--- a/src/components/developers/DevelopersNav/DevelopersNav.jsx
+++ b/src/components/developers/DevelopersNav/DevelopersNav.jsx
@@ -18,7 +18,7 @@ export default function DevelopersNav({ containerClassName }) {
             <Link
               partiallyActive
               to="/docs"
-              partiallyActiveIgnore={["/docs/rpc"]}
+              partiallyActiveIgnore={["/docs/rpc", "/docs/toolkit"]}
               activeClassName="active"
             >
               <DocsIcon height="16" width="16" className="me-2" />


### PR DESCRIPTION
- fix issue where both "documentation" and "toolkit" highlighted on secondary nav when toolkit section is selected
- make feature gate section default closed