### PR TITLE
Docs - programs/deploying

### DIFF
--- a/content/docs/programs/deploying.mdx
+++ b/content/docs/programs/deploying.mdx
@@ -1,53 +1,109 @@
 ---
 title: "Deploying Programs"
 description:
-  Deploying onchain programs can be done using the Solana CLI using the
-  Upgradable BPF loader to upload the compiled byte-code to the Solana
-  blockchain.
+  Uploading custom programs to the Solana blockchain using the Solana CLI.
 ---
 
-Solana programs are stored in "executable" accounts on the network. These
-accounts contain the program's compiled bytecode that define the instructions
-users invoke to interact with the program.
+This guide assumes knowledge of the following topics:
+- [Solana account model](/core/accounts)
+- [Solana programs in general](/core/programs)
+- [Developing custom Solana programs](/programs/rust/)
 
-## CLI Commands
+## Loader-v3 and Loader-v4
+There is currently an ongoing transition from loader-v3 (program subcommand) to
+loader-v4 (program **-v4** subcommand) as loader-v3 is being deprecated.
 
-The section is intended as a reference for the basic CLI commands for building
-and deploying Solana programs. For a step-by-step guide on creating your first
-program, start with [Developing Programs in Rust](/docs/programs/rust).
+For new deployments please use `solana program-v4 deploy` instead of
+`solana program deploy`.
 
-### Build Program
-
-To build your program, use the `cargo build-sbf` command.
-
+To migrate an existing program (which is essentially redeploying it):
 ```shell
-cargo build-sbf
+solana program migrate ./target/deploy/your_program-keypair.json
 ```
 
-This command will:
-
-1. Compile your program
-2. Create a `target/deploy` directory
-3. Generate a `<program-name>.so` file, where `<program-name>` matches your
-   program's name in `Cargo.toml`
-
-The output `.so` file contains your program's compiled bytecode that will be
-stored in a Solana account when you deploy your program.
-
-### Deploy Program
-
-To deploy your program, use the `solana program deploy` command followed by the
-path to the `.so` file created by the `cargo build-sbf` command.
-
+## Preparation
+First, the program needs to be build (compiled, linked, stripped).
 ```shell
-solana program deploy ./target/deploy/your_program.so
+cargo +solana build --target sbpf-solana-solana --release
+```
+This step must be performed before every re-/deployment.
+
+Check that sufficient funds are available to the default payer account
+proportional to the size of the executable:
+```shell
+du -h ./target/deploy/your_program.so 
+solana balance
 ```
 
+Additionally, each program has a program account and a program ID,
+which is the address of that program account. The following generates a keypair
+for the program account:
+```shell
+solana-keygen new -o ./target/deploy/your_program-keypair.json
+```
+This must only be performed once per program and will be reused for
+redeployments of the same program later on.
+
+The toolchain contained a short cut,
+it is however being phased out / deprecated:
+```shell
+cargo-build-sbf
+```
+
+## Initial Deployment
+Now the executable can be uploaded to the program account:
+
+### Loader-v3
+The parameter is called `program-id` even though it expects the file-path of a keypair:
+```shell
+solana program deploy ./target/deploy/your_program.so --program-id ./target/deploy/your_program-keypair.json
+```
+
+### Loader-v4
+```shell
+solana program-v4 deploy ./target/deploy/your_program.so --program-keypair ./target/deploy/your_program-keypair.json
+```
+
+## Redeployment
+Uploading a different executable to the same program account again will
+overwrite / replace it. However, for redeployments, only the program ID (pubkey
+of the program keypair) is needed, not the entire keypair, because the signer
+is the upgrade authority keypair instead.
+
+### Loader-v3
+This is exactly the same as the initial deployment:
+```shell
+solana program deploy ./target/deploy/your_program.so --program-id ./target/deploy/your_program-keypair.json
+```
+
+If the old executable was shorter than the new one it might be necessary to
+grow the programdata account first:
+```shell
+solana program extend ./target/deploy/your_program.so <ADDITIONAL_BYTES>
+```
+
+### Loader-v4
+Notice the initial deployment used `program-keypair`, while the redeployment
+uses `program-id` instead:
+```shell
+solana program-v4 deploy ./target/deploy/your_program.so --program-id ./target/deploy/your_program-keypair.json
+```
+
+## Prioritizing an Upload
 During times of congestion, there are a few additional flags you can use to help
