### PR TITLE
Update Scaled UI Amount Issuer Guide Documentation

### DIFF
--- a/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
@@ -23,10 +23,10 @@ using the `spl-token` CLI:
 ```terminal !! title="create-token.sh"
 $ spl-token --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb create-token --ui-amount-multiplier 1.5
 Creating token 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM under program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
- 
+
 Address:  66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM
 Decimals:  9
- 
+
 Signature: 2sPziXu9M3duTCvsDvxQE9UKC9nBiLayi8muDvnjhA2qYvfXSZuaUieoq39MFjg4kf8xFrw6crmYSkPyV59dvudF
 ```
 
@@ -129,13 +129,35 @@ export async function createScaledUiMint(
 ### Update the UI amount multiplier
 
 To update the UI amount multiplier, you need to use the
-`update-ui-amount-multiplier` command. A timestamp is optional and can be used
-to set a custom start time for the new multiplier. If no timestamp is provided,
-the current timestamp will be used.
+`update-ui-amount-multiplier` command. A timestamp, in seconds since the Unix
+epoch, is optional and can be used to set a custom start time for the new
+multiplier. If no timestamp is provided, the current timestamp will be used.
+
+**Important Note:** There is currently an idiosyncrasy in the process to update
+the scaled ui multiplier. Right now if you do the following:
+
+1. Set a scaled ui multiplier for the future
+2. Time passes beyond this update time
+3. Set another scaled ui multiplier for the future
+4. Then the previous scaled ui multiplier is overridden and by the new one
+   effectively removing it.
+
+There is a
+[merged PR to fix this](https://github.com/solana-program/token-2022/pull/522)
+so the multiplier properly updates to the current multiplier instead of being
+overridden, but this is not live yet.
+
+Until this time it is necessary to do 2 multiplier updates during step 3 above:
+
+1. Set the previous multiplier again with the timestamp to the same timestamp is
+   originally set in step 1 (this will properly set the multiplier as the
+   current multiplier)
+2. Set the new multiplier as described in step 3 above
 
 <CodeTabs>
 
 ```terminal !! title="update-ui-amount-multiplier.sh"
+$ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM 1.2 -- 1746470000 # 1.2 is the current multiplier as described in step 1 above
 $ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM 1.5 -- 1746471400
 ```
 
@@ -154,18 +176,33 @@ export async function updateScaledUiMultiplier(
   payer: Signer,
   mint: PublicKey,
   multiplier: number,
-  effectiveTimestamp: bigint
+  effectiveTimestamp: bigint,
+  previousMultiplier: number,
+  previousEffectiveTimestamp: bigint
 ): Promise<string> {
-  const transaction = new Transaction().add(
-    createUpdateMultiplierDataInstruction(
-      mint,
-      payer.publicKey,
-      multiplier,
-      effectiveTimestamp,
-      [],
-      TOKEN_2022_PROGRAM_ID
+  const transaction = new Transaction()
+    .add(
+      // Set the previous multiplier to the current multiplier
+      // This is temporarily needed until PR 522 is deployed to mainnet
+      createUpdateMultiplierDataInstruction(
+        mint,
+        payer.publicKey,
+        previousMultiplier,
+        previousEffectiveTimestamp,
+        [],
+        TOKEN_2022_PROGRAM_ID
+      )
     )
-  );
+    .add(
+      createUpdateMultiplierDataInstruction(
+        mint,
+        payer.publicKey,
+        multiplier,
+        effectiveTimestamp,
+        [],
+        TOKEN_2022_PROGRAM_ID
+      )
+    );
 
   const signature = await sendAndConfirmTransaction(
     connection,
@@ -182,12 +219,16 @@ export async function updateScaledUiMultiplier(
 }
 const multiplier = 1.5;
 const effectiveTimestamp = BigInt(Math.floor(Date.now() / 1000));
+const previousMultiplier = 1.2;
+const previousEffectiveTimestamp = BigInt(1746470000);
 const updateSignature = await updateScaledUiMultiplier(
   connection,
   payer,
   mintPubkey,
   multiplier,
-  effectiveTimestamp
+  effectiveTimestamp,
+  previousMultiplier,
+  previousEffectiveTimestamp
 );
 console.log("Update signature:", updateSignature);
 ```


### PR DESCRIPTION
### Summary
This PR updates the Scaled UI Amount Issuer Guide to address a critical idiosyncrasy in the token-2022 program regarding multiplier updates. The changes provide a temporary workaround for token issuers until a permanent fix is deployed to mainnet.

### Changes
1. Added detailed explanation of the current limitation when updating scaled UI multipliers
2. Documented a temporary workaround process that requires two multiplier updates
3. Updated both CLI and TypeScript code examples to demonstrate the workaround
4. Added reference to the merged PR (#522) that will permanently fix this issue
5. Clarified that timestamps should be in seconds since Unix epoch

### Why This Matters
Token issuers need to be aware of this limitation to avoid accidentally overriding their multiplier updates. The workaround ensures that multiplier updates work as expected until the permanent fix is deployed to mainnet.

### Related Links
- [Token-2022 PR #522](https://github.com/solana-program/token-2022/pull/522) - Permanent fix for multiplier updates