### PR TITLE
Add TypeScript Examples to Scaled UI Amount Documentation

### DIFF
--- a/content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx
@@ -9,26 +9,19 @@ description:
 
 ## Background
 
-A new token extension called “Scaled UI Amount” was launched recently that
-allows token issuers to specify a multiplier to be used when calculating the UI
-amount of a user’s token balance. This enables issuers to create rebasing tokens
-and to enable things like stock splits. This extension, like the interest
-bearing token extension, provides a purely cosmetic UI amount. The underlying
-calculations and transfers all occur using the raw amounts in the program.
+The Scaled UI Amount extension allows token issuers to specify a multiplier to
+be used when calculating the UI amount of a user’s token balance. This enables
+issuers to create rebasing tokens and to enable things like stock splits. This
+extension, like the interest bearing token extension, provides a purely cosmetic
+UI amount which means teams need to do some additional work to provide a good
+experience. Underlying calculations and transfers all occur using the raw
+amounts in the program.
 
 ### Resources:
 
 - [Developer Documentation](https://www.solana-program.com/docs/token-2022/extensions#scaled-ui-amount)
 - [Extension Rust Code](https://github.com/solana-program/token-2022/tree/main/program/src/extension/scaled_ui_amount)
 - [Amount to UI Amount Rust Code](https://github.com/solana-program/token-2022/blob/main/program/src/processor.rs#L1425)
-
-## Goals
-
-- Provide the best UX for end users
-- Provide clear and straightforward guidelines for teams to create a unified
-  experience of interest bearing tokens across the ecosystem
-- Identify and plan work to reduce work teams have to do to integrate with the
-  scaled UI amount extension
 
 ## TL;DR
 
@@ -136,19 +129,7 @@ set for a future date, you can automatically poll at this update time
   tokens that use the scaled UI amount extension and are happy to provide
   support during this process.
 
-## Utility Functions To Add To SPL-Token Library:
-
-- **\[Done\]** Amount to UIAmount: Provide a function to get the UIAmount at the
-  current time given the mint and raw amount
-- **\[Done\]** UIAmount to Amount: Provide a function to get the raw amount at
-  the current time given the mint and UIAmount
-- **\[Done\]** Amount to UIAmount for: Provide a function to get the UIAmount
-  for a given multiplier and decimal and raw amount
-- **\[Done\]** UIAmount to Amount: Provide a function to get the raw amount for
-  a given multiplier and decimal and UIAmount
-- **\[TODO\]** All above helper functionality for @solana/kit
-
-## Acceptance Criteria Per Platform
+## Recommended Integration Priorities Per Platform
 
 ### **General Requirements**
 

--- a/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
@@ -8,7 +8,8 @@ description:
 ## How to use the Scaled UI Amount extension
 
 To use the Scaled UI Amount extension, you need to enable it on a token mint or
-token account.
+token account. Note that once a token is created, you cannot modify which extensions
+are enabled.
 
 ### Enable the Scaled UI Amount extension on a token mint
 
@@ -17,15 +18,109 @@ To enable the Scaled UI Amount extension on a token mint, you need to set the
 example of how to create a token with the Scaled UI Amount extension enabled
 using the `spl-token` CLI:
 
-```terminal title="Create Token"
+<CodeTabs>
+```terminal !! title="create-token.sh"
 $ spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --ui-amount-multiplier 1.5
 Creating token 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM under program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
-
+ 
 Address:  66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM
 Decimals:  9
-
+ 
 Signature: 2sPziXu9M3duTCvsDvxQE9UKC9nBiLayi8muDvnjhA2qYvfXSZuaUieoq39MFjg4kf8xFrw6crmYSkPyV59dvudF
 ```
+
+```ts !! title="create-token.ts"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Signer,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction,
+} from "@solana/web3.js";
+import {
+  TOKEN_2022_PROGRAM_ID,
+  createInitializeMintInstruction,
+  createInitializeScaledUiAmountConfigInstruction,
+  ExtensionType,
+  getMintLen,
+} from "@solana/spl-token";
+
+/**
+ * Creates a new SPL-Token 2022 mint with the Scaled UI extension enabled
+ * and a UI multiplier of 1.1.
+ *
+ * @param connection – An initialized Solana Connection.
+ * @param payer      – Signer paying for fees and rent.
+ * @returns The newly created mint PublicKey.
+ */
+export async function createScaledUiMint(
+  connection: Connection,
+  payer: Signer
+): Promise<PublicKey> {
+  // 1) Generate a new mint Keypair
+  const mint = Keypair.generate();
+  const MINT_EXTENSIONS = [ExtensionType.ScaledUiAmountConfig];
+  const mintLen = getMintLen(MINT_EXTENSIONS);
+  const mintLamports = await connection.getMinimumBalanceForRentExemption(
+    mintLen
+  );
+  const mintTransaction = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: payer.publicKey,
+      newAccountPubkey: mint.publicKey,
+      space: mintLen,
+      lamports: mintLamports,
+      programId: TOKEN_2022_PROGRAM_ID,
+    }),
+    createInitializeScaledUiAmountConfigInstruction(
+      mint.publicKey,
+      payer.publicKey,
+      1.1,
+      TOKEN_2022_PROGRAM_ID
+    ),
+    createInitializeMintInstruction(
+      mint.publicKey,
+      0,
+      payer.publicKey,
+      null,
+      TOKEN_2022_PROGRAM_ID
+    )
+  );
+  await sendAndConfirmTransaction(
+    connection,
+    mintTransaction,
+    [payer, mint],
+    undefined
+  );
+
+  console.log(
+    "✅ Created mint w/ scaled-UI extension:",
+    mint.publicKey.toBase58()
+  );
+  return mint.publicKey;
+}
+(async () => {
+  // 1) Establish a connection to the Solana devnet
+  const connection = new Connection('https://api.devnet.solana.com', 'confirmed');
+
+  // 2) Generate a new fee-payer Keypair
+  const payer = Keypair.generate();
+
+  // 3) Airdrop 1 SOL to the fee-payer so it has funds for transactions
+  const airdropSignature = await connection.requestAirdrop(
+    payer.publicKey,
+    1_000_000_000 // 1 SOL in lamports
+  );
+
+  // 4) Create the scaled-UI mint using our helper
+  const mintPubkey = await createScaledUiMint(connection, payer);
+})().catch(err => {
+  console.error('Error running example:', err);
+});
+```
+</CodeTabs>
 
 ### Update the UI amount multiplier
 
@@ -34,14 +129,105 @@ To update the UI amount multiplier, you need to use the
 to set a custom start time for the new multiplier. If no timestamp is provided,
 the current timestamp will be used.
 
-```terminal title="Update UI Amount Multiplier"
-$ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM 1.5 -- 1746471400
+<CodeTabs>
+```terminal !! title="update-ui-amount-multiplier.sh"
+$ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM 1.5 -- 1746471400 
 ```