-with program deployment.
+with program deployment:
 
 - `--with-compute-unit-price`: Set compute unit price for transaction, in
   increments of 0.000001 lamports (micro-lamports) per compute unit.
+  Use the
+  [Priority Fee API by Helius](https://docs.helius.dev/guides/priority-fee-api)
+  to get an estimate of the priority fee to set.
+- `--use-rpc`: Send write transactions to the configured RPC instead of
+  validator TPUs. This flag requires a
+  [stake-weighted](/developers/guides/advanced/stake-weighted-qos) RPC
+  connection such as [Helius](https://www.helius.dev/) or
+  [Triton](https://triton.one/). This flag can also be configured to be
+  default using: `solana config set --url <RPC_URL>`.
 - `--max-sign-attempts`: Maximum number of attempts to sign or resign
   transactions after blockhash expiration. If any transactions sent during the
   program deploy are still unconfirmed after the initially chosen recent
@@ -56,275 +112,287 @@ with program deployment.
   transaction signing iterations. Each blockhash is valid for about 60 seconds,
   which means using the default value of 5 will lead to sending transactions for
   at least 5 minutes or until all transactions are confirmed, whichever comes
-  first. [default: 5]
-- `--use-rpc`: Send write transactions to the configured RPC instead of
-  validator TPUs. This flag requires a stake-weighted RPC connection.
+  first.
 
-You can use the flags individually or combine them together. For example:
+## Resuming an Upload
+It is possible that an upload gets stuck or is aborted.
 
+### Loader-v3
+If program deployment fails, there will be a hanging intermediate buffer account
+that contains a non-zero balance. In order to recoup that balance you may resume
+a failed deployment by providing the same intermediate buffer to a new call to
+`deploy`.
+
+Deployment failures will print an error message specifying the seed phrase
+needed to recover the generated intermediate buffer's keypair:
+
+```
+==================================================================================
+Recover the intermediate account's ephemeral keypair file with
+`solana-keygen recover` and the following 12-word seed phrase:
+==================================================================================
+valley flat great hockey share token excess clever benefit traffic avocado athlete
+==================================================================================
+To resume a deploy, pass the recovered keypair as
+the [BUFFER_SIGNER] to `solana program deploy` or `solana program write-buffer'.
+Or to recover the account's lamports, pass it as the
+[BUFFER_ACCOUNT_ADDRESS] argument to `solana program drain`.
+==================================================================================
+```
+
+To recover the keypair:
 ```shell
-solana program deploy ./target/deploy/your_program.so --with-compute-unit-price 10000 --max-sign-attempts 1000 --use-rpc
+solana-keygen recover -o ./target/deploy/buffer-keypair.json
 ```
+When asked, enter the 12-word seed phrase.
 
-- Use the
-  [Priority Fee API by Helius](https://docs.helius.dev/guides/priority-fee-api)
-  to get an estimate of the priority fee to set with the
-  `--with-compute-unit-price` flag.
-
-- Get a
-  [stake-weighted](/developers/guides/advanced/stake-weighted-qos)
-  RPC connection from [Helius](https://www.helius.dev/) or
-  [Triton](https://triton.one/) to use with the `--use-rpc` flag. The
-  `--use-rpc` flag should only be used with a stake-weighted RPC connection.
-
-To update your default RPC URL with a custom RPC endpoint, use the
-`solana config set` command.
-
+Then issue a new `deploy` command and specify the buffer:
 ```shell
-solana config set --url <RPC_URL>
+solana program deploy ./target/deploy/your_program.so --program-id ./target/deploy/your_program-keypair.json --buffer ./target/deploy/buffer-keypair.json
 ```
 
-You can view the list of programs you've deployed using the `program show`
-subcommand:
-
+### Loader-v4
+It is possible to resume an upload at a specified byte offset:
 ```shell
-solana program show --programs
+solana program deploy ./target/deploy/your_program.so --program-id ./target/deploy/your_program-keypair.json --start-offset <BYTES_UPLOADED_SO_FAR>
 ```
 
-Example output:
+## Finalization
+This is an **irreversible** action.
 
-```
-Program Id                                   | Slot      | Authority                                    | Balance
-2w3sK6CW7Hy1Ljnz2uqPrQsg4KjNZxD4bDerXDkSX3Q1 | 133132    | 4kh6HxYZiAebF8HWLsUWod2EaQQ6iWHpHYCz8UcmFbM1 | 0.57821592 SOL
-```
+A program can be made immutable by removing its upgrade authority.
 
-### Update Program
-
-A program's update authority can modify an existing Solana program by deploying
-a new `.so` file to the same program ID.
-
-To update an existing Solana program:
-
-- Make changes to your program source code
-- Run `cargo build-sbf` to generate an updated `.so` file
-- Run `solana program deploy ./target/deploy/your_program.so` to deploy the
-  updated `.so` file
-
-The update authority can be changed using the `set-upgrade-authority` subcommand
-as follows:
-
+### Loader-v3
 ```shell
-solana program set-upgrade-authority <PROGRAM_ADDRESS> --new-upgrade-authority <NEW_UPGRADE_AUTHORITY>
+solana program set-upgrade-authority ./target/deploy/your_program-keypair.json --final
 ```
 
-### Immutable Program
-
-A program can be made immutable by removing its update authority. This is an
-irreversible action.
-
+### Loader-v4
 ```shell
-solana program set-upgrade-authority <PROGRAM_ADDRESS> --final
+solana program finalize --program-id ./target/deploy/your_program-keypair.json
 ```
 
-You can specify that program should be immutable on deployment by setting the
-`--final` flag when deploying the program.
-
+Instead of overwriting programs it is also possible to provide users the choice
+of which version of a program they want to use by constructing a linked list of
+finalized programs:
 ```shell
-solana program deploy ./target/deploy/your_program.so --final
+solana program finalize --program-id ./target/deploy/your_program-keypair.json --next-version ../your_newer_program/target/deploy/your_newer_program-keypair.json
 ```
 
-### Close Program
+## Closing
+For programs deployed under loader-v3 only their programdata account, the
+buffer accounts and the funds locked in those can be reclaimed. The program
+account together with the program ID and funds locked in the program account
+specifically are stuck.
 
-You can close your Solana program to reclaim the SOL allocated to the account.
-Closing a program is irreversible, so it should be done with caution. To close a
-program, use the `program close` subcommand. For example:
+Programs deployed under loader-v4 can be closed with their program account,
+their program ID and their locked funds all becoming available for other uses
+again.
 
-```shell title="Terminal"
-solana program close 4Ujf5fXfLx2PAwRqcECCLtgDxHKPznoJpa43jUBxFfMz
---bypass-warning
-```
-
-Example output:
-
-```
-Closed Program Id 4Ujf5fXfLx2PAwRqcECCLtgDxHKPznoJpa43jUBxFfMz, 0.1350588 SOL
-reclaimed
-```
+### Loader-v3
+This is an **irreversible** action for programs deployed using loader-v3.
 
 Note that once a program is closed, its program ID cannot be reused. Attempting
 to deploy a program with a previously closed program ID will result in an error.
-
-```
-Error: Program 4Ujf5fXfLx2PAwRqcECCLtgDxHKPznoJpa43jUBxFfMz has been closed, use
-a new Program Id
-```
-
 If you need to redeploy a program after closing it, you must generate a new
-program ID. To generate a new keypair for the program, run the following
-command:
+program keypair file.
 
-```shell title="Terminal"
-solana-keygen new -o ./target/deploy/your_program-keypair.json --force
-```
-
-Alternatively, you can delete the existing keypair file and run
-`cargo build-sbf` again, which will generate a new keypair file.
-
-### Program Buffer Accounts
-
-Deploying a program requires multiple transactions due to the 1232 byte limit
-for transactions on Solana. An intermediate step of the deploy process involves
-writing the program's byte-code to temporary "buffer account".
-
-This buffer account is automatically closed after successful program deployment.
-However, if the deployment fails, the buffer account remains and you can either:
-
-- Continue the deployment using the existing buffer account
-- Close the buffer account to reclaim the allocated SOL (rent)
-
-You can check if you have any open buffer accounts by using the `program show`
-subcommand as follows:
-
+To close a single programdata account:
 ```shell
-solana program show --buffers
+solana program close ./target/deploy/your_program-keypair.json
 ```
 
-Example output:
-
-```
-Buffer Address                               | Authority                                    | Balance
-5TRm1DxYcXLbSEbbxWcQbEUCce7L4tVgaC6e2V4G82pM | 4kh6HxYZiAebF8HWLsUWod2EaQQ6iWHpHYCz8UcmFbM1 | 0.57821592 SOL
-```
-
-You can continue to the deployment using the `program deploy` subcommand as
-follows:
-
-```shell
-solana program deploy --buffer 5TRm1DxYcXLbSEbbxWcQbEUCce7L4tVgaC6e2V4G82pM
-```
-
-Expected output on successful deployment:
-
-```
-Program Id: 2w3sK6CW7Hy1Ljnz2uqPrQsg4KjNZxD4bDerXDkSX3Q1
-
-Signature: 3fsttJFskUmvbdL5F9y8g43rgNea5tYZeVXbimfx2Up5viJnYehWe3yx45rQJc8Kjkr6nY8D4DP4V2eiSPqvWRNL
-```
-
-To close buffer accounts, use the `program close` subcommand as follows:
-
+To close all the buffer accounts associated with the current authority:
 ```shell
 solana program close --buffers
 ```
 
-### ELF Dump
-
-The SBF shared object internals can be dumped to a text file to gain more
-insight into a program's composition and what it may be doing at runtime. The
-dump will contain both the ELF information as well as a list of all the symbols
-and the instructions that implement them. Some of the BPF loader's error log
-messages will reference specific instruction numbers where the error occurred.
-These references can be looked up in the ELF dump to identify the offending
-instruction and its context.
-
+### Loader-v4
 ```shell
-cargo build-sbf --dump
+solana program-v4 close --program-id ./target/deploy/your_program-keypair.json
 ```
 
-The file will be output to `/target/deploy/your_program-dump.txt`.
+## Inspecting Metadata
+The `show` subcommand lists the metadata of a program.
 
-## Program Deployment Process
+An example output looks like:
+```shell
+Program Id: 3KS2k14CmtnuVv2fvYcvdrNgC94Y11WETBpMUGgXyWZL
+Owner: BPFLoaderUpgradeab1e11111111111111111111111
+ProgramData Address: EHsACWBhgmw8iq5dmUZzTA1esRqcTognhKNHUkPi4q4g
+Authority: FwoGJNUaJN2zfVEex9BB11Dqb3NJKy3e9oY3KTh9XzCU
+Last Deployed In Slot: 63890568
+Data Length: 5216 (0x1460) bytes
+```
 
-Deploying a program on Solana requires multiple transactions, due to the max
-size limit of 1232 bytes for Solana transactions. The Solana CLI sends these
-transactions with the `solana program deploy` subcommand. The process can be
-broken down into the following 3 phases:
+- `Program Id` is the address that can be referenced in an instruction's
+  `program_id` field when invoking a program.
+- `Owner`: The loader this program was deployed with.
+- `ProgramData Address` is the programdata account associated with the program
+  account that holds the program's executable (loader-v3 only).
+- `Status`: `retracted`, `deployed` or `finalized` (loader-v4 only).
+- `Authority` is the program's upgrade authority.
+- `Last Deployed In Slot` is the slot in which the program was last deployed.
+- `Data Length` is the size of the space reserved for deployments. The actual
+  space used by the currently deployed program may be less.
 
-1. [Buffer initialization](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/cli/src/program.rs#L2113):
-   First, the CLI sends a transaction which
-   [creates a buffer account](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/cli/src/program.rs#L1903)
-   large enough for the byte-code being deployed. It also invokes the
-   [initialize buffer instruction](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/programs/bpf_loader/src/lib.rs#L320)
-   to set the buffer authority to restrict writes to the deployer's chosen
-   address.
-2. [Buffer writes](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/cli/src/program.rs#L2129):
-   Once the buffer account is initialized, the CLI
-   [breaks up the program byte-code](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/cli/src/program.rs#L1940)
-   into ~1KB chunks and
-   [sends transactions at a rate of 100 transactions per second](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/client/src/tpu_client.rs#L133)
-   to write each chunk with
-   [the write buffer instruction](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/programs/bpf_loader/src/lib.rs#L334).
-   These transactions are sent directly to the current leader's transaction
-   processing (TPU) port and are processed in parallel with each other. Once all
-   transactions have been sent, the CLI
-   [polls the RPC API with batches of transaction signatures](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/client/src/tpu_client.rs#L216)
-   to ensure that every write was successful and confirmed.
-3. [Finalization](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/cli/src/program.rs#L1807):
-   Once writes are completed, the CLI
-   [sends a final transaction](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/cli/src/program.rs#L2150)
-   to either
-   [deploy a new program](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/programs/bpf_loader/src/lib.rs#L362)
-   or
-   [upgrade an existing program](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/programs/bpf_loader/src/lib.rs#L513).
-   In either case, the byte-code written to the buffer account will be copied
-   into a program data account and verified.
+### Loader-v3
+To view a specific program:
+```shell
+solana program show ./target/deploy/your_program-keypair.json
+```
 
-## Upgradeable BPF Loader Program
+To view the list of programs deployed with the default authority:
+```shell
+solana program show --programs
+```
 
-The BPF loader program is the program that "owns" all executable accounts on
-Solana. When you deploy a program, the owner of the program account is set to
-the the BPF loader program.
+To show all buffer accounts regardless of the authority:
+```shell
+solana program show --buffers --all
+```
 
-### State accounts
+To specify a different authority:
+```shell
+solana program show --programs --buffer-authority ~/.config/solana/authority-keypair.json
+solana program show --buffers --buffer-authority ~/.config/solana/authority-keypair.json
+```
 
-The Upgradeable BPF loader program supports three different types of state
-accounts:
+### Loader-v4
+To view a specific program:
+```shell
+solana program-v4 show --program-id ./target/deploy/your_program-keypair.json
+```
 
-1. [Program account](https://github.com/solana-labs/solana/blob/master/sdk/program/src/bpf_loader_upgradeable.rs#L34):
-   This is the main account of an on-chain program and its address is commonly
-   referred to as a "program id." Program id's are what transaction instructions
-   reference in order to invoke a program. Program accounts are immutable once
-   deployed, so you can think of them as a proxy account to the byte-code and
-   state stored in other accounts.
-2. [Program data account](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/sdk/program/src/bpf_loader_upgradeable.rs#L39):
-   This account is what stores the executable byte-code of an on-chain program.
-   When a program is upgraded, this account's data is updated with new
-   byte-code. In addition to byte-code, program data accounts are also
-   responsible for storing the slot when it was last modified and the address of
-   the sole account authorized to modify the account (this address can be
-   cleared to make a program immutable).
-3. [Buffer accounts](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/sdk/program/src/bpf_loader_upgradeable.rs#L27):
-   These accounts temporarily store byte-code while a program is being actively
-   deployed through a series of transactions. They also each store the address
-   of the sole account which is authorized to do writes.
+To view the list of programs deployed with the default authority:
+```shell
+solana program-v4 show --all
+```
 
-### Instructions
+To view the list of programs deployed with a specific authority:
+```shell
+solana program-v4 show --authority ~/.config/solana/authority-keypair.json
+```
 
-The state accounts listed above can only be modified with one of the following
-instructions supported by the Upgradeable BPF Loader program:
+## Downloading the Executable
+Sometimes it is useful to download and compare a program to ensure it contains
+a known executable. The downloaded file can be truncated, hashed, and compared
+to the hash of the original program file.
 
-1. [Initialize buffer](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/sdk/program/src/loader_upgradeable_instruction.rs#L21):
-   Creates a buffer account and stores an authority address which is allowed to
-   modify the buffer.
-2. [Write](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/sdk/program/src/loader_upgradeable_instruction.rs#L28):
-   Writes byte-code at a specified byte offset inside a buffer account. Writes
-   are processed in small chunks due to a limitation of Solana transactions
-   having a maximum serialized size of 1232 bytes.
-3. [Deploy](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/sdk/program/src/loader_upgradeable_instruction.rs#L77):
-   Creates both a program account and a program data account. It fills the
-   program data account by copying the byte-code stored in a buffer account. If
-   the byte-code is valid, the program account will be set as executable,
-   allowing it to be invoked. If the byte-code is invalid, the instruction will
-   fail and all changes are reverted.
-4. [Upgrade](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/sdk/program/src/loader_upgradeable_instruction.rs#L102):
-   Fills an existing program data account by copying executable byte-code from a
-   buffer account. Similar to the deploy instruction, it will only succeed if
-   the byte-code is valid.
-5. [Set authority](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/sdk/program/src/loader_upgradeable_instruction.rs#L114):
-   Updates the authority of a program data or buffer account if the account's
-   current authority has signed the transaction being processed. If the
-   authority is deleted without replacement, it can never be set to a new
-   address and the account can never be closed.
-6. [Close](https://github.com/solana-labs/solana/blob/7409d9d2687fba21078a745842c25df805cdf105/sdk/program/src/loader_upgradeable_instruction.rs#L127):
-   Clears the data of a program data account or buffer account and reclaims the
-   SOL used for the rent exemption deposit.
+### Loader-v3
+```shell
+solana program dump ./target/deploy/your_program-keypair.json ./target/deploy/your_program.so
+```
+
+### Loader-v4
+```shell
+solana program download ./target/deploy/your_program.so --program-id ./target/deploy/your_program-keypair.json
+```
+
+## Advanced: Authority Transfer
+The right to change a given program lies with its authority. This authority can
+be transferred to another keypair without changing the program keypair, so that
+the program ID stays the same. Furthermore, a single authority can control
+multiple program accounts.
+
+If not explicitly specified during the initial deployment, then the default
+keypair is used as authority. This is why redeploying a program in the steps
+above didn't require an authority to be explicitly specified.
+
+An explicit authority is useful for offline signing and multi-entity governed
+programs.
+
+First, a keypair for the authority must be generated:
+```shell
+solana-keygen new -o ~/.config/solana/authority-keypair.json
+```
+
+### Loader-v3
+The authority can be specified during deployment:
+```shell
+solana program deploy ./target/deploy/your_program.so --upgrade-authority ~/.config/solana/authority-keypair.json
+```
+
+Or after deployment and using the default keypair as the current authority:
+```shell
+solana program set-upgrade-authority ./target/deploy/your_program-keypair.json --new-upgrade-authority ~/.config/solana/authority-keypair.json
+```
+
+Or after deployment and specifying the current authority:
+```shell
+solana program set-upgrade-authority ./target/deploy/your_program-keypair.json --upgrade-authority ~/.config/solana/authority-keypair.json --new-upgrade-authority ~/.config/solana/new_authority-keypair.json
+```
+
+### Loader-v4
+The authority can be specified during deployment:
+```shell
+solana program-v4 deploy ./target/deploy/your_program.so --program-keypair ./target/deploy/your_program-keypair.json --authority ~/.config/solana/authority-keypair.json
+```
+
+Or after deployment and using the default keypair as the current authority:
+```shell
+solana program-v4 transfer-authority --program-id ./target/deploy/your_program-keypair.json --new-authority ~/.config/solana/authority-keypair.json
+```
+
+Or after deployment and specifying the current authority:
+```shell
+solana program-v4 transfer-authority --program-id ./target/deploy/your_program-keypair.json --authority ~/.config/solana/authority-keypair.json --new-authority ~/.config/solana/new_authority-keypair.json
+```
+
+## Advanced: Two-Step Redeployment using a Buffer
+Instead of uploading directly to the program account, the executable can be
+uploaded to a staging buffer account first and then be transferred to the
+program account in a second step (the actual re-/deployment). This is useful
+for offline signing and multi-entity governed programs such as a DAO voting
+to choose or reject an uploaded executable before the actual redeployment.
+
+Keep in mind that using buffer accounts roughly doubles the funds required
+during the upload process because two accounts are holding one executable
+each, simultaneously.
+
+First, a keypair for the buffer account must be created:
+```shell
+solana-keygen new -o ~/.config/solana/buffer-keypair.json
+```
+The buffer account can be reused for different uploads and is not bound to
+any specific program account.
+
+### Loader-v3
+```shell
+solana program write-buffer ./target/deploy/your_program.so --buffer ~/.config/solana/buffer-keypair.json
+solana program deploy --program-id ./target/deploy/your_program-keypair.json --buffer ~/.config/solana/buffer-keypair.json
+```
+
+### Loader-v4
+```shell
+solana program-v4 deploy ./target/deploy/your_program.so --buffer ~/.config/solana/buffer-keypair.json
+solana program-v4 deploy --program-id ./target/deploy/your_program-keypair.json --buffer ~/.config/solana/buffer-keypair.json
+```
+
+## Advanced: Offline Signing
+Some security models require separating the signing process from the
+transaction broadcast, such that the signing keys can be completely
+disconnected from any network, also known as offline signing.
+
+Note that only the redeployments can be performed in offline mode.
+The initial program deployment **must** be performed from an online machine,
+and only subsequent program redeployments can leverage offline signing.
+
+A typical setup would consist of two different signers:
+- online signer (fee payer and authority of the buffer account)
+- offline signer (authority of the program account)
+
+The general process is a two-step redeployment with some extras:
+1. (online) create a new program
+2. (online) transfer the authority to the offline signer
+3. (online) create buffer and upload an executable to it
+4. (optional) verify the buffer's on-chain contents
+5. (offline) sign a transaction to redeploy the program using the buffer
+`--blockhash <VALUE> --sign-only`
+6. (online) use this signature to broadcast the redeployment transaction
+`--blockhash <VALUE> --signer <OFFLINE_SIGNER_PUBKEY>:<OFFLINE_SIGNER_SIGNATURE>`
+
+Look up a recent `blockhash` and paste it in to generate the offline
+transaction signature. The `blockhash` expires after ~60 seconds. If you didn't
+make it in time - just get another fresh hash and repeat until you succeed, or
+consider using durable transaction nonces.


### PR DESCRIPTION
### Problem

This is a continuation of #376, the effort to merge Anza and Foundation docs about programs. 

### Summary of Changes

- Merges docs.anza.xyz/cli/examples/deploy-a-program in here
- Adds program-v4 subcommands and migration
- Reorders sections by their relevance to the average dev
- Removes sections which are redundant to /core/accounts and /core/accounts