### PR TITLE
docs: remove link to fee amounts

### DIFF
--- a/content/docs/core/fees.mdx
+++ b/content/docs/core/fees.mdx
@@ -27,11 +27,8 @@ increase the probability that the transaction is processed by the current leader
 
 ## Base Transaction Fee
 
-The base fee is the minimum cost to send a transaction. The cost is a minimum of
-[5000 lamports](https://github.com/anza-xyz/agave/blob/v2.1.13/sdk/fee-calculator/src/lib.rs#L106)
-per signature, with a target of
-[10000 lamports](https://github.com/anza-xyz/agave/blob/v2.1.13/sdk/fee-calculator/src/lib.rs#L63)
-per signature.
+The base fee is the minimum cost to send a transaction. The cost is 5000
+lamports per signature.
 
 The base fee is automatically paid for by the transaction fee payer, which is
 the first signer on the transaction. The fee payer must be an account owned by

--- a/content/docs/core/fees.mdx
+++ b/content/docs/core/fees.mdx
@@ -28,7 +28,7 @@ increase the probability that the transaction is processed by the current leader
 ## Base Transaction Fee
 
 The base fee is the minimum cost to send a transaction. The cost is 5000
-lamports per signature.
+lamports per signature included in the transaction.
 
 The base fee is automatically paid for by the transaction fee payer, which is
 the first signer on the transaction. The fee payer must be an account owned by


### PR DESCRIPTION
- Removing links to base transaction fee amounts. Need to clarify if this is what's actually used on network.
- https://github.com/anza-xyz/agave/blob/v2.1.13/sdk/fee-calculator/src/lib.rs#L63
- https://github.com/anza-xyz/agave/blob/v2.1.13/sdk/fee-calculator/src/lib.rs#L106