### PR TITLE
Update installation.mdx

### DIFF
--- a/content/docs/intro/installation.mdx
+++ b/content/docs/intro/installation.mdx
@@ -249,12 +249,37 @@ export PATH="/Users/test/.local/share/solana/install/active_release/bin:$PATH"
 <Tabs groupId="language" items={["Linux", "Mac"]}>
 <Tab value="Linux">
 
-If you use Linux or WSL, you can add the `PATH` environment variable to your
-shell configuration file by running the command logged from the installation or
-by restarting your terminal.
+
+If you are using **Linux** or **WSL**, you need to add the Solana CLI binary 
+to your `PATH` so that the command is available in your terminal.
+
+First, run the following command to check which shell you are using:
+```terminal
+$ echo $SHELL
+```
+- If the output contains `/bash`, use `.bashrc`.
+- If the output contains `/zsh`, use `.zshrc`.
+
+Depending on your shell, run the appropriate command.
+
+For Bash (`bashrc`):
+```terminal
+$ echo 'export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"' >> ~/.bashrc
+$ source ~/.bashrc
+```
+
+For Zsh (`zshrc`):
+```terminal
+$ echo 'export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"' >> ~/.zshrc
+$ source ~/.zshrc
+```
+
+Then run the following command to refresh the terminal session or restart your
+terminal.
 
 ```terminal
-$ export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
+$ source ~/.bashrc # If using Bash
+$ source ~/.zshrc # If using Zsh
 ```
 
 </Tab>


### PR DESCRIPTION
### Problem
Faced an issue when installing the solana cli as per the installation steps in the current documentation at [https://solana.com/docs/intro/installation#install-the-solana-cli](https://solana.com/docs/intro/installation#install-the-solana-cli)

The command given for adding the solana cli binary is incomplete.  The given command has to be run everytime one opens the terminal to access solana-cli as the command isn't writing to bashrc file.

### Summary of Changes
Completed the command and added more directions to make it easy for the user.