### PR TITLE
docs: update associated token account snippets to be runnable

### DIFF
--- a/content/docs/en/tokens/basics/create-token-account.mdx
+++ b/content/docs/en/tokens/basics/create-token-account.mdx
@@ -852,7 +852,7 @@ Invocations (CPI).
 
 ### Typescript
 
-<CodeTabs storage="token-ts" >
+<CodeTabs storage="token-ts" flags="r">
 
 ```ts !! title="Kit"
 import {
@@ -1173,7 +1173,7 @@ console.log(
 
 ### Rust
 
-<CodeTabs storage="token-rs" >
+<CodeTabs storage="token-rs" flags="r">
 
 ```rust !! title="Rust"
 use anyhow::Result;


### PR DESCRIPTION
- add missing `flags="r"` to ata snippets to make code runnable