### PR TITLE
docs: vale line quickstart section

### DIFF
--- a/content/docs/intro/quick-start/cross-program-invocation.mdx
+++ b/content/docs/intro/quick-start/cross-program-invocation.mdx
@@ -36,7 +36,7 @@ section includes just the PDA section completed.
 
 ### Update the Update Instruction
 
-First, the code needs a simple "pay-to-update" mechanism by changing the
+First, the program needs a simple "pay-to-update" mechanism by changing the
 _rs`Update`_ struct and `update` function.
 
 Begin by updating the `lib.rs` file to bring into scope items from the

--- a/content/docs/intro/quick-start/cross-program-invocation.mdx
+++ b/content/docs/intro/quick-start/cross-program-invocation.mdx
@@ -9,34 +9,34 @@ description:
 h1: Cross Program Invocation
 ---
 
-In this section, we'll update the CRUD program from the previous PDA section by
+In this section, the CRUD program from the previous PDA section gets updated by
 adding Cross Program Invocations (CPIs), a feature that enables Solana programs
 to invoke each other.
 
-We'll also demonstrate how programs can "sign" for Program Derived Addresses
+This tutorial also shows how programs can "sign" for Program Derived Addresses
 (PDAs) when making Cross Program Invocations.
 
-We'll modify the `update` and `delete` instructions to handle SOL transfers
+The `update` and `delete` instructions need modification to handle SOL transfers
 between accounts by invoking the System Program.
 
-The purpose of this section is to walk through the process of implementing CPIs
-in a Solana program using the Anchor framework, building upon the PDA concepts
-we explored in the previous section. For more details, refer to the
+The purpose of this section includes walking through the process of implementing
+CPIs in a Solana program using the Anchor framework, building upon the PDA
+concepts explored in the previous section. For more details, refer to the
 [Cross Program Invocation](/docs/core/cpi) page.
 
