### PR TITLE
Fix incorrect wording about bump value

### DIFF
--- a/content/guides/advanced/how-to-optimize-compute.mdx
+++ b/content/guides/advanced/how-to-optimize-compute.mdx
@@ -178,7 +178,7 @@ but it's important to be aware of the compute usage of `find_program_address`
 and how you can optimize it.
 
 If `find_program_address` has to take a long time to find a valid address,
-meaning it has a high bump, the overall compute unit usage will be higher. You
+meaning it has a low bump, the overall compute unit usage will be higher. You
 can optimize finding the PDAs after initialization by saving the bump into an
 account and using it in the future.
 


### PR DESCRIPTION
### Problem
The doc currently states:

> If `find_program_address` has to take a long time to find a valid address,
meaning it has a high bump

If `find_program_address` takes a long time to find a valid address, this would mean that the bump has a low value (rather than a high one). 

This is because `find_program_address` starts at 255 and decrements it each time- so a lower bump would require more iterations. 

This can be seen in the Solana SDK here: https://github.com/anza-xyz/solana-sdk/blob/39c3ffd0fd7cafe1874d211e0ba8c6e2f75eac54/pubkey/src/lib.rs#L828-L840 



### Summary of Changes
Changed it from 'low bump' to 'high bump'


Fixes #