### PR TITLE
docs: update rpc curl examples to include maxSupportedTransactionVersion

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,6 @@ packages
 .next
 coverage
 content/**/meta.json
+
+# Ignore RPC docs to prevent formatting issues with custom codehike annotations
+content/docs/*/rpc/**

--- a/content/docs/en/rpc/http/getblock.mdx
+++ b/content/docs/en/rpc/http/getblock.mdx
@@ -16,7 +16,7 @@ ledger
   "method": "getBlock",
   "params": [
     // !hover slot number
-    430,
+    378967388,
     // !hover(1:6) 1
     {
       // !hover encoding
@@ -144,6 +144,8 @@ Configuration object.
 ##### !! commitment
 
 !type string
+!values confirmed finalized
+!default finalized
 
 The commitment describes how finalized a block is at that point in time. See
 [Configuring State Commitment](/docs/rpc#configuring-state-commitment).
@@ -182,13 +184,16 @@ Level of transaction detail to return.
 ##### !! maxSupportedTransactionVersion
 
 !type number
+!values 0
+!default 0
 
-The max transaction version to return in responses.
+Currently, the only valid value for this parameter is `0`. 
+Setting it to `0` allows you to fetch all transactions, including both Versioned and legacy transactions.
 
-- If the requested block contains a transaction with a higher version, an error
-  will be returned.
-- If this parameter is omitted, only legacy transactions will be returned, and a
-  block containing any versioned transaction will prompt the error.
+This parameter determines the maximum transaction version that will be returned in the response. 
+If you request a transaction with a higher version than this value, an error will be returned. 
+If you omit this parameter, only legacy transactions will be returned—any versioned transaction will result in an error.
+
 
 ##### !! rewards
 

--- a/content/docs/en/rpc/http/gettransaction.mdx
+++ b/content/docs/en/rpc/http/gettransaction.mdx
@@ -15,8 +15,16 @@ Returns transaction details for a confirmed transaction
   "method": "getTransaction",
   "params": [
     // !hover signature
-    "2nBhEBYYvfaAe16UMNqRHre4YNSskvuYgx3M6E4JP1oDYvZEJHvoPzyUidNgNX5r9sTyN1J9UxtbCXy2rqYcuyuv",
-    "json"
+    "5Pj5fCupXLUePYn18JkY8SrRaWFiUctuDTRwvUy2ML9yvkENLb1QMYbcBGcBXRrSVDjp7RjUwk9a3rLC6gpvtYpZ",
+    // !hover(1:5) config
+    {
+      // !hover commitment
+      "commitment": "confirmed",
+      // !hover maxSupportedTransactionVersion
+      "maxSupportedTransactionVersion": 0,
+      // !hover encoding
+      "encoding": "json"
+    }
   ]
 }
 ```
@@ -109,7 +117,7 @@ async fn main() -> Result<()> {
 
 Transaction signature, as base-58 encoded string
 
-#### !! 1
+#### !! config
 
 !type object
 
@@ -118,6 +126,8 @@ Configuration object containing the following fields:
 ##### !! commitment
 
 !type string
+!values confirmed finalized
+!default finalized
 
 The commitment describes how finalized a block is at that point in time. See
 [Configuring State Commitment](/docs/rpc#configuring-state-commitment).
@@ -127,11 +137,16 @@ The commitment describes how finalized a block is at that point in time. See
 ##### !! maxSupportedTransactionVersion
 
 !type number
+!values 0
+!default 0
 
-Set the max transaction version to return in responses. If the requested
-transaction is a higher version, an error will be returned. If this parameter is
-omitted, only legacy transactions will be returned, and any versioned
-transaction will prompt the error.
+Currently, the only valid value for this parameter is `0`. 
+Setting it to `0` allows you to fetch all transactions, including both Versioned and legacy transactions.
+
+This parameter determines the maximum transaction version that will be returned in the response. 
+If you request a transaction with a higher version than this value, an error will be returned. 
+If you omit this parameter, only legacy transactions will be returned—any versioned transaction will result in an error.
+
 
 ##### !! encoding
 
@@ -153,42 +168,77 @@ Encoding for the returned Transaction
 ```jsonc !response
 {
   "jsonrpc": "2.0",
-  // !hover(1:32) result
+  // !hover(1:64) result
   "result": {
-    // !hover slot
-    "slot": 430,
     // !hover blockTime
-    "blockTime": null,
-    // !hover(1:13) meta
+    "blockTime": 1746479684,
+    // !hover(1:30) meta
+    // !collapse(1:30) collapsed
     "meta": {
+      "computeUnitsConsumed": 150,
       "err": null,
       "fee": 5000,
       "innerInstructions": [],
-      "postBalances": [499998932500, 26858640, 1, 1, 1],
+      "loadedAddresses": {
+        "readonly": [],
+        "writable": []
+      },
+      "logMessages": [
+        "Program 11111111111111111111111111111111 invoke [1]",
+        "Program 11111111111111111111111111111111 success"
+      ],
+      "postBalances": [
+        989995000,
+        10000000,
+        1
+      ],
       "postTokenBalances": [],
-      "preBalances": [499998937500, 26858640, 1, 1, 1],
+      "preBalances": [
+        1000000000,
+        0,
+        1
+      ],
       "preTokenBalances": [],
       "rewards": [],
       "status": {
         "Ok": null
       }
     },
-    // !hover(1:15) transaction
+    // !hover slot
+    "slot": 378917547,
+    // !hover(1:29) transaction
+    // !collapse(1:29) collapsed
     "transaction": {
       "message": {
         "accountKeys": [
-          "3UVYmECPPMZSCqWKfENfuoTv51fTDTWicX9xmBD2euKe",
-          "AjozzgE83A3x1sHNUR64hfH7zaEBWeMaFuAN9kQgujrc"
+          "7BvfixZx7Rwywf6EJFgRW6acEQ2FLSFJr4n3kLLVeEes",
+          "6KtbxYovphtE3eHjPjr2sWwDfgaDwtAn2FcojDyzZWT6",
+          "11111111111111111111111111111111"
         ],
+        "header": {
+          "numReadonlySignedAccounts": 0,
+          "numReadonlyUnsignedAccounts": 1,
+          "numRequiredSignatures": 1
+        },
         "instructions": [
           {
-            "accounts": [1, 2, 3, 0],
-            "data": "37u9WtQpcm6ULa3WRQHmj49EPs4if7o9f1jSRVZpm2dvihR9C8jY4NqEwXUbLwx15HBSNcP1",
-            "programIdIndex": 4
+            "accounts": [
+              0,
+              1
+            ],
+            "data": "3Bxs4NN8M2Yn4TLb",
+            "programIdIndex": 2,
+            "stackHeight": null
           }
-        ]
-      }
-    }
+        ],
+        "recentBlockhash": "23dwTHxFhSzqohXhdni5LwpuSRpgN36YvVMCAM2VXQSf"
+      },
+      "signatures": [
+        "5Pj5fCupXLUePYn18JkY8SrRaWFiUctuDTRwvUy2ML9yvkENLb1QMYbcBGcBXRrSVDjp7RjUwk9a3rLC6gpvtYpZ"
+      ]
+    },
+    // !hover version
+    "version": "legacy"
   },
   "id": 1
 }

--- a/content/docs/en/rpc/websocket/blocksubscribe.mdx
+++ b/content/docs/en/rpc/websocket/blocksubscribe.mdx
@@ -31,10 +31,12 @@ Subscribe to receive notification anytime a new block is `confirmed` or
       "commitment": "confirmed",
       // !hover encoding
       "encoding": "base64",
-      // !hover showRewards
-      "showRewards": true,
       // !hover transactionDetails
-      "transactionDetails": "full"
+      "transactionDetails": "full",
+      // !hover maxSupportedTransactionVersion
+      "maxSupportedTransactionVersion": 0,
+      // !hover showRewards
+      "showRewards": true
     }
   ]
 }
@@ -64,7 +66,8 @@ Configuration object containing the following fields:
 
 ##### !! commitment
 
-!type string  
+!type string
+!values confirmed finalized
 !default finalized
 
 The commitment describes how finalized a block is at that point in time. See
@@ -103,13 +106,16 @@ level of transaction detail to return
 ##### !! maxSupportedTransactionVersion
 
 !type number
+!values 0
+!default 0
 
-the max transaction version to return in responses.
+Currently, the only valid value for this parameter is `0`. 
+Setting it to `0` allows you to fetch all transactions, including both Versioned and legacy transactions.
 
-- If the requested block contains a transaction with a higher version, an error
-  will be returned.
-- If this parameter is omitted, only legacy transactions will be returned, and a
-  block containing any versioned transaction will prompt the error.
+This parameter determines the maximum transaction version that will be returned in the response. 
+If you request a transaction with a higher version than this value, an error will be returned. 
+If you omit this parameter, only legacy transactions will be returned—any versioned transaction will result in an error.
+
 
 ##### !! showRewards
 

--- a/src/app/components/request-client.tsx
+++ b/src/app/components/request-client.tsx
@@ -116,8 +116,9 @@ function ParamInput({
       <Input
         id={param.name}
         type={param.type === "number" ? "number" : "text"}
+        min={param.type === "number" ? 0 : undefined}
         value={param.type === "number" ? Number(text) : text}
-        className="flex-1 max-w-lg h-8"
+        className="flex-1 h-8 max-w-lg"
         onChange={(e) => setText(e.target.value)}
         onBlur={(e) => onChange(e.target.value)}
       />
@@ -149,8 +150,8 @@ export function RequestClientContent() {
       data-playground={isOpen}
       className="bg-ch-tabs-background"
     >
-      <CollapsibleTrigger className="p-2 gap-2 w-full justify-between items-center flex cursor-pointer text-ch-tab-inactive-foreground hover:text-ch-tab-active-foreground transition-colors duration-200">
-        <div className="h-5 shrink-0 font-medium flex items-center gap-2">
+      <CollapsibleTrigger className="flex items-center justify-between w-full gap-2 p-2 transition-colors duration-200 cursor-pointer text-ch-tab-inactive-foreground hover:text-ch-tab-active-foreground">
+        <div className="flex items-center h-5 gap-2 font-medium shrink-0">
           <Play className="size-3" fill="currentColor" />
           <span className="text-ch-tab-active-foreground">Try it</span>
         </div>
@@ -171,7 +172,7 @@ export function RequestClientContent() {
               />
             ))}
         </div>
-        <div className="p-2 gap-2 flex">
+        <div className="flex gap-2 p-2">
           <Select
             value={values["SERVER"]}
             onValueChange={(value) => setValue("SERVER", value)}


### PR DESCRIPTION
-  update rpc curl examples to include maxSupportedTransactionVersion
-  updated pages: `getTransaction`, `getBlock`, `blockSubscribe`
- set min value to 0 for inputs that are `number` in "Try It" component