### PR TITLE
fix: add mobile menu not closing

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,7 +3,7 @@
 import Navbar from "react-bootstrap/Navbar";
 import { useRouter } from "@/hooks/useRouter";
 import { Link } from "../utils/Link";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import SolanaLogo from "../../public/src/img/logos-solana/logotype.inline.svg";
 import Moon from "../../public/src/img/icons/Moon.inline.svg";
 import Sun from "../../public/src/img/icons/Sun.inline.svg";
@@ -18,6 +18,7 @@ const Header = ({ className = "", containerClassName = "" }) => {
   const router = useRouter();
   const { theme, toggleTheme, isThemePage } = useTheme();
   const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
 
   useEffect(() => {
     const navbar = document.getElementById("navbar");
@@ -31,10 +32,21 @@ const Header = ({ className = "", containerClassName = "" }) => {
     }
   }, [t, theme, isThemePage]);
 
+  useEffect(() => {
+    // Close mobile navigation on route change
+    setExpanded(false);
+  }, [router.asPath]);
+
   return (
     <>
       <header className={`position-sticky sticky-top ${className}`}>
-        <Navbar id="navbar" expand="lg" variant="">
+        <Navbar
+          id="navbar"
+          expand="lg"
+          variant=""
+          expanded={expanded}
+          onToggle={setExpanded}
+        >
           <div className={`container-xl ${containerClassName}`}>
             <Link to="/" className="d-flex" aria-label="Solana">
               <SolanaLogo


### PR DESCRIPTION
### Problem

The mobile menu does not close on the learn section and docs. This is less visible on other pages as a lot of them perform full navigation to sub domains.

N.B. these are legacy menus but this is a production issue that has been live for a bit. It's worth fixing. A further followup would be to replace those menus with shadcn or radix but this will be done later this week.


### Summary of Changes

- add a useffect watching a route change.

Fixes #

https://solana-foundation.slack.com/archives/C04DSGVR8MR/p1752530891736369?thread_ts=1752530756.198289&cid=C04DSGVR8MR
