### PR TITLE
Fix scaled ui effective timestamp to use seconds instead of milliseconds

### DIFF
--- a/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
@@ -181,7 +181,7 @@ export async function updateScaledUiMultiplier(
   return signature;
 }
 const multiplier = 1.5;
-const effectiveTimestamp = BigInt(Date.now());
+const effectiveTimestamp = BigInt(Math.floor(Date.now() / 1000));
 const updateSignature = await updateScaledUiMultiplier(
   connection,
   payer,


### PR DESCRIPTION
This PR updates the TypeScript example in the Scaled UI Amount Issuer Guide to ensure the effectiveTimestamp passed to the multiplier update uses seconds (via Math.floor(Date.now() / 1000)) instead of milliseconds. This matches the expected precision for the Solana program and prevents incorrect future timestamps.
No other logic or documentation was changed.