### PR TITLE
CI: migrate workflows to setup-node v4

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Use Node.js node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
       - name: before_install
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Use Node.js node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: "18"
       - name: before_install


### PR DESCRIPTION
Updated actions/setup-node to v4 for better compatibility with the latest runner environments. Workflows only updated—no functional changes. Release notes: https://github.com/actions/setup-node/releases/tag/v4.0.0