### PR TITLE
docs: add back staking pages

### DIFF
--- a/content/docs/references/meta.json
+++ b/content/docs/references/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "References",
-  "pages": ["clusters", "terminology", "feature-gates"],
+  "pages": ["clusters", "staking", "feature-gates", "terminology"],
   "defaultOpen": false
 }

--- a/content/docs/references/staking/index.mdx
+++ b/content/docs/references/staking/index.mdx
@@ -1,0 +1,98 @@
+---
+title: Staking
+h1: Staking on Solana
+---
+
+_Note before reading: All references to increases in values are in absolute
+terms with regards to balance of SOL. This document makes no suggestion as to
+the monetary value of SOL at any time._
+
+By staking your SOL tokens, you help secure the network and
+[earn rewards](https://docs.anza.xyz/implemented-proposals/staking-rewards)
+while doing so.
+
+You can stake by delegating your tokens to validators who process transactions
+and run the network.
+
+Delegating stake is a shared-risk shared-reward financial model that may provide
+returns to holders of tokens delegated for a long period. This is achieved by
+aligning the financial incentives of the token-holders (delegators) and the
+validators to whom they delegate.
+
+The more stake delegated to a validator, the more often this validator is chosen
+to write new transactions to the ledger. The more transactions the validator
+writes, the more rewards the validator and its delegators earn. Validators who
+configure their systems to be able to process more transactions earn
+proportionally more rewards and because they keep the network running as fast
+and as smoothly as possible.
+
+Validators incur costs by running and maintaining their systems, and this is
+passed on to delegators in the form of a fee collected as a percentage of
+rewards earned. This fee is known as a _commission_. Since validators earn more
+rewards the more stake is delegated to them, they may compete with one another
+to offer the lowest commission for their services.
+
+Although this is not implemented in the Solana protocol today, in the future,
+delegators could risk losing tokens when staking through a process known as
+_slashing_. Slashing involves the removal and destruction of a portion of a
+validator's SOL in response to intentional malicious behavior, such as creating
+invalid transactions or censoring certain types of transactions or network
+participants.
+
+There is no in protocol implementation of slashing currently. For more
+information on slashing see the
+[slashing roadmap](https://docs.anza.xyz/proposals/optimistic-confirmation-and-slashing#slashing-roadmap).
+
+## How do I stake my SOL tokens?
+
+You can stake SOL by moving your tokens into a wallet that supports staking. The
+wallet provides steps to create a stake account and do the delegation.
+
+#### Supported Wallets
+
+Many web and mobile wallets support Solana staking operations. Please check with
+your favorite wallet's maintainers regarding status
+
+#### Solana command line tools
+
+- Solana command line tools can perform all stake operations in conjunction with
+  a CLI-generated keypair file wallet, a paper wallet, or with a connected
+  Ledger Nano.
+  [Staking commands using the Solana Command Line Tools](https://docs.anza.xyz/cli/examples/delegate-stake).
+
+#### Create a Stake Account
+
+Follow the wallet's instructions for creating a staking account. This account
+will be of a different type than one used to simply send and receive tokens.
+
+#### Select a Validator
+
+Follow the wallet's instructions for selecting a validator. You can get
+information about potentially performant validators from the links below. The
+Solana Foundation does not recommend any particular validator.
+
+The site solanabeach.io is built and maintained by one of our validators,
+Staking Facilities. It provides a some high-level graphical information about
+the network as a whole, as well as a list of each validator and some recent
+performance statistics about each one.
+
+- https://solanabeach.io
+
+To view block production statistics, use the Solana command-line tools:
+
+- `solana validators`
+- `solana block-production`
+
+The Solana team does not make recommendations on how to interpret this
+information. Do your own due diligence.
+
+#### Delegate your Stake
+
+Follow the wallet's instructions for delegating your stake to your chosen
+validator.
+
+## Stake Account Details
+
+For more information about the operations and permissions associated with a
+stake account, please see
+[Stake Accounts](/docs/references/staking/stake-accounts)

--- a/content/docs/references/staking/index.mdx
+++ b/content/docs/references/staking/index.mdx
@@ -48,24 +48,24 @@ information on slashing see the
 You can stake SOL by moving your tokens into a wallet that supports staking. The
 wallet provides steps to create a stake account and do the delegation.
 
-#### Supported Wallets
+### Supported Wallets
 
 Many web and mobile wallets support Solana staking operations. Please check with
 your favorite wallet's maintainers regarding status
 
-#### Solana command line tools
+### Solana command line tools
 
 - Solana command line tools can perform all stake operations in conjunction with
   a CLI-generated keypair file wallet, a paper wallet, or with a connected
   Ledger Nano.
   [Staking commands using the Solana Command Line Tools](https://docs.anza.xyz/cli/examples/delegate-stake).
 
-#### Create a Stake Account
+### Create a Stake Account
 
 Follow the wallet's instructions for creating a staking account. This account
 will be of a different type than one used to simply send and receive tokens.
 
-#### Select a Validator
+### Select a Validator
 
 Follow the wallet's instructions for selecting a validator. You can get
 information about potentially performant validators from the links below. The
@@ -86,13 +86,7 @@ To view block production statistics, use the Solana command-line tools:
 The Solana team does not make recommendations on how to interpret this
 information. Do your own due diligence.
 
-#### Delegate your Stake
+### Delegate your Stake
 
 Follow the wallet's instructions for delegating your stake to your chosen
 validator.
-
-## Stake Account Details
-
-For more information about the operations and permissions associated with a
-stake account, please see
-[Stake Accounts](/docs/references/staking/stake-accounts)

--- a/content/docs/references/staking/meta.json
+++ b/content/docs/references/staking/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Staking",
-  "pages": ["stake-accounts"]
+  "pages": ["stake-accounts", "stake-program"]
 }

--- a/content/docs/references/staking/meta.json
+++ b/content/docs/references/staking/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Staking",
+  "pages": ["stake-accounts"]
+}

--- a/content/docs/references/staking/stake-accounts.mdx
+++ b/content/docs/references/staking/stake-accounts.mdx
@@ -1,0 +1,145 @@
+---
+title: Stake Accounts
+---
+
+A stake account on Solana can be used to delegate tokens to validators on the
+network to potentially earn rewards for the owner of the stake account. Stake
+accounts are created and managed differently than a traditional wallet address,
+known as a _system account_. A system account is only able to send and receive
+SOL from other accounts on the network, whereas a stake account supports more
+complex operations needed to manage a delegation of tokens.
+
+Stake accounts on Solana also work differently than those of other
+Proof-of-Stake blockchain networks that you may be familiar with. This document
+describes the high-level structure and functions of a Solana stake account.
+
+#### Account Address
+
+Each stake account has a unique address which can be used to look up the account
+information in the command line or in any network explorer tools. However,
+unlike a wallet address in which the holder of the address's keypair controls
+the wallet, the keypair associated with a stake account address does not
+necessarily have any control over the account. In fact, a keypair or private key
+may not even exist for a stake account's address.
+
+The only time a stake account's address has a keypair file is when
+[creating a stake account using the command line tools](https://docs.anza.xyz/cli/examples/delegate-stake#create-a-stake-account).
+A new keypair file is created first only to ensure that the stake account's
+address is new and unique.
+
+#### Understanding Account Authorities
+
+Certain types of accounts may have one or more _signing authorities_ associated
+with a given account. An account authority is used to sign certain transactions
+for the account it controls. This is different from some other blockchain
+networks where the holder of the keypair associated with the account's address
+controls all of the account's activity.
+
+Each stake account has two signing authorities specified by their respective
+address, each of which is authorized to perform certain operations on the stake
+account.
+
+The _stake authority_ is used to sign transactions for the following operations:
+
+- Delegating stake
+- Deactivating the stake delegation
+- Splitting the stake account, creating a new stake account with a portion of
+  the funds in the first account
+- Merging two stake accounts into one
+- Setting a new stake authority
+
+The _withdraw authority_ signs transactions for the following:
+
+- Withdrawing un-delegated stake into a wallet address
+- Setting a new withdraw authority
+- Setting a new stake authority
+
+The stake authority and withdraw authority are set when the stake account is
+created, and they can be changed to authorize a new signing address at any time.
+The stake and withdraw authority can be the same address or two different
+addresses.
+
+The withdraw authority keypair holds more control over the account as it is
+needed to liquidate the tokens in the stake account, and can be used to reset
+the stake authority if the stake authority keypair becomes lost or compromised.
+
+Securing the withdraw authority against loss or theft is of utmost importance
+when managing a stake account.
+
+#### Multiple Delegations
+
+Each stake account may only be used to delegate to one validator at a time. All
+of the tokens in the account are either delegated or un-delegated, or in the
+process of becoming delegated or un-delegated. To delegate a fraction of your
+tokens to a validator, or to delegate to multiple validators, you must create
+multiple stake accounts.
+
+This can be accomplished by creating multiple stake accounts from a wallet
+address containing some tokens, or by creating a single large stake account and
+using the stake authority to split the account into multiple accounts with token
+balances of your choosing.
+
+The same stake and withdraw authorities can be assigned to multiple stake
+accounts.
+
+#### Merging stake accounts
+
+Two stake accounts that have the same authorities and lockup can be merged into
+a single resulting stake account. A merge is possible between two stakes in the
+following states with no additional conditions:
+
+- two deactivated stakes
+- an inactive stake into an activating stake during its activation epoch
+
+For the following cases, the voter pubkey and vote credits observed must match:
+
+- two activated stakes
+- two activating accounts that share an activation epoch, during the activation
+  epoch
+
+All other combinations of stake states will fail to merge, including all
+"transient" states, where a stake is activating or deactivating with a non-zero
+effective stake.
+
+#### Delegation Warmup and Cooldown
+
+When a stake account is delegated, or a delegation is deactivated, the operation
+does not take effect immediately.
+
+A delegation or deactivation takes several
+[epochs](/docs/references/terminology#epoch) to complete, with a fraction of the
+delegation becoming active or inactive at each epoch boundary after the
+transaction containing the instructions has been submitted to the cluster.
+
+There is also a limit on how much total stake can become delegated or
+deactivated in a single epoch, to prevent large sudden changes in stake across
+the network as a whole. Since warmup and cooldown are dependent on the behavior
+of other network participants, their exact duration is difficult to predict.
+Details on the warmup and cooldown timing can be found
+[here](https://docs.anza.xyz/consensus/stake-delegation-and-rewards#stake-warmup-cooldown-withdrawal).
+
+#### Lockups
+
+Stake accounts can have a lockup which prevents the tokens they hold from being
+withdrawn before a particular date or epoch has been reached. While locked up,
+the stake account can still be delegated, un-delegated, or split, and its stake
+authority can be changed as normal. Only withdrawal into another wallet or
+updating the withdraw authority is not allowed.
+
+A lockup can only be added when a stake account is first created, but it can be
+modified later, by the _lockup authority_ or _custodian_, the address of which
+is also set when the account is created.
+
+#### Destroying a Stake Account
+
+Like other types of accounts on the Solana network, a stake account that has a
+balance of 0 SOL is no longer tracked. If a stake account is not delegated and
+all of the tokens it contains are withdrawn to a wallet address, the account at
+that address is effectively destroyed, and will need to be manually re-created
+for the address to be used again.
+
+#### Viewing Stake Accounts
+
+Stake account details can be viewed on the
+[Solana Explorer](http://explorer.solana.com/) by copying and pasting an account
+address into the search bar.

--- a/content/docs/references/staking/stake-accounts.mdx
+++ b/content/docs/references/staking/stake-accounts.mdx
@@ -13,7 +13,7 @@ Stake accounts on Solana also work differently than those of other
 Proof-of-Stake blockchain networks that you may be familiar with. This document
 describes the high-level structure and functions of a Solana stake account.
 
-#### Account Address
+### Account Address
 
 Each stake account has a unique address which can be used to look up the account
 information in the command line or in any network explorer tools. However,
@@ -27,7 +27,7 @@ The only time a stake account's address has a keypair file is when
 A new keypair file is created first only to ensure that the stake account's
 address is new and unique.
 
-#### Understanding Account Authorities
+### Understanding Account Authorities
 
 Certain types of accounts may have one or more _signing authorities_ associated
 with a given account. An account authority is used to sign certain transactions
@@ -66,7 +66,7 @@ the stake authority if the stake authority keypair becomes lost or compromised.
 Securing the withdraw authority against loss or theft is of utmost importance
 when managing a stake account.
 
-#### Multiple Delegations
+### Multiple Delegations
 
 Each stake account may only be used to delegate to one validator at a time. All
 of the tokens in the account are either delegated or un-delegated, or in the
@@ -82,7 +82,7 @@ balances of your choosing.
 The same stake and withdraw authorities can be assigned to multiple stake
 accounts.
 
-#### Merging stake accounts
+### Merging stake accounts
 
 Two stake accounts that have the same authorities and lockup can be merged into
 a single resulting stake account. A merge is possible between two stakes in the
@@ -101,7 +101,7 @@ All other combinations of stake states will fail to merge, including all
 "transient" states, where a stake is activating or deactivating with a non-zero
 effective stake.
 
-#### Delegation Warmup and Cooldown
+### Delegation Warmup and Cooldown
 
 When a stake account is delegated, or a delegation is deactivated, the operation
 does not take effect immediately.
@@ -118,7 +118,7 @@ of other network participants, their exact duration is difficult to predict.
 Details on the warmup and cooldown timing can be found
 [here](https://docs.anza.xyz/consensus/stake-delegation-and-rewards#stake-warmup-cooldown-withdrawal).
 
-#### Lockups
+### Lockups
 
 Stake accounts can have a lockup which prevents the tokens they hold from being
 withdrawn before a particular date or epoch has been reached. While locked up,
@@ -130,7 +130,7 @@ A lockup can only be added when a stake account is first created, but it can be
 modified later, by the _lockup authority_ or _custodian_, the address of which
 is also set when the account is created.
 
-#### Destroying a Stake Account
+### Destroying a Stake Account
 
 Like other types of accounts on the Solana network, a stake account that has a
 balance of 0 SOL is no longer tracked. If a stake account is not delegated and
@@ -138,7 +138,7 @@ all of the tokens it contains are withdrawn to a wallet address, the account at
 that address is effectively destroyed, and will need to be manually re-created
 for the address to be used again.
 
-#### Viewing Stake Accounts
+### Viewing Stake Accounts
 
 Stake account details can be viewed on the
 [Solana Explorer](http://explorer.solana.com/) by copying and pasting an account

--- a/content/docs/references/staking/stake-program.mdx
+++ b/content/docs/references/staking/stake-program.mdx
@@ -1,0 +1,31 @@
+---
+title: Stake Programming
+---
+
+To maximize stake distribution, decentralization, and censorship resistance on
+the Solana network, staking can be performed programmatically. The team and
+community have developed several on-chain and offchain programs to make stakes
+easier to manage.
+
+### Solana Foundation Delegation Program
+
+The
+[Solana Foundation Delegation Program](https://solana.org/delegation-program) is
+designed to serve the needs of the network by targeting the following goals:
+
+1. Maximize decentralization, reliability, and performance of Solana
+2. Maximize the number of validators who have diverse sources of stake
+3. Sustain a large and representative testnet
+
+### Stake Pools
+
+This on-chain program pools together SOL to be staked by a manager, allowing SOL
+holders to stake and earn rewards without managing stakes. Users deposit SOL in
+exchange for SPL tokens (staking derivatives) that represent their ownership in
+the stake pool. The pool manager stakes deposited SOL according to their
+strategy, perhaps using a variant of an auto-delegation bot as described above.
+As stakes earn rewards, the pool and pool tokens grow proportionally in value.
+Finally, pool token holders can send SPL tokens back to the stake pool to redeem
+SOL, thereby participating in decentralization with much less work required.
+More information can be found at the
+[SPL stake pool documentation](https://spl.solana.com/stake-pool).

--- a/rewrites-redirects.mjs
+++ b/rewrites-redirects.mjs
@@ -733,7 +733,7 @@ export default {
     },
     {
       source: "/docs/references/economics/staking/:path*",
-      destination: "/staking",
+      destination: "/docs/references/staking/:path*",
     },
   ],
 };

--- a/rewrites-redirects.mjs
+++ b/rewrites-redirects.mjs
@@ -731,9 +731,5 @@ export default {
       source: "/docs/advanced/:path*",
       destination: "/developers/guides/advanced/:path*",
     },
-    {
-      source: "/docs/references/economics/staking/:path*",
-      destination: "/docs/references/staking/:path*",
-    },
   ],
 };


### PR DESCRIPTION
- Add back staking pages to docs
- Updated staking program page to link to Solana Foundation Delegation program instead of stake-o-matic (deprecated)