-For reference, here is the
+For reference, this link includes the
 [final code](https://beta.solpg.io/668304cfcffcf4b13384d20a) after completing
 both the PDA and CPI sections.
 
-Here is the [starter code](https://beta.solpg.io/679d75eecffcf4b13384d604) for
-this section, with just the PDA section completed.
+The [starter code](https://beta.solpg.io/679d75eecffcf4b13384d604) for this
+section includes just the PDA section completed.
 
 <Steps>
 <Step>
 
-### Modify Update Instruction
+### Update the Update Instruction
 
-First, we'll implement a simple "pay-to-update" mechanism by modifying the
+First, the code needs a simple "pay-to-update" mechanism by changing the
 _rs`Update`_ struct and `update` function.
 
 Begin by updating the `lib.rs` file to bring into scope items from the
@@ -57,9 +57,9 @@ use anchor_lang::system_program::{transfer, Transfer};
 </Accordion>
 </Accordions>
 
-Next, update the _rs`Update`_ struct to include an additional account called
-`vault_account`. This account, controlled by our program, will receive SOL from
-a user when they update their message account.
+Next, update the _rs`Update`_ struct to include a new account called
+`vault_account`. This account, controlled by the program, receives SOL from a
+user when they update their message account.
 
 ```rs title="lib.rs"
 #[account(
@@ -102,37 +102,37 @@ pub struct Update<'info> {
 </Accordion>
 <Accordion title="Explanation">
 
-We're adding a new account called `vault_account` to our _rs`Update`_ struct.
-This account serves as a program-controlled "vault" that will receive SOL from
-users when they update their messages.
+This section adds a new account called `vault_account` to the _rs`Update`_
+struct. This account serves as a program-controlled "vault" that receives SOL
+from users when they update their messages.
 
-By using a PDA for the vault, we create a program-controlled account unique to
-each user, enabling us to manage user funds within our program's logic.
+By using a PDA for the vault, the program creates a program-controlled account
+unique to each user, enabling fund management within the program's logic.
 
 ---
 
 Key aspects of the `vault_account`:
 
-- The address of the account is a PDA derived using seeds
+- The address of the account comes from a PDA derived using seeds
   _rs`[b"vault", user.key().as_ref()]`_
-- As a PDA, it has no private key, so only our program can "sign" for the
+- As a PDA, it has no private key, so only the program can "sign" for the
   address when performing CPIs
-- As a _rs`SystemAccount`_ type, it's owned by the System Program like regular
-  wallet accounts
+- As a _rs`SystemAccount`_ type, the System Program owns it like regular wallet
+  accounts
 
-This setup allows our program to:
+This setup allows the program to:
 
 - Generate unique, deterministic addresses for each user's "vault"
 - Control funds without needing a private key to sign for transactions.
 
-In the `delete` instruction, we'll demonstrate how our program can "sign" for
-this PDA in a CPI.
+In the `delete` instruction, you'll see how the program can "sign" for this PDA
+in a CPI.
 
 </Accordion>
 </Accordions>
 
-Next, implement the CPI logic in the `update` instruction to transfer 0.001 SOL
-from the user's account to the vault account.
+Next, add the CPI logic in the `update` instruction to transfer 0.001 SOL from
+the user's account to the vault account.
 
 <WithNotes>
 
@@ -160,13 +160,12 @@ Program's transfer instruction.
 
 ### !cpi_context
 
-The _rs`CpiContext`_ struct is used to specify the program and accounts for a
-Cross Program Invocation (CPI).
+The _rs`CpiContext`_ struct specifies the program and accounts for a Cross
+Program Invocation (CPI).
 
 ### !transfer
 
-The _rs`transfer()`_ function is used to invoke the System Program's transfer
-instruction.
+The _rs`transfer()`_ function invokes the System Program's transfer instruction.
 
 </WithNotes>
 
@@ -195,10 +194,10 @@ instruction.
 </Accordion>
 <Accordion title="Explanation">
 
-In the `update` instruction, we implement a Cross Program Invocation (CPI) to
-invoke the System Program's `transfer` instruction. This demonstrates how to
-perform a CPI from within our program, enabling the composability of Solana
-programs.
+In the `update` instruction, the implementation includes a Cross Program
+Invocation (CPI) to invoke the System Program's `transfer` instruction. This
+demonstrates how to perform a CPI from within the program, enabling the
+composability of Solana programs.
 
 The _rs`Transfer`_ struct specifies the required accounts for the System
 Program's transfer instruction:
@@ -215,7 +214,7 @@ Program's transfer instruction:
 
 The _rs`CpiContext`_ specifies:
 
-- The program to be invoked (System Program)
+- The program to invoke (System Program)
 - The accounts required in the CPI (defined in the _rs`Transfer`_ struct)
 
   ```rs title="lib.rs"
@@ -229,7 +228,7 @@ The `transfer` function then invokes the transfer instruction on the System
 Program, passing in the:
 
 - The `cpi_context` (program and accounts)
-- The `amount` to transfer (1,000,000 lamports, equivalent to 0.001 SOL)
+- The `amount` to transfer (1,000,000 lamports, or 0.001 SOL)
 
   ```rs title="lib.rs"
   transfer(cpi_context, 1_000_000)?;
@@ -237,10 +236,10 @@ Program, passing in the:
 
 <Callout>
 
-The setup for a CPI matches how client-side instructions are built, where we
+The setup for a CPI matches how client-side instructions get built, where you
 specify the program, accounts, and instruction data for a particular instruction
-to invoke. When our program's `update` instruction is invoked, it internally
-invokes the System Program's transfer instruction.
+to invoke. When the program's `update` instruction receives an invocation, it
+internally invokes the System Program's transfer instruction.
 
 </Callout>
 
@@ -256,13 +255,13 @@ $ build
 </Step>
 <Step>
 
-### Modify Delete Instruction
+### Update the Delete Instruction
 
-We'll now implement a "refund on delete" mechanism by modifying the _rs`Delete`_
-struct and `delete` function.
+Now add a "refund on delete" mechanism by changing the _rs`Delete`_ struct and
+`delete` function.
 
 First, update the _rs`Delete`_ struct to include the `vault_account`. This
-allows us to transfer any SOL in the vault back to the user when they close
+allows the transfer of any SOL in the vault back to the user when they close
 their message account.
 
 ```rs title="lib.rs"
@@ -312,17 +311,17 @@ pub struct Delete<'info> {
 
 The `vault_account` uses the same PDA derivation as in the Update struct.
 
-Add the `vault_account` to the Delete struct enables our program to access the
-user's vault account during the delete instruction to transfer any accumulated
-SOL back to the user.
+Adding the `vault_account` to the Delete struct enables the program to access
+the user's vault account during the delete instruction to transfer any
+accumulated SOL back to the user.
 
 </Accordion>
 </Accordions>
 
 <WithNotes>
 
-Next, implement the CPI logic in the `delete` instruction to transfer SOL from
-the vault account back to the user's account.
+Next, add the CPI logic in the `delete` instruction to transfer SOL from the
+vault account back to the user's account.
 
 ```rs title="lib.rs"
 let user_key = ctx.accounts.user.key();
@@ -351,16 +350,16 @@ the PDA.
 
 The _rs`with_signer()`_ method passes the signer seeds with the CPI.
 
-This allows a program to "sign" for a PDA that was derived using its program ID.
+This allows a program to "sign" for a PDA that derived from its program ID.
 
-During instruction processing, the runtime will verify that the provided signer
-seeds correctly derive to the PDA's address. If verified, that PDA account will
-be marked as a signer for the duration of the CPI.
+During instruction processing, the runtime verifies that the provided signer
+seeds correctly derive to the PDA's address. If verified, the runtime treats
+that PDA account as a signer for the duration of the CPI.
 
 </WithNotes>
 
-Note that we updated _rs`_ctx: Context<Delete>`_ to _rs`ctx: Context<Delete>`_
-as we'll be using the context in the body of the function.
+Note that _rs`_ctx: Context<Delete>`_ changes to _rs`ctx: Context<Delete>`_ to
+use the context in the body of the function.
 
 <Accordions>
 <Accordion title="Diff">
@@ -391,11 +390,11 @@ as we'll be using the context in the body of the function.
 </Accordion>
 <Accordion title="Explanation">
 
-In the delete instruction, we implement another Cross Program Invocation (CPI)
-to invoke the System Program's transfer instruction. This CPI demonstrates how
-to make a transfer that requires a Program Derived Address (PDA) signer.
+In the delete instruction, another Cross Program Invocation (CPI) implements the
+System Program's transfer instruction. This CPI demonstrates how to make a
+transfer that requires a Program Derived Address (PDA) signer.
 
-First, we define the signer seeds for the vault PDA:
+First, define the signer seeds for the vault PDA:
 
 ```rs title="lib.rs"
 let user_key = ctx.accounts.user.key();
@@ -418,7 +417,7 @@ Program's transfer instruction:
 
 The _rs`CpiContext`_ specifies:
 
-- The program to be invoked (System Program)
+- The program to invoke (System Program)
 - The accounts involved in the transfer (defined in the Transfer struct)
 - The signer seeds for the PDA
 
@@ -439,10 +438,10 @@ System Program, passing:
   transfer(cpi_context, ctx.accounts.vault_account.lamports())?;
   ```
 
-This CPI implementation demonstrates how programs can utilize PDAs to manage
-funds. When our program's delete instruction is invoked, it internally calls the
-System Program's transfer instruction, signing for the PDA to authorize the
-transfer of all funds from the vault back to the user.
+This CPI implementation shows how programs can use PDAs to manage funds. When
+the program's delete instruction receives an invocation, it internally calls the
+System Program's transfer instruction, signing for the PDA to allow the transfer
+of all funds from the vault back to the user.
 
 </Accordion>
 </Accordions>
@@ -458,9 +457,9 @@ $ build
 
 ### Redeploy Program
 
-After making these changes, we need to redeploy our updated program. This
-ensures that our modified program is available for testing. On Solana, updating
-a program simply requires deploying the program at the same program ID.
+After making these changes, redeploy the updated program. This ensures the
+modified program becomes available for testing. On Solana, updating a program
+simply requires deploying the program at the same program ID.
 
 <Callout>
 
@@ -478,12 +477,12 @@ Deployment successful. Completed in 17s.
 <Accordions>
 <Accordion title="Explanation">
 
-Only the upgrade authority of the program can update it. The upgrade authority
-is set when the program is deployed, and it's the only account with permission
-to modify or close the program. If the upgrade authority is revoked, then the
-program becomes immutable and can never be closed or upgraded.
+Only the upgrade authority of the program can update it. The developer sets the
+upgrade authority during program deployment, and it remains the only account
+with permission to change or close the program. If someone revokes the upgrade
+authority, then the program becomes immutable.
 
-When deploying programs on Solana Playground, your Playground wallet is the
+When deploying programs on Solana Playground, your Playground wallet acts as the
 upgrade authority for all your programs.
 
 </Accordion>
@@ -494,8 +493,8 @@ upgrade authority for all your programs.
 
 ### Update Test File
 
-Next, we'll update our `anchor.test.ts` file to include the new vault account in
-our instructions. This requires deriving the vault PDA and including it in our
+Next, update the `anchor.test.ts` file to include the new vault account in the
+instructions. This requires deriving the vault PDA and including it in the
 update and delete instruction calls.
 
 #### Derive Vault PDA
@@ -534,7 +533,7 @@ describe("pda", () => {
 </Accordion>
 </Accordions>
 
-#### Modify Update Test
+#### Change Update Test
 
 <WithMentions>
 
@@ -569,7 +568,7 @@ const transactionSignature = await program.methods
 </Accordion>
 </Accordions>
 
-#### Modify Delete Test
+#### Change Delete Test
 
 <WithMentions>
 
@@ -609,7 +608,7 @@ const transactionSignature = await program.methods
 
 ### Rerun Test
 
-After making these changes, run the tests to ensure everything is working as
+After making these changes, run the tests to ensure everything works as
 expected:
 
 ```terminal
@@ -653,7 +652,7 @@ If you encounter any errors, you can reference the
 
 ## Next Steps
 
-Congratulations on completing the Solana Quickstart guide! You've gained
+Congratulations on completing the Solana Quickstart guide. You've gained
 hands-on experience with key Solana concepts including:
 
 - Fetching and reading data from accounts
@@ -679,5 +678,5 @@ to view the Anchor project from this
 [Github repo](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana/anchor).
 
 Click the `Import` button and enter a project name to add it to your list of
-projects in Solana Playground. Once a project is imported, all changes are
-automatically saved and persisted.
+projects in Solana Playground. Once a project gets imported, all changes receive
+automatic saving and persistence.

--- a/content/docs/intro/quick-start/deploying-programs.mdx
+++ b/content/docs/intro/quick-start/deploying-programs.mdx
@@ -8,12 +8,13 @@ description:
 h1: Deploying Your First Solana Program
 ---
 
-In this section, we'll build, deploy, and test a simple Solana program (smart
+In this section, you'll build, deploy, and test a simple Solana program (smart
 contract) using the Anchor framework. By the end, you'll have deployed your
-first program to the Solana blockchain!
+first program to the Solana blockchain.
 
-The purpose of this section is to familiarize you with the Solana Playground.
-We'll walk through a more detailed example in the PDA and CPI sections. For more
+The purpose of this section focuses on familiarizing you with the Solana
+Playground. The guide walks through a more detailed example in the Program
+Derived Address (PDA) and Cross-Program Invocation (CPI) sections. For more
 details, refer to the [Programs on Solana](/docs/core/programs) page.
 
 <Steps>
@@ -32,11 +33,11 @@ First, open https://beta.solpg.io in a new browser tab.
 
 You'll see a new project created with the program code in the `src/lib.rs` file.
 
-This is a basic Solana program that creates a new account and stores a number in
-it. The program has one instruction (`initialize`) that takes a _rs`u64`_ number
-as input, creates a new account, and saves that number in the account's data.
-When the instruction is invoked, it also logs a message to the transaction's
-program logs.
+This basic Solana program creates a new account and stores a number in it. The
+program contains one instruction (`initialize`) that takes a _rs`u64`_ number as
+input, creates a new account, and saves that number in the account's data. When
+you call the instruction, it also logs a message to the transaction's program
+logs.
 
 <WithNotes>
 
@@ -84,8 +85,8 @@ pub struct NewAccount {
 
 ### !declare_id
 
-The _rs`declare_id!()`_ macro specifies the on-chain address of your program. It
-will be updated when you build the project.
+The _rs`declare_id!()`_ macro specifies the on-chain address of your program.
+Solana Playground updates this address when you build the project.
 
 ### !program
 
@@ -100,25 +101,27 @@ program's accounts.
 ### !account
 
 The _rs`#[account]`_ attribute defines a struct that represents the data type
-for accounts that can be created and owned by this program.
+for accounts this program can create and own.
 
 ### !constraints
 
 The _rs`#[account(...)]`_ attributes specify the constraints for the account.
 
-These are additional check or functionality Anchor provides.
+These add common checks or features that Anchor provides to enhance
+program security.
 
 </WithNotes>
 
 <Accordions>
 <Accordion title="Explanation">
 
-For now, we'll only cover the high-level overview of the program code:
+For now, this covers the high-level overview of the program code:
 
 <WithMentions>
 
-- The declare_id! macro specifies the on-chain address of your program. It will
-  be automatically updated when we build the program in the next step.
+- The declare_id! macro specifies the on-chain address of your program. Solana
+  Playground automatically updates this address when you build the program in
+  the next step.
 
 ```rs
 declare_id!("11111111111111111111111111111111");
@@ -151,8 +154,8 @@ parameters:
 
 1. `ctx: Context<Initialize>` - Passes to the function the accounts required for
    this instruction, as specified in the `Initialize` struct.
-2. `data: u64` - An additional parameter that must be provided when the
-   instruction is invoked.
+2. `data: u64` - A custom parameter you must provide when you call the
+   instruction.
 
 The function body [sets the `data` field of `new_account`](mention:three) to the
 provided `data` argument and then prints a message to the program logs.
@@ -161,13 +164,13 @@ provided `data` argument and then prints a message to the program logs.
 
 <WithMentions>
 
-- The [`#[derive(Accounts)]`](mention:one) attribute is used to define a struct
-  that specifies the accounts required for a particular instruction, where each
-  field represents a separate account.
+- The [`#[derive(Accounts)]`](mention:one) attribute defines a struct that
+  specifies the accounts required for a particular instruction, where each field
+  represents a separate account.
 
-  The field types (ex. `Signer<'info>`) and constraints (ex. `#[account(mut)]`)
-  are used by Anchor to automatically handle common security checks related to
-  account validation.
+  Anchor automatically handles common security checks related to account
+  validation through field types (ex. `Signer<'info>`) and constraints (ex.
+  `#[account(mut)]`).
 
   ```rs
   // !mention one
@@ -186,7 +189,7 @@ provided `data` argument and then prints a message to the program logs.
 <WithMentions>
 
 - The [`#[account]`](mention:one) attribute defines a struct that represents the
-  data type for accounts that can be created and owned by this program.
+  data type for accounts this program creates and owns.
 
 ```rs
 // !mention one
@@ -214,12 +217,12 @@ Building...
 Build successful. Completed in 1.46s.
 ```
 
-Note that the address in _rs`declare_id!()`_ has been updated. This is your
-program's on-chain address.
+Solana Playground updates the address in _rs`declare_id!()`_. This address
+represents your program's on-chain address (program ID).
 
-Once the program is built, run _shell`deploy`_ in the terminal to deploy the
-program to the network (devnet by default). To deploy a program, SOL must be
-allocated to the on-chain account that stores the program.
+After building the program, run _shell`deploy`_ in the terminal to deploy the
+program to the network (devnet by default). Program deployment requires
+allocating SOL to the on-chain account that stores the program.
 
 Before deployment, ensure you have enough SOL. You can get devnet SOL by either
 running _shell`solana airdrop 5`_ in the Playground terminal or using the
@@ -232,12 +235,12 @@ Warning: 1 transaction not confirmed, retrying...
 Deployment successful. Completed in 19s.
 ```
 
-Alternatively, you can also use the `Build` and `Deploy` buttons on the
+You can also use the `Build` and `Deploy` buttons on the
 left-side panel.
 
 ![Build and Deploy](/assets/docs/intro/quickstart/pg-build-deploy.png)
 
-Once the program is deployed, you can now invoke its instructions.
+After deploying the program, you can call its instructions.
 
 </Step>
 <Step>
@@ -246,7 +249,7 @@ Once the program is deployed, you can now invoke its instructions.
 
 <WithMentions>
 
-Included with the starter code is a test file found in `tests/anchor.test.ts`.
+The starter code includes a test file located in `tests/anchor.test.ts`.
 This file demonstrates how to invoke the [`initialize`](mention:one) instruction
 on the program from the client.
 
@@ -290,7 +293,7 @@ describe("Test", () => {
 
 </WithMentions>
 
-To run the test file once the program is deployed, run _shell`test`_ in the
+To run the test file after deploying the program, run _shell`test`_ in the
 terminal.
 
 ```terminal
@@ -304,7 +307,7 @@ Running tests...
   1 passing (963ms)
 ```
 
-You should see an output indicating that the test passed successfully.
+Look for output that confirms the test passed successfully.
 
 You can also use the `Test` button on the left-side panel.
 
@@ -359,15 +362,14 @@ Transaction executed in slot 308150984:
 Confirmed
 ```
 
-Alternatively, you can view the transaction details on
+You can also view the transaction details on
 [SolanaFM](https://solana.fm/) or
 [Solana Explorer](https://explorer.solana.com/?cluster=devnet) by searching for
 the transaction signature (hash).
 
 <Callout>
-  Reminder to update the cluster (network) connection on the Explorer you are
-  using to match Solana Playground. Solana Playground's default cluster is
-  devnet.
+  Remember to update the cluster (network) connection on the Explorer you use
+  to match Solana Playground. Solana Playground defaults to the devnet cluster.
 </Callout>
 
 </Step>
@@ -375,8 +377,7 @@ the transaction signature (hash).
 
 ### Close Program
 
-Lastly, the SOL allocated to the on-chain program can be fully recovered by
-closing the program.
+Lastly, closing the program allows full recovery of the SOL allocated to the on-chain program.
 
 You can close a program by running the following command and specifying the
 program address found in _rs`declare_id!()`_:
@@ -395,19 +396,19 @@ Closed Program Id 2VvQ11q8xrn5tkPNyeraRsPaATdiPx8weLAD8aD4dn2r, 2.79511512 SOL r
 <Accordions>
 <Accordion title="Explanation">
 
-Only the upgrade authority of the program can close it. The upgrade authority is
-set when the program is deployed, and it's the only account with permission to
-modify or close the program. If the upgrade authority is revoked, then the
-program becomes immutable and can never be closed or updated.
+Only the upgrade authority of the program can close it. The deployment process
+sets the upgrade authority when you deploy the program. This account has exclusive permission to
+update or close the program. If someone revokes the upgrade authority, the
+program becomes immutable without any possibility for closure or updates.
 
-When deploying programs on Solana Playground, your Playground wallet is the
+When deploying programs on Solana Playground, your Playground wallet automatically becomes the
 upgrade authority for all your programs.
 
 </Accordion>
 </Accordions>
 
-Congratulations! You've just built and deployed your first Solana program using
-the Anchor framework!
+Congratulations. You've just built and deployed your first Solana program using
+the Anchor framework.
 
 </Step>
 </Steps>

--- a/content/docs/intro/quick-start/index.mdx
+++ b/content/docs/intro/quick-start/index.mdx
@@ -7,15 +7,14 @@ description:
 h1: Solana Quick Start Guide
 ---
 
-Welcome to the Solana Quick Start Guide! This hands-on guide will introduce you
-to the core concepts for building on Solana, regardless of your prior
-experience.
+Welcome to the Solana Quick Start Guide. This hands-on guide introduces you to
+the core concepts for building on Solana, regardless of your prior experience.
 
 ## What You'll Learn
 
 In this tutorial, you'll learn about:
 
-- **Solana Accounts**: Learn how data is stored on the Solana network.
+- **Solana Accounts**: Learn how the Solana network stores data.
 - **Sending Transactions**: Learn to interact with the Solana network by sending
   transactions.
 - **Building and Deploying Programs**: Create your first Solana program and
@@ -24,19 +23,19 @@ In this tutorial, you'll learn about:
   deterministic addresses for accounts.
 - **Cross-Program Invocations (CPIs)**: Learn how to call other programs from
   within your program, enabling complex interactions and composability between
-  multiple programs on Solana.
+  different programs on Solana.
 
-The best part? You don't need to install anything! We'll be using Solana
-Playground, a browser-based development environment. This means you can follow
-along, copy and paste code, and see results immediately, all from your web
-browser. Basic programming knowledge is helpful but not required.
+The best part? You don't need to install anything. This guide uses Solana
+Playground, a browser-based development environment. Follow along, copy, and
+paste code, and see results immediately, all from your web browser. Basic
+programming knowledge helps but is not required.
 
-Let's dive in and start building on Solana!
+Time to dive in and start building on Solana.
 
 ## Solana Playground
 
-Solana Playground (Solpg) is a browser-based development environment that allows
-you to quickly develop, deploy, and test Solana programs!
+Solana Playground (Solpg) provides a browser-based development environment that
+allows you to quickly develop, deploy, and test Solana programs.
 
 Open a new tab in your web browser and navigate to https://beta.solpg.io/.
 
@@ -45,9 +44,8 @@ Open a new tab in your web browser and navigate to https://beta.solpg.io/.
 
 ### Create Playground Wallet
 
-If you're new to Solana Playground, the first step is to create your Playground
-Wallet. This wallet will allow you to interact with the Solana network right
-from your browser.
+New Solana Playground users should first create a Playground Wallet. This wallet
+enables you to interact with the Solana network right from your browser.
 
 #### Step 1. Connect to Playground
 
@@ -57,7 +55,7 @@ Click the "Not connected" button at the bottom left of the screen.
 
 #### Step 2. Create Your Wallet
 
-You'll be prompted to save your wallet's keypair. Once you are ready, click
+The system prompts you to save your wallet's keypair. Once ready, click
 "Continue" to proceed.
 
 ![Create Playground Wallet](/assets/docs/intro/quickstart/pg-create-wallet.png)
@@ -68,24 +66,24 @@ You should now see your wallet's address, SOL balance, and connected cluster
 ![Connected](/assets/docs/intro/quickstart/pg-connected.png)
 
 <Callout>
-  Your Playground Wallet will be saved in your browser's local storage. Clearing
-  your browser cache will remove your saved wallet. Your Playground Wallet
-  should only be used for testing and development. Do not send real assets (from
-  mainnet) to this address.
+  Your browser's local storage saves your Playground Wallet. Clearing your
+  browser cache removes your saved wallet. Use your Playground Wallet only for
+  testing and development. Don't send real assets (from mainnet) to this
+  address.
 </Callout>
 
 Some definitions you may find helpful:
 
 - _wallet address_: a 32-byte public key from a Ed25519 keypair, generally
-  displayed as a base-58 encoded string (eg.
+  displayed as a base-58 encoded string (e.g.,
   `7MNj7pL1y7XpPnN7ZeuaE4ctwg3WeufbX5o85sA91J1`). The corresponding private key
-  is used to sign transactions from this address. On Solana, an address is the
-  unique idenifier for a user's wallet, a program (smart contract), or any other
-  account on the network.
-- _connected cluster_: the Solana network you're currently interacting with.
-  Common clusters include:
+  signs transactions from this address. On Solana, an address serves as the
+  unique identifier for a user's wallet, a program (smart contract), or any
+  other account on the network.
+- _connected cluster_: the Solana network for your current interactions. Common
+  clusters include:
   - `devnet`: A development network for developer experimentation
-  - `testnet`: A network reserved for validator testing (do not use as app
+  - `testnet`: A network reserved for validator testing (don't use as app
     developer)
   - `mainnet-beta`: The main Solana network for live transactions
 
@@ -94,14 +92,14 @@ Some definitions you may find helpful:
 
 ### Get Devnet SOL
 
-Before we start building, we need to obtain some devnet SOL.
+Before starting development, you need to get some devnet SOL.
 
-As a developer, SOL is required for two main use cases:
+As a developer, you need SOL for two main use cases:
 
 - Creating new accounts to store data or deploy programs on the network
 - Paying transaction fees when interacting with the Solana network
 
-Below are two methods to fund your wallet with devnet SOL:
+Two methods to fund your wallet with devnet SOL:
 
 #### Option 1: Using the Playground Terminal
 

--- a/content/docs/intro/quick-start/index.mdx
+++ b/content/docs/intro/quick-start/index.mdx
@@ -28,7 +28,7 @@ In this tutorial, you'll learn about:
 The best part? You don't need to install anything. This guide uses Solana
 Playground, a browser-based development environment. Follow along, copy, and
 paste code, and see results immediately, all from your web browser. Basic
-programming knowledge helps but is not required.
+programming knowledge helps but isn't required.
 
 Time to dive in and start building on Solana.
 

--- a/content/docs/intro/quick-start/program-derived-address.mdx
+++ b/content/docs/intro/quick-start/program-derived-address.mdx
@@ -9,39 +9,38 @@ description:
 h1: Program Derived Address
 ---
 
-In this section, we'll walk through how to build a basic CRUD (Create, Read,
-Update, Delete) program.
+In this section, you'll learn how to build a basic Create, Read, Update, Delete
+(CRUD) program.
 
-We'll create a simple program where users can create, update, and delete a
-message. Each message will be stored in an account with a deterministic address
+This guide demonstrates a simple program where users can create, update, and
+delete a message. Each message exists in an account with a deterministic address
 derived from the program itself (Program Derived Address or PDA).
 
-The purpose of this section is to guide you through building and testing a
-Solana program using the Anchor framework while demonstrating how to use Program
-Derived Addresses (PDAs). For more details, refer to the
-[Program Derived Addresses](/docs/core/pda) page.
+This guide walks you through building and testing a Solana program using the
+Anchor framework while demonstrating Program Derived Addresses (PDAs). For more
+details, refer to the [Program Derived Addresses](/docs/core/pda) page.
 
-For reference, here is the
+For reference, you can view the
 [final code](https://beta.solpg.io/668304cfcffcf4b13384d20a) after completing
-both the PDA and CPI sections.
+both the PDA and Cross-Program Invocation (CPI) sections.
 
 <Steps>
 <Step>
 
 ### Starter Code
 
-Begin by opening this
+Start by opening this
 [Solana Playground link](https://beta.solpg.io/66734b7bcffcf4b13384d1ad) with
-the starter code. Then click the "Import" button, which will add the program to
-your list of projects on Solana Playground.
+the starter code. Then click the "Import" button to add the program to your
+Solana Playground projects.
 
 ![Import](/assets/docs/intro/quickstart/pg-import.png)
 
 <WithMentions>
 
-In the `lib.rs` file, you'll find a program scaffolded with the
-[`create`](mention:one), [`update`](mention:two), and [`delete`](mention:three)
-instructions we'll implement in the following steps.
+In the `lib.rs` file, you'll find a program with the [`create`](mention:one),
+[`update`](mention:two), and [`delete`](mention:three) instructions to add
+in the following steps.
 
 ```rs title="lib.rs"
 use anchor_lang::prelude::*;
@@ -83,7 +82,7 @@ pub struct MessageAccount {}
 
 </WithMentions>
 
-Before we begin, run _shell`build`_ in the Playground terminal to check the
+Before beginning, run _shell`build`_ in the Playground terminal to check the
 starter program builds successfully.
 
 ```terminal
@@ -97,8 +96,9 @@ Build successful. Completed in 3.50s.
 
 ### Define Message Account Type
 
-First, let's define the structure for the message account that our program will
-create. This is the data that we'll store in the account created by the program.
+First, define the structure for the message account that the program
+creates. This structure defines the data to store in the account created by the
+program.
 
 <WithNotes>
 
@@ -119,24 +119,24 @@ pub struct MessageAccount {
 
 ### !account
 
-The _rs`#[account]`_ attribute in an Anchor program is used to annotate structs
-that represent account data (data type to store in the Account's data field).
+The _rs`#[account]`_ attribute in an Anchor program annotates structs that
+represent account data (data type to store in the Account's data field).
 
 ### !user
 
-The _rs`user`_ field is a _rs`Pubkey`_ representing the user who created the
-message account.
+The _rs`user`_ field contains a _rs`Pubkey`_ that identifies the user who
+created the message account.
 
 ### !message
 
-The _rs`message`_ field is a _rs`String`_ containing the user's message.
+The _rs`message`_ field holds a _rs`String`_ containing the user's message.
 
 ### !bump
 
-The _rs`bump`_ field is a _rs`u8`_ storing the
+The _rs`bump`_ field stores a _rs`u8`_
 ["bump" seed](/docs/core/pda#canonical-bump) used to derive a program derived
 address (PDA). Storing this value saves compute by eliminating the need to
-derive it in subsequent instructions.
+recalculate it in later instructions.
 
 </WithNotes>
 
@@ -158,24 +158,25 @@ derive it in subsequent instructions.
 </Accordion>
 <Accordion title="Explanation">
 
-The _rs`#[account]`_ attribute in an Anchor program is used to annotate structs
-that represent account data (data type to store in the Account's data field).
+The _rs`#[account]`_ attribute in an Anchor program annotates structs that
+represent account data (data type to store in the Account's data field).
 
-In this example, we're defining a _rs`MessageAccount`_ struct to store a message
-created by users that contains three fields:
+In this example, the _rs`MessageAccount`_ struct stores a message created by
+users that contains three fields:
 
-- `user` - _rs`Pubkey`_ representing the user who created the message account.
-- `message` - _rs`String`_ containing the user's message.
-- `bump` - _rs`u8`_ storing the ["bump" seed](/docs/core/pda#canonical-bump)
-  used to derive the program derived address (PDA). Storing this value saves
-  compute by eliminating the need to derive it in subsequent instructions.
+- `user` - _rs`Pubkey`_ that identifies the user who created the message
+  account.
+- `message` - _rs`String`_ that contains the user's message.
+- `bump` - _rs`u8`_ that stores the ["bump" seed](/docs/core/pda#canonical-bump)
+  for deriving the program derived address (PDA). Storing this value saves
+  compute by eliminating the need to recalculate it in later instructions.
 
-When an account is created, the _rs`MessageAccount`_ data will be serialized and
-stored in the new account's data field.
+When creating an account, the program serializes the _rs`MessageAccount`_ data
+and stores it in the new account's data field.
 
-Later, when reading from the account, this data can be deserialized back into
-the _rs`MessageAccount`_ data type. The process of creating and reading the
-account data will be demonstrated in the testing section.
+Later, when reading from the account, the program deserializes this data back
+into the _rs`MessageAccount`_ data type. The testing section demonstrates the
+process of creating and reading account data.
 
 </Accordion>
 </Accordions>
@@ -186,15 +187,15 @@ Build the program again by running _shell`build`_ in the terminal.
 $ build
 ```
 
-We've just defined what data to store on the message account. Next, we'll
-implement the program instructions.
+This code defines what data to store on the message account. Next, you'll add
+the program instructions.
 
 </Step>
 <Step>
 
-### Implement Create Instruction
+### Add Create Instruction
 
-Now, let's implement the _rs`create`_ instruction to create and initialize the
+Now, add the _rs`create`_ instruction that creates and initializes the
 _rs`MessageAccount`_.
 
 Start by defining the accounts required for the instruction by updating the
@@ -233,11 +234,11 @@ pub struct Create<'info> {
 
 ### !mut
 
-The _rs`mut`_ constraint is used to declare the account as mutable.
+The _rs`mut`_ constraint declares the account as mutable.
 
 ### !init
 
-The _rs`init`_ constraint is used to create a new account.
+The _rs`init`_ constraint creates a new account.
 
 ### !seeds
 
@@ -245,44 +246,42 @@ The _rs`seeds`_ constraint defines the optional inputs used to derive the PDA.
 
 ### !bump
 
-The _rs`bump`_ constraint is used to declare the bump seed for the PDA.
+The _rs`bump`_ constraint declares the bump seed for the PDA.
 
-If a value is not specified, then it is automatically calculated.
+If you don't specify a value, Anchor automatically calculates it.
 
 ### !payer
 
-The _rs`payer`_ constraint is used to specify the account paying for the new
-account.
+The _rs`payer`_ constraint specifies which account pays for the new account
+creation.
 
 ### !space
 
-The _rs`space`_ constraint is used to specify the number of bytes allocated to
-the new account's data field.
+The _rs`space`_ constraint specifies the number of bytes to assign for the new
+account's data field.
 
 ### !signer
 
-The _rs`Signer<'info>`_ type is used to declare the account must be a signer on
-the transaction.
+The _rs`Signer<'info>`_ type requires that the account sign the transaction.
 
 ### !account
 
-The _rs`Account<'info, T>`_ type is used to declare the account must be an
-instance of the specified type.
+The _rs`Account<'info, T>`_ type requires that the account match the specified
+type.
 
-In this case, the account must the custom _rs`MessageAccount`_ type.
+In this case, the account must match the custom _rs`MessageAccount`_ type.
 
 ### !program
 
-The _rs`Program<'info, T>`_ type is used to declare the account must be a
-program.
+The _rs`Program<'info, T>`_ type requires the account to match a program.
 
-In this case, the account must be a program of the _rs`System`_ type, which is
-the System Program.
+In this case, the account must match the _rs`System`_ type, which refers to the
+System Program.
 
 ### !instruction
 
-The _rs`#[instruction(message: String)]`_ annotation enables the _rs`Create`_
-struct to access the _rs`message`_ parameter from the `create` instruction.
+The _rs`#[instruction(message: String)]`_ annotation lets the _rs`Create`_
+struct access the _rs`message`_ parameter from the `create` instruction.
 
 </WithNotes>
 
@@ -314,22 +313,21 @@ struct to access the _rs`message`_ parameter from the `create` instruction.
 </Accordion>
 <Accordion title="Explanation">
 
-The _rs`#[derive(Accounts)]`_ attribute in an Anchor program is used to annotate
-structs that define the accounts required by an instruction.
+The _rs`#[derive(Accounts)]`_ attribute in an Anchor program annotates structs
+that define the accounts required by an instruction.
 
-Each field in the struct represents an account which is validated in two ways:
+Each field in the struct represents an account validated in two ways:
 
 1. The account type (like _rs`Signer<'info>`_ or _rs`Account<'info, T>`_) that
-   specifies what kind of account is expected
+   specifies what kind of account the program expects
 2. Optional constraints (like _rs`#[account(mut)]`_ or _rs`#[account(init)]`_)
-   that define additional requirements
+   that define extra requirements
 
-Together, these are used by Anchor to automatically validate accounts passed to
-the instruction and secure the program.
+Together, these enable Anchor to automatically verify accounts passed to the
+instruction and secure the program.
 
-The field names in the struct are used for accessing the accounts in your
-program code, but don't affect the actual validation. While you can name them
-anything, it is recommended to use descriptive names.
+The field names in the struct provide access to the accounts in your program
+code, but don't affect validation. You should use descriptive names for clarity.
 
 In this example, the _rs`Create`_ struct defines the accounts required for the
 _rs`create`_ instruction.
@@ -337,37 +335,35 @@ _rs`create`_ instruction.
 1. _rs`user: Signer<'info>`_
 
    - Represents the user creating the message account
-   - Marked as mutable (_rs`#[account(mut)]`_) as it pays for the new account
-   - Must be a signer to approve the transaction, as lamports are deducted from
-     the account
+   - Needs mutable status (_rs`#[account(mut)]`_) since it pays for the new
+     account
+   - Must sign the transaction to approve lamport deduction from this account
 
 2. _rs`message_account: Account<'info, MessageAccount>`_
 
-   - The new account created to store the user's message
-   - `init` constraint indicates the account will be created in the instruction
-   - `seeds` and `bump` constraints indicate the address of the account is a
-     Program Derived Address (PDA)
-   - `payer = user` specifies the account paying for the creation of the new
-     account
-   - `space` specifies the number of bytes allocated to the new account's data
-     field
+   - The new account that stores the user's message
+   - `init` constraint creates the account during instruction execution
+   - `seeds` and `bump` constraints derive the account address as a Program
+     Derived Address (PDA)
+   - `payer = user` identifies who pays for the creation of the new account
+   - `space` allocates the required bytes for the account's data field
 
 3. _rs`system_program: Program<'info, System>`_
 
-   - Required for creating new accounts
-   - Under the hood, the `init` constraint invokes the System Program to create
-     a new account allocated with the specified `space` and reassigns the
-     program owner to the current program.
+   - Necessary for account creation
+   - Behind the scenes, the `init` constraint calls the System Program to create
+     a new account with the specified `space` and changes the owner to the
+     current program.
 
 ---
 
-The _rs`#[instruction(message: String)]`_ annotation enables the _rs`Create`_
-struct to access the _rs`message`_ parameter from the `create` instruction.
+The _rs`#[instruction(message: String)]`_ annotation lets the _rs`Create`_
+struct access the _rs`message`_ parameter from the `create` instruction.
 
 ---
 
-The `seeds` and `bump` constraints are used together to specify that an
-account's address is a Program Derived Address (PDA).
+The `seeds` and `bump` constraints together define an account's address as a
+Program Derived Address (PDA).
 
 ```rs title="lib.rs"
 seeds = [b"message", user.key().as_ref()],
@@ -376,12 +372,12 @@ bump,
 
 The `seeds` constraint defines the optional inputs used to derive the PDA.
 
-- _rs`b"message"`_ - A hardcoded string as the first seed.
+- _rs`b"message"`_ - A fixed string as the first seed.
 - _rs`user.key().as_ref()`_ - The public key of the _rs`user`_ account as the
   second seed.
 
 The `bump` constraint tells Anchor to automatically find and use the correct
-bump seed. Anchor will use the `seeds` and `bump` to derive the PDA.
+bump seed. Anchor uses the `seeds` and `bump` to derive the PDA.
 
 ---
 
@@ -402,18 +398,18 @@ pub struct MessageAccount {
 }
 ```
 
-All accounts created through an Anchor program require 8 bytes for an account
-discriminator, which is an identifier for the account type that is automatically
-generated when the account is created.
+All accounts created through an Anchor program need 8 bytes for an account
+discriminator, which serves as an identifier for the account type that Anchor 
+automatically generates when creating the account.
 
-A _rs`String`_ type requires 4 bytes to store the length of the string, and the
-remaining length is the actual data.
+A _rs`String`_ type needs 4 bytes to store the length of the string, and the
+remaining length contains the actual data.
 
 </Accordion>
 </Accordions>
 
-Next, implement the business logic for the _rs`create`_ instruction by updating
-the `create` function with the following:
+Next, add the business logic for the _rs`create`_ instruction by updating the
+`create` function with the following:
 
 ```rs title="lib.rs"
 pub fn create(ctx: Context<Create>, message: String) -> Result<()> {
@@ -452,7 +448,7 @@ account's data. It takes two parameters:
 
 1. _rs`ctx: Context<Create>`_ - Provides access to the accounts specified in the
    _rs`Create`_ struct.
-2. _rs`message: String`_ - The user's message to be stored.
+2. _rs`message: String`_ - The user's message for storage.
 
 The body of the function then performs the following logic:
 
@@ -501,12 +497,12 @@ $ build
 </Step>
 <Step>
 
-### Implement Update Instruction
+### Add Update Instruction
 
-Next, implement the `update` instruction to update the `MessageAccount` with a
-new message.
+Next, add the `update` instruction to change the `MessageAccount` with a new
+message.
 
-Just as before, the first step is to specify the accounts required by the
+Like the previous step, first specify the accounts required by the
 `update` instruction.
 
 Update the `Update` struct with the following:
@@ -538,16 +534,16 @@ pub struct Update<'info> {
 
 ### !realloc
 
-The _rs`realloc`_ constraint is used to reallocate the account's data.
+The _rs`realloc`_ constraint reallocates the account's data.
 
 ### !realloc::payer
 
-The _rs`realloc::payer`_ constraint is used to specify the account paying for
+The _rs`realloc::payer`_ constraint specifies the account paying for
 the reallocation.
 
 ### !realloc::zero
 
-The _rs`realloc::zero`_ constraint is used to zero out the account's data.
+The _rs`realloc::zero`_ constraint zeros out the account's data.
 
 </WithNotes>
 
@@ -586,16 +582,16 @@ instruction.
 1. _rs`user: Signer<'info>`_
 
    - Represents the user updating the message account
-   - Marked as mutable (_rs`#[account(mut)]`_) as it may pay for additional
-     space for the `message_account` if needed
-   - Must be a signer to approve the transaction
+   - Marked as mutable (_rs`#[account(mut)]`_) as it might pay for more
+     space for the `message_account` when needed
+   - Must sign the transaction
 
 2. _rs`message_account: Account<'info, MessageAccount>`_
 
-   - The existing account storing the user's message that will be updated
-   - `mut` constraint indicates this account's data will be modified
-   - `realloc` constraint allows for resizing the account's data
-   - `seeds` and `bump` constraints ensure the account is the correct PDA
+   - The existing account storing the user's message for updating
+   - `mut` constraint indicates data modification for this account
+   - `realloc` constraint allows resizing of the account's data
+   - `seeds` and `bump` constraints verify the account as the correct PDA
 
 3. _rs`system_program: Program<'info, System>`_
    - Required for potential reallocation of account space
@@ -611,7 +607,7 @@ struct to access the _rs`message`_ parameter from the _rs`update`_ instruction.
 </Accordion>
 </Accordions>
 
-Next, implement the logic for the `update` instruction.
+Next, add the logic for the `update` instruction.
 
 ```rs title="lib.rs"
 pub fn update(ctx: Context<Update>, message: String) -> Result<()> {
@@ -668,9 +664,9 @@ $ build
 </Step>
 <Step>
 
-### Implement Delete Instruction
+### Add Delete Instruction
 
-Next, implement the _rs`delete`_ instruction to close the _rs`MessageAccount`_.
+Next, add the _rs`delete`_ instruction to close the _rs`MessageAccount`_.
 
 Update the _rs`Delete`_ struct with the following:
 
@@ -697,20 +693,20 @@ pub struct Delete<'info> {
 
 ### !seeds
 
-The _rs`seeds`_ constraint is used to specify the seeds used to derive the PDA.
+The _rs`seeds`_ constraint specifies the seeds used to derive the PDA.
 
 ### !bump
 
-The _rs`bump`_ constraint is used to specify the bump seed for the PDA.
+The _rs`bump`_ constraint specifies the bump seed for the PDA.
 
-In this case, we are using the existing bump seed stored on the
+In this case, the code uses the existing bump seed stored on the
 _rs`message_account`_.
 
 ### !close
 
-The _rs`close`_ constraint is used to close the account.
+The _rs`close`_ constraint closes the account.
 
-In this case, the _rs`user`_ account is the account to receive the lamports from
+In this case, the _rs`user`_ account receives the lamports from
 the closed _rs`message_account`_.
 
 </WithNotes>
@@ -746,23 +742,23 @@ instruction:
 1. _rs`user: Signer<'info>`_
 
    - Represents the user closing the message account
-   - Marked as mutable (_rs`#[account(mut)]`_) as it will receive the lamports
+   - Marked as mutable (_rs`#[account(mut)]`_) to receive the lamports
      from the closed account
-   - Must be a signer to ensure only the correct user can close their message
+   - Must sign to ensure only the correct user can close their message
      account
 
 2. _rs`message_account: Account<'info, MessageAccount>`_
 
-   - The account being closed
-   - `mut` constraint indicates this account will be modified
-   - `seeds` and `bump` constraints ensure the account is the correct PDA
-   - `close = user` constraint specifies that this account will be closed and
-     its lamports transferred to the `user` account
+   - The account for closing
+   - `mut` constraint indicates data modification
+   - `seeds` and `bump` constraints verify the account as the correct PDA
+   - `close = user` constraint marks this account for closing and
+     transfers its lamports to the `user` account
 
 </Accordion>
 </Accordions>
 
-Next, implement the logic for the `delete` instruction.
+Next, add the logic for the `delete` instruction.
 
 ```rs title="lib.rs"
 pub fn delete(_ctx: Context<Delete>) -> Result<()> {
@@ -791,13 +787,12 @@ pub fn delete(_ctx: Context<Delete>) -> Result<()> {
 The `delete` function takes one parameter:
 
 1. _rs`_ctx: Context<Delete>`_ - Provides access to the accounts specified in
-   the _rs`Delete`_ struct. The _rs`_ctx`_ syntax indicates we won't be using
-   the Context in the body of the function.
+   the _rs`Delete`_ struct. The _rs`_ctx`_ syntax shows that the function doesn't use
+   the Context in its body.
 
-The body of the function only prints a message to program logs using the
-_rs`msg!()`_ macro. The function does not require any additional logic because
-the actual closing of the account is handled by the _rs`close`_ constraint in
-the _rs`Delete`_ struct.
+The function body just prints a message to program logs using the
+_rs`msg!()`_ macro. The function needs no extra logic because
+the _rs`close`_ constraint in the _rs`Delete`_ struct handles the account closing.
 
 </Accordion>
 </Accordions>
@@ -813,7 +808,7 @@ $ build
 
 ### Deploy Program
 
-The basic CRUD program is now complete. Deploy the program by running `deploy`
+You've now completed the basic CRUD program. Deploy the program by running `deploy`
 in the Playground terminal.
 
 <Callout type="info">
@@ -834,7 +829,7 @@ Deployment successful. Completed in 17s.
 
 ### Set Up Test File
 
-Included with the starter code is also a test file in `anchor.test.ts`.
+The starter code also includes a test file in `anchor.test.ts`.
 
 ```ts title="anchor.test.ts"
 import { PublicKey } from "@solana/web3.js";
@@ -886,13 +881,13 @@ const [messagePda, messageBump] = PublicKey.findProgramAddressSync(
 </Accordion>
 <Accordion title="Explanation">
 
-In this section, we are simply setting up the test file.
+In this section, this code simply sets up the test file.
 
 <WithMentions>
 
 Solana Playground removes some boilerplate setup where
-[`pg.program`](mention:one) allows us to access the methods for interacting with
-the program, while [`pg.wallet`](mention:two) is your playground wallet.
+[`pg.program`](mention:one) allows access to methods for interacting with
+the program, while [`pg.wallet`](mention:two) gives access to your playground wallet.
 
 ```ts title="anchor.test.ts"
 // !mention one
@@ -903,8 +898,8 @@ const wallet = pg.wallet;
 
 </WithMentions>
 
-As part of the setup, we derive the message account PDA. This demonstrates how
-to derive the PDA in Javascript using the seeds specified in the program.
+As part of the setup, the code derives the message account PDA. This demonstrates how
+to derive the PDA in Javascript using the same seeds specified in the program.
 
 ```ts title="anchor.test.ts"
 const [messagePda, messageBump] = PublicKey.findProgramAddressSync(
@@ -917,7 +912,7 @@ const [messagePda, messageBump] = PublicKey.findProgramAddressSync(
 </Accordions>
 
 Run the test file by running _shell`test`_ in the Playground terminal to check
-the file runs as expected. We will implement the tests in the following steps.
+that it runs as expected. The next steps add the actual tests.
 
 ```terminal
 $ test
@@ -968,20 +963,20 @@ it("Create Message Account", async () => {
 
 ### !create
 
-The _ts`create()`_ method is used to invoke the `create` instruction.
+The _ts`create()`_ method invokes the `create` instruction.
 
 ### !accounts
 
-The _ts`accounts()`_ method is used to specify the accounts required for the
+The _ts`accounts()`_ method specifies the accounts required for the
 _ts`create()`_ instruction.
 
 ### !rpc
 
-The _ts`rpc()`_ method is used to send the transaction to the network.
+The _ts`rpc()`_ method sends the transaction to the network.
 
 ### !fetch
 
-The _ts`fetch()`_ method is used to fetch the account data from the network.
+The _ts`fetch()`_ method retrieves the account data from the network.
 
 </WithNotes>
 
@@ -1016,7 +1011,7 @@ The _ts`fetch()`_ method is used to fetch the account data from the network.
 </Accordion>
 <Accordion title="Explanation">
 
-First, we send a transaction that invokes the `create` instruction, passing in
+First, the code sends a transaction that invokes the `create` instruction, passing
 "Hello, World!" as the message.
 
 ```ts title="anchor.test.ts"
@@ -1029,7 +1024,7 @@ const transactionSignature = await program.methods
   .rpc({ commitment: "confirmed" });
 ```
 
-Once the transaction is sent and the account is created, we then fetch the
+After sending the transaction and creating the account, the code fetches the
 account using its address (`messagePda`).
 
 ```ts title="anchor.test.ts"
@@ -1039,7 +1034,7 @@ const messageAccount = await program.account.messageAccount.fetch(
 );
 ```
 
-Lastly, we log the account data and a link to view the transaction details.
+Lastly, the code logs the account data and a link to the transaction details.
 
 ```ts title="anchor.test.ts"
 console.log(JSON.stringify(messageAccount, null, 2));
@@ -1089,20 +1084,20 @@ it("Update Message Account", async () => {
 
 ### !update
 
-The _ts`update()`_ method is used to invoke the `update` instruction.
+The _ts`update()`_ method invokes the `update` instruction.
 
 ### !accounts
 
-The _ts`accounts()`_ method is used to specify the accounts required for the
+The _ts`accounts()`_ method specifies the accounts required for the
 _ts`update()`_ instruction.
 
 ### !rpc
 
-The _ts`rpc()`_ method is used to send the transaction to the network.
+The _ts`rpc()`_ method sends the transaction to the network.
 
 ### !fetch
 
-The _ts`fetch()`_ method is used to fetch the account data from the network.
+The _ts`fetch()`_ method retrieves the account data from the network.
 
 </WithNotes>
 
@@ -1137,7 +1132,7 @@ The _ts`fetch()`_ method is used to fetch the account data from the network.
 </Accordion>
 <Accordion title="Explanation">
 
-First, we send a transaction that invokes the `update` instruction, passing in
+First, the code sends a transaction invoking the `update` instruction, passing
 "Hello, Solana!" as the new message.
 
 ```ts title="anchor.test.ts"
@@ -1150,7 +1145,7 @@ const transactionSignature = await program.methods
   .rpc({ commitment: "confirmed" });
 ```
 
-Once the transaction is sent and the account is updated, we then fetch the
+After sending the transaction and updating the account, the code fetches the
 account using its address (`messagePda`).
 
 ```ts title="anchor.test.ts"
@@ -1160,7 +1155,7 @@ const messageAccount = await program.account.messageAccount.fetch(
 );
 ```
 
-Lastly, we log the account data and a link to view the transaction details.
+Lastly, the code logs the account data and a link to the transaction details.
 
 ```ts title="anchor.test.ts"
 console.log(JSON.stringify(messageAccount, null, 2));
@@ -1210,23 +1205,23 @@ it("Delete Message Account", async () => {
 
 ### !delete
 
-The _ts`delete()`_ method is used to invoke the `delete` instruction.
+The _ts`delete()`_ method invokes the `delete` instruction.
 
 ### !accounts
 
-The _ts`accounts()`_ method is used to specify the accounts required for the
+The _ts`accounts()`_ method specifies the accounts required for the
 _ts`delete()`_ instruction.
 
 ### !rpc
 
-The _ts`rpc()`_ method is used to send the transaction to the network.
+The _ts`rpc()`_ method sends the transaction to the network.
 
 ### !fetchNullable
 
-The _ts`fetchNullable()`_ method is used to fetch the account data from the
-network that may or may not exist.
+The _ts`fetchNullable()`_ method retrieves account data from the
+network that might not exist.
 
-This is used because the account is closed and the data is no longer available.
+The code uses this because the account closes and the data becomes unavailable.
 
 </WithNotes>
 
@@ -1260,8 +1255,8 @@ This is used because the account is closed and the data is no longer available.
 </Accordion>
 <Accordion title="Explanation">
 
-First, we send a transaction that invokes the `delete` instruction to close the
-message account.
+First, this code sends a transaction invoking the `delete` instruction to
+close the message account.
 
 ```ts title="anchor.test.ts"
 const transactionSignature = await program.methods
@@ -1272,9 +1267,9 @@ const transactionSignature = await program.methods
   .rpc({ commitment: "confirmed" });
 ```
 
-Once the transaction is sent and the account is closed, we attempt to fetch the
-account using its address (`messagePda`) using `fetchNullable` since we expect
-the return value to be null because the account is closed.
+After sending the transaction and closing the account, the example tries to
+fetch the account using its address (`messagePda`) with `fetchNullable`. This
+method returns null when the account no longer exists after closing.
 
 ```ts title="anchor.test.ts"
 const messageAccount = await program.account.messageAccount.fetchNullable(
@@ -1283,8 +1278,8 @@ const messageAccount = await program.account.messageAccount.fetchNullable(
 );
 ```
 
-Lastly, we log the account data and a link to view the transaction details where
-the account data should be logged as null.
+Finally, the code logs the account data and a link to the transaction
+details. The account data shows as null since the account no longer exists.
 
 ```ts title="anchor.test.ts"
 console.log(JSON.stringify(messageAccount, null, 2));
@@ -1302,7 +1297,7 @@ console.log(
 
 ### Run Test
 
-Once the tests are set up, run the test file by running _shell`test`_ in the
+After preparing your tests, run the test file with _shell`test`_ in the
 Playground terminal.
 
 ```terminal
@@ -1330,7 +1325,7 @@ Running tests...
   3 passing (3s)
 ```
 
-You can then inspect the SolanaFM links to view the transaction details.
+Inspect the SolanaFM links to view the transaction details.
 
 </Step>
 </Steps>

--- a/content/docs/intro/quick-start/program-derived-address.mdx
+++ b/content/docs/intro/quick-start/program-derived-address.mdx
@@ -39,8 +39,8 @@ Solana Playground projects.
 <WithMentions>
 
 In the `lib.rs` file, you'll find a program with the [`create`](mention:one),
-[`update`](mention:two), and [`delete`](mention:three) instructions to add
-in the following steps.
+[`update`](mention:two), and [`delete`](mention:three) instructions to add in
+the following steps.
 
 ```rs title="lib.rs"
 use anchor_lang::prelude::*;
@@ -96,9 +96,8 @@ Build successful. Completed in 3.50s.
 
 ### Define Message Account Type
 
-First, define the structure for the message account that the program
-creates. This structure defines the data to store in the account created by the
-program.
+First, define the structure for the message account that the program creates.
+This structure defines the data to store in the account created by the program.
 
 <WithNotes>
 
@@ -399,7 +398,7 @@ pub struct MessageAccount {
 ```
 
 All accounts created through an Anchor program need 8 bytes for an account
-discriminator, which serves as an identifier for the account type that Anchor 
+discriminator, which serves as an identifier for the account type that Anchor
 automatically generates when creating the account.
 
 A _rs`String`_ type needs 4 bytes to store the length of the string, and the
@@ -502,8 +501,8 @@ $ build
 Next, add the `update` instruction to change the `MessageAccount` with a new
 message.
 
-Like the previous step, first specify the accounts required by the
-`update` instruction.
+Like the previous step, first specify the accounts required by the `update`
+instruction.
 
 Update the `Update` struct with the following:
 
@@ -538,8 +537,8 @@ The _rs`realloc`_ constraint reallocates the account's data.
 
 ### !realloc::payer
 
-The _rs`realloc::payer`_ constraint specifies the account paying for
-the reallocation.
+The _rs`realloc::payer`_ constraint specifies the account paying for the
+reallocation.
 
 ### !realloc::zero
 
@@ -582,8 +581,8 @@ instruction.
 1. _rs`user: Signer<'info>`_
 
    - Represents the user updating the message account
-   - Marked as mutable (_rs`#[account(mut)]`_) as it might pay for more
-     space for the `message_account` when needed
+   - Marked as mutable (_rs`#[account(mut)]`_) as it might pay for more space
+     for the `message_account` when needed
    - Must sign the transaction
 
 2. _rs`message_account: Account<'info, MessageAccount>`_
@@ -699,15 +698,15 @@ The _rs`seeds`_ constraint specifies the seeds used to derive the PDA.
 
 The _rs`bump`_ constraint specifies the bump seed for the PDA.
 
-In this case, the code uses the existing bump seed stored on the
+In this case, the program uses the existing bump seed stored on the
 _rs`message_account`_.
 
 ### !close
 
 The _rs`close`_ constraint closes the account.
 
-In this case, the _rs`user`_ account receives the lamports from
-the closed _rs`message_account`_.
+In this case, the _rs`user`_ account receives the lamports from the closed
+_rs`message_account`_.
 
 </WithNotes>
 
@@ -742,18 +741,17 @@ instruction:
 1. _rs`user: Signer<'info>`_
 
    - Represents the user closing the message account
-   - Marked as mutable (_rs`#[account(mut)]`_) to receive the lamports
-     from the closed account
-   - Must sign to ensure only the correct user can close their message
-     account
+   - Marked as mutable (_rs`#[account(mut)]`_) to receive the lamports from the
+     closed account
+   - Must sign to ensure only the correct user can close their message account
 
 2. _rs`message_account: Account<'info, MessageAccount>`_
 
    - The account for closing
    - `mut` constraint indicates data modification
    - `seeds` and `bump` constraints verify the account as the correct PDA
-   - `close = user` constraint marks this account for closing and
-     transfers its lamports to the `user` account
+   - `close = user` constraint marks this account for closing and transfers its
+     lamports to the `user` account
 
 </Accordion>
 </Accordions>
@@ -787,12 +785,12 @@ pub fn delete(_ctx: Context<Delete>) -> Result<()> {
 The `delete` function takes one parameter:
 
 1. _rs`_ctx: Context<Delete>`_ - Provides access to the accounts specified in
-   the _rs`Delete`_ struct. The _rs`_ctx`_ syntax shows that the function doesn't use
-   the Context in its body.
+   the _rs`Delete`_ struct. The _rs`_ctx`_ syntax shows that the function
+   doesn't use the Context in its body.
 
-The function body just prints a message to program logs using the
-_rs`msg!()`_ macro. The function needs no extra logic because
-the _rs`close`_ constraint in the _rs`Delete`_ struct handles the account closing.
+The function body just prints a message to program logs using the _rs`msg!()`_
+macro. The function needs no extra logic because the _rs`close`_ constraint in
+the _rs`Delete`_ struct handles the account closing.
 
 </Accordion>
 </Accordions>
@@ -808,8 +806,8 @@ $ build
 
 ### Deploy Program
 
-You've now completed the basic CRUD program. Deploy the program by running `deploy`
-in the Playground terminal.
+You've now completed the basic CRUD program. Deploy the program by running
+`deploy` in the Playground terminal.
 
 <Callout type="info">
 
@@ -886,8 +884,9 @@ In this section, this code simply sets up the test file.
 <WithMentions>
 
 Solana Playground removes some boilerplate setup where
-[`pg.program`](mention:one) allows access to methods for interacting with
-the program, while [`pg.wallet`](mention:two) gives access to your playground wallet.
+[`pg.program`](mention:one) allows access to methods for interacting with the
+program, while [`pg.wallet`](mention:two) gives access to your playground
+wallet.
 
 ```ts title="anchor.test.ts"
 // !mention one
@@ -898,8 +897,9 @@ const wallet = pg.wallet;
 
 </WithMentions>
 
-As part of the setup, the code derives the message account PDA. This demonstrates how
-to derive the PDA in Javascript using the same seeds specified in the program.
+As part of the setup, the test file derives the message account PDA. This
+demonstrates how to derive the PDA in Javascript using the same seeds specified
+in the program.
 
 ```ts title="anchor.test.ts"
 const [messagePda, messageBump] = PublicKey.findProgramAddressSync(
@@ -1011,8 +1011,8 @@ The _ts`fetch()`_ method retrieves the account data from the network.
 </Accordion>
 <Accordion title="Explanation">
 
-First, the code sends a transaction that invokes the `create` instruction, passing
-"Hello, World!" as the message.
+First, the test file sends a transaction that invokes the `create` instruction,
+passing "Hello, World!" as the message.
 
 ```ts title="anchor.test.ts"
 const message = "Hello, World!";
@@ -1024,8 +1024,8 @@ const transactionSignature = await program.methods
   .rpc({ commitment: "confirmed" });
 ```
 
-After sending the transaction and creating the account, the code fetches the
-account using its address (`messagePda`).
+After sending the transaction and creating the account, the test file fetches
+the account using its address (`messagePda`).
 
 ```ts title="anchor.test.ts"
 const messageAccount = await program.account.messageAccount.fetch(
@@ -1034,7 +1034,8 @@ const messageAccount = await program.account.messageAccount.fetch(
 );
 ```
 
-Lastly, the code logs the account data and a link to the transaction details.
+Lastly, the test file logs the account data and a link to the transaction
+details.
 
 ```ts title="anchor.test.ts"
 console.log(JSON.stringify(messageAccount, null, 2));
@@ -1132,7 +1133,7 @@ The _ts`fetch()`_ method retrieves the account data from the network.
 </Accordion>
 <Accordion title="Explanation">
 
-First, the code sends a transaction invoking the `update` instruction, passing
+First, test file sends a transaction invoking the `update` instruction, passing
 "Hello, Solana!" as the new message.
 
 ```ts title="anchor.test.ts"
@@ -1145,8 +1146,8 @@ const transactionSignature = await program.methods
   .rpc({ commitment: "confirmed" });
 ```
 
-After sending the transaction and updating the account, the code fetches the
-account using its address (`messagePda`).
+After sending the transaction and updating the account, the test file fetches
+the account using its address (`messagePda`).
 
 ```ts title="anchor.test.ts"
 const messageAccount = await program.account.messageAccount.fetch(
@@ -1155,7 +1156,8 @@ const messageAccount = await program.account.messageAccount.fetch(
 );
 ```
 
-Lastly, the code logs the account data and a link to the transaction details.
+Lastly, the test file logs the account data and a link to the transaction
+details.
 
 ```ts title="anchor.test.ts"
 console.log(JSON.stringify(messageAccount, null, 2));
@@ -1218,10 +1220,11 @@ The _ts`rpc()`_ method sends the transaction to the network.
 
 ### !fetchNullable
 
-The _ts`fetchNullable()`_ method retrieves account data from the
-network that might not exist.
+The _ts`fetchNullable()`_ method retrieves account data from the network that
+might not exist.
 
-The code uses this because the account closes and the data becomes unavailable.
+The test file uses this because the account closes and the data becomes
+unavailable.
 
 </WithNotes>
 
@@ -1255,8 +1258,8 @@ The code uses this because the account closes and the data becomes unavailable.
 </Accordion>
 <Accordion title="Explanation">
 
-First, this code sends a transaction invoking the `delete` instruction to
-close the message account.
+First, this code sends a transaction invoking the `delete` instruction to close
+the message account.
 
 ```ts title="anchor.test.ts"
 const transactionSignature = await program.methods
@@ -1278,7 +1281,7 @@ const messageAccount = await program.account.messageAccount.fetchNullable(
 );
 ```
 
-Finally, the code logs the account data and a link to the transaction
+Finally, the test file logs the account data and a link to the transaction
 details. The account data shows as null since the account no longer exists.
 
 ```ts title="anchor.test.ts"

--- a/content/docs/intro/quick-start/reading-from-network.mdx
+++ b/content/docs/intro/quick-start/reading-from-network.mdx
@@ -7,37 +7,35 @@ description:
   library.
 ---
 
-Now, let's explore how to read data from the Solana network. We'll fetch a few
+This guide explores how to read data from the Solana network by fetching
 different accounts to understand the structure of a Solana account.
 
-On Solana, all data is contained in what we call "accounts". You can think of
-data on Solana as a public database with a single "Accounts" table, where each
-entry in this table is an individual account with the same base
+On Solana, all data exists in "accounts". You can think of data on Solana as a
+public database with a single "Accounts" table, where each entry in this table
+represents an individual account with the same base
 [Account type](https://github.com/anza-xyz/agave/blob/v2.1.11/sdk/account/src/lib.rs#L48-L60).
 
 ![Accounts](/assets/docs/core/accounts/accounts.png)
 
-Accounts on Solana can store "state" or "executable" programs, all of which can
-be thought of as entries in the same "Accounts" table. Each account has an
-"address" (public key) that serves as its unique ID used to locate its
+Accounts on Solana can store "state" or "executable" programs. Each account has
+an "address" (public key) that serves as its unique ID used to locate its
 corresponding on-chain data.
 
 Solana accounts contain either:
 
-- State: This is data that's meant to be read from and persisted. It could be
-  information about tokens, user data, or any other type of data defined within
-  a program.
-- Executable Programs: These are accounts that contain the actual code of Solana
-  programs. They contain the instructions that can be executed on the network.
+- State: Data meant for reading and persistence. This includes information about
+  tokens, user data, or other data defined within a program.
+- Executable Programs: Accounts containing the actual code of Solana programs.
+  These accounts store instructions that the network executes.
 
-This separation of program code and program state is a key feature of Solana's
+This separation of program code and program state forms a key feature of Solana's
 Account Model. For more details, refer to the
 [Solana Account Model](/docs/core/accounts) page.
 
 ## Fetch Playground Wallet
 
-Let's start by looking at a familiar account - your own Playground Wallet! We'll
-fetch this account and examine its structure to understand what a basic Solana
+Next, you can look at a familiar account - your own Playground Wallet. This example
+fetches this account and examines its structure to understand what a basic Solana
 account looks like.
 
 <Steps>
@@ -111,31 +109,31 @@ in the terminal.
 <Accordions>
 <Accordion title="Explanation">
 
-Your wallet is actually an account owned by the
+Your wallet appears as an account owned by the
 [System Program](https://github.com/anza-xyz/agave/tree/v2.1.11/programs/system),
-one of Solana's native programs. The main purpose of the wallet account is to
-store your SOL balance (amount in the `lamports` field).
+one of Solana's native programs. The main purpose of the wallet account involves
+storing your SOL balance (amount in the `lamports` field).
 
-At its core, all Solana accounts are just bytes that deserialize into the same
+At their core, all Solana accounts consist of bytes that deserialize into the same
 base
 [Account type](https://github.com/anza-xyz/agave/blob/v2.1.11/sdk/account/src/lib.rs#L48-L60).
 
-Let's break down the fields in the output:
+The fields in the output include:
 
-- `data` - This field contains what we generally refer to as the account "data".
-  For a wallet, it's empty (0 bytes), but other accounts use this field to store
-  any arbitrary data as a serialized buffer of bytes.
+- `data` - The field containing the account "data".
+  For a wallet, this remains empty (0 bytes), but other accounts use this field to store
+  arbitrary data as a serialized buffer of bytes.
 
-- `executable` - A flag that indicates whether the account is an executable
-  program. For wallets and any accounts that store state, this is `false`.
-- `owner` - This field shows which program controls the account. For wallets,
-  it's always the System Program, with the address
+- `executable` - A flag indicating whether the account functions as an executable
+  program. For wallets and accounts that store state, this shows `false`.
+- `owner` - The field showing which program controls the account. For wallets,
+  the System Program always appears as the owner, with the address
   `11111111111111111111111111111111`.
 - `lamports` - The account's balance in lamports (1 SOL = 1,000,000,000
   lamports).
 - `rentEpoch` - A legacy field related to Solana's deprecated rent collection
-  mechanism (currently not in use).
-- `space` - Indicates byte capacity (length) of the `data` field (not a field in
+  mechanism (currently unused).
+- `space` - The byte capacity (length) of the `data` field (not a field in
   the `Account` type)
 
 </Accordion>
@@ -146,7 +144,7 @@ Let's break down the fields in the output:
 
 ## Fetch Token Program
 
-Next, we'll examine the Token Extensions program, an executable program for
+Next, this guide examines the Token Extensions program, an executable program for
 interacting with tokens on Solana.
 
 <Steps>
@@ -167,7 +165,7 @@ const accountInfo = await pg.connection.getAccountInfo(address);
 console.log(JSON.stringify(accountInfo, null, 2));
 ```
 
-Instead of fetching your Playground wallet, here we fetch the Token Extensions
+Instead of fetching your Playground wallet, this example fetches the Token Extensions
 Program account.
 
 </Step>
@@ -206,18 +204,17 @@ account.
 <Accordions>
 <Accordion title="Explanation">
 
-The Token Extensions program is an executable program account, but note that it
-has the same `Account` structure.
+The Token Extensions program functions as an executable program account, maintaining 
+the same `Account` structure.
 
-Key differences to note from the output:
+Key differences from the output:
 
-- `executable` - Set to `true`, indicating this account represents an executable
-  program.
+- `executable` - Set to `true`, indicating an executable program account.
 - `data` - Contains serialized data (unlike the empty data in a wallet account).
   The data for a program account stores the address of another account (Program
-  Executable Data Account) that contains the program's bytecode.
-- `owner` - The account is owned by the Upgradable BPF Loader
-  (`BPFLoaderUpgradeab1e11111111111111111111111`), a native program that manages
+  Executable Data Account) containing the program's bytecode.
+- `owner` - The Upgradable Berkeley Packet Filter (BPF) Loader
+  (`BPFLoaderUpgradeab1e11111111111111111111111`) owns this account, functioning as a native program that manages
   executable accounts.
 
 You can inspect the Solana Explorer for the
@@ -237,7 +234,7 @@ Extensions Program
 
 ## Fetch Mint Account
 
-In this step, we'll examine a Mint account, which represents a unique token on
+In this step, the guide examines a Mint account, which represents a unique token on
 the Solana network.
 
 <Steps>
@@ -258,7 +255,7 @@ const accountInfo = await pg.connection.getAccountInfo(address);
 console.log(JSON.stringify(accountInfo, null, 2));
 ```
 
-In this example, we'll fetch the address of an existing Mint account on devnet.
+In this example, the code fetches the address of an existing Mint account on devnet.
 
 </Step>
 <Step>
@@ -293,10 +290,10 @@ Running client...
 <Accordions>
 <Accordion title="Explanation">
 
-Key differences to note from the output:
+Key differences from the output:
 
-- `owner` - The mint account is owned by the Token Extensions program
-  (`TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`).
+- `owner` - The Token Extensions program
+  (`TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`) owns the mint account.
 - `executable` - Set to `false`, as this account stores state rather than
   executable code.
 - `data`: Contains serialized data about the token (mint authority, supply,
@@ -310,9 +307,9 @@ Key differences to note from the output:
 
 ### Deserialize Mint Account Data
 
-An account's `data` field contains bytes that need to be further deserialized
-into the expected data type. The structure of this data is defined by the
-program that owns the account.
+An account's `data` field contains bytes requiring further deserialization
+into the expected data type. The program that owns the account 
+defines this data structure.
 
 To help with deserialization, most program developers provide helper functions
 in their client libraries that handle converting the raw bytes into the
@@ -400,15 +397,15 @@ You should see the following deserialized Mint account data.
 
 The `getMint` function deserializes the account data into the
 [Mint](https://github.com/solana-labs/solana-program-library/blob/b1c44c171bc95e6ee74af12365cb9cbab68be76c/token/program/src/state.rs#L18-L32)
-data type defined in the Token Extensions program source code.
+data type from the Token Extensions program source code.
 
 - `address` - The Mint account's address
 - `mintAuthority` - The authority allowed to mint new tokens
 - `supply` - The total supply of tokens
 - `decimals` - The number of decimal places for the token
-- `isInitialized` - Whether the Mint data has been initialized
+- `isInitialized` - Whether the program initialized the Mint data
 - `freezeAuthority` - The authority allowed to freeze token accounts
-- `tlvData` - Additional data for Token Extensions (requires further
+- `tlvData` - Extra data for Token Extensions (requires further
   deserialization)
 
 You can view the fully deserialized

--- a/content/docs/intro/quick-start/writing-to-network.mdx
+++ b/content/docs/intro/quick-start/writing-to-network.mdx
@@ -6,36 +6,36 @@ description:
   new tokens using the System Program and Token Extensions Program.
 ---
 
-In the previous section, we learned how to read data from the Solana network.
-Now let's explore how to write data to it. Writing to the Solana network
-involves sending transactions that contain one or more instructions.
+In the previous section, you learned how to read data from the Solana network.
+Now explore how to write data to it. Writing to the Solana network involves
+sending transactions that contain one or more instructions.
 
-These instructions are processed by programs (smart contracts) that contain the
+Programs (smart contracts) process these instructions according to their
 business logic for each respective instruction. When you submit a transaction,
 the Solana runtime executes each instruction in sequence and atomically (meaning
 either all instructions succeed or the entire transaction fails).
 
-In this section, we'll walk through two basic examples:
+In this section, you'll see two basic examples:
 
 1. Transferring SOL between accounts
 2. Creating a new token
 
-These examples demonstrate how to build and send transactions to invoke Solana
+These examples show how to build and send transactions to invoke Solana
 programs. For more details, refer to the
 [Transactions and Instructions](/docs/core/transactions) and
 [Fees on Solana](/docs/core/fees) pages.
 
 ## Transfer SOL
 
-Let's start with a simple example of transferring SOL between accounts. To
-transfer SOL from our Playground wallet, we need to invoke the System Program's
+Start with a simple example of transferring SOL between accounts. To transfer
+SOL from the Playground wallet, you need to invoke the System Program's
 [transfer](https://github.com/anza-xyz/agave/blob/v2.1.11/programs/system/src/system_processor.rs#L183-L213)
 instruction.
 
-A key concept of Solana's account model is that only the program that owns an
-account can deduct an account's lamport (SOL) balance. This means if you want to
-transfer SOL from a wallet account, you must invoke the System Program since it
-is the program specified in the
+A key concept of Solana's account model requires that only the program that owns
+an account can deduct an account's lamport (SOL) balance. This means if you want
+to transfer SOL from a wallet account, you must invoke the System Program since
+it appears as the program owner in the
 [owner](https://github.com/anza-xyz/agave/blob/v2.1.11/sdk/account/src/lib.rs#L55)
 field of the account.
 
@@ -196,14 +196,13 @@ explorer.
 
 ![Transfer SOL](/assets/docs/intro/quickstart/transfer-sol.png)
 
-Congratulations! You've just sent your first transaction on Solana! Let's break
-down what happened:
+Congratulations. You've just sent your first transaction on Solana.
 
-- First, we created an instruction specifying what we wanted to do
-- Then, we added that instruction to a transaction
-- Finally, we sent the transaction to be processed by the Solana network
+- First, you created an instruction specifying what to do
+- Then, you added that instruction to a transaction
+- Finally, you sent the transaction for the Solana network to process
 
-This is the basic pattern for building transactions to interact with the
+This represents the basic pattern for building transactions to interact with the
 programs on the Solana.
 
 </Step>
@@ -211,8 +210,8 @@ programs on the Solana.
 
 ## Create a Token
 
-Next, let's create a new token using the Token Extensions Program. This requires
-two invoking instructions:
+Next, create a new token using the Token Extensions Program. This requires
+invoking two instructions:
 
 1. Create a new account using the System Program
 2. Initialize the account's data as a Mint using the Token Extensions Program
@@ -251,7 +250,7 @@ const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
 // !tooltip[/mint/] mint
 const mint = new Keypair();
 
-// Calculate minimum lamports for space required by mint account
+// Calculate lamports for space required by mint account
 // !tooltip[/rentLamports/] rentLamports
 const rentLamports = await getMinimumBalanceForRentExemptMint(connection);
 
@@ -309,11 +308,11 @@ Define `wallet` as the Playground wallet.
 
 ### !mint
 
-Generate a new keypair to use as the address of the Mint account we will create.
+Generate a new keypair to use as the address of the Mint account to create.
 
 ### !rentLamports
 
-Calculate the minimum lamports needed for a Mint account.
+Calculate the lamports needed for a Mint account.
 
 ### !createAccountInstruction
 
@@ -329,8 +328,8 @@ type.
 
 Create new transaction and add both instructions.
 
-The order of instructions is relevant here. The `createAccountInstruction` must
-be invoked before the `initializeMintInstruction`.
+The order of instructions matters here. The `createAccountInstruction` must come
+before the `initializeMintInstruction`.
 
 ### !sendAndConfirmTransaction
 
@@ -356,7 +355,7 @@ This example does the following:
   const mint = new Keypair();
   ```
 
-- Calculates the minimum lamports needed for a Mint account
+- Calculates the lamports needed for a Mint account
 
   ```ts
   const rentLamports = await getMinimumBalanceForRentExemptMint(connection);
@@ -420,8 +419,8 @@ This example does the following:
 - Sends and confirms the transaction with [two required signers](mention:one):
 
   1. The wallet keypair to pay for account creation and transaction fee
-  2. The mint keypair because we're creating a new account using its public key
-     as the address of the account
+  2. The mint keypair to create a new account using its public key as the
+     address of the account
 
   ```ts
   const transactionSignature = await sendAndConfirmTransaction(
@@ -487,16 +486,16 @@ account on SolanaFM.
 
 ![Mint Account](/assets/docs/intro/quickstart/mint-account.png)
 
-In this example, we demonstrated how to combine multiple instructions into a
-single transaction. The transaction contains two key instructions:
+In this example, you saw how to combine instructions into a single transaction.
+The transaction contains two key instructions:
 
 1. Creating a new account using the System Program
 2. Initializing that account as a token mint using the Token Extensions Program
 
-This pattern of combining multiple instructions from different programs into one
-transaction is common when building more complex Solana transactions. It allows
-you to sequentially and atomically execute multiple instructions, ensuring they
-either all succeed or all fail together.
+This pattern of combining instructions from different programs into one
+transaction occurs frequently when building complex Solana transactions. It
+allows sequential and atomic execution of instructions, ensuring they either all
+succeed or all fail together.
 
 </Step>
 </Steps>


### PR DESCRIPTION
- use [vale](https://vale.sh/docs) to lint content wording in quickstart section