### PR TITLE
docs: update transaction section cookbook

### DIFF
--- a/content/cookbook/index.mdx
+++ b/content/cookbook/index.mdx
@@ -68,21 +68,6 @@ Learn how to manage Solana accounts effectively.
 | [How to Close an Account](/developers/cookbook/accounts/close-account)                 | Rust             | Remove accounts            |
 | [How to Get Account Balance](/developers/cookbook/accounts/get-account-balance)        | JavaScript       | Check account balances     |
 
-## Program Development
-
-Develop Solana programs with these comprehensive guides.
-
-| Guide                                                                                        | Client | Description                  |
-| -------------------------------------------------------------------------------------------- | ------ | ---------------------------- |
-| [How to Transfer SOL in a Solana Program](/developers/cookbook/programs/transfer-sol)        | Rust   | Program-based SOL transfers  |
-| [How to Get Clock in a Program](/developers/cookbook/programs/clock)                         | Rust   | Access program clock         |
-| [How to Change Account Size](/developers/cookbook/programs/change-account-size)              | Rust   | Modify account sizes         |
-| [How to Do Cross Program Invocation](/developers/cookbook/programs/cross-program-invocation) | Rust   | CPI operations               |
-| [How to Create a Program Derived Address](/developers/cookbook/programs/create-pda)          | Rust   | Generate PDAs                |
-| [How to Read Accounts in a Program](/developers/cookbook/programs/read-accounts)             | Rust   | Account data access          |
-| [Reading Multiple Instructions](/developers/cookbook/programs/read-multiple-instructions)    | Rust   | Handle multiple instructions |
-| [How to Verify Accounts in a Solana Program](/developers/cookbook/programs/verify-accounts)  | Rust   | Account verification         |
-
 ## Token Operations
 
 Comprehensive guides for working with tokens on Solana.

--- a/content/cookbook/transactions/add-memo.mdx
+++ b/content/cookbook/transactions/add-memo.mdx
@@ -9,7 +9,59 @@ Any transaction can add a message making use of the SPL memo program.
 
 <CodeTabs >
 
