### PR TITLE
Docs - core/accounts and core/programs

### DIFF
--- a/content/docs/core/accounts.mdx
+++ b/content/docs/core/accounts.mdx
@@ -27,11 +27,9 @@ entry in this table is an individual account with the same base
   [owner](https://github.com/anza-xyz/agave/blob/v2.1.13/sdk/account/src/lib.rs#L55).
   Only the program that owns an account can modify its data or deduct its
   lamport balance. However, anyone can increase the balance.
-- **Programs** (smart contracts) are stateless accounts that store executable
-  code.
-- **Data accounts** are created by programs to store and manage program state.
-- **Native programs** are built-in programs included with the Solana runtime.
 - **Sysvar accounts** are special accounts that store network cluster state.
+- **Program accounts** store the executable code of smart contracts.
+- **Data accounts** are created by programs to store and manage program state.
 
 ## Account
 
@@ -70,7 +68,7 @@ Every Account on Solana has the following fields:
   read-only. For program accounts (smart contracts), this contains the
   executable program code. The data field is commonly referred to as "account
   data".
-- `executable`: A boolean flag that indicates if the account is a program.
+- `executable`: This boolean flag used to indicate if an account was a program.
 - `lamports`: The account's balance in lamports, the smallest unit of SOL (1 SOL
   = 1 billion lamports).
 - `owner`: The program ID (public key) of the program that owns this account.
