### PR TITLE
feat: update Accelerate landing page (header) with post conf data

### DIFF
--- a/public/locales/ar/common.json
+++ b/public/locales/ar/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/de/common.json
+++ b/public/locales/de/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/el/common.json
+++ b/public/locales/el/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/es/common.json
+++ b/public/locales/es/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/hi/common.json
+++ b/public/locales/hi/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/id/common.json
+++ b/public/locales/id/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/it/common.json
+++ b/public/locales/it/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/ja/common.json
+++ b/public/locales/ja/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/ko/common.json
+++ b/public/locales/ko/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/nl/common.json
+++ b/public/locales/nl/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/pl/common.json
+++ b/public/locales/pl/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/pt/common.json
+++ b/public/locales/pt/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/ru/common.json
+++ b/public/locales/ru/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/tr/common.json
+++ b/public/locales/tr/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/uk/common.json
+++ b/public/locales/uk/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/vi/common.json
+++ b/public/locales/vi/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/public/locales/zh/common.json
+++ b/public/locales/zh/common.json
@@ -1029,7 +1029,7 @@
      "speakers": "Speakers",
      "sponsors": "Sponsors",
      "faq": "FAQ",
-     "get-tickets": "Get Tickets"
+     "get-tickets": "Breakpoint Tickets"
    }
  },
   "format": {

--- a/src/components/accelerate/AccelerateHeader.jsx
+++ b/src/components/accelerate/AccelerateHeader.jsx
@@ -35,19 +35,6 @@ const Header = () => {
                 className={styles.logoWord}
               />
             </a>
-
-            <div>
-              <Link href="/accelerate#speakers">
-                {t("accelerate.header.speakers")}
-              </Link>
-              <a
-                target="_blank"
-                rel="noopener noreferrer"
-                href="https://lu.ma/solana-accelerate?compact=true"
-              >
-                Agenda
-              </a>
-            </div>
           </div>
 
           <Link
@@ -66,18 +53,7 @@ const Header = () => {
           </Link>
 
           <div className={styles.col}>
-            <Link href="/accelerate#sponsors">
-              {t("accelerate.header.sponsors")}
-            </Link>
-            <Link href="/accelerate#faq">{t("accelerate.header.faq")}</Link>
-            <a
-              href="https://lu.ma/solana-nyc?tag=accelerate"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              side events
-            </a>
-            <Link className={styles.cta} href="/accelerate#tickets">
+            <Link className={styles.cta} href="/breakpoint">
               <span>
                 {t("accelerate.header.get-tickets")} <ArrowUpRight />
               </span>
@@ -103,49 +79,10 @@ const Header = () => {
           fill
           className={styles.mobileBackground}
         />
-        <div className={styles.mobileLinks}>
-          <Link
-            href="/accelerate#speakers"
-            onClick={() => {
-              handleMenu();
-            }}
-          >
-            {t("accelerate.header.speakers")}
-          </Link>
-          <a
-            href="https://lu.ma/solana-accelerate?compact=true"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Agenda
-          </a>
-          <Link
-            href="/accelerate#sponsors"
-            onClick={() => {
-              handleMenu();
-            }}
-          >
-            {t("accelerate.header.sponsors")}
-          </Link>
-          <Link
-            href="/accelerate#faq"
-            onClick={() => {
-              handleMenu();
-            }}
-          >
-            {t("accelerate.header.faq")}
-          </Link>
-          <a
-            href="https://lu.ma/solana-nyc?tag=accelerate"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Side Events
-          </a>
-        </div>
+        <div className={styles.mobileLinks}></div>
 
         <Link
-          href="/accelerate#tickets"
+          href="/breakpoint"
           onClick={() => {
             handleMenu();
           }}


### PR DESCRIPTION
### Problem

The Accelerate LP is still showing pre conf marketing state. This PR prepare the new header stripping all previous links and redirecting the "Get Tickets" to "Breakpoint Tickets". 

Draft staging changes can be reviewed on [builder.io staging](https://staging.solana.com/accelerate?builder.space=983ae1dad0ba4ca4ac6dd4ac310edee1&builder.user.permissions=read%2Ccreate%2Cpublish%2CeditCode%2CeditDesigns%2CeditLayouts%2CeditLayers%2CeditContentPriority%2CeditFolders&builder.user.role.name=Staging%2520Editor&builder.user.role.id=90f6d0fb934c41f59745e2953f97ba71&builder.cachebust=true&builder.preview=accelerate-pages&builder.noCache=true&builder.allowTextEdit=true&__builder_editing__=true&builder.overrides.accelerate-pages=983ae1dad0ba4ca4ac6dd4ac310edee1_2688ca0998084d59837cde5cb26e56b0&builder.overrides.983ae1dad0ba4ca4ac6dd4ac310edee1_2688ca0998084d59837cde5cb26e56b0=983ae1dad0ba4ca4ac6dd4ac310edee1_2688ca0998084d59837cde5cb26e56b0&builder.options.includeRefs=true&builder.options.enrich=true&builder.options.locale=Default)

### Summary of Changes

- Update i18n common files Get Tickets -> Breakpoint Tickets
- Remove irrelevant header menu links 
