### PR TITLE
Note that reward data can't be refused when using `getTransaction()`

### DIFF
--- a/content/docs/rpc/http/gettransaction.mdx
+++ b/content/docs/rpc/http/gettransaction.mdx
@@ -102,8 +102,8 @@ Encoding for the returned Transaction
     - DEPRECATED: `status: <object>` - Transaction status
       - `"Ok": <null>` - Transaction was successful
       - `"Err": <ERR>` - Transaction failed with TransactionError
-    - `rewards: <array|null>` - transaction-level rewards, populated if rewards
-      are requested; an array of JSON objects containing:
+    - `rewards: <array|null>` - transaction-level rewards; an array of JSON 
+      objects containing:
       - `pubkey: <string>` - The public key, as base-58 encoded string, of the
         account that received the reward
       - `lamports: <i64>`- number of reward lamports credited or debited by the


### PR DESCRIPTION
I'm pretty sure that the `getTransaction()` API does not have a `rewards` property like `getBlock()` does.