### PR TITLE
docs(actions & blinks): Add type field to LinkedAction type

### DIFF
--- a/content/guides/advanced/actions.mdx
+++ b/content/guides/advanced/actions.mdx
@@ -460,6 +460,15 @@ export interface Action<T extends ActionType> {
     and input fields based on the items listed in the `links.actions` field. The
     client should not render a button for the contents of the root `label`.
 
+/**
+ * Type of action to determine client side handling
+ */
+export type LinkedActionType =
+  | "transaction"
+  | "message"
+  | "post"
+  | "external-link";
+
 ```ts title="LinkedAction"
 export interface LinkedAction {
   /** Type of action to be performed by user */

--- a/content/guides/advanced/actions.mdx
+++ b/content/guides/advanced/actions.mdx
@@ -460,6 +460,7 @@ export interface Action<T extends ActionType> {
     and input fields based on the items listed in the `links.actions` field. The
     client should not render a button for the contents of the root `label`.
 
+```ts title="LinkedActionType"
 /**
  * Type of action to determine client side handling
  */
@@ -468,6 +469,7 @@ export type LinkedActionType =
   | "message"
   | "post"
   | "external-link";
+```
 
 ```ts title="LinkedAction"
 export interface LinkedAction {

--- a/content/guides/advanced/actions.mdx
+++ b/content/guides/advanced/actions.mdx
@@ -460,16 +460,6 @@ export interface Action<T extends ActionType> {
     and input fields based on the items listed in the `links.actions` field. The
     client should not render a button for the contents of the root `label`.
 
-/**
- * Type of action to determine client side handling
- */
-export type LinkedActionType =
-  | "transaction"
-  | "message"
-  | "post"
-  | "external-link";
-```
-
 ```ts title="LinkedAction"
 export interface LinkedAction {
   /** Type of action to be performed by user */

--- a/content/guides/advanced/actions.mdx
+++ b/content/guides/advanced/actions.mdx
@@ -460,7 +460,6 @@ export interface Action<T extends ActionType> {
     and input fields based on the items listed in the `links.actions` field. The
     client should not render a button for the contents of the root `label`.
 
-```ts title="LinkedActionType"
 /**
  * Type of action to determine client side handling
  */

--- a/content/guides/advanced/actions.mdx
+++ b/content/guides/advanced/actions.mdx
@@ -462,6 +462,8 @@ export interface Action<T extends ActionType> {
 
 ```ts title="LinkedAction"
 export interface LinkedAction {
+  /** Type of action to be performed by user */
+  type: LinkedActionType;
   /** URL endpoint for an action */
   href: string;
   /** button text rendered to the user */


### PR DESCRIPTION
### Problem
The LinkedAction interface is missing a field: type


### Summary of Changes
Adds the type field to the LinkedAction interface


Fixes #