### PR TITLE
fix: update link to correct secp256r1 program docs

### DIFF
--- a/content/docs/en/core/programs.mdx
+++ b/content/docs/en/core/programs.mdx
@@ -213,7 +213,7 @@ by the signature cost verify multiplier.
 
 | Program           | Program ID                                    | Description                                                                                                   | Instructions                                                                                        |
 | ----------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Secp256r1 Program | `Secp256r1SigVerify1111111111111111111111111` | Verifies up to 8 secp256r1 signatures. Takes a signature, public key, and message. Returns error if any fail. | [Instructions](https://docs.rs/solana-secp256k1-recover/latest/solana_secp256k1_recover/index.html) |
+| Secp256r1 Program | `Secp256r1SigVerify1111111111111111111111111` | Verifies up to 8 secp256r1 signatures. Takes a signature, public key, and message. Returns error if any fail. | [Instructions](https://docs.rs/solana-secp256r1-program/latest/solana_secp256r1_program/all.html) |
 
 The secp256r1 program processes an instruction. The first `u8` is a count of the
 number of signatures to check, followed by a single byte padding. After that,


### PR DESCRIPTION
Current incorrect link: https://docs.rs/solana-secp256k1-recover/latest/solana_secp256k1_recover/index.html

Correct link: https://docs.rs/solana-secp256r1-program/latest/solana_secp256r1_program/all.html

### Problem

The current link to the secp256r1 instructions points to the k1 program

### Summary of Changes

Updated link to the correct address

Fixes #

Point to R1 instead of K1