### PR TITLE
docs: update cookbook with CodeTabs with storage key

### DIFF
--- a/content/cookbook/accounts/calculate-rent.mdx
+++ b/content/cookbook/accounts/calculate-rent.mdx
@@ -10,7 +10,7 @@ Keeping accounts alive on Solana incurs a data storage cost called
 amount of data you intend to store in the account. Rent can be reclaimed in full
 if the account is closed.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="gill"
 import { getMinimumBalanceForRentExemption, createSolanaClient } from "gill";

--- a/content/cookbook/accounts/create-account.mdx
+++ b/content/cookbook/accounts/create-account.mdx
@@ -11,7 +11,7 @@ access to write to its data or transfer lamports. When creating an account, we
 have to preallocate a fixed storage space in bytes (space) and enough lamports
 to cover the rent.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="gill"
 import {

--- a/content/cookbook/accounts/create-pda-account.mdx
+++ b/content/cookbook/accounts/create-pda-account.mdx
@@ -15,7 +15,7 @@ Generating with the same seeds will always generate the same PDA.
 
 ## Generating a PDA
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="web3.js"
 import { PublicKey } from "@solana/web3.js";
@@ -82,7 +82,7 @@ fn process_instruction(
 
 ## Client
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import {

--- a/content/cookbook/accounts/get-account-balance.mdx
+++ b/content/cookbook/accounts/get-account-balance.mdx
@@ -8,7 +8,7 @@ description:
 Every Solana account is required to maintain a minimum balance of native SOL
 (measured in lamports) to persist its data on the blockchain.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="gill"
 import { createSolanaClient, LAMPORTS_PER_SOL, address } from "gill";

--- a/content/cookbook/development/connect-environment.mdx
+++ b/content/cookbook/development/connect-environment.mdx
@@ -63,7 +63,7 @@ async fn main() -> anyhow::Result<()> {
 You can also connect to a public RPC endpoint by specifying its network name
 (moniker):
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```ts !! title="Gill"
 import { createSolanaClient } from "gill";

--- a/content/cookbook/development/load-keypair-from-file.mdx
+++ b/content/cookbook/development/load-keypair-from-file.mdx
@@ -11,7 +11,7 @@ _shell`solana-keygen grind --starts-with hi:1`_. This will generate a keypair
 with a public key starting with "hi" and output the keypair to a json file. You
 can then load this keypair using the helper function below.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```ts !! title="Gill"
 import { loadKeypairSignerFromFile } from "gill/node";

--- a/content/cookbook/development/subscribing-events.mdx
+++ b/content/cookbook/development/subscribing-events.mdx
@@ -7,7 +7,7 @@ Websockets provide an interface where you can listen for certain events. Instead
 of pinging a HTTP endpoint at an interval to get frequent updates, you can
 instead receive those updates only when they happen.
 
-<CodeTabs>
+<CodeTabs storage="cookbook">
 
 ```ts !! title="Kit"
 import {

--- a/content/cookbook/development/test-sol.mdx
+++ b/content/cookbook/development/test-sol.mdx
@@ -10,7 +10,7 @@ To send transactions while developing locally or on devnet, you'll need SOL.
 You can fund an address by requesting an airdrop. If on devnet, you can use the
 [faucet](https://faucet.solana.com/).
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Kit"
 import {

--- a/content/cookbook/tokens/approve-token-delegate.mdx
+++ b/content/cookbook/tokens/approve-token-delegate.mdx
@@ -10,7 +10,7 @@ is like an another owner of your token account.
   A token account can only delegate to one account at a time.
 </Callout>
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import {

--- a/content/cookbook/tokens/burn-tokens.mdx
+++ b/content/cookbook/tokens/burn-tokens.mdx
@@ -5,7 +5,7 @@ description: "Learn how to burn Tokens on Solana"
 
 You can burn tokens if you are the token account authority.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { Connection, Keypair } from "@solana/web3.js";

--- a/content/cookbook/tokens/close-token-accounts.mdx
+++ b/content/cookbook/tokens/close-token-accounts.mdx
@@ -11,7 +11,7 @@ situations:
 1. Wrapped SOL - Closing converts Wrapped SOL to SOL
 2. Other Tokens - You can close it only if token account's balance is 0.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { Connection, Keypair } from "@solana/web3.js";

--- a/content/cookbook/tokens/create-mint-account.mdx
+++ b/content/cookbook/tokens/create-mint-account.mdx
@@ -6,7 +6,7 @@ description: "Learn how to create tokens on Solana."
 Creating tokens is done by creating what is called a "mint account". This mint
 account is later used to mint tokens to a user's Associated Token Account (ATA).
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="gill"
 import {

--- a/content/cookbook/tokens/create-nft.mdx
+++ b/content/cookbook/tokens/create-nft.mdx
@@ -111,7 +111,7 @@ import Arweave from "arweave";
 
 ### Mint the NFT
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";

--- a/content/cookbook/tokens/create-token-account.mdx
+++ b/content/cookbook/tokens/create-token-account.mdx
@@ -11,7 +11,7 @@ A user will have at least one token account for every type of token they own.
 Associated Token Accounts (ATAs) are deterministically created accounts for
 every keypair. ATAs are the recommended method of managing token accounts.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="gill"
 import {

--- a/content/cookbook/tokens/fetch-all-nfts.mdx
+++ b/content/cookbook/tokens/fetch-all-nfts.mdx
@@ -4,7 +4,7 @@ description:
   "Learn how to fetch all non-fungible tokens (NFTs) from a wallet on Solana."
 ---
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";

--- a/content/cookbook/tokens/fetch-nft-metadata.mdx
+++ b/content/cookbook/tokens/fetch-nft-metadata.mdx
@@ -4,7 +4,7 @@ description:
   "Learn how to fetch the metadata of a non-fungible token (NFT) on Solana."
 ---
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { createUmi } from "@metaplex-foundation/umi-bundle-defaults";

--- a/content/cookbook/tokens/get-all-token-accounts.mdx
+++ b/content/cookbook/tokens/get-all-token-accounts.mdx
@@ -9,7 +9,7 @@ You can fetch token accounts by owner. There are two ways to do it.
 
 1. Get All Token Account
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { clusterApiUrl, Connection, PublicKey } from "@solana/web3.js";
@@ -102,7 +102,7 @@ async fn main() -> anyhow::Result<()> {
 
 2. Filter By Mint
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";

--- a/content/cookbook/tokens/get-nft-owner.mdx
+++ b/content/cookbook/tokens/get-nft-owner.mdx
@@ -13,7 +13,7 @@ other token accounts for that mint key will have a balance of 0.
 
 Once the largest token account is identified, we can retrieve its owner.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { Connection, PublicKey } from "@solana/web3.js";

--- a/content/cookbook/tokens/get-token-account.mdx
+++ b/content/cookbook/tokens/get-token-account.mdx
@@ -8,7 +8,7 @@ description:
 Every token account has information on the token such as the owner, mint,
 amount(balance).
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { clusterApiUrl, Connection, PublicKey } from "@solana/web3.js";

--- a/content/cookbook/tokens/get-token-balance.mdx
+++ b/content/cookbook/tokens/get-token-balance.mdx
@@ -8,7 +8,7 @@ description:
 The token account holds the token balance, which can be retrieved with a single
 PRC call
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { clusterApiUrl, Connection, PublicKey } from "@solana/web3.js";

--- a/content/cookbook/tokens/get-token-mint.mdx
+++ b/content/cookbook/tokens/get-token-mint.mdx
@@ -8,7 +8,7 @@ description:
 In order to get the current supply, authority, or decimals a token has, you will
 need to get the account info for the token mint.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { clusterApiUrl, Connection, PublicKey } from "@solana/web3.js";

--- a/content/cookbook/tokens/manage-wrapped-sol.mdx
+++ b/content/cookbook/tokens/manage-wrapped-sol.mdx
@@ -25,7 +25,7 @@ There are two ways to add balance for Wrapped SOL
 
 ### 1. By SOL Transfer
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import {
@@ -164,7 +164,7 @@ async fn main() -> anyhow::Result<()> {
 
 ### 2. By Token Transfer
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import {

--- a/content/cookbook/tokens/mint-tokens.mdx
+++ b/content/cookbook/tokens/mint-tokens.mdx
@@ -8,7 +8,7 @@ description:
 When you mint tokens, you increase the supply and transfer the new tokens to a
 specific token account.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { clusterApiUrl, Connection, PublicKey, Keypair } from "@solana/web3.js";

--- a/content/cookbook/tokens/revoke-token-delegate.mdx
+++ b/content/cookbook/tokens/revoke-token-delegate.mdx
@@ -7,7 +7,7 @@ description:
 
 Revoke will set delegate to null and set delegated amount to 0.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import {

--- a/content/cookbook/tokens/set-update-token-authority.mdx
+++ b/content/cookbook/tokens/set-update-token-authority.mdx
@@ -12,7 +12,7 @@ You can set/update authority. There are 4 types:
 3. AccountOwner (token account)
 4. CloseAccount (token account)
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Legacy"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";

--- a/content/cookbook/tokens/transfer-tokens.mdx
+++ b/content/cookbook/tokens/transfer-tokens.mdx
@@ -16,7 +16,7 @@ Associated Token Account (ATA) address, which is derived from:
 You can both get the token account's address and send tokens to it with the
 following examples:
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="gill"
 import {

--- a/content/cookbook/transactions/add-memo.mdx
+++ b/content/cookbook/transactions/add-memo.mdx
@@ -7,7 +7,7 @@ description:
 
 Any transaction can add a message making use of the SPL memo program.
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```ts !! title="Kit"
 import {

--- a/content/cookbook/transactions/add-priority-fees.mdx
+++ b/content/cookbook/transactions/add-priority-fees.mdx
@@ -10,7 +10,7 @@ leader processes your transaction.
 To add a priority fee to a transaction, invoke instructions from the
 [Compute Budget Program](https://github.com/solana-program/compute-budget).
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Kit"
 import {

--- a/content/cookbook/transactions/calculate-cost.mdx
+++ b/content/cookbook/transactions/calculate-cost.mdx
@@ -9,7 +9,7 @@ Every transaction consumes compute units and requires a transaction fee in
 lamports to execute. The number of signatures included on a transaction
 determines the base transaction fee (5000 lamports per signature).
 
-<CodeTabs >
+<CodeTabs storage="cookbook">
 
 ```typescript !! title="Kit"
 import {

--- a/content/cookbook/transactions/send-sol.mdx
+++ b/content/cookbook/transactions/send-sol.mdx
@@ -9,7 +9,7 @@ To send SOL, invoke the
 [SystemProgram's](https://github.com/solana-program/system) transfer
 instruction.
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Kit"
 import {

--- a/content/cookbook/wallets/check-publickey.mdx
+++ b/content/cookbook/wallets/check-publickey.mdx
@@ -10,7 +10,7 @@ have a private key associated with them. You can check this by looking to see if
 the public key lies on the ed25519 curve. Only public keys that lie on the curve
 can be controlled by users with wallets.
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Legacy"
 import { PublicKey } from "@solana/web3.js";

--- a/content/cookbook/wallets/create-keypair.mdx
+++ b/content/cookbook/wallets/create-keypair.mdx
@@ -14,7 +14,7 @@ need to generate a keypair to sign your transactions.
 
 ### Extractable keypair
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Kit"
 import { generateKeyPairSigner } from "@solana/kit";

--- a/content/cookbook/wallets/generate-mnemonic.mdx
+++ b/content/cookbook/wallets/generate-mnemonic.mdx
@@ -10,7 +10,7 @@ generally used to make the user experience within wallets better than a Keypair
 file by using a list of readable words (instead of a shorter string of random
 numbers and letters).
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Typescript"
 import * as bip39 from "bip39";

--- a/content/cookbook/wallets/restore-from-mnemonic.mdx
+++ b/content/cookbook/wallets/restore-from-mnemonic.mdx
@@ -8,7 +8,7 @@ convert the mnemonic to Keypairs for local testing.
 
 ## Restoring BIP39 format mnemonics
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Kit"
 import { createKeyPairSignerFromPrivateKeyBytes } from "@solana/kit";
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
 
 ## Restoring BIP44 format mnemonics
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Kit"
 import { HDKey } from "micro-ed25519-hdkey";

--- a/content/cookbook/wallets/restore-keypair.mdx
+++ b/content/cookbook/wallets/restore-keypair.mdx
@@ -8,7 +8,7 @@ allows you to access your wallet and sign transactions in your dApp.
 
 ## From Bytes
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Kit"
 import { createKeyPairSignerFromBytes } from "@solana/kit";
@@ -75,7 +75,7 @@ fn main() -> Result<()> {
 
 ## From Base58 String
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Kit"
 import {

--- a/content/cookbook/wallets/sign-message.mdx
+++ b/content/cookbook/wallets/sign-message.mdx
@@ -7,7 +7,7 @@ The primary function of a keypair is to sign messages, transactions and enable
 verification of the signature. Verification of a signature allows the recipient
 to be sure that the data was signed by the owner of a specific private key.
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```typescript !! title="Kit"
 import {

--- a/content/cookbook/wallets/verify-keypair.mdx
+++ b/content/cookbook/wallets/verify-keypair.mdx
@@ -7,7 +7,7 @@ description:
 If you are given a keypair, you can verify if the secret matches the given
 public key:
 
-<CodeTabs flags="r">
+<CodeTabs flags="r" storage="cookbook">
 
 ```ts !! title="Kit"
 import { createKeyPairSignerFromBytes, address } from "@solana/kit";


### PR DESCRIPTION
- `storage` key saves the user's currently selected tabs across pages, defaults to first tab if selection unavailable