### PR TITLE
Update installation.mdx

### DIFF
--- a/content/docs/en/intro/installation.mdx
+++ b/content/docs/en/intro/installation.mdx
@@ -261,9 +261,8 @@ names: `stable`, `beta`, or `edge`.
 For a first-time installation of the Solana CLI, you may see the following
 message prompting you to add a `PATH` environment variable:
 
-```
 Close and reopen your terminal to apply the PATH changes or run the following in your existing shell:
-
+```
 export PATH="/Users/test/.local/share/solana/install/active_release/bin:$PATH"
 ```
 


### PR DESCRIPTION
text excluded from the snippet so copy button does not copies it.

### Problem: text was inside snippet so it gets copied with the command ( when copy icon used)



### Summary of Changes: removed from the cli snippet, so only command gets copied.


