### PR TITLE
fix: remove speakers redirect

### DIFF
--- a/rewrites-redirects.mjs
+++ b/rewrites-redirects.mjs
@@ -147,7 +147,6 @@ export default {
     },
     { source: "/breakpoint/side-events", destination: "/breakpoint" },
     { source: "/breakpoint/sponsors", destination: "/breakpoint" },
-    { source: "/breakpoint/speakers", destination: "/breakpoint" },
     {
       source: "/verifiable-builds",
       destination:


### PR DESCRIPTION
### Problem

Removes active redirect to `/breakpoint/speakers` which will be live on the new BP25 site.
