### PR TITLE
Improve tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "cheerio": "^1.0.0",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.5.1",
-    "codehike": "^1.0.5",
+    "codehike": "^1.0.7",
     "date-fns": "^4.1.0",
     "date-fns-tz": "^3.2.0",
     "feed": "^4.2.2",

--- a/src/app/components/code/notes.tooltip.tsx
+++ b/src/app/components/code/notes.tooltip.tsx
@@ -19,12 +19,6 @@ export function NoteTooltip({
   if (!note) {
     note = { name, type: "prose", children: name };
   }
-  const className = {
-    code: "p-0 [&>div]:!my-0 border-none overflow-auto rounded-none bg-transparent",
-    prose:
-      "[&>*]:first-child:mt-0 [&>*]:last-child:mb-0 p-4 prose dark:prose-invert bg-fd-background",
-    image: "p-0 [&>*]:first:mt-0 [&>*]:last:mb-0 border-none bg-transparent",
-  }[note.type || "prose"];
 
   return (
     <TooltipProvider delayDuration={100}>
@@ -34,11 +28,37 @@ export function NoteTooltip({
             {children}
           </span>
         </TooltipTrigger>
-        <TooltipContent
-          className={cn("min-w-44 max-w-96 whitespace-normal", className)}
-        >
-          {note?.children}
-        </TooltipContent>
+
+        {note.type === "code" ? (
+          <TooltipContent
+            className={cn(
+              "min-w-44 max-w-96 whitespace-normal",
+              "p-0 [&>div]:!my-0 border-none overflow-auto rounded-none bg-transparent",
+            )}
+          >
+            {note?.children}
+          </TooltipContent>
+        ) : note.type === "image" ? (
+          <TooltipContent
+            className={cn(
+              "min-w-44 max-w-96 whitespace-normal",
+              "p-0 [&>*]:first:mt-0 [&>*]:last:mb-0 border-none bg-transparent",
+            )}
+          >
+            {note?.children}
+          </TooltipContent>
+        ) : (
+          <TooltipContent
+            className={cn(
+              "min-w-44 max-w-96 whitespace-normal",
+              "p-4 prose dark:prose-invert bg-fd-background",
+            )}
+          >
+            <div className="[&>:first-child]:mt-0 [&>:last-child]:mb-0">
+              {note?.children}
+            </div>
+          </TooltipContent>
+        )}
       </Tooltip>
     </TooltipProvider>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -4541,10 +4541,10 @@ coa@^2.0.2:
     chalk "^2.4.1"
     q "^1.1.2"
 
-codehike@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/codehike/-/codehike-1.0.5.tgz#b2ec8f14e97d927d85d70711898894be46e151a8"
-  integrity sha512-y3lL/3nPcvT7GNuEKw687AIip1Mg864lA/knWcCGn7Yp2FBQovsPqPTCpf/aodzWZ12HjWGfli+oxaSeuSyFXg==
+codehike@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/codehike/-/codehike-1.0.7.tgz#9fd70f84693878ee5cd2c5742c76b8e3d71d7952"
+  integrity sha512-m4YOQv1l06qoGBLCgXRNT45MKAudXjir9v+WTs7Xb0gfze6LN3ZiUp08+WRA1N/QGT1SHbzvck8txvPq+C2EPg==
   dependencies:
     "@code-hike/lighter" "1.0.1"
     diff "^5.1.0"


### PR DESCRIPTION
### Summary of Changes

- Remove the extra bottom margin in tooltips
- Better regexp support in annotations. This should work now: (note the escaped `[]` since it's a regexp)

````
```rs
// !tooltip[/#\[program\]/] example
#[program]
pub mod cookbook {
```
````

Since it's a regexp, you can even use `.` as wildcard to match any char:

````
```rs
// !tooltip[/..program./] example
#[program]
pub mod cookbook {
```
````

Related #288