### PR TITLE
Correct `commitment` property of `getBlockCommitment`

### DIFF
--- a/content/docs/rpc/http/getblockcommitment.mdx
+++ b/content/docs/rpc/http/getblockcommitment.mdx
@@ -24,7 +24,7 @@ The result field will be a JSON object containing:
   - `<null>` - Unknown block
   - `<array>` - commitment, array of u64 integers logging the amount of cluster
     stake in lamports that has voted on the block at each depth from 0 to
-    `MAX_LOCKOUT_HISTORY` + 1
+    `MAX_LOCKOUT_HISTORY`
 - `totalStake` - total active stake, in lamports, of the current epoch
 
 </DocLeftSide>


### PR DESCRIPTION
### Problem

The `commitment` array refers to how much stake has lent 1-32 confirmations to a block. The array is 32 items long. This would imply that the depth ranges from 0 to 31 (zero-indexed) – not 0 to 32 as implied by the docs.

### Summary of Changes

Remove the “+ 1”