### PR TITLE
Remove Github auth from java.mdx

### DIFF
--- a/content/docs/en/clients/java.mdx
+++ b/content/docs/en/clients/java.mdx
@@ -29,58 +29,11 @@ with your idl to produce a Java compatible client.
         <version>VERSION</version>
     </dependency>
 </dependencies>
-
-<repositories>
-  <repository>
-      <id>gpr-sava</id>
-      <name>sava</name>
-      <url>https://maven.pkg.github.com/sava-software/sava</url>
-  </repository>
-  <repository>
-      <id>gpr-json-iterator</id>
-      <name>json-iterator</name>
-      <url>https://maven.pkg.github.com/comodal/json-iterator</url>
-  </repository>
-</repositories>
-```
-
-```xml  title="settings.xml"
-<settings>
-  <servers>
-    <server>
-        <id>gpr-sava</id>
-        <username>GITHUB_USERNAME</username>
-        <password>GITHUB_PERSONAL_ACCESS_TOKEN</password>
-    </server>
-    <server>
-        <id>gpr-json-iterator</id>
-        <username>GITHUB_USERNAME</username>
-        <password>GITHUB_PERSONAL_ACCESS_TOKEN</password>
-    </server>
-  </servers>
-</settings>
 ```
 
 ### Gradle
 
 ```bash  title="build.gradle"
-repositories {
-  maven {
-    url = "https://maven.pkg.github.com/sava-software/sava"
-    credentials {
-      username = GITHUB_USERNAME
-      password = GITHUB_PERSONAL_ACCESS_TOKEN
-    }
-  }
-  maven {
-    url = "https://maven.pkg.github.com/comodal/json-iterator"
-    credentials {
-      username = GITHUB_USERNAME
-      password = GITHUB_PERSONAL_ACCESS_TOKEN
-    }
-  }
-}
-
 dependencies {
   implementation "software.sava:sava-core:$VERSION"
   implementation "software.sava:sava-rpc:$VERSION"


### PR DESCRIPTION
GitHub Package Repository authentication is no longer required now that signed release are published to Maven Central.