### PR TITLE
CI: migrate workflows to checkout v4

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Use Node.js node
         uses: actions/setup-node@v2
         with:
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Use Node.js node
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
GitHub-hosted runners now use Node 20, so actions/checkout@v4 is required. Workflows only updated—no functional changes.