### PR TITLE
docs: update fee page, add context for transaction priority

### DIFF
--- a/content/docs/en/core/fees.mdx
+++ b/content/docs/en/core/fees.mdx
@@ -90,9 +90,24 @@ guide for more details on priority fees.
 
 ### Calculate Prioritization Fee
 
-The prioritization fee is calculated as:
+The
+[prioritization fee](https://github.com/anza-xyz/agave/blob/v2.2.14/compute-budget/src/compute_budget_limits.rs#L47-L48)
+is calculated as:
 
 **Prioritization Fee = Compute Unit Limit × Compute Unit Price**
+
+The recommended approach for setting priority fees is to first
+[simulate](/developers/guides/advanced/how-to-request-optimal-compute) the
+transaction to estimate the required compute units. Then, add a 10% safety
+margin to this estimate and use the resulting value as the `Compute Unit Limit`.
+
+The
+[transaction priority](https://github.com/anza-xyz/agave/blob/v2.2.14/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs#L646),
+which determines how it's prioritized relative to other transactions, is
+calculated using the following formula:
+
+**Priority = ((Compute Unit Limit \* Compute Unit Price) + Base Fee) / (1 +
+Compute Unit Limit + Signature CUs + Write Lock CUs)**
 
 Use these instructions to set the compute unit limit and price on a transaction:
 


### PR DESCRIPTION
- Add context for transaction priority

References from Agave:
- [calculate_priority_and_cost](https://github.com/anza-xyz/agave/blob/v2.2.14/core/src/banking_stage/transaction_scheduler/receive_and_buffer.rs#L646)
- [calculate_cost](https://github.com/anza-xyz/agave/blob/master/cost-model/src/cost_model.rs#L37)
- [calculate_non_vote_transaction_cost](https://github.com/anza-xyz/agave/blob/master/cost-model/src/cost_model.rs#L113)