+```ts !! title="update-ui-amount-multiplier.ts"
+/**
+ * Updates the scaled UI multiplier for an existing SPL-Token 2022 mint.
+ *
+ * @param connection – An initialized Solana Connection.
+ * @param payer      – Signer paying for fees and rent.
+ * @param mint       – PublicKey of the mint to update.
+ * @param multiplier – New multiplier value to set.
+ * @returns The transaction signature.
+ */
+export async function updateScaledUiMultiplier(
+  connection: Connection,
+  payer: Signer,
+  mint: PublicKey,
+  multiplier: number,
+  effectiveTimestamp: bigint
+): Promise<string> {
+  const transaction = new Transaction().add(
+    createUpdateMultiplierDataInstruction(
+      mint,
+      payer.publicKey,
+      multiplier,
+      effectiveTimestamp,
+      [],
+      TOKEN_2022_PROGRAM_ID
+    )
+  );
+
+  const signature = await sendAndConfirmTransaction(
+    connection,
+    transaction,
+    [payer],
+    undefined
+  );
+
+  console.log(
+    `✅ Updated scaled-UI multiplier to ${multiplier} for mint:`,
+    mint.toBase58()
+  );
+  return signature;
+}
+const multiplier = 1.5;
+const effectiveTimestamp = BigInt(Date.now());
+const updateSignature = await updateScaledUiMultiplier(
+  connection,
+  payer,
+  mintPubkey,
+  multiplier,
+  effectiveTimestamp
+);
+console.log('Update signature:', updateSignature);
+```
+</CodeTabs>
 
 ### Fetch the Balance
 
 To fetch the balance, you need to use the `balance` command.
 
-```terminal title="Fetch Balance"
+<CodeTabs>
+```terminal !! title="balance.sh"
 $ spl-token balance 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM
 ```
+```ts !! title="balance.ts"
+/**
+ * Gets the scaled UI amount balance for a token holder.
+ *
+ * @param connection – An initialized Solana Connection.
+ * @param mint       – PublicKey of the mint to check.
+ * @param owner      – PublicKey of the token holder.
+ * @returns The scaled UI amount balance.
+ */
+export async function getScaledUiAmountBalance(
+  connection: Connection,
+  mint: PublicKey,
+  owner: PublicKey
+): Promise<number> {
+  // Get the token account for this mint/owner pair
+  const tokenAccount = getAssociatedTokenAddressSync(
+    mint,
+    owner,
+    false,
+    TOKEN_2022_PROGRAM_ID
+  );
+
+  // Get the token account info
+  const accountInfo = await connection.getAccountInfo(tokenAccount);
+  if (!accountInfo) {
+    throw new Error('Token account not found');
+  }
+
+  const info = await connection.getTokenAccountBalance(tokenAccount);
+  if (info.value.uiAmount == null) throw new Error('No balance found');
+  console.log('Balance: ', info.value.uiAmount);
+  return info.value.uiAmount;
+}
+const balance = await getScaledUiAmountBalance(connection, mint, owner);
+```
+</CodeTabs>


### PR DESCRIPTION
# Add TypeScript Examples to Scaled UI Amount Documentation

## Changes
- Added TypeScript code examples to the Scaled UI Amount Issuer Guide for:
  - Creating a token with the Scaled UI Amount extension
  - Updating the UI amount multiplier
  - Fetching token balances
- Cleaned up and clarified language in the Integration Guide