### PR TITLE
fix: update Solana web3.js doc links

### DIFF
--- a/content/guides/javascript/get-program-accounts.mdx
+++ b/content/guides/javascript/get-program-accounts.mdx
@@ -32,7 +32,7 @@ The `getProgramAccounts` RPC method has the following syntax:
     [State commitment](/docs/rpc/#configuring-state-commitment)
   - (optional) `encoding`: `string` - Encoding for account data, either:
     `base58`, `base64`, or `jsonParsed`. Note, web3js users should instead use
-    [`getParsedProgramAccounts`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#getParsedProgramAccounts)
+    [`getParsedProgramAccounts`](https://solana-foundation.github.io/solana-web3.js/classes/Connection.html#getparsedprogramaccounts)
   - (optional) `dataSlice`: `object` - Limit the returned account data based on:
     - `offset`: `number` - Number of bytes into account data to begin returning
     - `length`: `number` - Number of bytes of account data to return
@@ -303,5 +303,5 @@ interested in.
 ## Other Resources
 
 - [RPC API Documentation](/docs/rpc/http/getprogramaccounts)
-- [web3.js documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#getProgramAccounts)
-- [getParsedProgramAccounts documentation](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#getParsedProgramAccounts)
+- [getProgramAccounts documentation](https://solana-foundation.github.io/solana-web3.js/classes/Connection.html#getprogramaccounts)
+- [getParsedProgramAccounts documentation](https://solana-foundation.github.io/solana-web3.js/classes/Connection.html#getparsedprogramaccounts)


### PR DESCRIPTION
### Problem

Some Solana web3.js documentation links (such as getProgramAccounts and getParsedProgramAccounts) were broken, making it difficult for developers to access the relevant API reference pages.

### Summary of Changes

- Updated all web3.js documentation links to use valid anchor links under solana-foundation.github.io.
- Kept and recommended the Solana Cookbook reference link for better developer experience.

Fixes #530