### PR TITLE
update transfer fee flag

### DIFF
--- a/content/guides/token-extensions/getting-started.mdx
+++ b/content/guides/token-extensions/getting-started.mdx
@@ -48,7 +48,7 @@ are the flags to add to create tokens with each type of extension.
 | Extension                                                                        | CLI Flag                                  |
 | -------------------------------------------------------------------------------- | ----------------------------------------- |
 | [Mint Close Authority](/developers/guides/token-extensions/mint-close-authority) | --enable-close                            |
-| [Transfer Fees](/developers/guides/token-extensions/transfer-fee)                | --transfer-fee \<basis points> \<max fee> |
+| [Transfer Fees](/developers/guides/token-extensions/transfer-fee)                | --transfer-fee-basis-points \<basis points> --transfer-fee-maximum-fee \<max fee> |
 | [Non-Transferable](/developers/guides/token-extensions/non-transferable)         | --enable-non-transferable                 |
 | [Interest-Bearing](/developers/guides/token-extensions/interest-bearing-tokens)  | --interest-rate \<rate>                   |
 | [Permanent Delegate](/developers/guides/token-extensions/permanent-delegate)     | --enable-permanent-delegate               |


### PR DESCRIPTION
### Problem

In the Token Extensions Getting Started, the current stated flag for Transfer Fees is deprecated.
For more details, see #356. 


### Summary of Changes

Update the mentioned flag from

```
--transfer-fee \<basis points> \<max fee>
``` 

to

```
--transfer-fee-basis-points \<basis points> --transfer-fee-maximum-fee \<max fee>
```


Fixes #356