### PR TITLE
fix(intro-to-reading-data.md): set `module` to `Node16` to match `moduleResolution: Node16`

### DIFF
--- a/content/courses/intro-to-solana/intro-to-reading-data.mdx
+++ b/content/courses/intro-to-solana/intro-to-reading-data.mdx
@@ -91,7 +91,7 @@ Make sure your project includes the following tsconfig.json setup:
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "es2022",
+    "module": "Node16",
     "moduleResolution": "node16",
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
### Problem

Option 'module' must be set to 'Node16' when option 'moduleResolution' is set to 'Node16'.ts

Specify what module code is generated.
See more: https://www.typescriptlang.org/tsconfig#module

### Summary of Changes

set `module` to `Node16` to match `moduleResolution: Node16`