### PR TITLE
fix: rm wildcard for seo from /developers/courses

### DIFF
--- a/rewrites-redirects.mjs
+++ b/rewrites-redirects.mjs
@@ -799,7 +799,7 @@ export default {
       destination: "/docs/core/accounts",
     },
     {
-      source: "/developers/courses/:path*",
+      source: "/developers/courses",
       destination: "https://learn.blueshift.gg",
     },
     {


### PR DESCRIPTION
### Problem

Small fix for SEO purposes

### Summary of Changes

- updated `/developers/courses` redirect