### PR TITLE
docs: remove duplicate text in rpc transaction metadata description

### DIFF
--- a/content/docs/rpc/json-structures.mdx
+++ b/content/docs/rpc/json-structures.mdx
@@ -235,8 +235,8 @@ information:
   enabled during this transaction
 - `logMessages: <array|null>` - array of string log messages or `null` if log
   message recording was not enabled during this transaction
-- `rewards: <array|null>` - transaction-level rewards, populated if rewards are
-  requested; an array of JSON objects containing:
+- `rewards: <array|null>` - transaction-level rewards; an array of JSON objects
+  containing:
   - `pubkey: <string>` - The public key, as base-58 encoded string, of the
     account that received the reward
   - `lamports: <i64>`- number of reward lamports credited or debited by the
@@ -270,18 +270,6 @@ information:
 - `signatures: <array>` - present if "signatures" are requested for transaction
   details; an array of signatures strings, corresponding to the transaction
   order in the block
-- `rewards: <array|null>` - transaction-level rewards; an array of JSON objects
-  containing:
-  - `pubkey: <string>` - The public key, as base-58 encoded string, of the
-    account that received the reward
-  - `lamports: <i64>`- number of reward lamports credited or debited by the
-    account, as a i64
-  - `postBalance: <u64>` - account balance in lamports after the reward was
-    applied
-  - `rewardType: <string|undefined>` - type of reward: "fee", "rent", "voting",
-    "staking"
-  - `commission: <u8|undefined>` - vote account commission when the reward was
-    credited, only present for voting and staking rewards
 
 ## Inner Instructions
 


### PR DESCRIPTION
- duplicate text