### PR TITLE
[WIP] Sync cookie with URL locale

### DIFF
--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -7,6 +7,7 @@ export const routing = defineRouting({
   locales,
   defaultLocale,
   localePrefix: "as-needed", // default locale won't have a prefix
+  localeDetection: false,
 });
 
 export const { Link, redirect, usePathname, useRouter } =

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -1,28 +1,39 @@
 import createMiddleware from "next-intl/middleware";
 import { routing } from "@/i18n/routing";
 import { NextResponse } from "next/server";
-import { locales } from "@/i18n/config.cjs";
+import { locales, defaultLocale } from "@/i18n/config.cjs";
 
 const handleI18nRouting = createMiddleware(routing);
 
+const getUrlLocale = (pathname) =>
+  locales.find(
+    (locale) => pathname.startsWith(`/${locale}/`) || pathname === `/${locale}`,
+  );
+
 export default async function middleware(req) {
+  // Handle lowercase redirects
   if (req.nextUrl.pathname !== req.nextUrl.pathname.toLowerCase()) {
     return NextResponse.redirect(
       `${req.nextUrl.origin + req.nextUrl.pathname.toLowerCase()}`,
     );
   }
 
+  // Clean up invalid locale params from the URL
   const localeParam = req.nextUrl?.searchParams?.get("locale");
   if (localeParam && !locales.includes(localeParam)) {
-    // An invalid locale search param means that the pages router was trying
-    // to do a soft navigation and matched the route pages/[locale]/[...slug]
-    // the right route will be resolved after the middleware adds the right locale prefix
-    // we can safely remove the locale and slug params to avoid poluting the URL
     req.nextUrl.searchParams.delete("locale");
     req.nextUrl.searchParams.delete("slug");
   }
 
-  return handleI18nRouting(req);
+  const response = await handleI18nRouting(req);
+
+  // Sync cookie with URL locale for better consistency
+  response.cookies.set(
+    "NEXT_LOCALE",
+    getUrlLocale(req.nextUrl.pathname) || defaultLocale,
+  );
+
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
### Problem
When switching to a locale (e.g., solana.com/es) either by manually typing it in the address bar or selecting it from the footer dropdown, then manually removing `/es` from the URL, the `es` Next.js locale cookie is aggressively reapplied.

### Summary of Changes
Sync cookie with URL locale for UX consistency

---

Scenarios:

1. User is on `/de/validators`, clicks link to `/news`
    * Redirects to `/de/news` => preserves de locale
2. User manually changes URL from `/de/validators` to `/validators`
    * Stays at `/validators` => respects manual change
3. User on `/validators` clicks link to `/news`
    * Stays on `/news` => no locale to preserve
