### PR TITLE
Fix typo in actions.mdx

### DIFF
--- a/content/guides/advanced/actions.mdx
+++ b/content/guides/advanced/actions.mdx
@@ -111,7 +111,7 @@ lifecycle.
 
 Actions also support some level of invalidation before execution. The `GET` and
 `POST` request may return some metadata that states whether the action is
-capable of be taken (like with the `disabled` field).
+capable of being taken (like with the `disabled` field).
 
 For example, if there was an Action endpoint that facilitates voting on a DAO
 governance proposal whose voting window has closed, the initial


### PR DESCRIPTION
Fixed a typographical error on guides/advanced/actions.mdx -> line 114.

### Problem
A typographical error in the below line  (under section Solana Actions Execution and Lifecycle).

> The GET and POST request may return some metadata that states whether the action is capable of _be_ taken (like with the disabled field).

### Summary of Changes

- Corrected a spelling error from "be" to "being" in guides/advanced/actions.mdx -> line 114 (under section Solana Actions Execution and Lifecycle).
- No other changes were made.
- This improves readability and maintains consistency.


Fixes #
```
- some metadata that states whether the action is capable of be taken (like with the disabled field). 
+ some metadata that states whether the action is capable of being taken (like with the disabled field). 
```