### PR TITLE
fix: learn sidescroll

### DIFF
--- a/src/components/learn/learn-page-content.tsx
+++ b/src/components/learn/learn-page-content.tsx
@@ -78,7 +78,7 @@ export default function LearnPageContent({
   ];
 
   return (
-    <>
+    <div className="overflow-hidden">
       <DevelopersHeroSection
         title={translations.heroTitle}
         description={translations.heroSubtitle}
@@ -185,6 +185,6 @@ export default function LearnPageContent({
           </div>
         </div>
       </section>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
### Problem

There is a side scroll on the `/learn` landing page

### Summary of Changes

wrap in a no scroll wrapper like on /developer where these other components are consumed. This change aligns with precedent for simpler future upgrades if we are to remove these components.

Fixes #