### PR TITLE
fix: transparency in the chapter nav

### DIFF
--- a/src/components/learn/mobile-chapter-navigation.tsx
+++ b/src/components/learn/mobile-chapter-navigation.tsx
@@ -26,8 +26,8 @@ export default function MobileChapterNavigation({
   translations,
 }: MobileChapterNavigationProps) {
   return (
-    <div className="xl:hidden sticky top-16 z-10 -mx-4 px-4 pb-6">
-      <details className="rounded-lg">
+    <div className="xl:hidden sticky top-16 z-50 -mx-4 px-4 pb-6 bg-[rgb(18_18_18_/_95%)] backdrop-blur-md">
+      <details className="rounded-lg relative">
         <summary
           className="px-4 py-3 cursor-pointer flex items-center justify-between text-white hover:bg-zinc-800 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-black"
           aria-label={translations.toggleChapterNavigation}
@@ -49,7 +49,7 @@ export default function MobileChapterNavigation({
           </svg>
         </summary>
         <nav
-          className="px-2 pb-2"
+          className="absolute top-full left-0 right-0 px-2 pb-2 bg-[rgb(18_18_18_/_95%)] backdrop-blur-md max-h-[70vh] overflow-y-auto"
           aria-label={translations.chapterNavigationAriaLabel}
         >
           {tutorials.map((tutorial, index) => {


### PR DESCRIPTION
### Problem

There is a transparency issue with the current mobile chapter navigation. This fixes it.

Before:
<img width="607" height="552" alt="Screenshot 2025-07-14 at 11 16 54 AM" src="https://github.com/user-attachments/assets/b3d38429-217f-439c-9ae0-00e83eddece2" />

after:
<img width="537" height="765" alt="Screenshot 2025-07-14 at 11 16 13 AM" src="https://github.com/user-attachments/assets/2fe58e61-e4a8-4693-94e1-3f6e0acda4f5" />


### Summary of Changes

css tweaks


Fixes #