### PR TITLE
fix #554: Language selector dropdown menu breaking footer

### DIFF
--- a/src/components/LanguageSelector.js
+++ b/src/components/LanguageSelector.js
@@ -24,7 +24,13 @@ const Language = () => {
         <ChevronDown size="17" />
       </Dropdown.Toggle>
 
-      <Dropdown.Menu className="bg-light">
+      <Dropdown.Menu
+        className="bg-light"
+        style={{
+          maxHeight: "50vh",
+          overflowY: "auto",
+        }}
+      >
         {Object.keys(languages).map((language) => (
           <Dropdown.Item key={language} href={"/" + language + asPath}>
             {languages[language]}


### PR DESCRIPTION
### Problem

The language selector’s dropdown was overflowing past the footer, and users also couldn’t scroll to see all available languages in alternate solution.

![image](https://github.com/user-attachments/assets/dd428bea-69cb-4aa7-a471-caf99985ccc2)

### Summary of Changes

- Added inline styles to <Dropdown.Menu> to avoid overflow and added constraints to enable vertical scrolling when content exceeds that height

This ensures the menu is never cut off and remains fully scrollable.

![image](https://github.com/user-attachments/assets/f135d087-1c0b-44a0-9430-aceacabc43fc)

Fixes issue no. #554 


thanks!