### PR TITLE
`end_slot` in `getBlocks` represents slots, not blocks

### DIFF
--- a/content/docs/rpc/http/getblocks.mdx
+++ b/content/docs/rpc/http/getblocks.mdx
@@ -43,7 +43,7 @@ Configuration object containing the following fields:
 
 The result field will be an array of u64 integers listing confirmed blocks
 between `start_slot` and either `end_slot` - if provided, or latest confirmed
-block, inclusive. Max range allowed is 500,000 slots.
+slot, inclusive. Max range allowed is 500,000 slots.
 
 </DocLeftSide>
 


### PR DESCRIPTION
I didn't read the code, but this property is supposed to represent the latest confirmed _slot_, not the latest confirmed _block_, right? I presume that this is correct because a slot can be confirmed but have had no block produced during it.