### PR TITLE
Update toolkit fuzz tester page 

### DIFF
--- a/content/docs/en/toolkit/test-suite/fuzz-tester.mdx
+++ b/content/docs/en/toolkit/test-suite/fuzz-tester.mdx
@@ -6,6 +6,7 @@ keywords:
   - solana fuzz testing
   - solana fuzzer
   - fuzz tests
+  - trident
 h1: Solana Fuzz Tester
 ---
 
@@ -30,51 +31,72 @@ This command does the following:
 - Reads the generated IDL.
 - Based on the IDL creates the fuzzing template.
 
-## Define Fuzz Accounts
 
-Define `AccountsStorage` type for each `Account` you would like to use:
+## Write Fuzz Tests
+
+For projects without custom PDA seeds, Trident automatically generates a complete working fuzz test. Remove functions containing `todo!` macros from the generated fuzz test and you can proceed directly to the [Execute Fuzz Tests](#execute-fuzz-tests) section.
+
+### Instruction Accounts
+
+Define account properties using intuitive macro constraints:
 
 ```rust
-#[doc = r" Use AccountsStorage<T> where T can be one of:"]
-#[doc = r" Keypair, PdaStore, TokenStore, MintStore, ProgramStore"]
-#[derive(Default)]
-pub struct FuzzAccounts {
-    author: AccountsStorage<Keypair>,
-    hello_world_account: AccountsStorage<PdaStore>,
-    // No need to fuzz system_program
-    // system_program: AccountsStorage<todo!()>,
+pub struct InitializeFnInstructionAccounts {
+    #[account(mut,signer,storage = author)]
+    pub author: TridentAccount,
+    #[account(
+        mut,
+        storage = hello_world_account,
+        seeds = [b"hello_world_seed"],
+    )]
+    pub hello_world_account: TridentAccount,
+    #[account(address = "11111111111111111111111111111111", skip_snapshot)]
+    pub system_program: TridentAccount,
 }
 ```
 
-## Implement Fuzz Instructions
+For programs with complex seed structures, you'll need to configure accounts manually through the `set_accounts` function.
 
-Each Instruction in the fuzz test has to have defined the following functions:
+Refer to [detailed documentation](https://ackee.xyz/trident/docs/latest/start-fuzzing/writting-fuzz-test/instruction-accounts/#instruction-accounts) for advanced configurations.
 
-- `get_program_id()` specifies which program the instruction belongs to. This
-  function is automatically defined and should not need any updates. Its
-  important to use especially if you have multiple programs in your workspace,
-  allowing Trident to generate instruction sequences corresponding to different
-  programs.
-- `get_data()` specifies what instruction inputs are sent to the program
-  instructions.
-- `get_accounts()` specifies what accounts are sent to the program instructions.
+### Instruction Data
+
+Trident automatically handles data generation for primitive types (`u64`, `bool`, etc.). For custom data types or manual data specification, utilize the `set_data` function. 
+
+Learn more in [instruction data guide](https://ackee.xyz/trident/docs/latest/start-fuzzing/writting-fuzz-test/instruction-data/).
+
+## Customize Fuzz Tests
+
+Enhance your fuzzing strategy with Trident's advanced features:
+
+- [Fuzzing flows](https://ackee.xyz/trident/docs/latest/trident-advanced/trident-transactions/trident-fuzzing-flows/): Control the order of transaction execution. This feature lets you test specific sequences of instructions, ensuring your program handles state transitions correctly.
+
+- [Invariant checks](https://ackee.xyz/trident/docs/latest/trident-advanced/trident-transactions/transaction-hooks/invariant-check/): Add validation functions that run after each successful transaction. Use these to verify your program maintains correct state throughout the test execution.
+
+- [Transaction hooks](https://ackee.xyz/trident/docs/latest/trident-advanced/trident-transactions/transaction-hooks/pre-post-execution/): Insert custom logic before and after each transaction. This enables setup of preconditions and verification of post-conditions for each test case.
+
+See [advanced documentation](https://ackee.xyz/trident/docs/latest/trident-advanced/) for additional features and examples.
 
 ## Execute Fuzz Tests
+
+From your `trident-tests` directory, launch the fuzzer:
 
 ```shell
 # Replace <TARGET_NAME> with the name of the
 # fuzz test (for example: "fuzz_0")
-trident fuzz run-hfuzz <TARGET_NAME>
+trident fuzz run-afl <TARGET_NAME>
 ```
 
 ## Debug Fuzz Tests
 
+When issues are detected, analyze them with the debugging tool:
+
 ```shell
 # fuzzer will run the <TARGET_NAME> with the specified <CRASH_FILE_PATH>
-trident fuzz debug-hfuzz <TARGET_NAME> <CRASH_FILE_PATH>
+trident fuzz debug-afl <TARGET_NAME> <CRASH_FILE_PATH>
 ```
 
-For additional documentation go [here](https://ackee.xyz/trident/docs/latest/).
+For comprehensive guidance, consult [documentation](https://ackee.xyz/trident/docs/latest/) or use the `--help` flag.
 
 ## Additional Resources
 


### PR DESCRIPTION
### Problem

Current fuzz tester page contains outdated instructions on how to initialize, write and run Trident fuzz test.

### Summary of Changes

Modified outdated information and added Write Fuzz Tests and Customize Fuzz Tests sections.

Fixes #