### PR TITLE
fix: clarify getEpochSchedule docs

### DIFF
--- a/content/docs/en/rpc/http/getepochschedule.mdx
+++ b/content/docs/en/rpc/http/getepochschedule.mdx
@@ -4,7 +4,7 @@ hideTableOfContents: true
 h1: getEpochSchedule RPC Method
 ---
 
-Returns the epoch schedule information from this cluster's genesis config
+Returns the epoch schedule information from this cluster
 
 <APIMethod>
 


### PR DESCRIPTION
while a cluster's epoch schedule is _originally_ specified in genesis. it is in fact stored in out-of-band (not accounts) cluster state and can be changed via feature gate in the future