### PR TITLE
Fix selected tab when stored title doesn't exist

### DIFF
--- a/src/app/components/code/code.client.tsx
+++ b/src/app/components/code/code.client.tsx
@@ -20,15 +20,15 @@ export function MultiCode({
   group: CodeGroup;
   className?: string;
 }) {
-  const [currentTitle, setCurrentTitle] = useStateOrLocalStorage(
+  const [storedTitle, setCurrentTitle] = useStateOrLocalStorage(
     group.storage,
     group.tabs[0].title,
   );
   const current =
-    group.tabs.find((tab) => tab.title === currentTitle) || group.tabs[0];
+    group.tabs.find((tab) => tab.title === storedTitle) || group.tabs[0];
 
   const { code } = current;
-
+  const currentTitle = current?.title;
   const runnable = group.options.runnable;
 
   const tabs = (


### PR DESCRIPTION
### Problem

When using `storage` with CodeTab, if there isn't a matching snippet with the same key, none get rendered.

### Summary of Changes

- Default to first tab if the stored tab title no longer exists.

Related #288