### PR TITLE
docs: add tsconfig.json guidance for top-level await in reading-from-network

### DIFF
--- a/content/courses/intro-to-solana/intro-to-reading-data.mdx
+++ b/content/courses/intro-to-solana/intro-to-reading-data.mdx
@@ -31,8 +31,8 @@ All data on Solana is stored in accounts. Accounts can store:
 ### SOL
 
 SOL is Solana's 'native token' - this means SOL is used to pay transaction fees,
-rent for accounts, and other common operations on the Solana blockchain, such as 
-staking for network security and governance participation. SOL is sometimes shown 
+rent for accounts, and other common operations on the Solana blockchain, such as
+staking for network security and governance participation. SOL is sometimes shown
 with the `◎` symbol.
 Each SOL is made from 1 billion **Lamports**.
 
@@ -81,6 +81,32 @@ Running this TypeScript (`npx esrun example.ts`) shows:
 ```
 ✅ Connected!
 ```
+
+### Update Your TypeScript Configuration
+
+To be able to read the balance in the next step — and because we're using await at the top level — your TypeScript project needs to be configured to support this modern syntax.
+
+Make sure your project includes the following tsconfig.json setup:
+```json
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "module": "es2022",
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "outDir": "./dist"
+  },
+  "include": ["src"]
+}
+```
+
+This ensures everything runs smoothly as you follow along with the guide.
 
 ### Read from the Network
 


### PR DESCRIPTION
Add tsconfig.json block to support top-level await in TypeScript

### Problem

The "Read Data From The Solana Network" guide uses top-level `await`, which can cause confusion or compiler issues without the proper TypeScript configuration (e.g., TS1378).

### Summary of Changes

- Added a minimal `tsconfig.json` block to the guide
- Improves developer experience for TypeScript users

Fixes n/a