### PR TITLE
docs: fix link causing issue on mobile

### DIFF
--- a/content/guides/advanced/verified-builds.mdx
+++ b/content/guides/advanced/verified-builds.mdx
@@ -531,9 +531,8 @@ solana-verify export-pda-tx https://github.com/solana-developers/verify-squads -
 
 Submit the transaction through Squads again.
 
-You can see an example transaction here:
-
-https://solana.fm/tx/4zJ1vK2KToAwxuEYzTMLqPkcebjoi9rdeeyxtEEx9L5Q4vWDA8h6Rr4kPRuRxcV7ZLKMr6qx1LTWb6x3ZpUJaFUW?cluster=mainnet-alpha
+You can see an example transaction
+[here](https://solana.fm/tx/4zJ1vK2KToAwxuEYzTMLqPkcebjoi9rdeeyxtEEx9L5Q4vWDA8h6Rr4kPRuRxcV7ZLKMr6qx1LTWb6x3ZpUJaFUW?cluster=mainnet-alpha).
 
 Then submit for another remote build:
 


### PR DESCRIPTION
- long link on verified build page caused mobile to display page incorrectly