### PR TITLE
docs: remove link to mirror

### DIFF
--- a/src/app/components/code/code.runnable.tsx
+++ b/src/app/components/code/code.runnable.tsx
@@ -352,13 +352,6 @@ function ConsoleHeader({ className }: { className?: string }) {
       )}
     >
       <span>Console</span>
-      <a
-        href="https://mirror.ad"
-        target="_blank"
-        className="text-sm hover:underline"
-      >
-        Powered by Mirror
-      </a>
     </div>
   );
 }


### PR DESCRIPTION
- remove link to mirror.ad in runnable code component
- mirror is no longer maintained, and one less link for readers to bounce from page
- currently looking into alternative for running code on docs using [txtx'](https://github.com/txtx/surfpool)s surfnet service