### PR TITLE
Add Scaled UI Amount Extension Documentation

### DIFF
--- a/content/docs/en/tokens/extensions/meta.json
+++ b/content/docs/en/tokens/extensions/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Extensions",
-  "pages": ["confidential-transfer"]
+  "pages": ["confidential-transfer", "scaled-ui-amount"]
 }

--- a/content/docs/en/tokens/extensions/scaled-ui-amount/index.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/index.mdx
@@ -1,0 +1,34 @@
+---
+title: Scaled UI Amount
+description:
+  Learn about the Scaled UI Amount extension and how to use it to scale the UI
+  amount of a token.
+---
+
+## What is the Scaled UI Amount extension?
+
+The scaled UI amount extension allows issuers to apply an updatable multiplier
+to the UI amount of a token. This is useful for scenarios where the token is
+used to represent a real-world asset, such as a stock or dividend.
+
+For example, a stock split doubles the number of shares for all holders. Without
+this extension, it is currently impractical to mint new tokens to all holders
+during a split event in an efficient and scalable way.
+
+With the Token-2022 extension model, however, we have the possibility to change
+how the UI amount of tokens are represented. Using the ScaledUiAmount extension
+and the `amount_to_ui_amount` instruction, you can set a UI multiplier on your
+token and fetch its UI amount at any time.
+[source code](https://github.com/solana-program/token-2022/tree/main/program/src/extension/scaled_ui_amount).
+
+This feature can also be used for dividends or distributing yield.
+
+Note: No new tokens are ever created, the UI amount returns the raw amount of
+tokens multiplied by the current multiplier. The feature is entirely cosmetic.
+
+<Callout type="info">
+  Some extensions are incompatible with each other and you can't enable them
+  simultaneously on the same token mint or token account. You should not enable
+  both the `ScaledUiAmount` extension and the `InterestBearingMint` extension on the same
+  token mint or token account.
+</Callout>

--- a/content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx
@@ -1,0 +1,216 @@
+---
+title: Scaled UI Amount Integration Guide
+description:
+  Learn how to integrate a token that uses the Scaled UI Amount extension in
+  your application.
+---
+
+# Supporting Scaled UI Amount Extension on Solana
+
+## Background
+
+A new token extension called “Scaled UI Amount” was launched recently that
+allows token issuers to specify a multiplier to be used when calculating the UI
+amount of a user’s token balance. This enables issuers to create rebasing tokens
+and to enable things like stock splits. This extension, like the interest
+bearing token extension, provides a purely cosmetic UI amount. The underlying
+calculations and transfers all occur using the raw amounts in the program.
+
+### Resources:
+
+- [Developer Documentation](https://www.solana-program.com/docs/token-2022/extensions#scaled-ui-amount)
+- [Extension Rust Code](https://github.com/solana-program/token-2022/tree/main/program/src/extension/scaled_ui_amount)
+- [Amount to UI Amount Rust Code](https://github.com/solana-program/token-2022/blob/main/program/src/processor.rs#L1425)
+
+## Goals
+
+- Provide the best UX for end users
+- Provide clear and straightforward guidelines for teams to create a unified
+  experience of interest bearing tokens across the ecosystem
+- Identify and plan work to reduce work teams have to do to integrate with the
+  scaled UI amount extension
+
+## TL;DR
+
+- End users should interact with the UIAmount (raw amount \* multiplier) for the
+  token price, token balance, and token amounts whenever possible
+- dApps and service providers should use the raw amount and non-scaled prices
+  for all calculations and convert for users at the edge
+- Historical price feeds need to be provided for both scaled and non-scaled
+  amounts for easier integration
+- Historical multiplier values need to be accessible for accurate historical
+  data
+
+## Terms Definitions
+
+- Multiplier: static updatable multiplier that’s used for UI Amount calculations
+- UIAmount: multiplier \* raw amount (AKA: scaled amount)
+- Raw Amount: amount (AKA: non-scaled amount)
+
+## Current Balance
+
+### Current Amount for Display
+
+- Anytime you display amounts for tokens that use the scaled UI amount extension
+  to end users you should use either:
+  - UIAmount/UIAmountString (**_preferred_**)
+  - A manual calculation of raw amount \* multiplier
+  - We recommend truncating this value based on the number of decimals the token
+    has.
+    - Ex: if yUSD has 6 decimals and a user has a UIAmount of 1.123456789 you
+      should display “1.123456”
+
+### Where to get this data:
+
+- For a user’s live balance you can get updated information on the above amounts
+  by calling either getTokenAccountBalance or getAccountInfo
+- If you need to know the UI Amount for an arbitrary amount you can get this
+  calculation by calling the
+  [`amountToUiAmountForMintWithoutSimulation`](https://github.com/solana-program/token-2022/blob/main/clients/js-legacy/src/actions/amountToUiAmount.ts#L164)
+  (web3.js v1) function or simulating a transaction using amountToUiAmount.
+  - Note: amountToUiAmount requires a transaction simulation which means it also
+    needs a valid fee payer with balance. Because of this, this should not be
+    the default way to get a balance.
+
+### Updating the Current Amount
+
+Because Issuers can update the multiplier at any given time you can consider
+occasionally polling in order to keep the account balance updated. Issuers are
+unlikely to update this multiplier more than once per day. If a multiplier is
+set for a future date, you can automatically poll at this update time
+
+## Token Amounts in Transactions (transfers / swaps etc)
+
+- Users should enter amounts to be interpreted as the scaled “UIAmount”. The app
+  that has to process this should convert to the raw token amount for the
+  transaction.
+  - If there are rounding issues, round down and prefer leaving a tiny amount of
+    dust rather than risk the transaction failing
+  - To do this conversion you can use the
+    [`uiAmountToAmountForMintWithoutSimulation`](https://github.com/solana-program/token-2022/blob/main/clients/js-legacy/src/actions/amountToUiAmount.ts#L312C23-L312C63)
+    (web3.js v1) function or simulating a transaction using amountToUiAmount.
+- Apps should use the total raw amount when a user requests to do an action with
+  “max” or “all” of their balance. This ensures that there is no dust left over.
+  - Optional: You can consider automatically closing an account when “max” is
+    used to refund the user of their storage deposit
+
+## Token Price
+
+- Token price should always be displayed as the scaled price wherever possible.
+- If you are a price feed service provider, such as an oracle, you should expose
+  both the scaled and non-scaled price.
+  - Wherever possible provide an SDK/API that abstracts the scaled UI amount
+    extension complexities away.
+
+## Current Multiplier
+
+- The current multiplier can be read from the token mint at any time by calling
+  `getAccountInfo`. Additionally, if a future multiplier is set, this
+  information is also available from the token mint. We recommend not showing
+  this multiplier as it can confuse the UX.
+
+## Historical Data
+
+### Historical Data for Price Feed
+
+- Services who provide historical data should store and **surface both the
+  scaled and non-scaled prices for the scaled UI amount extension**.
+- We expect scaled amounts to be used most frequently as this aligns with how
+  the traditional finance world treats charts related to tokens with stock
+  splits.
+
+### Historical Data for Amounts
+
+- If you would like to show the balance transferred in the past you need access
+  to the multiplier at that given slot. You can also save the UiAmount for
+  transfers as you process transactions to avoid doing this calculation in the
+  future.
+
+## Backwards Compatibility
+
+- By default wallets and applications that do not understand the scaled UI
+  amount extension will show the correct total price of an activity by
+  multiplying the non-scaled price \* raw amount.
+- They would, however, display the non-scaled price causing some user confusion.
+- We hope this encourages teams to update their dapps to be compatible with
+  tokens that use the scaled UI amount extension and are happy to provide
+  support during this process.
+
+## Utility Functions To Add To SPL-Token Library:
+
+- **\[Done\]** Amount to UIAmount: Provide a function to get the UIAmount at the
+  current time given the mint and raw amount
+- **\[Done\]** UIAmount to Amount: Provide a function to get the raw amount at
+  the current time given the mint and UIAmount
+- **\[Done\]** Amount to UIAmount for: Provide a function to get the UIAmount
+  for a given multiplier and decimal and raw amount
+- **\[Done\]** UIAmount to Amount: Provide a function to get the raw amount for
+  a given multiplier and decimal and UIAmount
+- **\[TODO\]** All above helper functionality for @solana/kit
+
+## Acceptance Criteria Per Platform
+
+### **General Requirements**
+
+| Requirement                         | Description                                                                                                                                                                              | Priority |
+| :---------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- |
+| Support User Actions Using UiAmount | All user actions should be entered in UiAmount when UiAmount is enabled throughout the app. If UiAmount is not visible in the app, they should use raw amounts until the app is updated. | **P0**   |
+
+---
+
+### **Wallets**
+
+| Requirement                                    | Description                                                                                                        | Priority |
+| :--------------------------------------------- | :----------------------------------------------------------------------------------------------------------------- | :------- |
+| Display Scaled Balance                         | Show the scaled amount (uiAmount) as the primary balance.                                                          | **P0**   |
+| Support for Token Transfers                    | End users should input transfer amounts with their scaled balances (raw amount \* balance).                        | **P0**   |
+| Display Spot Price                             | Display the scaled spot price for users                                                                            | **P0**   |
+| Transaction History Metadata                   | Show the scaled amount (UIAmount) for each transfer wherever possible.                                             | **P1**   |
+| Show Multiplier Updates in Transaction History | When multiplier updates occur, show this as an event in the user’s transaction history including the amount gained | **P2**   |
+| Display Price History Graph                    | Reflect the scaled prices in the price graph                                                                       | **P1**   |
+| Onboarding/Tooltips                            | Offer tooltips or onboarding to educate users about tokens that use the scaled ui amount extension                 | **P2**   |
+
+---
+
+### **Explorers**
+
+| Requirement                                               | Description                                                                          | Priority |
+| :-------------------------------------------------------- | :----------------------------------------------------------------------------------- | :------- |
+| Token Details Page Enhancements                           | Display metadata such as total scaled market cap and current multiplier              | **P0**   |
+| Display Scaled Balance for Balances                       | Display scaled balances (UiAmount) for current balances.                             | **P0**   |
+| Display Scaled Balance for Transactions                   | Display scaled balances (UiAmount) for transfer amounts for historical transactions. | **P0**   |
+| Display Scaled Price for Transactions                     | Display scaled prices for previous transactions                                      | **P1**   |
+| Properly Parse and Display Multiplier Update Transactions | Properly show details about the multiplier update                                    | **P2**   |
+
+---
+
+### **Market Data Aggregators (Ex: CoinGecko)**
+
+| Requirement                         | Description                                                                                        | Priority |
+| :---------------------------------- | :------------------------------------------------------------------------------------------------- | :------- |
+| API Updates for Scaled Data         | Extend API functionality to include multiplier changes over time as well as the scaled price feed. | **P0**   |
+| Total Supply With Scaled Adjustment | When displaying total supply and total market cap, take the scaled balances into account           | **P0**   |
+| Historical Price Tracking           | Provide a historical chart of prices using the scaled price over time.                             | **P1**   |
+| Historical Multiplier Tracking      | Provide historical markers of multiplier updates for interest-bearing tokens.                      | **P2**   |
+| Educational Content or Explanations | Include brief descriptions or tooltips explaining how scaled tokens work.                          | **P2**   |
+
+---
+
+### **Price Feed Providers**
+
+| Requirement                     | Description                                                                    | Priority |
+| :------------------------------ | :----------------------------------------------------------------------------- | :------- |
+| Scaled & non-scaled Price Feeds | Provide price feeds for both scaled and non-scaled prices.                     | **P0**   |
+| Historical Multiplier Data      | Offer APIs with historical multiplier changes.                                 | **P0**   |
+| Historical Price Data           | Offer APIs with historical prices based on both scaled and non-scaled amounts. | **P0**   |
+
+---
+
+### **DEXes**
+
+| Requirement                    | Description                                                                                            | Priority |
+| :----------------------------- | :----------------------------------------------------------------------------------------------------- | :------- |
+| Display Rebased Token Balances | Show scaled balances for trading or liquidity provision on the UI. (backend can still use raw amounts) | **P0**   |
+| Support for Token Actions      | End users should input action amounts with their UiAmount balances (multiplier \* raw amount).         | **P0**   |
+| Price Feed Adaptation          | Anywhere a price feed is used to display current price, provide the scaled price to end users.         | **P1**   |
+| Display Price History Graph    | Reflect the scaled prices in the price graph                                                           | **P1**   |

--- a/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
@@ -1,0 +1,51 @@
+---
+title: Scaled UI Amount Issuer Guide
+description:
+  Learn how to use the Scaled UI Amount extension to scale the UI amount of a
+  token.
+---
+
+## How to use the Scaled UI Amount extension
+
+To use the Scaled UI Amount extension, you need to enable it on a token mint or
+token account.
+
+### Enable the Scaled UI Amount extension on a token mint
+
+To enable the Scaled UI Amount extension on a token mint, you need to set the
+`scaled_ui_amount_extension` field to `true` in the `Mint` account. Here is an
+example of how to create a token with the Scaled UI Amount extension enabled using
+the `spl-token` CLI:
+
+<CodeTabs>
+```bash
+$ spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --ui-amount-multiplier 1.5
+Creating token 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM under program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
+ 
+Address:  66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM
+Decimals:  9
+ 
+Signature: 2sPziXu9M3duTCvsDvxQE9UKC9nBiLayi8muDvnjhA2qYvfXSZuaUieoq39MFjg4kf8xFrw6crmYSkPyV59dvudF
+```
+</CodeTabs>
+### Update the UI amount multiplier
+
+To update the UI amount multiplier, you need to use the `update-ui-amount-multiplier`
+command. A timestamp is optional and can be used to set a custom start time for
+the new multiplier. If no timestamp is provided, the current timestamp will be
+used.
+
+<CodeTabs>
+```bash
+$ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM 1.5 -- 1746471400 
+```
+</CodeTabs>
+### Fetch the UI amount
+
+To fetch the UI amount, you need to use the `balance` command.
+
+<CodeTabs>
+```bash
+$ spl-token balance 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM
+```
+</CodeTabs>

--- a/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
@@ -18,7 +18,7 @@ example of how to create a token with the Scaled UI Amount extension enabled usi
 the `spl-token` CLI:
 
 <CodeTabs>
-```bash
+```bash !! title="Create Token"
 $ spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --ui-amount-multiplier 1.5
 Creating token 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM under program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
  
@@ -28,6 +28,7 @@ Decimals:  9
 Signature: 2sPziXu9M3duTCvsDvxQE9UKC9nBiLayi8muDvnjhA2qYvfXSZuaUieoq39MFjg4kf8xFrw6crmYSkPyV59dvudF
 ```
 </CodeTabs>
+
 ### Update the UI amount multiplier
 
 To update the UI amount multiplier, you need to use the `update-ui-amount-multiplier`
@@ -36,16 +37,17 @@ the new multiplier. If no timestamp is provided, the current timestamp will be
 used.
 
 <CodeTabs>
-```bash
+```bash !! title="Update UI Amount Multiplier"
 $ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM 1.5 -- 1746471400 
 ```
 </CodeTabs>
-### Fetch the UI amount
 
-To fetch the UI amount, you need to use the `balance` command.
+### Fetch the Balance
+
+To fetch the balance, you need to use the `balance` command.
 
 <CodeTabs>
-```bash
+```bash !! title="Fetch Balance"
 $ spl-token balance 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM
 ```
 </CodeTabs>

--- a/content/docs/en/tokens/extensions/scaled-ui-amount/meta.json
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "Scaled UI Amount",
+  "pages": [
+    "issuer-guide",
+    "integration-guide"
+  ]
+}


### PR DESCRIPTION
# Add Scaled UI Amount Extension Documentation

## Overview
This PR adds comprehensive documentation for the Scaled UI Amount extension, a Token-2022 feature that allows token issuers to apply an updatable multiplier to token UI amounts. This is particularly useful for scenarios like stock splits or dividend distributions.

## Changes
Added three new documentation files:

1. `content/docs/en/tokens/extensions/scaled-ui-amount/index.mdx`
   - Introduces the Scaled UI Amount extension
   - Explains its use cases and key concepts
   - Notes compatibility considerations with the interest bearing extension

2. `content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx`
   - Provides very basic step-by-step instructions for creating a token with this extension
   - Includes CLI examples for creating tokens with the extension
   - Covers multiplier updates and balance checking

3. `content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx`
   - Detailed integration guidelines for developers
   - Best practices for displaying balances and handling transactions
   - Platform-specific requirements for wallets, explorers, DEXes, and price feeds
   - Clear acceptance criteria for different types of applications