### PR TITLE
docs: update issuer-guide page snippets

### DIFF
--- a/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
@@ -14,40 +14,34 @@ token account.
 
 To enable the Scaled UI Amount extension on a token mint, you need to set the
 `scaled_ui_amount_extension` field to `true` in the `Mint` account. Here is an
-example of how to create a token with the Scaled UI Amount extension enabled using
-the `spl-token` CLI:
+example of how to create a token with the Scaled UI Amount extension enabled
+using the `spl-token` CLI:
 
-<CodeTabs>
-```bash !! title="Create Token"
+```terminal title="Create Token"
 $ spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --ui-amount-multiplier 1.5
 Creating token 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM under program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
- 
+
 Address:  66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM
 Decimals:  9
- 
+
 Signature: 2sPziXu9M3duTCvsDvxQE9UKC9nBiLayi8muDvnjhA2qYvfXSZuaUieoq39MFjg4kf8xFrw6crmYSkPyV59dvudF
 ```
-</CodeTabs>
 
 ### Update the UI amount multiplier
 
-To update the UI amount multiplier, you need to use the `update-ui-amount-multiplier`
-command. A timestamp is optional and can be used to set a custom start time for
-the new multiplier. If no timestamp is provided, the current timestamp will be
-used.
+To update the UI amount multiplier, you need to use the
+`update-ui-amount-multiplier` command. A timestamp is optional and can be used
+to set a custom start time for the new multiplier. If no timestamp is provided,
+the current timestamp will be used.
 
-<CodeTabs>
-```bash !! title="Update UI Amount Multiplier"
-$ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM 1.5 -- 1746471400 
+```terminal title="Update UI Amount Multiplier"
+$ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM 1.5 -- 1746471400
 ```
-</CodeTabs>
 
 ### Fetch the Balance
 
 To fetch the balance, you need to use the `balance` command.
 
-<CodeTabs>
-```bash !! title="Fetch Balance"
+```terminal title="Fetch Balance"
 $ spl-token balance 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM
 ```
-</CodeTabs>


### PR DESCRIPTION
- Update snippest to use custom `terminal` lang identifier instead of `bash`
- Current syntax causing lingo translated pages to break due to parsing issue