### PR TITLE
Improve locale path transformation logic in sitemap configuration

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   siteUrl: "https://solana.com/",
   transform: (config, path) => {
-    // remove the "en" locale from the path
-    const loc = path == "/en" ? "/" : path.replace("/en/", "/");
+    // Remove the "en" locale from the path
+    const loc = path.startsWith("/en/") ? path.replace("/en/", "/") : path === "/en" ? "/" : path;
     return {
       loc,
       changefreq: config.changefreq,


### PR DESCRIPTION
Optimized the locale removal logic in the transform function by replacing the direct equality check (path == "/en") with .startsWith("/en/"). This ensures that any paths starting with /en/ are correctly transformed while maintaining support for the root /en case. The updated logic is more robust and prevents potential issues where /en/ appears in different positions within the path. This improves the reliability of the sitemap URL generation.