### PR TITLE
feat: rework learn menu

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -760,8 +760,14 @@
       "start": {
         "title": "Start here",
         "items": {
+          "what-is-solana": {
+            "description": "Fast, low-cost network for digital assets"
+          },
           "wallet": {
             "description": "Your gateway to internet capital markets"
+          },
+          "defi": {
+            "description": "Explore decentralized finance opportunities"
           },
           "transactions": {
             "description": "Master the basics of Solana transactions"
@@ -1021,6 +1027,11 @@
           "title": "What is a Wallet?",
           "description": "Learn what a Solana wallet is, how it works, and how to set one up safely. Your wallet is the tool you'll use to interact with Solana applications.",
           "category": "Wallet Basics"
+        },
+        "getting-started": {
+          "title": "Getting Started with Solana",
+          "description": "Learn the basics of Solana and how to get started with digital transactions",
+          "category": "Solana Basics"
         },
         "understanding-solana-transaction-fees": {
           "title": "Understanding Solana Transaction Fees",

--- a/src/components/header/HeaderList.js
+++ b/src/components/header/HeaderList.js
@@ -4,11 +4,11 @@ import AngleUp from "../../../public/src/img/icons/Angle-up.inline.svg";
 import AngleDown from "../../../public/src/img/icons/Angle-down.inline.svg";
 import { useTranslation } from "next-i18next";
 import { useRouter } from "@/hooks/useRouter";
-import { Link } from "@/utils/Link";
 import HeaderListBuild from "./HeaderListBuild";
 import HeaderListSolutions from "./HeaderListSolutions";
 import HeaderListNetwork from "./HeaderListNetwork";
 import HeaderListCommunity from "./HeaderListCommunity";
+import HeaderListLearn from "./HeaderListLearn";
 
 const HeaderList = () => {
   const { t } = useTranslation();
@@ -18,11 +18,13 @@ const HeaderList = () => {
   const [showSolutions, updateShowSolutions] = useState(false);
   const [showDevelopers, updateShowDevelopers] = useState(false);
   const [showCommunity, updateShowCommunity] = useState(false);
+  const [showLearn, updateShowLearn] = useState(false);
 
   useEffect(() => {
     // links from "developers" (app router) doesnt reload the page
     // so we need to close the dropdown when the route changes
     updateShowDevelopers(false);
+    updateShowLearn(false);
   }, [asPath]);
 
   const isLearnActive = asPath.includes("/learn") || asPath === "/environment";
@@ -44,15 +46,30 @@ const HeaderList = () => {
 
   return (
     <ul className="navbar-nav ms-auto">
-      <li className="nav-item" style={{ "--color-active": "#19fb9b" }}>
-        <Link
-          to="/learn"
-          className={`nav-link nav-link--primary ${isLearnActive && "active"}`}
+      <Dropdown
+        as="li"
+        className={`nav-item`}
+        onToggle={(isOpen) => {
+          isOpen ? updateShowLearn(true) : updateShowLearn(false);
+        }}
+        show={showLearn}
+        style={{ "--color-active": "#19fb9b" }}
+      >
+        <Dropdown.Toggle
+          as="button"
+          type="button"
+          className={`nav-link nav-link--primary dropdown-toggle ${
+            isLearnActive && "active"
+          }`}
           suppressHydrationWarning={true}
         >
           {t("nav.learn.title")}
-        </Link>
-      </li>
+          {showLearn ? <AngleUp /> : <AngleDown />}
+        </Dropdown.Toggle>
+        <Dropdown.Menu>
+          <HeaderListLearn />
+        </Dropdown.Menu>
+      </Dropdown>
 
       <Dropdown
         as="li"

--- a/src/components/header/HeaderListLearn.js
+++ b/src/components/header/HeaderListLearn.js
@@ -6,56 +6,52 @@ const HeaderListLearn = () => {
   const { t } = useTranslation("common");
 
   return (
-    <div className="d-lg-flex">
+    <div>
+      <div className="text-uppercase py-2 d-flex align-items-center">
+        <StartSVG className="me-3" />
+        {t("nav.learn.start.title")}
+      </div>
       <div>
-        <div className="text-uppercase py-2 d-flex align-items-center">
-          <StartSVG className="me-3" />
-          {t("nav.learn.start.title")}
-        </div>
-        <div>
-          <Link
-            to="/learn/what-is-a-wallet"
-            className="nav-link nav-link--secondary"
-            activeClassName="active"
-          >
-            <strong className="d-block text-white">
-              {t("learn.tutorials.items.what-is-a-wallet.title")}
-            </strong>
-            {t("nav.learn.start.items.wallet.description")}
-          </Link>
-          <Link
-            to="/learn/sending-and-receiving-sol"
-            className="nav-link nav-link--secondary"
-            activeClassName="active"
-          >
-            <strong className="d-block text-white">
-              {t("learn.tutorials.items.sending-and-receiving-sol.title")}
-            </strong>
-            {t("nav.learn.start.items.transactions.description")}
-          </Link>
-          <Link
-            to="/learn/understanding-solana-transaction-fees"
-            className="nav-link nav-link--secondary"
-            activeClassName="active"
-          >
-            <strong className="d-block text-white">
-              {t(
-                "learn.tutorials.items.understanding-solana-transaction-fees.title",
-              )}
-            </strong>
-            {t("nav.learn.start.items.fees.description")}
-          </Link>
-          <Link
-            to="/learn#tutorials"
-            className="nav-link nav-link--secondary"
-            activeClassName="active"
-          >
-            <strong className="d-block text-white">
-              {t("nav.learn.start.items.all.title")}
-            </strong>
-            {t("nav.learn.start.items.all.description")}
-          </Link>
-        </div>
+        <Link
+          to="/learn"
+          className="nav-link nav-link--secondary"
+          activeClassName="active"
+        >
+          <strong className="d-block text-white">
+            {t("nav.learn.start.items.all.title")}
+          </strong>
+          {t("nav.learn.start.items.all.description")}
+        </Link>
+        <Link
+          to="/learn/what-is-solana"
+          className="nav-link nav-link--secondary"
+          activeClassName="active"
+        >
+          <strong className="d-block text-white">
+            {t("learn.tutorials.items.what-is-solana.title")}
+          </strong>
+          {t("nav.learn.start.items.what-is-solana.description")}
+        </Link>
+        <Link
+          to="/learn/what-is-a-wallet"
+          className="nav-link nav-link--secondary"
+          activeClassName="active"
+        >
+          <strong className="d-block text-white">
+            {t("learn.tutorials.items.what-is-a-wallet.title")}
+          </strong>
+          {t("nav.learn.start.items.wallet.description")}
+        </Link>
+        <Link
+          to="/learn/introduction-to-defi-on-solana"
+          className="nav-link nav-link--secondary"
+          activeClassName="active"
+        >
+          <strong className="d-block text-white">
+            {t("learn.tutorials.items.introduction-to-defi-on-solana.title")}
+          </strong>
+          {t("nav.learn.start.items.defi.description")}
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
### Problem

As @h4rkl pointed, the first implementation of the learn menu was hiding some key SEO pages. This reworks the menu to align it more to the current other menus


<img width="649" height="533" alt="Screenshot 2025-07-14 at 2 23 35 PM" src="https://github.com/user-attachments/assets/40323bde-4223-4f4f-8a8e-968380447e60" />



### Summary of Changes

- bring 4 links into a drop down instead



Fixes #