@@ -96,17 +94,6 @@ pub struct Account {
 }
 ```
 
-### Program Owner
-
-Program ownership is a key aspect of the Solana Account Model. Every account has
-a designated program as its owner. Only the owner program can:
-
-- Modify the account's `data` field
-- Deduct lamports from the account's balance
-
-Any modifications to an account's data or lamport balance must be done through
-instructions explicitly defined in the owner program's code.
-
 ### Rent
 
 To store data on-chain, accounts must also maintain a minimum lamport (SOL)
@@ -122,27 +109,16 @@ The term "rent" is due to a deprecated mechanism that regularly deducted
 lamports from accounts that fell below the rent threshold. This mechanism is no
 longer active.
 
-## Native Programs
+### Program Owner
 
-The Solana validator implementation includes a list of special programs that
-provide various core functionalities for the network. These are sometimes
-referred to as "built-in" or "native" programs. You can find the full list
-[here](https://docs.anza.xyz/runtime/programs).
+On Solana, "smart contracts" are referred to as [programs](/docs/core/programs).
+Program ownership is a key aspect of the Solana Account Model. Every account has
+a designated program as its owner. Only the owner program can:
 
-Among the native programs, two are particularly important for Solana
-development:
+- Modify the account's `data` field
+- Deduct lamports from the account's balance
 
-1. The System Program:
-
-   - Creates all new accounts on the network
-   - Allocates data space (bytes) for accounts
-   - Assigns account ownership to custom programs
-
-2. The BPF Loader:
-   - The program owner for all deployed custom programs
-   - Handles program deployment and upgrades
-
-### System Program
+## System Program
 
 By default, all new accounts are owned by the
 [System Program](https://github.com/anza-xyz/agave/tree/v2.1.13/programs/system/src).
@@ -152,7 +128,7 @@ The System Program performs several key tasks:
   Only the System Program can create new accounts.
 - [Space Allocation](https://github.com/anza-xyz/agave/blob/v2.1.13/programs/system/src/system_processor.rs#L71):
   Sets the byte capacity for the data field of each account.
-- [Assign Program Ownership](https://github.com/anza-xyz/agave/blob/v2.1.13/programs/system/src/system_processor.rs#L113):
+- [Transfer / Assign Program Ownership](https://github.com/anza-xyz/agave/blob/v2.1.13/programs/system/src/system_processor.rs#L113):
   Once the System Program creates an account, it can reassign the designated
   program owner to a different program account. This is how custom programs take
   ownership of new accounts created by the System Program.
@@ -164,14 +140,6 @@ transaction fee payers.
 
 ![System Account](/assets/docs/core/accounts/system-account.svg)
 
-### BPFLoader Program
-
-The
-[BPF Loader](https://github.com/anza-xyz/agave/tree/v2.1.13/programs/bpf_loader/src)
-is the program owner of all custom programs on the network, excluding other
-native programs. It is responsible for deploying, upgrading, and executing
-custom programs.
-
 ## Sysvar Accounts
 
 Sysvar accounts are special accounts located at predefined addresses that
@@ -179,51 +147,37 @@ provide access to cluster state data. These accounts are dynamically updated
 with data about the network cluster. You can find the full list of Sysvar
 Accounts [here](https://docs.anza.xyz/runtime/sysvars).
 
-## Custom Programs
+## Program Account
 
-On Solana, "smart contracts" are referred to as [programs](/docs/core/programs).
-Programs are accounts that contain executable code. You can identify program
-accounts by their "executable" flag being set to true.
-
-Programs are deployed to the network and can be invoked by users and other
-programs to execute their instructions.
-
-### Program Account
-
-When new programs are currently
-[deployed](https://github.com/anza-xyz/agave/blob/v2.1.13/programs/bpf_loader/src/lib.rs#L527)
-on Solana, technically three separate accounts are created:
-
-- **Program Account**: The main account representing an on-chain program. This
-  account stores the address of an executable data account (which stores the
-  compiled program code) and the update authority for the program (address
-  authorized to make changes to the program).
-- **Program Executable Data Account**: An account that contains the executable
-  code for the program.
-- **Buffer Account**: A temporary account created during program deployment or
-  upgrades that stores the program's executable code. Upon successful
-  deployment, the code is moved to the Program Executable Data Account and the
-  buffer account is closed.
-
-For example, here are links to the Solana Explorer for the Token Extensions
-[Program Account](https://explorer.solana.com/address/TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb)
-and its corresponding
-[Program Executable Data Account](https://explorer.solana.com/address/DoU57AYuPFu2QU514RktNPG22QhApEjnKxnBcu4BHDTY).
-
-![Program and Executable Data Accounts](/assets/docs/core/accounts/program-account-expanded.svg)
-
-For simplicity, you can think of the Program Account as the program itself. When
-invoking a program's instructions, you specify the Program Account's address
-(commonly referred to as the "Program ID"). The details regarding the two
-separate accounts is primarily for understanding how programs are deployed and
-upgraded.
-
+Except for loader-v3 all loaders store the executable code of the programs
+they manage in a so called program account:
 ![Program Account](/assets/docs/core/accounts/program-account-simple.svg)
 
-### Data Account
+For simplicity, you can think of the program account as the program itself. When
+invoking a program's instructions, you specify the program account's address
+(commonly referred to as the "Program ID").
 
-Programs on Solana are "stateless", which means program accounts only store
-executable code and do not store data that's meant to be read from.
+### Buffer Account
+
+Loader-v3 has a special account type for temporarily staging the upload of a
+program during deployment or redeployment / upgrades. In loader-v4 there are
+still buffers, however they are just normal program accounts.
+
+### Programdata Account
+
+Loader-v3 works differently from all other loaders as it has one indirection
+for each program. The program account only contains the address of the
+programdata account which then in turn holds the actual executable code:
+![Programdata Account](/assets/docs/core/accounts/program-account-expanded.svg)
+
+These programdata accounts are not to be confused with the data accounts of
+programs (see below).
+
+## Data Account
+
+On Solana the executable code of a program is stored in a different account
+than the state of the program is. This is comparable to how operating systems
+typically have separate files for programs themselves and their data.
 
 To maintain state, programs define instructions to create separate accounts that
 are owned by the program. Each of these accounts has its own unique address and
@@ -233,7 +187,7 @@ can store any arbitrary data defined by the program.
 
 Note that only the [System Program](/docs/core/accounts#system-program) can
 create new accounts. Once the System Program creates an account, it can then
-transfer ownership of the new account to another program.
+transfer / assign ownership of the new account to another program.
 
 In other words, creating a data account for a custom program requires two steps:
 

--- a/content/docs/core/programs.mdx
+++ b/content/docs/core/programs.mdx
@@ -86,3 +86,268 @@ files contain Solana's custom version of
 [eBPF](https://en.wikipedia.org/wiki/EBPF) bytecode, called "Solana Bytecode
 Format" (sBPF). The ELF file contains the program's binary and is stored
 on-chain in an executable account when the program is deployed.
+
+## Built-in Programs
+
+### Loader Programs
+
+Every program itself is owned by another program, which is its loader. There
+are currently five loaders:
+
+1. native loader:
+
+  - Program id: `NativeLoader1111111111111111111111111111111`
+  - Owns the other four loaders
+
+2. loader-v1:
+
+  - Program id: `BPFLoader1111111111111111111111111111111111`
+  - Management instructions are disabled, but programs still execute
+
+3. loader-v2:
+
+  - Program id: `BPFLoader2111111111111111111111111111111111`
+  - [Instructions](https://docs.rs/solana-loader-v2-interface/latest/solana_loader_v2_interface/enum.LoaderInstruction.html)
+  - Management instructions are disabled, but programs still execute
+
+4. loader-v3:
+
+  - Program id: `BPFLoaderUpgradeab1e11111111111111111111111`
+  - [Instructions](https://docs.rs/solana-loader-v3-interface/latest/solana_loader_v3_interface/instruction/enum.UpgradeableLoaderInstruction.html)
+  - Is being phased out
+
+5. loader-v4:
+
+  - Program id: `LoaderV411111111111111111111111111111111111`
+  - [Instructions](https://docs.rs/solana-loader-v4-interface/latest/solana_loader_v4_interface/instruction/enum.LoaderV4Instruction.html)
+  - Will become the standard loader
+
+These loaders are necessary to create and manage custom programs:
+
+- Deploy a new program or buffer
+- Close a program or buffer
+- Redeploy / upgrade an existing program
+- Transfer the authority over a program
+- Finalize a program
+
+Loader-v3 and loader-v4 support modifications to programs after their initial
+deployment. Permission to do so is regulated by the authority of a program
+because the account ownership of each program resides with the loader.
+
+### Precompile Programs
+
+#### Ed25519 Program
+
+The program for verifying ed25519 signatures. It takes an ed25519 signature, a public key, and a message.
+Multiple signatures can be verified. If any of the signatures fail to verify, an error is returned.
+
+- Program id: `Ed25519SigVerify111111111111111111111111111`
+- [Instructions](https://docs.rs/solana-ed25519-program/latest/solana_ed25519_program/index.html)
+
+The ed25519 program processes an instruction. The first `u8` is a count of the number of
+signatures to check, which is followed by a single byte padding. After that, the
+following struct is serialized, one for each signature to check.
+
+```
+struct Ed25519SignatureOffsets {
+    signature_offset: u16,             // offset to ed25519 signature of 64 bytes
+    signature_instruction_index: u16,  // instruction index to find signature
+    public_key_offset: u16,            // offset to public key of 32 bytes
+    public_key_instruction_index: u16, // instruction index to find public key
+    message_data_offset: u16,          // offset to start of message data
+    message_data_size: u16,            // size of message data
+    message_instruction_index: u16,    // index of instruction data to get message data
+}
+```
+
+The pseudo code of the signature verification:
+
+```
+process_instruction() {
+    for i in 0..count {
+        // i'th index values referenced:
+        instructions = &transaction.message().instructions
+        instruction_index = ed25519_signature_instruction_index != u16::MAX ? ed25519_signature_instruction_index : current_instruction;
+        signature = instructions[instruction_index].data[ed25519_signature_offset..ed25519_signature_offset + 64]
+        instruction_index = ed25519_pubkey_instruction_index != u16::MAX ? ed25519_pubkey_instruction_index : current_instruction;
+        pubkey = instructions[instruction_index].data[ed25519_pubkey_offset..ed25519_pubkey_offset + 32]
+        instruction_index = ed25519_message_instruction_index != u16::MAX ? ed25519_message_instruction_index : current_instruction;
+        message = instructions[instruction_index].data[ed25519_message_data_offset..ed25519_message_data_offset + ed25519_message_data_size]
+        if pubkey.verify(signature, message) != Success {
+            return Error
+        }
+    }
+    return Success
+}
+```
+
+#### Secp256k1 Program
+
+Verify secp256k1 public key recovery operations (ecrecover).
+
+- Program id: `KeccakSecp256k11111111111111111111111111111`
+- [Instructions](https://docs.rs/solana-secp256k1-program/latest/solana_secp256k1_program/index.html)
+
+The secp256k1 program processes an instruction which takes in as the first byte
+a count of the following struct serialized in the instruction data:
+
+```
+struct Secp256k1SignatureOffsets {
+    secp_signature_offset: u16,            // offset to [signature,recovery_id] of 64+1 bytes
+    secp_signature_instruction_index: u8,  // instruction index to find signature
+    secp_pubkey_offset: u16,               // offset to ethereum_address pubkey of 20 bytes
+    secp_pubkey_instruction_index: u8,     // instruction index to find pubkey
+    secp_message_data_offset: u16,         // offset to start of message data
+    secp_message_data_size: u16,           // size of message data
+    secp_message_instruction_index: u8,    // instruction index to find message data
+}
+```
+
+The pseudo code of the recovery verification:
+
+```
+process_instruction() {
+  for i in 0..count {
+      // i'th index values referenced:
+      instructions = &transaction.message().instructions
+      signature = instructions[secp_signature_instruction_index].data[secp_signature_offset..secp_signature_offset + 64]
+      recovery_id = instructions[secp_signature_instruction_index].data[secp_signature_offset + 64]
+      ref_eth_pubkey = instructions[secp_pubkey_instruction_index].data[secp_pubkey_offset..secp_pubkey_offset + 20]
+      message_hash = keccak256(instructions[secp_message_instruction_index].data[secp_message_data_offset..secp_message_data_offset + secp_message_data_size])
+      pubkey = ecrecover(signature, recovery_id, message_hash)
+      eth_pubkey = keccak256(pubkey[1..])[12..]
+      if eth_pubkey != ref_eth_pubkey {
+          return Error
+      }
+  }
+  return Success
+}
+```
+
+This allows the user to specify any instruction data in the transaction for
+signature and message data. By specifying a special instructions sysvar, one can
+also receive data from the transaction itself.
+
+Cost of the transaction will count the number of signatures to verify multiplied
+by the signature cost verify multiplier.
+
+#### Secp256r1 Program
+
+The program for verifying secp256r1 signatures. It takes a secp256r1 signature,
+a public key, and a message. Up to 8 signatures can be verified. If any of the
+signatures fail to verify, an error is returned.
+
+- Program id: `Secp256r1SigVerify1111111111111111111111111`
+- [Instructions](https://docs.rs/solana-secp256k1-recover/latest/solana_secp256k1_recover/index.html)
+
+The secp256r1 program processes an instruction. The first `u8` is a count of the number of signatures to check, followed by a single byte padding. After that, the following struct is serialized, one for each signature to check:
+
+```rust
+struct Secp256r1SignatureOffsets {
+    signature_offset: u16,             // offset to compact secp256r1 signature of 64 bytes
+    signature_instruction_index: u16,  // instruction index to find signature
+    public_key_offset: u16,            // offset to compressed public key of 33 bytes
+    public_key_instruction_index: u16, // instruction index to find public key
+    message_data_offset: u16,          // offset to start of message data
+    message_data_size: u16,            // size of message data
+    message_instruction_index: u16,    // index of instruction data to get message data
+}
+
+```
+
+The pseudo code of the signature verification:
+```
+process_instruction() {
+    if data.len() < SIGNATURE_OFFSETS_START {
+        return Error
+    }
+
+    num_signatures = data[0] as usize
+    if num_signatures == 0 || num_signatures > 8 {
+        return Error
+    }
+
+    expected_data_size = num_signatures * SIGNATURE_OFFSETS_SERIALIZED_SIZE + SIGNATURE_OFFSETS_START
+    if data.len() < expected_data_size {
+        return Error
+    }
+
+    for i in 0..num_signatures {
+        offsets = parse_signature_offsets(data, i)
+
+        signature = get_data_slice(data, instruction_datas, offsets.signature_instruction_index, offsets.signature_offset, SIGNATURE_SERIALIZED_SIZE)
+
+        if s > half_curve_order {
+            return Error
+        }
+
+        pubkey = get_data_slice(data, instruction_datas, offsets.public_key_instruction_index, offsets.public_key_offset, COMPRESSED_PUBKEY_SERIALIZED_SIZE)
+
+        message = get_data_slice(data, instruction_datas, offsets.message_instruction_index, offsets.message_data_offset, offsets.message_data_size)
+
+        if !verify_signature(signature, pubkey, message) {
+            return Error
+        }
+    }
+
+    return Success
+}
+```
+Note: Low S values are enforced for all signatures to avoid accidental signature
+malleability.
+
+### Core Programs
+
+The Solana cluster genesis includes a list of special programs that provide
+various core functionalities for the network. Historically these were referred
+to as "native" programs and they used to be distributed together with the
+validator code.
+
+1. System Program
+
+- Program id: `11111111111111111111111111111111`
+- [Instructions](https://docs.rs/solana-program/latest/solana_program/system_instruction/enum.SystemInstruction.html)
+- Create new accounts, allocate account data, assign accounts to owning
+programs, transfer lamports from System Program owned accounts and pay
+transaction fees.
+
+2. Vote Program
+
+- Program id: `Vote111111111111111111111111111111111111111`
+- [Instructions](https://docs.rs/solana-vote-program/latest/solana_vote_program/vote_instruction/enum.VoteInstruction.html)
+- Create and manage accounts that track validator voting state and rewards.
+
+3. Stake Program
+
+- Program id: `Stake11111111111111111111111111111111111111`
+- [Instructions](https://docs.rs/solana-sdk/latest/solana_sdk/stake/instruction/enum.StakeInstruction.html)
+- Create and manage accounts representing stake and rewards for delegations to
+validators.
+
+4. Config Program
+
+- Program id: `Config1111111111111111111111111111111111111`
+- [Instructions](https://docs.rs/solana-config-program/latest/solana_config_program/config_instruction/index.html)
+- Add configuration data to the chain, followed by the list of public keys that
+are allowed to modify it. Unlike the other programs, the Config program does
+not define any individual instructions. It has just one implicit instruction:
+"store". Its instruction data is a set of keys that gate access to the account
+and the data to store inside of it.
+
+5. Compute Budget Program
+
+- Program id: `ComputeBudget111111111111111111111111111111`
+- [Instructions](https://docs.rs/solana-compute-budget-interface/latest/solana_compute_budget_interface/enum.ComputeBudgetInstruction.html)
+
+6. Address Lookup Table Program
+
+- Program id: `AddressLookupTab1e1111111111111111111111111`
+- [Instructions](https://docs.rs/solana-sdk/latest/solana_sdk/address_lookup_table/instruction/enum.ProgramInstruction.html)
+
+7. Zk Token Proof Program
+
+- Program id: `ZkTokenProof1111111111111111111111111111111`
+
+8. Zk Elgamal Proof Program
+
+- Program id: `ZkE1Gama1Proof11111111111111111111111111111`


### PR DESCRIPTION
### Problem
The documentation of programs is somewhat outdated (e.g. missing loader-v4 and core programs).
Also, there is documentation around native programs in the Agave docs which should be moved here as these are being migrated to core programs which are independent of the validator implementations.

### Summary of Changes

- Updates accounts docs to reflect current state of affairs.
- Moves list of programs from docs.anza.xyz/runtime/programs here.
