### PR TITLE
docs: replace terminal lang identifer in scaled UI docs page

### DIFF
--- a/content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx
+++ b/content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx
@@ -72,7 +72,7 @@ amounts in the program.
 
 <CodeTabs>
 
-```terminal !! title="curl-getTokenAccountBalance.sh"
+```txt !! title="curl-getTokenAccountBalance.sh"
 $ curl http://localhost:8899 -s -X POST -H "Content-Type: application/json" -d '
 {"jsonrpc": "2.0", "id": 1, "method": "getTokenAccountBalance", "params": ["2uuvxpnEKw52aTqNerHiQ3WeSqZriCMNVt8LhWfrkbPk"]}' | jq .
 


### PR DESCRIPTION
There is currently a parsing issue with lingo translation where it outputs:

```
---CODE-PLACEHOLDER-8eb4de427fbd2e92f131db254b4f8072---
```

Changing lang identifier from `terminal` to `txt` to see if it fixes.
Merging to have github action run and see results.