### PR TITLE
docs: add terminiology page redirect

### DIFF
--- a/rewrites-redirects.mjs
+++ b/rewrites-redirects.mjs
@@ -751,5 +751,13 @@ export default {
       source: "/accelerate/ship-or-die",
       destination: "/accelerate",
     },
+    {
+      source: "/accelerate/ship-or-die",
+      destination: "/accelerate",
+    },
+    {
+      source: "/docs/terminology",
+      destination: "/docs/references/terminology",
+    },
   ],
 };


### PR DESCRIPTION
add redirect 

from: /docs/terminology
to: /docs/references/terminology