### PR TITLE
docs: Update Tusky description for clarity

### DIFF
--- a/content/guides/getstarted/how-to-create-a-token.mdx
+++ b/content/guides/getstarted/how-to-create-a-token.mdx
@@ -199,8 +199,8 @@ publicly accessible online.
 For production tokens, a decentralized storage service like one of the following
 is considered more appropriate:
 
-- [Tusky](https://tusky.io/) - uploads to Walrus, 1 GB free (files hosted for 30
-  days)
+- [Tusky](https://tusky.io/) - uploads to Walrus, offering app, API, SDK, CDN
+  and aggregator
 - [Filebase](https://filebase.com/) - 5GB free on IPFS, free CDN + Gateway, - S3
   compatible, supports IPNS
 - [Irys](https://irys.xyz/) - formerly known as Bundlr, uploads to Arweave


### PR DESCRIPTION
### Problem

The Tusky description was cutoff in the previous [PR](https://github.com/solana-foundation/solana-com/pull/485) merge. The description now sounds like all files are only hosted for 30 days, which is very misleading.

### Summary of Changes

New Tusky description is added.

Fixes #

Docs updated.