### PR TITLE
docs: vale lint doc and installation pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ yalc.lock
 
 # docskit component syntax reference
 content/docs/docskit.mdx
+
+# Vale Formatter
+vale/styles/*
+.vale.ini

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -24,8 +24,8 @@ description:
 
 ## Try Solana: Play 2048
 
-Play 2048 on Solana where each move is a processed transaction. Click "Play" to
-start with a funded devnet wallet and use the arrow keys (swipe on mobile) to
+Play 2048 on Solana where every move processes a transaction. Click "Play" to
+start with a funded devnet wallet and use the arrow keys. If on mobile, swipe to
 control the tiles.
 
 <Accordions>
@@ -57,13 +57,13 @@ Learn the key concepts specific to Solana development.
 
 <Cards>
   <Card title="Accounts" href="/docs/core/accounts">
-    How data is stored on Solana
+    How Solana stores data
   </Card>
   <Card title="Fees on Solana" href="/docs/core/fees">
-    Various costs associated with using the network
+    Costs to send transactions on Solana
   </Card>
   <Card title="Transactions" href="/docs/core/transactions">
-    How to interact with the network
+    How to interact with the Solana network
   </Card>
   <Card title="Programs" href="/docs/core/programs">
     Smart contracts on Solana
@@ -78,12 +78,12 @@ Learn the key concepts specific to Solana development.
 
 ### Client Side Development
 
-If you're developing on the client-side, Solana has community-contributed SDKs
-to help developers interact with the Solana network in most popular languages :
+If you develop on the client side, community-contributed SDKs from Solana help
+you interact with the network in popular languages:
 
 | Language   | SDK                                                                                                                                       |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| RUST       | [solana_sdk](https://docs.rs/solana-sdk/latest/solana_sdk/)                                                                               |
+| Rust       | [solana_sdk](https://docs.rs/solana-sdk/latest/solana_sdk/)                                                                               |
 | Typescript | [@solana/web3.js](https://github.com/anza-xyz/solana-web3.js)                                                                             |
 | Python     | [solders](https://github.com/kevinheavey/solders)                                                                                         |
 | Java       | [sava](https://sava.software) or [solanaj](https://github.com/skynetcap/solanaj) or [solana4j](https://github.com/LMAX-Exchange/solana4j) |
@@ -106,8 +106,7 @@ Explore what it takes to operate a Solana validator and help secure the network.
     title="System Requirements"
     href="https://docs.anza.xyz/operations/requirements"
   >
-    Recommended hardware requirements and expected SOL needed to operate a
-    validator
+    Recommended hardware requirements and SOL required to operate a validator
   </Card>
   <Card
     title="Validator Setup"

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -25,8 +25,8 @@ description:
 ## Try Solana: Play 2048
 
 Play 2048 on Solana where every move processes a transaction. Click "Play" to
-start with a funded devnet wallet and use the arrow keys. If on mobile, swipe to
-control the tiles.
+start with a funded devnet wallet and use the arrow keys to play. If on mobile,
+swipe to control the tiles.
 
 <Accordions>
 <Accordion title="Play Solana 2048">
@@ -78,7 +78,7 @@ Learn the key concepts specific to Solana development.
 
 ### Client Side Development
 
-If you develop on the client side, community-contributed SDKs from Solana help
+If you develop on the client side, the following community-contributed SDKs help
 you interact with the network in popular languages:
 
 | Language   | SDK                                                                                                                                       |

--- a/content/docs/index.mdx
+++ b/content/docs/index.mdx
@@ -24,9 +24,9 @@ description:
 
 ## Try Solana: Play 2048
 
-Play 2048 on Solana where every move processes a transaction. Click "Play" to
-start with a funded devnet wallet and use the arrow keys to play. If on mobile,
-swipe to control the tiles.
+Play 2048 on Solana where every move sends a transaction. Click "Play" to start
+with a funded devnet wallet and use the arrow keys to play. If on mobile, swipe
+to control the tiles.
 
 <Accordions>
 <Accordion title="Play Solana 2048">

--- a/content/docs/intro/installation.mdx
+++ b/content/docs/intro/installation.mdx
@@ -19,12 +19,12 @@ $ curl --proto '=https' --tlsv1.2 -sSfL https://raw.githubusercontent.com/solana
 ```
 
 <Callout type="warn">
-  Windows Users: You must first install WSL (see [Install
-  Dependencies](#install-dependencies)). Then run the command above in the
+  Windows users: you must first install WSL (see [Install
+  Dependencies](#install-dependencies)). Then run the preceding command in the
   Ubuntu (Linux) terminal.
 </Callout>
 
-After installation, you should see output similar to the following:
+After installation, you should see output like the following:
 
 ```
 Installed Versions:
@@ -37,7 +37,7 @@ Yarn: 1.22.1
 
 <Callout>
 
-If the quick installation command above doesn't work, please refer to the
+If the quick installation command doesn't work, please refer to the
 [Install Dependencies](#install-dependencies) section below for instructions to
 install each dependency individually.
 
@@ -49,7 +49,7 @@ If the quick install command runs successfully, skip to the
 
 ## Install Dependencies
 
-The instructions below will guide you through installing each dependency
+The instructions below guides you through installing each dependency
 individually.
 
 - Windows users must first install WSL (Windows subsystem for Linux) and then
@@ -63,10 +63,9 @@ individually.
 
 To develop Solana programs on Windows **you must use
 [WSL](https://learn.microsoft.com/en-us/windows/wsl/install)** (Windows
-subsystem for Linux). All additional dependencies must be installed through the
-Linux terminal.
+subsystem for Linux). Install all other dependencies through the Linux terminal.
 
-Once WSL is installed, install the dependencies specified in the Linux section
+After installing WSL, install the dependencies specified in the Linux section
 below before proceeding to install Rust, Solana CLI, and Anchor CLI.
 
 To install WSL, run the following command in Windows PowerShell:
@@ -75,7 +74,7 @@ To install WSL, run the following command in Windows PowerShell:
 $ wsl --install
 ```
 
-The install process will prompt you to create a default user account.
+The install process prompts you to create a default user account.
 
 ![WSL Install](/assets/docs/intro/installation/wsl-install.png)
 
@@ -100,7 +99,7 @@ Ubuntu again. The terminal should now look like the image below, where
 
 ![Ubuntu Terminal](/assets/docs/intro/installation/wsl-ubuntu-terminal-2.png)
 
-If you are using VS Code, the
+If you use VS Code, the
 [WSL extension](https://code.visualstudio.com/docs/remote/wsl-tutorial) enables
 you to use WSL and VS Code together.
 
@@ -110,11 +109,11 @@ You should then see the following in the VS Code status bar:
 
 ![WSL: Ubuntu](/assets/docs/intro/installation/wsl-vscode-ubuntu.png)
 
-Once you have WSL set up, all additional dependencies **must** be installed
-through the Ubuntu (Linux) terminal.
+Once you have WSL set up, install all other dependencies through the Ubuntu
+(Linux) terminal.
 
 To install the required Solana dependencies, first try running the
-[quick installation](#quick-installation) command above in the Ubuntu (Linux)
+[quick installation](#quick-installation) command in the Ubuntu (Linux)
 terminal.
 
 <Callout>
@@ -132,7 +131,7 @@ If the quick install command runs successfully, skip to the
 </Accordion>
 <Accordion title="Linux">
 
-The following dependencies are required for the Anchor CLI installation.
+The Anchor CLI installation requires the following dependencies.
 
 First, run the following command:
 
@@ -167,11 +166,10 @@ is only available from another source
 
 ### Install Rust
 
-Solana programs are written in the
+Developers build Solana programs using the
 [Rust programming language](https://www.rust-lang.org/).
 
-The recommended installation method for Rust is
-[rustup](https://www.rust-lang.org/tools/install).
+Install Rust with [rustup](https://www.rust-lang.org/tools/install).
 
 Run the following command to install Rust:
 
@@ -209,13 +207,13 @@ Cargo's bin directory:
 $ . "$HOME/.cargo/env"
 ```
 
-To verify that the installation was successful, check the Rust version:
+To verify the installation succeeded, check the Rust version:
 
 ```terminal
 $ rustc --version
 ```
 
-You should see output similar to the following:
+You should see output like the following:
 
 ```
 rustc 1.84.1 (e71f9a9a9 2025-01-27)
@@ -239,7 +237,7 @@ You can replace `stable` with the release tag matching the software version of
 your desired release (i.e. `v2.0.3`), or use one of the three symbolic channel
 names: `stable`, `beta`, or `edge`.
 
-If it is your first time installing the Solana CLI, you may see the following
+For a first-time installation of the Solana CLI, you may see the following
 message prompting you to add a `PATH` environment variable:
 
 ```
@@ -251,9 +249,9 @@ export PATH="/Users/test/.local/share/solana/install/active_release/bin:$PATH"
 <Tabs groupId="language" items={["Linux", "Mac"]}>
 <Tab value="Linux">
 
-If you are using a Linux or WSL terminal, you can add the `PATH` environment
-variable to your shell configuration file by running the command logged from the
-installation or by restarting your terminal.
+If you use Linux or WSL, you can add the `PATH` environment variable to your
+shell configuration file by running the command logged from the installation or
+by restarting your terminal.
 
 ```terminal
 $ export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
@@ -262,8 +260,8 @@ $ export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
 </Tab>
 <Tab value="Mac">
 
-If you're on Mac using `zsh`, running the default `export PATH` command logged
-from the installation does not persist once you close your terminal.
+If you use a Mac with `zsh`, running the default `export PATH` command logged
+from the installation doesn't persist once you close your terminal.
 
 Instead, you can add the PATH to your shell configuration file by running the
 following command:
@@ -282,13 +280,13 @@ $ source ~/.zshrc
 </Tab>
 </Tabs>
 
-To verify that the installation was successful, check the Solana CLI version:
+To verify that the installation succeeded, check the Solana CLI version:
 
 ```terminal
 $ solana --version
 ```
 
-You should see output similar to the following:
+You should see output like the following:
 
 ```
 solana-cli 2.0.26 (src:3dccb3e7; feat:607245837, client:Agave)
@@ -320,7 +318,7 @@ $ agave-install update
 programs. The Anchor framework leverages Rust macros to simplify the process of
 writing Solana programs.
 
-There are two ways to install the Anchor CLI and tooling:
+You can install the Anchor CLI and tooling in two ways:
 
 1. Anchor Version Manager (AVM) - Recommended installation method
 2. Without AVM - Install directly from GitHub
@@ -337,7 +335,7 @@ Install AVM with the following command:
 $ cargo install --git https://github.com/coral-xyz/anchor avm --force
 ```
 
-Check that AVM was installed successfully:
+Confirm that AVM installed successfully:
 
 ```terminal
 $ avm --version
@@ -350,8 +348,8 @@ $ avm install latest
 $ avm use latest
 ```
 
-Alternatively, you can install a specific version of Anchor CLI by specifying
-the version number:
+You can install a specific version of Anchor CLI by specifying the version
+number:
 
 ```terminal
 $ avm install 0.30.1
@@ -360,8 +358,8 @@ $ avm use 0.30.1
 
 <Callout type="info">
 
-Don't forget to run the _shell`avm use`_ command to declare which Anchor CLI
-version should be used on your system.
+Don't forget to run the _shell`avm use`_ command to declare the Anchor CLI
+version to run on your system.
 
 - If you installed the `latest` version, run _shell`avm use latest`_.
 - If you installed the version `0.30.1`, run _shell`avm use 0.30.1`_.
@@ -381,13 +379,13 @@ $ cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-c
 </Tab>
 </Tabs>
 
-To verify that the installation was successful, check the Anchor CLI version:
+To verify that the installation succeeded, check the Anchor CLI version:
 
 ```terminal
 $ anchor --version
 ```
 
-You should see output similar to the following:
+You should see output like the following:
 
 ```
 anchor-cli 0.30.1
@@ -412,15 +410,14 @@ If you see this error message:
 
 #### Node.js and Yarn
 
-Node.js and Yarn are required to run the default Anchor project test file
-(TypeScript) created with the _shell`anchor init`_ command. (Rust test template
-is also available using _shell`anchor init --test-template rust`_)
+The default Anchor project test file (TypeScript) created with the
+_shell`anchor init`_ command requires Node.js and Yarn. (Rust test template is
+available using _shell`anchor init --test-template rust`_)
 
 <Accordions>
 <Accordion title="Node Installation">
 
-The recommended way to install node is using
-[Node Version Manager (nvm)](https://github.com/nvm-sh/nvm).
+Install node using [Node Version Manager (nvm)](https://github.com/nvm-sh/nvm).
 
 Install nvm using the following command:
 
@@ -428,7 +425,7 @@ Install nvm using the following command:
 $ curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/master/install.sh | bash
 ```
 
-Restart your terminal and verify that nvm is installed:
+Restart your terminal and confirm that the nvm command runs successfully:
 
 ```terminal
 $ command -v nvm
@@ -440,13 +437,13 @@ Next, use `nvm` to install node:
 $ nvm install node
 ```
 
-To verify that the installation was successful, check the Node version:
+To verify that the installation succeeded, check the Node version:
 
 ```terminal
 $ node --version
 ```
 
-You should see output similar to the following:
+You should see output like the following:
 
 ```
 v23.7.0
@@ -461,13 +458,13 @@ Install Yarn:
 $ npm install --global yarn
 ```
 
-To verify that the installation was successful, check the Yarn version:
+To verify that the installation succeeded, check the Yarn version:
 
 ```terminal
 $ yarn --version
 ```
 
-You should the following output:
+You should see the following output:
 
 ```
 1.22.1
@@ -495,7 +492,7 @@ Try these solutions:
 $ cargo build-sbf --force-tools-install
 ```
 
-2. If the solution above doesn't work, clear the Solana cache:
+2. If the preceding solution doesn't work, clear the Solana cache:
 
 ```terminal
 $ rm -rf ~/.cache/solana/*
@@ -518,14 +515,15 @@ information.
 
 </Accordions>
 
-After applying the solution above, attempt to run _shell`anchor build`_ again.
+After applying the preceding solution, attempt to run _shell`anchor build`_
+again.
 
 </Callout>
 
 <Callout type="warn">
 
 When running _shell`anchor test`_ after creating a new Anchor project on Linux
-or WSL, you may encounter the following errors if Node.js or Yarn are not
+or WSL, you may encounter the following errors if you don't have Node.js or Yarn
 installed:
 
 ```
@@ -543,8 +541,7 @@ No such file or directory (os error 2)
 
 ## Solana CLI Basics
 
-This section will walk through some common Solana CLI commands to get you
-started.
+This section walks through some common Solana CLI commands to get you started.
 
 <Steps>
 <Step>
@@ -557,7 +554,7 @@ To see your current config:
 $ solana config get
 ```
 
-You should see output similar to the following:
+You should see output like the following:
 
 ```
 Config File: /Users/test/.config/solana/cli/config.yml
@@ -567,8 +564,8 @@ Keypair Path: /Users/test/.config/solana/id.json
 Commitment: confirmed
 ```
 
-The RPC URL and Websocket URL specify the Solana cluster the CLI will make
-requests to. By default this will be mainnet-beta.
+The RPC URL and Websocket URL specify the Solana cluster the CLI makes requests
+to.
 
 You can update the Solana CLI cluster using the following commands:
 
@@ -606,7 +603,7 @@ To generate a keypair at the default Keypair Path, run the following command:
 $ solana-keygen new
 ```
 
-You should see output similar to the following:
+You should see output like the following:
 
 ```
 Generating a new keypair
@@ -630,7 +627,7 @@ cream bleak tortoise ocean nasty game gift forget fancy salon mimic amazing
 <Callout type="info">
 
 If you already have a file system wallet saved at the default location, this
-command will **NOT** override it unless you explicitly force override using the
+command doesn't override it unless you explicitly force override using the
 `--force` flag.
 
 </Callout>
@@ -663,7 +660,7 @@ $ solana airdrop 2
 
 <Callout>
 
-Devnet airdrops are limited to 5 SOL per request. If you hit rate limits or
+Devnet airdrops limit requests to 5 SOL per request. If you hit rate limits or
 encounter errors, try using the [Web Faucet](https://faucet.solana.com) instead.
 
 </Callout>
@@ -705,8 +702,8 @@ $ solana config set -ul
 
 ## Anchor CLI Basics
 
-This section will walk through some common Anchor CLI commands to get you
-started. For more information on the Anchor CLI, see the
+This section walks through some common Anchor CLI commands to get you started.
+For more information on the Anchor CLI, see the
 [Anchor documentation](https://www.anchor-lang.com/docs).
 
 <Steps>
@@ -749,7 +746,7 @@ To build your project, run the following command:
 $ anchor build
 ```
 
-The compiled program can be found in the `/target/deploy` directory.
+You can find the compiled program in the `/target/deploy` directory.
 
 </Step>
 <Step>
@@ -762,7 +759,7 @@ To deploy your project, run the following command:
 $ anchor deploy
 ```
 
-This command will deploy your program to the `cluster` specified in the
+This command deploys your program to the `cluster` specified in the
 [`Anchor.toml`](https://www.anchor-lang.com/docs/references/anchor-toml) file.
 
 </Step>


### PR DESCRIPTION
- use [vale](https://vale.sh/docs) to lint content wording
- configured to use google [developer documentation style guide](https://developers.google.com/style)