### PR TITLE
fix: Make format equal for all languages and add Quicknode Priority Fee

### DIFF
--- a/content/docs/ar/core/fees.mdx
+++ b/content/docs/ar/core/fees.mdx
@@ -72,10 +72,11 @@ description:
 استخدم هذه الموارد للحصول على توصيات في الوقت الفعلي حول سعر وحدة الحوسبة
 الحالي:
 
-- [واجهة برمجة تطبيقات رسوم الأولوية](https://docs.helius.dev/solana-apis/priority-fee-api)
-  من Helius
-- [متتبع رسوم الأولوية العالمي](https://triton.one/solana-prioritization-fees/)
-  من Triton
+| مزود الخدمة                           |      واجهة برمجة تطبيقات رسوم الأولوية                                                    |
+| ------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)     | [واجهة برمجة تطبيقات رسوم الأولوية](https://docs.helius.dev/solana-apis/priority-fee-api) |
+| [QuickNode](https://www.quicknode.com/) | [رسوم الأولوية](https://marketplace.quicknode.com/add-on/solana-priority-fee)           |
+| [Triton](https://triton.one/)         | [متتبع رسوم الأولوية العالمي](https://triton.one/solana-prioritization-fees/)             |
 
 راجع دليل
 [كيفية استخدام رسوم الأولوية](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/de/core/fees.mdx
+++ b/content/docs/de/core/fees.mdx
@@ -84,10 +84,11 @@ Preis wird verwendet, um die priority fee für Ihre Transaktion zu berechnen.
 Nutzen Sie diese Ressourcen, um Echtzeit-Empfehlungen zum aktuellen
 Compute-Einheiten-Preis zu erhalten:
 
-| Anbieter                          | Priority Fee API                                                                  |
-| --------------------------------- | --------------------------------------------------------------------------------- |
-| [Helius](https://www.helius.dev/) | [Dokumentation](https://docs.helius.dev/solana-apis/priority-fee-api)             |
-| [Triton](https://triton.one/)     | [Dokumentation](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
+| Anbieter                                | Priority Fee API                                                                  |
+| --------------------------------------- | --------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [Dokumentation](https://docs.helius.dev/solana-apis/priority-fee-api)             |
+| [QuickNode](https://www.quicknode.com/) | [Dokumentation](https://marketplace.quicknode.com/add-on/solana-priority-fee)     |
+| [Triton](https://triton.one/)           | [Dokumentation](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
 
 Weitere Details zu priority fees finden Sie im
 [Leitfaden zur Verwendung von Priority Fees](/developers/guides/advanced/how-to-use-priority-fees).

--- a/content/docs/el/core/fees.mdx
+++ b/content/docs/el/core/fees.mdx
@@ -87,10 +87,11 @@ lamports ανά υπογραφή που περιλαμβάνεται στη συ
 Χρησιμοποιήστε αυτούς τους πόρους για να λάβετε συστάσεις σε πραγματικό χρόνο
 σχετικά με την τρέχουσα τιμή μονάδας υπολογισμού:
 
-- [Priority Fee API](https://docs.helius.dev/solana-apis/priority-fee-api) από
-  Helius
-- [Global Priority Fee Tracker](https://triton.one/solana-prioritization-fees/)
-  από Triton
+| Πάροχος                                 | API Προτεραιότητας Τελών                                                          |
+| --------------------------------------- | --------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [Priority Fee API](https://docs.helius.dev/solana-apis/priority-fee-api)          |
+| [QuickNode](https://www.quicknode.com/) | [Priority Fee API](https://marketplace.quicknode.com/add-on/solana-priority-fee)  |
+| [Triton](https://triton.one/)           | [Global Priority Fee Tracker](https://triton.one/solana-prioritization-fees/)     |
 
 Δείτε τον οδηγό
 [Πώς να χρησιμοποιήσετε τις προμήθειες προτεραιότητας](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/en/core/fees.mdx
+++ b/content/docs/en/core/fees.mdx
@@ -79,10 +79,11 @@ prioritization fee for your transaction.
 Use these resources to get real-time recommendations on the current compute unit
 price:
 
-| Provider                          | Priority Fee API                                                                  |
-| --------------------------------- | --------------------------------------------------------------------------------- |
-| [Helius](https://www.helius.dev/) | [Documentation](https://docs.helius.dev/solana-apis/priority-fee-api)             |
-| [Triton](https://triton.one/)     | [Documentation](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
+| Provider                              | Priority Fee API                                                                      |
+| ------------------------------------- | ------------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)     | [Documentation](https://docs.helius.dev/solana-apis/priority-fee-api)                 |
+| [QuickNode](https://www.quicknode.com/) | [Documentation](https://marketplace.quicknode.com/add-on/solana-priority-fee)       |
+| [Triton](https://triton.one/)         | [Documentation](https://docs.triton.one/chains/solana/improved-priority-fees-api)     |
 
 See the
 [How to Use Priority Fees](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/es/core/fees.mdx
+++ b/content/docs/es/core/fees.mdx
@@ -85,8 +85,9 @@ Utiliza estos recursos para obtener recomendaciones en tiempo real sobre el
 precio actual de unidad de cómputo:
 
 | Proveedor                         | API de Tarifas Prioritarias                                                       |
-| --------------------------------- | --------------------------------------------------------------------------------- |
+|-----------------------------------|-----------------------------------------------------------------------------------|
 | [Helius](https://www.helius.dev/) | [Documentación](https://docs.helius.dev/solana-apis/priority-fee-api)             |
+| [QuickNode](https://quicknode.com)| [Documentación](https://marketplace.quicknode.com/add-on/solana-priority-fee)     |
 | [Triton](https://triton.one/)     | [Documentación](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
 
 Consulta la guía

--- a/content/docs/fi/core/fees.mdx
+++ b/content/docs/fi/core/fees.mdx
@@ -78,10 +78,11 @@ transaktiosi priorisointimaksun laskemiseen.
 Käytä näitä resursseja saadaksesi reaaliaikaisia suosituksia nykyisestä
 laskentayksikön hinnasta:
 
-- [Priority Fee API](https://docs.helius.dev/solana-apis/priority-fee-api)
-  Heliuksen tarjoamana
-- [Global Priority Fee Tracker](https://triton.one/solana-prioritization-fees/)
-  Tritonin tarjoamana
+| Palveluntarjoaja                        | Prioriteettimaksu-API                                                             |
+| --------------------------------------- | --------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [Priority Fee API](https://docs.helius.dev/solana-apis/priority-fee-api)          |
+| [QuickNode](https://www.quicknode.com/) | [Priority Fee](https://marketplace.quicknode.com/add-on/solana-priority-fee)      |
+| [Triton](https://triton.one/)           | [Global Priority Fee Tracker](https://triton.one/solana-prioritization-fees/)     |
 
 Katso
 [Kuinka käyttää prioriteettimaksuja](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/fr/core/fees.mdx
+++ b/content/docs/fr/core/fees.mdx
@@ -84,10 +84,11 @@ utilisé pour calculer les frais de priorisation de votre transaction.
 Utilisez ces ressources pour obtenir des recommandations en temps réel sur le
 prix actuel des unités de calcul :
 
-| Fournisseur                       | API de frais prioritaires                                                         |
-| --------------------------------- | --------------------------------------------------------------------------------- |
-| [Helius](https://www.helius.dev/) | [Documentation](https://docs.helius.dev/solana-apis/priority-fee-api)             |
-| [Triton](https://triton.one/)     | [Documentation](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
+| Fournisseur                        | API de frais prioritaires                                                         |
+| ---------------------------------- | --------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)  | [Documentation](https://docs.helius.dev/solana-apis/priority-fee-api)             |
+| [QuickNode](https://quicknode.com) | [Documentation](https://marketplace.quicknode.com/add-on/solana-priority-fee)     |
+| [Triton](https://triton.one/)      | [Documentation](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
 
 Consultez le guide
 [Comment utiliser les frais prioritaires](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/id/core/fees.mdx
+++ b/content/docs/id/core/fees.mdx
@@ -81,10 +81,11 @@ menghitung biaya prioritas untuk transaksi Anda.
 Gunakan sumber daya berikut untuk mendapatkan rekomendasi real-time tentang
 harga compute unit saat ini:
 
-| Penyedia                          | API Biaya Prioritas                                                             |
-| --------------------------------- | ------------------------------------------------------------------------------- |
-| [Helius](https://www.helius.dev/) | [Dokumentasi](https://docs.helius.dev/solana-apis/priority-fee-api)             |
-| [Triton](https://triton.one/)     | [Dokumentasi](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
+| Penyedia                           | API Biaya Prioritas                                                             |
+| ---------------------------------- | ------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)  | [Dokumentasi](https://docs.helius.dev/solana-apis/priority-fee-api)             |
+| [QuickNode](https://quicknode.com) | [Dokumentasi](https://marketplace.quicknode.com/add-on/solana-priority-fee)     |
+| [Triton](https://triton.one/)      | [Dokumentasi](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
 
 Lihat panduan
 [Cara Menggunakan Biaya Prioritas](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/it/core/fees.mdx
+++ b/content/docs/it/core/fees.mdx
@@ -86,10 +86,11 @@ transazione.
 Utilizza queste risorse per ottenere consigli in tempo reale sul prezzo corrente
 dell'unità di calcolo:
 
-- [API per commissioni di priorità](https://docs.helius.dev/solana-apis/priority-fee-api)
-  di Helius
-- [Monitoraggio globale delle commissioni di priorità](https://triton.one/solana-prioritization-fees/)
-  di Triton
+| Fornitore                               | API per commissioni di priorità                                                                      |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [API per commissioni di priorità](https://docs.helius.dev/solana-apis/priority-fee-api)              |
+| [QuickNode](https://www.quicknode.com/) | [Commissioni di priorità](https://marketplace.quicknode.com/add-on/solana-priority-fee)              |
+| [Triton](https://triton.one/)           | [Monitoraggio globale delle commissioni di priorità](https://triton.one/solana-prioritization-fees/) |
 
 Consulta la guida
 [Come utilizzare le commissioni di priorità](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/ja/core/fees.mdx
+++ b/content/docs/ja/core/fees.mdx
@@ -56,8 +56,11 @@ Programが所有するアカウントでなければなりません。
 
 現在のコンピュートユニット価格に関するリアルタイムの推奨事項を得るには、以下のリソースを使用してください：
 
-- Heliusによる[優先手数料API](https://docs.helius.dev/solana-apis/priority-fee-api)
-- Tritonによる[グローバル優先手数料トラッカー](https://triton.one/solana-prioritization-fees/)
+| プロバイダー                            | 優先手数料API                                                                       |
+| --------------------------------------- | ------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [優先手数料API](https://docs.helius.dev/solana-apis/priority-fee-api)             |
+| [QuickNode](https://www.quicknode.com/) | [優先手数料](https://marketplace.quicknode.com/add-on/solana-priority-fee)        |
+| [Triton](https://triton.one/)           | [グローバル優先手数料トラッカー](https://triton.one/solana-prioritization-fees/)     |
 
 優先手数料の詳細については、[優先手数料の使用方法](/developers/guides/advanced/how-to-use-priority-fees)ガイドをご覧ください。
 

--- a/content/docs/ko/core/fees.mdx
+++ b/content/docs/ko/core/fees.mdx
@@ -76,10 +76,11 @@ lamport입니다.
 
 현재 컴퓨트 유닛 가격에 대한 실시간 추천을 얻으려면 다음 리소스를 사용하세요:
 
-- Helius의
-  [우선순위 수수료 API](https://docs.helius.dev/solana-apis/priority-fee-api)
-- Triton의
-  [글로벌 우선순위 수수료 트래커](https://triton.one/solana-prioritization-fees/)
+| 제공업체                                | 우선순위 수수료 API                                                               |
+| --------------------------------------- | --------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [우선순위 수수료 API](https://docs.helius.dev/solana-apis/priority-fee-api)     |
+| [QuickNode](https://www.quicknode.com/) | [우선순위 수수료](https://marketplace.quicknode.com/add-on/solana-priority-fee) |
+| [Triton](https://triton.one/)           | [글로벌 우선순위 수수료 트래커](https://triton.one/solana-prioritization-fees/)    |
 
 우선순위 수수료에 대한 자세한 내용은
 [우선순위 수수료 사용 방법](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/nl/core/fees.mdx
+++ b/content/docs/nl/core/fees.mdx
@@ -86,10 +86,11 @@ de prioriteitvergoeding voor je transactie te berekenen.
 Gebruik deze bronnen om realtime aanbevelingen te krijgen over de huidige
 compute unit prijs:
 
-- [Priority Fee API](https://docs.helius.dev/solana-apis/priority-fee-api) door
-  Helius
-- [Global Priority Fee Tracker](https://triton.one/solana-prioritization-fees/)
-  door Triton
+| Aanbieder                               | Prioriteitsvergoeding API                                                         |
+| --------------------------------------- | --------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [Priority Fee API](https://docs.helius.dev/solana-apis/priority-fee-api)          |
+| [QuickNode](https://www.quicknode.com/) | [Priority Fee](https://marketplace.quicknode.com/add-on/solana-priority-fee)      |
+| [Triton](https://triton.one/)           | [Global Priority Fee Tracker](https://triton.one/solana-prioritization-fees/)     |
 
 Bekijk de
 [Hoe prioriteitsvergoedingen te gebruiken](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/pl/core/fees.mdx
+++ b/content/docs/pl/core/fees.mdx
@@ -82,10 +82,11 @@ obliczenia opłaty priorytetowej dla Twojej transakcji.
 Skorzystaj z tych zasobów, aby uzyskać rekomendacje w czasie rzeczywistym
 dotyczące aktualnej ceny jednostki obliczeniowej:
 
-- [Priority Fee API](https://docs.helius.dev/solana-apis/priority-fee-api) od
-  Helius
-- [Global Priority Fee Tracker](https://triton.one/solana-prioritization-fees/)
-  od Triton
+| Dostawca                                | API opłat priorytetowych                                                            |
+| --------------------------------------- | ----------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [Priority Fee API](https://docs.helius.dev/solana-apis/priority-fee-api)            |
+| [QuickNode](https://www.quicknode.com/) | [Priority Fee](https://marketplace.quicknode.com/add-on/solana-priority-fee)        |
+| [Triton](https://triton.one/)           | [Global Priority Fee Tracker](https://triton.one/solana-prioritization-fees/)       |
 
 Zobacz przewodnik
 [Jak korzystać z opłat priorytetowych](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/ru/core/fees.mdx
+++ b/content/docs/ru/core/fees.mdx
@@ -83,10 +83,11 @@ lamport за каждую подпись, включенную в транзак
 Используйте эти ресурсы для получения рекомендаций в реальном времени о текущей
 цене вычислительной единицы:
 
-| Провайдер                         | API приоритетных комиссий                                                        |
-| --------------------------------- | -------------------------------------------------------------------------------- |
-| [Helius](https://www.helius.dev/) | [Документация](https://docs.helius.dev/solana-apis/priority-fee-api)             |
-| [Triton](https://triton.one/)     | [Документация](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
+| Провайдер                         | API приоритетных комиссий                                                       |
+|---------------------------------- |-------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/) | [Документация](https://docs.helius.dev/solana-apis/priority-fee-api)            |
+| [QuickNode](https://quicknode.com)| [Документация](https://marketplace.quicknode.com/add-on/solana-priority-fee)    |
+| [Triton](https://triton.one/)     | [Документация](https://docs.triton.one/chains/solana/improved-priority-fees-api)|
 
 Смотрите руководство
 [Как использовать комиссии за приоритет](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/tr/core/fees.mdx
+++ b/content/docs/tr/core/fees.mdx
@@ -82,10 +82,11 @@ işleminizin önceliklendirme ücretini hesaplamak için kullanılır.
 Mevcut hesaplama birimi fiyatı hakkında gerçek zamanlı öneriler almak için bu
 kaynakları kullanın:
 
-| Sağlayıcı                         | Öncelik Ücreti API'si                                                             |
-| --------------------------------- | --------------------------------------------------------------------------------- |
-| [Helius](https://www.helius.dev/) | [Dokümantasyon](https://docs.helius.dev/solana-apis/priority-fee-api)             |
-| [Triton](https://triton.one/)     | [Dokümantasyon](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
+| Sağlayıcı                               | Öncelik Ücreti API'si                                                             |
+| --------------------------------------- | --------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [Dokümantasyon](https://docs.helius.dev/solana-apis/priority-fee-api)             |
+| [QuickNode](https://www.quicknode.com/) | [Dokümantasyon](https://marketplace.quicknode.com/add-on/solana-priority-fee)     |
+| [Triton](https://triton.one/)           | [Dokümantasyon](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
 
 Öncelik ücretleri hakkında daha fazla ayrıntı için
 [Öncelik Ücretleri Nasıl Kullanılır](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/uk/core/fees.mdx
+++ b/content/docs/uk/core/fees.mdx
@@ -84,10 +84,11 @@ lamport за кожен підпис, включений у транзакцію
 Використовуйте ці ресурси, щоб отримати рекомендації в реальному часі щодо
 поточної ціни обчислювальної одиниці:
 
-- [API комісій за пріоритет](https://docs.helius.dev/solana-apis/priority-fee-api)
-  від Helius
-- [Глобальний трекер комісій за пріоритет](https://triton.one/solana-prioritization-fees/)
-  від Triton
+| Постачальник                            | API комісій за пріоритет                                                                 |
+| --------------------------------------- | ---------------------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [API комісій за пріоритет](https://docs.helius.dev/solana-apis/priority-fee-api)         |
+| [QuickNode](https://www.quicknode.com/) | [Комісії за пріоритет](https://marketplace.quicknode.com/add-on/solana-priority-fee)     |
+| [Triton](https://triton.one/)           | [Глобальний трекер комісій за пріоритет](https://triton.one/solana-prioritization-fees/) |
 
 Дивіться посібник
 [Як використовувати комісії за пріоритет](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/vi/core/fees.mdx
+++ b/content/docs/vi/core/fees.mdx
@@ -79,10 +79,11 @@ dụng để tính toán phí ưu tiên cho giao dịch của bạn.
 Sử dụng các tài nguyên sau để nhận khuyến nghị thời gian thực về giá đơn vị tính
 toán hiện tại:
 
-| Nhà cung cấp                      | API Phí Ưu tiên                                                              |
-| --------------------------------- | ---------------------------------------------------------------------------- |
-| [Helius](https://www.helius.dev/) | [Tài liệu](https://docs.helius.dev/solana-apis/priority-fee-api)             |
-| [Triton](https://triton.one/)     | [Tài liệu](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
+| Nhà cung cấp                            | API Phí Ưu tiên                                                              |
+| --------------------------------------- | ---------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)       | [Tài liệu](https://docs.helius.dev/solana-apis/priority-fee-api)             |
+| [QuickNode](https://www.quicknode.com/) | [Tài liệu](https://marketplace.quicknode.com/add-on/solana-priority-fee)     |
+| [Triton](https://triton.one/)           | [Tài liệu](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
 
 Xem hướng dẫn
 [Cách sử dụng phí ưu tiên](/developers/guides/advanced/how-to-use-priority-fees)

--- a/content/docs/zh/core/fees.mdx
+++ b/content/docs/zh/core/fees.mdx
@@ -60,10 +60,11 @@ description:
 
 使用以下资源获取当前计算单元价格的实时建议：
 
-| 提供商                            | Priority Fee API                                                         |
-| --------------------------------- | ------------------------------------------------------------------------ |
-| [Helius](https://www.helius.dev/) | [文档](https://docs.helius.dev/solana-apis/priority-fee-api)             |
-| [Triton](https://triton.one/)     | [文档](https://docs.triton.one/chains/solana/improved-priority-fees-api) |
+| 提供商                                    | Priority Fee API                                                           |
+| ---------------------------------------- | -------------------------------------------------------------------------- |
+| [Helius](https://www.helius.dev/)        | [文档](https://docs.helius.dev/solana-apis/priority-fee-api)               |
+| [QuickNode](https://www.quicknode.com/)  | [文档](https://marketplace.quicknode.com/add-on/solana-priority-fee)       |
+| [Triton](https://triton.one/)            | [文档](https://docs.triton.one/chains/solana/improved-priority-fees-api)   |
 
 请参阅
 [如何使用优先费用](https://developers/guides/advanced/how-to-use-priority-fees)


### PR DESCRIPTION
### Problem

Markdown formatting uses a different format for Priority fee links. (tables and lists)


### Summary of Changes

Unify the formatting and add the Quicknode Priority fee to the list. 
