### PR TITLE
fix: Add RTL support for Arabic locale

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -27,8 +27,9 @@ export default async function RootLayout({ children, params }: Props) {
   const { resources } = await initTranslations(locale, namespaces);
   const googleTagManagerID = config.siteMetadata.googleTagManagerID;
   const builderLocale = locale == "en" ? "Default" : locale;
+  const isArabic = locale === "ar";
   return (
-    <html lang={locale} suppressHydrationWarning>
+    <html lang={locale} suppressHydrationWarning dir={isArabic ? "rtl" : "ltr"}>
       <body suppressHydrationWarning>
         {/* Google Tag Manager (noscript) */}
         <noscript>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -248,3 +248,10 @@ html {
     --radius: 0.5rem;
   }
 }
+
+/* Force LTR for code blocks to avoid RTL issues on Arabic pages */
+pre,
+code {
+  direction: ltr !important;
+  unicode-bidi: embed;
+}


### PR DESCRIPTION
### Problem

Arabic pages were not rendered in right-to-left (RTL) layout, which caused a poor reading experience for Arabic users. The layout direction did not automatically switch based on the locale.

### Summary of Changes

- Dynamically set the `dir` attribute on the `<html>` element to `rtl` when the locale is Arabic (`ar`), and to `ltr` for all other locales.
- This ensures that the entire page layout is correctly displayed in RTL for Arabic users, while other languages remain unaffected.

Fixes #548