### PR TITLE
Fix: Add title to Terminal CodeTabs for Proper Display

### DIFF
--- a/content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx
@@ -72,7 +72,7 @@ amounts in the program.
 
 <CodeTabs>
 
-```terminal
+```terminal !! title="curl-getTokenAccountBalance.sh"
 $ curl http://localhost:8899 -s -X POST -H "Content-Type: application/json" -d '
 {"jsonrpc": "2.0", "id": 1, "method": "getTokenAccountBalance", "params": ["2uuvxpnEKw52aTqNerHiQ3WeSqZriCMNVt8LhWfrkbPk"]}' | jq .
 
@@ -144,7 +144,7 @@ console.log("Token Balance:",tokenBalance);
 
 <CodeTabs>
 
-```terminal
+```terminal !! title="curl-getAccountInfo.sh"
 $ curl http://localhost:8899 -s -X POST -H "Content-Type: application/json" -d '
 {"jsonrpc": "2.0", "id": 1, "method": "getAccountInfo", "params": ["2uuvxpnEKw52aTqNerHiQ3WeSqZriCMNVt8LhWfrkbPk", {"encoding": "jsonParsed"}]}' | jq .
 


### PR DESCRIPTION
This PR updates the terminal code blocks in the Scaled UI Amount Integration Guide to include the title attribute within each <CodeTabs> section. This ensures that terminal examples are properly labeled and displayed in the documentation UI, fixing the issue where this tab didn't appear previously

No content or logic was changed—only the formatting of code examples for better rendering.