### PR TITLE
Add uiAmountToAmountForMintWithoutSimulation Example

### DIFF
--- a/content/docs/tokens/extensions.mdx
+++ b/content/docs/tokens/extensions.mdx
@@ -18,7 +18,8 @@ token account creation. When initializing either account, you can enable
 specific extensions simultaneously for different functionality. Most extensions
 can't be added after an account is initialized. This is an important
 consideration when designing your token, as you'll need to plan ahead for which
-features you want your token to support.
+features you want your token to support. Integration guides for each extension
+are available in the [Token Extensions developer documentation](/developers/guides/token-extensions/getting-started).
 
 <Callout type="info">
   Some extensions are incompatible with each other and you can't enable them

--- a/content/guides/token-extensions/interest-bearing-tokens.mdx
+++ b/content/guides/token-extensions/interest-bearing-tokens.mdx
@@ -27,7 +27,7 @@ frequent rebase or update operations to adjust for accrued interest.
 <Callout type="info">
 
 Note that the interest accrual is only a
-[calculation](https://github.com/solana-labs/solana-program-library/blob/master/token/program-2022/src/extension/interest_bearing_mint/mod.rs#L85),
+[calculation](https://github.com/solana-program/token-2022/blob/main/program/src/extension/interest_bearing_mint/mod.rs#L88),
 and does not involve minting new tokens.
 
 </Callout>
@@ -93,6 +93,7 @@ import {
   getMintLen,
   TOKEN_2022_PROGRAM_ID,
   amountToUiAmount,
+  uiAmountToAmountForMintWithoutSimulation,
   getInterestBearingMintConfigState,
   getMint,
 } from "@solana/spl-token";
@@ -277,6 +278,28 @@ Lastly, let's calculate the interest accrued for a given amount. Note that this
 calculation can be performed independently for any amount, without the need for
 minting tokens.
 
+
+```javascript
+// Wait 1 second
+sleep(1000);
+
+// Amount to calculate interest for
+const amount = 100;
+
+// Convert amount to UI amount with accrued interest
+// This helper function gets all the necessary state from the Mint Account
+// and performs the calculation without the need for onchain transaction simulation
+const uiAmount = await uiAmountToAmountForMintWithoutSimulation(
+  connection, // Connection to the Solana cluster
+  mint, // Address of the Mint account
+  amount, // Amount to be converted
+);
+
+console.log("\nAmount with Accrued Interest:", uiAmount);
+```
+Alternatively, you can use the program's `amountToUiAmount` function to
+calculate the accrued interest. Note this requires a valid signer for the transaction.
+
 ```javascript
 // Wait 1 second
 sleep(1000);
@@ -284,7 +307,7 @@ sleep(1000);
 // Amount to convert
 const amount = 100;
 // Convert amount to UI amount with accrued interest
-const uiAmount = await amountToUiAmount(
+const uiAmountSimulated = await amountToUiAmount(
   connection, // Connection to the Solana cluster
   payer, // Account that will transfer lamports for the transaction
   mint, // Address of the Mint account
@@ -292,7 +315,7 @@ const uiAmount = await amountToUiAmount(
   TOKEN_2022_PROGRAM_ID, // Token Extension Program ID
 );
 
-console.log("\nAmount with Accrued Interest:", uiAmount);
+console.log("\nAmount with Accrued Interest:", uiAmountSimulated);
 ```
 
 Run the script by clicking the `Run` button. You can then inspect the


### PR DESCRIPTION
# Add uiAmountToAmountForMintWithoutSimulation Example

### Problem
This change helps developers understand there are two ways to calculate accrued interest:
1. Using `uiAmountToAmountForMintWithoutSimulation` which doesn't require a transaction
2. Using `amountToUiAmount` which requires a valid signer and transaction simulation

The new method is more efficient for UI calculations where you just need to display uiAmounts as it does not need a valid signer.

### Summary of Changes
- Added code example showing how to use `uiAmountToAmountForMintWithoutSimulation`
- Kept existing `amountToUiAmount` example for comparison
- Updated imports to include the new helper function
- Added a link to the token extensions guide from the TE homepage

Fixes #
- Fixed a link to the new token-2022 github