-```typescript !! title="gill"
+```ts !! title="Kit"
+import {
+  airdropFactory,
+  appendTransactionMessageInstructions,
+  createSolanaRpc,
+  createSolanaRpcSubscriptions,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  getSignatureFromTransaction,
+  lamports,
+  pipe,
+  sendAndConfirmTransactionFactory,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners
+} from "@solana/kit";
+import { getAddMemoInstruction } from "@solana-program/memo";
+
+const rpc = createSolanaRpc("http://localhost:8899");
+const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
+
+const sender = await generateKeyPairSigner();
+const LAMPORTS_PER_SOL = 1_000_000_000n;
+await airdropFactory({ rpc, rpcSubscriptions })({
+  recipientAddress: sender.address,
+  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
+  commitment: "confirmed"
+});
+
+// !mark(1:3)
+const memoInstruction = getAddMemoInstruction({
+  memo: "Hello, world!"
+});
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const transactionMessage = pipe(
+  createTransactionMessage({ version: 0 }),
+  (tx) => setTransactionMessageFeePayerSigner(sender, tx),
+  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+  (tx) => appendTransactionMessageInstructions([transferInstruction], tx)
+);
+
+const signedTransaction =
+  await signTransactionMessageWithSigners(transactionMessage);
+await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
+  signedTransaction,
+  { commitment: "confirmed" }
+);
+const transactionSignature = getSignatureFromTransaction(signedTransaction);
+console.log("Transaction Signature:", transactionSignature);
+```
+
+```typescript !! title="Gill"
 import {
   getExplorerLink,
   createTransaction,
@@ -33,6 +85,7 @@ const transaction = createTransaction({
   version: "legacy",
   feePayer: signer,
   instructions: [
+    // !mark(1:3)
     getAddMemoInstruction({
       memo: "Memo message to send in this transaction"
     })
@@ -86,6 +139,7 @@ await connection.confirmTransaction({
 });
 
 // Create a memo instruction
+// !mark
 const memoInstruction = createMemoInstruction("Hello, World!");
 
 // Create transaction and add the memo instruction
@@ -118,6 +172,7 @@ async fn main() -> anyhow::Result<()> {
     let signer_keypair = Keypair::new();
     let memo = String::from("Memo message to be logged in this transaction");
 
+    // !mark
     let memo_ix = build_memo(memo.as_bytes(), &[&signer_keypair.pubkey()]);
 
     let transaction_signature = client

--- a/content/cookbook/transactions/add-priority-fees.mdx
+++ b/content/cookbook/transactions/add-priority-fees.mdx
@@ -1,94 +1,18 @@
 ---
 title: How to Add Priority Fees to a Transaction
 description:
-  "Transactions executed in order they are prioritized on Solana. Learn how to
-  increase your transaction priority with priority fees on Solana."
+  "Learn how to increase your transaction priority with priority fees on Solana."
 ---
 
-Transaction (TX) priority is achieved by paying a Prioritization Fee in addition
-to the Base Fee. By default the compute budget is the product of 200,000 Compute
-Units (CU) \* number of instructions, with a max of 1.4M CU. The Base Fee is
-5,000 Lamports per signature. A microLamport is 0.000001 Lamports.
+A priority fee is an optional fee paid to increase the chance that the current
+leader processes your transaction.
 
-> You can find a detailed guide here on
-> [how to use priority fees](/developers/guides/advanced/how-to-use-priority-fees).
+To add a priority fee to a transaction, invoke instructions from the
+[Compute Budget Program](https://github.com/solana-program/compute-budget).
 
-The total compute budget or Prioritization Fee for a single TX can be changed by
-adding instructions from the ComputeBudgetProgram.
+<CodeTabs flags="r">
 
-`ComputeBudgetProgram.setComputeUnitPrice({ microLamports: number })` will add a
-Prioritization Fee above the Base Fee (5,000 Lamports). The value provided in
-microLamports will be multiplied by the CU budget to determine the
-Prioritization Fee in Lamports. For example, if your CU budget is 1M CU, and you
-add 1 microLamport/CU, the Prioritization Fee will be 1 Lamport (1M \*
-0.000001). The total fee will then be 5001 Lamports.
-
-Use `ComputeBudgetProgram.setComputeUnitLimit({ units: number })` to set the new
-compute budget. The value provided will replace the default value. Transactions
-should request the minimum amount of CU required for execution to maximize
-throughput, or minimize fees.
-
-<CodeTabs >
-
-```typescript !! title="gill"
-import {
-  getExplorerLink,
-  createTransaction,
-  createSolanaClient,
-  getSignatureFromTransaction,
-  signTransactionMessageWithSigners
-} from "gill";
-import { loadKeypairSignerFromFile } from "gill/node";
-import {
-  getAddMemoInstruction,
-  getSetComputeUnitPriceInstruction
-} from "gill/programs";
-
-const { rpc, sendAndConfirmTransaction } = createSolanaClient({
-  urlOrMoniker: "devnet" // or `mainnet`, `localnet`, etc
-});
-
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-
-// load a Signer from the default Solana CLI keypair file
-const signer = await loadKeypairSignerFromFile();
-
-// provide the `computeUnitPrice` value to set a priority fee
-const transaction = createTransaction({
-  version: "legacy",
-  feePayer: signer,
-  instructions: [
-    getAddMemoInstruction({ memo: "Memo message to send in this transaction" })
-  ],
-  latestBlockhash,
-  computeUnitPrice: 10_000 // set compute unit price of 10k micro-lamports per CU
-});
-
-// or you can manually add the compute unit price instruction to set a priority fee
-const transaction2 = createTransaction({
-  version: "legacy",
-  feePayer: signer,
-  instructions: [
-    getAddMemoInstruction({ memo: "Memo message to send in this transaction" }),
-    getSetComputeUnitPriceInstruction({ microLamports: 10_000 }) // set compute unit price of 10k micro-lamports per CU
-  ],
-  latestBlockhash
-});
-
-const signedTransaction = await signTransactionMessageWithSigners(transaction);
-
-console.log(
-  "Sending transaction:",
-  getExplorerLink({
-    cluster: "devnet",
-    transaction: getSignatureFromTransaction(signedTransaction)
-  })
-);
-
-await sendAndConfirmTransaction(signedTransaction);
-```
-
-```typescript !! title="Kit"
+```ts !! title="Kit"
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
@@ -144,6 +68,7 @@ const transactionMessage = pipe(
   (m) =>
     appendTransactionMessageInstructions(
       [
+        // !mark
         getSetComputeUnitPriceInstruction({ microLamports: 5000n }),
         getAddMemoInstruction({ memo: "Hello, world!" })
       ],
@@ -159,6 +84,7 @@ console.log(
 
 // Add compute unit limit instruction to the transaction
 const budgetedTransactionMessage = prependTransactionMessageInstructions(
+  // !mark
   [getSetComputeUnitLimitInstruction({ units: estimatedComputeUnits })],
   transactionMessage
 );
@@ -172,7 +98,66 @@ await sendAndConfirmTransaction(signedTx, { commitment: "confirmed" });
 console.log(`Transaction Signature: ${transactionSignature}`);
 ```
 
-```typescript !! title="Legacy"
+```ts !! title="Gill"
+import {
+  getExplorerLink,
+  createTransaction,
+  createSolanaClient,
+  getSignatureFromTransaction,
+  signTransactionMessageWithSigners
+} from "gill";
+import { loadKeypairSignerFromFile } from "gill/node";
+import {
+  getAddMemoInstruction,
+  getSetComputeUnitPriceInstruction
+} from "gill/programs";
+
+const { rpc, sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet" // or `mainnet`, `localnet`, etc
+});
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+// load a Signer from the default Solana CLI keypair file
+const signer = await loadKeypairSignerFromFile();
+
+// provide the `computeUnitPrice` value to set a priority fee
+const transaction = createTransaction({
+  version: "legacy",
+  feePayer: signer,
+  instructions: [
+    getAddMemoInstruction({ memo: "Memo message to send in this transaction" })
+  ],
+  latestBlockhash,
+  computeUnitPrice: 10_000 // set compute unit price of 10k micro-lamports per CU
+});
+
+// or you can manually add the compute unit price instruction to set a priority fee
+const transaction2 = createTransaction({
+  version: "legacy",
+  feePayer: signer,
+  instructions: [
+    getAddMemoInstruction({ memo: "Memo message to send in this transaction" }),
+    // !mark
+    getSetComputeUnitPriceInstruction({ microLamports: 10_000 }) // set compute unit price of 10k micro-lamports per CU
+  ],
+  latestBlockhash
+});
+
+const signedTransaction = await signTransactionMessageWithSigners(transaction);
+
+console.log(
+  "Sending transaction:",
+  getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTransaction)
+  })
+);
+
+await sendAndConfirmTransaction(signedTransaction);
+```
+
+```ts !! title="Legacy"
 import {
   ComputeBudgetProgram,
   Connection,
@@ -206,6 +191,7 @@ await connection.confirmTransaction({
 
 // Create instructions
 const instructions = [
+  // !mark(1:8)
   // Set compute unit limit (1M units)
   ComputeBudgetProgram.setComputeUnitLimit({
     units: 1000000
@@ -240,7 +226,7 @@ const transactionSignature = await connection.sendTransaction(transaction);
 console.log(`Transaction Signature: ${transactionSignature}`);
 ```
 
-```rust !! title="Rust"
+```rs !! title="Rust"
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
     commitment_config::CommitmentConfig, compute_budget, native_token::LAMPORTS_PER_SOL,
@@ -256,6 +242,7 @@ async fn main() -> anyhow::Result<()> {
 
     let signer_keypair = Keypair::new();
 
+    // !mark(1:2)
     let modify_cu_ix = compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(1_000_000);
     let add_priority_fee_ix = compute_budget::ComputeBudgetInstruction::set_compute_unit_price(1);
 

--- a/content/cookbook/transactions/calculate-cost.mdx
+++ b/content/cookbook/transactions/calculate-cost.mdx
@@ -9,7 +9,7 @@ Every transaction consumes compute units and requires a transaction fee in
 lamports to execute. The number of signatures included on a transaction
 determines the base transaction fee (5000 lamports per signature).
 
-<CodeTabs>
+<CodeTabs >
 
 ```typescript !! title="Kit"
 import {

--- a/content/cookbook/transactions/offline-transactions.mdx
+++ b/content/cookbook/transactions/offline-transactions.mdx
@@ -8,89 +8,110 @@ description: Learn how to create and sign transactions offline.
 To create an offline transaction, you have to sign the transaction and then
 anyone can broadcast it on the network.
 
-<CodeTabs >
-```typescript !! title="web3.js"
+```typescript title="Legacy"
 import {
   Connection,
   Keypair,
   Transaction,
   SystemProgram,
   LAMPORTS_PER_SOL,
-  Message,
+  Message
 } from "@solana/web3.js";
 import nacl from "tweetnacl";
 import bs58 from "bs58";
 
-// To complete an offline transaction, I will separate them into four steps
-// 1. Create Transaction // 2. Sign Transaction // 3. Recover Transaction // 4.
-Send Transaction
-
-(async () => { // create connection const connection = new Connection(
-"http://127.0.0.1:8899", "confirmed" );
-
-// create an example tx, alice transfer to bob and feePayer is `feePayer` //
-alice and feePayer are signer in this tx const feePayer = Keypair.generate();
-await connection.confirmTransaction( await
-connection.requestAirdrop(feePayer.publicKey, LAMPORTS_PER_SOL) ); const alice =
-Keypair.generate(); await connection.confirmTransaction( await
-connection.requestAirdrop(alice.publicKey, LAMPORTS_PER_SOL) ); const bob =
-Keypair.generate();
-
-// 1. Create Transaction let tx = new Transaction().add(
-SystemProgram.transfer({ fromPubkey: alice.publicKey, toPubkey: bob.publicKey,
-lamports: 0.1 \* LAMPORTS_PER_SOL, }) ); tx.recentBlockhash = (await
-connection.getRecentBlockhash()).blockhash; tx.feePayer = feePayer.publicKey;
-let realDataNeedToSign = tx.serializeMessage(); // the real data singer need to
-sign.
-
-// 2. Sign Transaction // use any lib you like, the main idea is to use ed25519
-to sign it. // the return signature should be 64 bytes. let feePayerSignature =
-nacl.sign.detached( realDataNeedToSign, feePayer.secretKey ); let aliceSignature
-= nacl.sign.detached(realDataNeedToSign, alice.secretKey);
-
+// To complete an offline transaction:
+// 1. Create Transaction
+// 2. Sign Transaction
 // 3. Recover Transaction
+// 4. Send Transaction
 
-// you can verify signatures before you recovering the transaction let
-verifyFeePayerSignatureResult = nacl.sign.detached.verify( realDataNeedToSign,
-feePayerSignature, feePayer.publicKey.toBytes() // you should use the raw pubkey
-(32 bytes) to verify );
-console.log(`verify feePayer signature: ${verifyFeePayerSignatureResult}`);
+(async () => {
+  // create connection
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
 
-let verifyAliceSignatureResult = nacl.sign.detached.verify( realDataNeedToSign,
-aliceSignature, alice.publicKey.toBytes() );
-console.log(`verify alice signature: ${verifyAliceSignatureResult}`);
+  // create an example tx, alice transfer to bob and feePayer is `feePayer`
+  // alice and feePayer are signer in this tx
+  const feePayer = Keypair.generate();
+  await connection.confirmTransaction(
+    await connection.requestAirdrop(feePayer.publicKey, LAMPORTS_PER_SOL)
+  );
+  const alice = Keypair.generate();
+  await connection.confirmTransaction(
+    await connection.requestAirdrop(alice.publicKey, LAMPORTS_PER_SOL)
+  );
+  const bob = Keypair.generate();
 
-// there are two ways you can recover the tx // 3.a Recover Transaction (use
-populate then addSignature) { let recoverTx =
-Transaction.populate(Message.from(realDataNeedToSign));
-recoverTx.addSignature(feePayer.publicKey, Buffer.from(feePayerSignature));
-recoverTx.addSignature(alice.publicKey, Buffer.from(aliceSignature));
+  // 1. Create Transaction
+  let tx = new Transaction().add(
+    SystemProgram.transfer({
+      fromPubkey: alice.publicKey,
+      toPubkey: bob.publicKey,
+      lamports: 0.1 * LAMPORTS_PER_SOL
+    })
+  );
+  tx.recentBlockhash = (await connection.getRecentBlockhash()).blockhash;
+  tx.feePayer = feePayer.publicKey;
+  let realDataNeedToSign = tx.serializeMessage(); // the real data singer need to sign.
+
+  // 2. Sign Transaction
+  // use any lib you like, the main idea is to use ed25519 to sign it.
+  // the return signature should be 64 bytes.
+  let feePayerSignature = nacl.sign.detached(
+    realDataNeedToSign,
+    feePayer.secretKey
+  );
+  let aliceSignature = nacl.sign.detached(realDataNeedToSign, alice.secretKey);
+
+  // 3. Recover Transaction
+
+  // you can verify signatures before you recovering the transaction
+  let verifyFeePayerSignatureResult = nacl.sign.detached.verify(
+    realDataNeedToSign,
+    feePayerSignature,
+    feePayer.publicKey.toBytes() // you should use the raw pubkey (32 bytes) to verify
+  );
+  console.log(`verify feePayer signature: ${verifyFeePayerSignatureResult}`);
+
+  let verifyAliceSignatureResult = nacl.sign.detached.verify(
+    realDataNeedToSign,
+    aliceSignature,
+    alice.publicKey.toBytes()
+  );
+  console.log(`verify alice signature: ${verifyAliceSignatureResult}`);
+
+  // there are two ways you can recover the tx
+  // 3.a Recover Transaction (use populate then addSignature)
+  {
+    let recoverTx = Transaction.populate(Message.from(realDataNeedToSign));
+    recoverTx.addSignature(feePayer.publicKey, Buffer.from(feePayerSignature));
+    recoverTx.addSignature(alice.publicKey, Buffer.from(aliceSignature));
 
     // 4. Send transaction
     console.log(
       `txhash: ${await connection.sendRawTransaction(recoverTx.serialize())}`
     );
+  }
 
-}
+  // or
 
-// or
-
-// 3.b. Recover Transaction (use populate with signature) { let recoverTx =
-Transaction.populate(Message.from(realDataNeedToSign), [
-bs58.encode(feePayerSignature), bs58.encode(aliceSignature), ]);
+  // 3.b. Recover Transaction (use populate with signature)
+  {
+    let recoverTx = Transaction.populate(Message.from(realDataNeedToSign), [
+      bs58.encode(feePayerSignature),
+      bs58.encode(aliceSignature)
+    ]);
 
     // 4. Send transaction
     console.log(
       `txhash: ${await connection.sendRawTransaction(recoverTx.serialize())}`
     );
+  }
 
-}
-
-// if this process takes too long, your recent blockhash will expire (after 150
-blocks). // you can use `durable nonce` to get rid of it. })();
-
-````
-</CodeTabs>
+  // if this process takes too long, your recent blockhash will expire (after 150 blocks).
+  // you can use `durable nonce` to get rid of it.
+})();
+```
 
 ## Partial Sign Transaction
 
@@ -105,12 +126,12 @@ Some examples of when this is useful:
 
 In this example Bob sends Alice an SPL token in return for her payment:
 
-```typescript title="partial-sign-transaction.ts"
+```typescript title="Legacy"
 import {
   createTransferCheckedInstruction,
   getAssociatedTokenAddress,
   getMint,
-  getOrCreateAssociatedTokenAccount,
+  getOrCreateAssociatedTokenAccount
 } from "@solana/spl-token";
 import {
   clusterApiUrl,
@@ -119,7 +140,7 @@ import {
   LAMPORTS_PER_SOL,
   PublicKey,
   SystemProgram,
-  Transaction,
+  Transaction
 } from "@solana/web3.js";
 import base58 from "bs58";
 
@@ -133,19 +154,19 @@ import base58 from "bs58";
   const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
 
   const alicePublicKey = new PublicKey(
-    "5YNmS1R9nNSCDzb5a7mMJ1dwK9uHeAAF4CmPEwKgVWr8",
+    "5YNmS1R9nNSCDzb5a7mMJ1dwK9uHeAAF4CmPEwKgVWr8"
   );
   const bobKeypair = Keypair.fromSecretKey(
     base58.decode(
-      "4NMwxzmYj2uvHuq8xoqhY8RXg63KSVJM1DXkpbmkUY7YQWuoyQgFnnzn6yo3CMnqZasnNPNuAT2TLwQsCaKkUddp",
-    ),
+      "4NMwxzmYj2uvHuq8xoqhY8RXg63KSVJM1DXkpbmkUY7YQWuoyQgFnnzn6yo3CMnqZasnNPNuAT2TLwQsCaKkUddp"
+    )
   );
   const tokenAddress = new PublicKey(
-    "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr",
+    "Gh9ZwEmdLJ8DscKNTkTqPbNwLNNBjuSzaG9Vp2KGtKJr"
   );
   const bobTokenAddress = await getAssociatedTokenAddress(
     tokenAddress,
-    bobKeypair.publicKey,
+    bobKeypair.publicKey
   );
 
   // Alice may not have a token account, so Bob creates one if not
@@ -153,7 +174,7 @@ import base58 from "bs58";
     connection,
     bobKeypair, // Bob pays the fee to create it
     tokenAddress, // which token the account is for
-    alicePublicKey, // who the token account is for
+    alicePublicKey // who the token account is for
   );
 
   // Get the details about the token mint
@@ -165,7 +186,7 @@ import base58 from "bs58";
   const transaction = new Transaction({
     recentBlockhash: blockhash,
     // Alice pays the transaction fee
-    feePayer: alicePublicKey,
+    feePayer: alicePublicKey
   });
 
   // Transfer 0.01 SOL from Alice -> Bob
@@ -173,8 +194,8 @@ import base58 from "bs58";
     SystemProgram.transfer({
       fromPubkey: alicePublicKey,
       toPubkey: bobKeypair.publicKey,
-      lamports: 0.01 * LAMPORTS_PER_SOL,
-    }),
+      lamports: 0.01 * LAMPORTS_PER_SOL
+    })
   );
 
   // Transfer 1 token from Bob -> Alice
@@ -185,8 +206,8 @@ import base58 from "bs58";
       aliceTokenAccount.address, // destination
       bobKeypair.publicKey, // owner of source account
       1 * 10 ** tokenMint.decimals, // amount to transfer
-      tokenMint.decimals, // decimals of token
-    ),
+      tokenMint.decimals // decimals of token
+    )
   );
 
   // Partial sign as Bob
@@ -195,17 +216,17 @@ import base58 from "bs58";
   // Serialize the transaction and convert to base64 to return it
   const serializedTransaction = transaction.serialize({
     // We will need Alice to deserialize and sign the transaction
-    requireAllSignatures: false,
+    requireAllSignatures: false
   });
   const transactionBase64 = serializedTransaction.toString("base64");
   return transactionBase64;
 
   // The caller of this can convert it back to a transaction object:
   const recoveredTransaction = Transaction.from(
-    Buffer.from(transactionBase64, "base64"),
+    Buffer.from(transactionBase64, "base64")
   );
 })();
-````
+```
 
 ## Durable Nonce
 
@@ -220,7 +241,7 @@ durable nonce, your transaction must:
 
 ### Create Nonce Account
 
-```typescript title="create-nonce-account.ts"
+```typescript title="Legacy"
 import {
   clusterApiUrl,
   Connection,
@@ -303,7 +324,7 @@ import {
 
 ### Use Nonce Account
 
-```typescript title="use-nonce-account.ts"
+```typescript title="Legacy"
 import {
   clusterApiUrl,
   Connection,

--- a/content/cookbook/transactions/optimize-compute.mdx
+++ b/content/cookbook/transactions/optimize-compute.mdx
@@ -12,14 +12,14 @@ You can also find more information about
 [using priority fees](/developers/guides/advanced/how-to-use-priority-fees) in
 this detailed guide.
 
-```typescript title="optimize-compute.ts"
+```typescript title="Legacy"
 // import { ... } from "@solana/web3.js"
 
 async function buildOptimalTransaction(
   connection: Connection,
   instructions: Array<TransactionInstruction>,
   signer: Signer,
-  lookupTables: Array<AddressLookupTableAccount>,
+  lookupTables: Array<AddressLookupTableAccount>
 ) {
   const [microLamports, units, recentBlockhash] = await Promise.all([
     100 /* Get optimal priority fees - https://solana.com/developers/guides/advanced/how-to-use-priority-fees*/,
@@ -27,13 +27,13 @@ async function buildOptimalTransaction(
       connection,
       instructions,
       signer.publicKey,
-      lookupTables,
+      lookupTables
     ),
-    connection.getLatestBlockhash(),
+    connection.getLatestBlockhash()
   ]);
 
   instructions.unshift(
-    ComputeBudgetProgram.setComputeUnitPrice({ microLamports }),
+    ComputeBudgetProgram.setComputeUnitPrice({ microLamports })
   );
   if (units) {
     // probably should add some margin of error to units
@@ -44,10 +44,10 @@ async function buildOptimalTransaction(
       new TransactionMessage({
         instructions,
         recentBlockhash: recentBlockhash.blockhash,
-        payerKey: signer.publicKey,
-      }).compileToV0Message(lookupTables),
+        payerKey: signer.publicKey
+      }).compileToV0Message(lookupTables)
     ),
-    recentBlockhash,
+    recentBlockhash
   };
 }
 ```

--- a/content/cookbook/transactions/send-sol.mdx
+++ b/content/cookbook/transactions/send-sol.mdx
@@ -5,12 +5,71 @@ description:
   Solana."
 ---
 
-To send SOL, you will need to interact with the
-[SystemProgram](https://docs.anza.xyz/runtime/programs#system-program).
+To send SOL, invoke the
+[SystemProgram's](https://github.com/solana-program/system) transfer
+instruction.
 
-<CodeTabs >
+<CodeTabs flags="r">
 
-```typescript !! title="gill"
+```ts !! title="Kit"
+import {
+  airdropFactory,
+  appendTransactionMessageInstructions,
+  createSolanaRpc,
+  createSolanaRpcSubscriptions,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  getSignatureFromTransaction,
+  lamports,
+  pipe,
+  sendAndConfirmTransactionFactory,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners
+} from "@solana/kit";
+import { getTransferSolInstruction } from "@solana-program/system";
+
+const rpc = createSolanaRpc("http://localhost:8899");
+const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
+
+const sender = await generateKeyPairSigner();
+const recipient = await generateKeyPairSigner();
+
+const LAMPORTS_PER_SOL = 1_000_000_000n;
+const transferAmount = lamports(LAMPORTS_PER_SOL / 100n); // 0.01 SOL
+
+await airdropFactory({ rpc, rpcSubscriptions })({
+  recipientAddress: sender.address,
+  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
+  commitment: "confirmed"
+});
+
+// !mark(1:5)
+const transferInstruction = getTransferSolInstruction({
+  source: sender,
+  destination: recipient.address,
+  amount: transferAmount
+});
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const transactionMessage = pipe(
+  createTransactionMessage({ version: 0 }),
+  (tx) => setTransactionMessageFeePayerSigner(sender, tx),
+  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+  (tx) => appendTransactionMessageInstructions([transferInstruction], tx)
+);
+
+const signedTransaction =
+  await signTransactionMessageWithSigners(transactionMessage);
+await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
+  signedTransaction,
+  { commitment: "confirmed" }
+);
+const transactionSignature = getSignatureFromTransaction(signedTransaction);
+console.log("Transaction Signature:", transactionSignature);
+```
+
+```ts !! title="Gill"
 import {
   address,
   lamports,
@@ -54,10 +113,11 @@ const tx = createTransaction({
 });
 
 const signedTransaction = await signTransactionMessageWithSigners(tx);
-await sendAndConfirmTransaction(signedTransaction);
+const signature = await sendAndConfirmTransaction(signedTransaction);
+console.log("Transaction Signature:", signature);
 ```
 
-```typescript !! title="Legacy"
+```ts !! title="Legacy"
 import {
   Connection,
   Keypair,
@@ -89,10 +149,15 @@ const transferTransaction = new Transaction().add(
   })
 );
 
-await sendAndConfirmTransaction(connection, transferTransaction, [fromKeypair]);
+const signature = await sendAndConfirmTransaction(
+  connection,
+  transferTransaction,
+  [fromKeypair]
+);
+console.log("Transaction Signature:", signature);
 ```
 
-```rust !! title="Rust"
+```rs !! title="Rust"
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
     commitment_config::CommitmentConfig, native_token::LAMPORTS_PER_SOL, signature::Keypair,

--- a/content/cookbook/transactions/send-sol.mdx
+++ b/content/cookbook/transactions/send-sol.mdx
@@ -103,6 +103,7 @@ const tx = createTransaction({
   version: "legacy",
   feePayer: signer,
   instructions: [
+    // !mark(1:5)
     getTransferSolInstruction({
       source: signer,
       destination,
@@ -141,6 +142,7 @@ await connection.confirmTransaction(airdropSignature);
 
 const lamportsToSend = 1_000_000;
 
+// !mark(1:7)
 const transferTransaction = new Transaction().add(
   SystemProgram.transfer({
     fromPubkey: fromKeypair.publicKey,
@@ -174,6 +176,7 @@ async fn main() -> anyhow::Result<()> {
     let from_keypair = Keypair::new();
     let to_keypair = Keypair::new();
 
+    // !mark(1:5)
     let transfer_ix = transfer(
         &from_keypair.pubkey(),
         &to_keypair.pubkey(),


### PR DESCRIPTION
- update the existing "transactions" section of cookbook
- `/calculate-cost` and `/add-memo` aren't working on mirror for web3js and rust. May be missing dependencies on server
- `/optimize-compute` snippet isn't full example, leaving as is for now
- `/offline-transactions` page has only web3js snippets, leaving as is for now