### PR TITLE
docs: add warning to confidential transfer pages, zk program disable

### DIFF
--- a/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
+++ b/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
@@ -3,6 +3,13 @@ title: Apply Pending Balance
 description: Learn how to apply pending balance to make funds available.
 ---
 
+<Callout type="warn">
+  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
+  undergoes a security audit. This means that confidential transfers extension
+  is currently unavailable. While the concepts are still valid, the code
+  examples will not run.
+</Callout>
+
 ## How to apply pending balance to available balance
 
 Before tokens can be transferred confidentially, the public token balance must

--- a/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
+++ b/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
@@ -4,6 +4,13 @@ description:
   Learn how to create a token mint with the Confidential Transfer extension.
 ---
 
+<Callout type="warn">
+  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
+  undergoes a security audit. This means that confidential transfers extension
+  is currently unavailable. While the concepts are still valid, the code
+  examples will not run.
+</Callout>
+
 ## How to create a mint with Confidential Transfer extension
 
 The Confidential Transfer extension enables private token transfers by adding

--- a/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
+++ b/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
@@ -4,6 +4,13 @@ description:
   Learn how to create a token account with the Confidential Transfer extension.
 ---
 
+<Callout type="warn">
+  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
+  undergoes a security audit. This means that confidential transfers extension
+  is currently unavailable. While the concepts are still valid, the code
+  examples will not run.
+</Callout>
+
 ## How to create a token account with the Confidential Transfer extension
 
 The Confidential Transfer extension enables private token transfers by adding

--- a/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
+++ b/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
@@ -3,6 +3,13 @@ title: Deposit Tokens
 description: Learn how to deposit tokens to confidential state.
 ---
 
+<Callout type="warn">
+  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
+  undergoes a security audit. This means that confidential transfers extension
+  is currently unavailable. While the concepts are still valid, the code
+  examples will not run.
+</Callout>
+
 ## How to deposit tokens to confidential pending balance
 
 Before tokens can be transferred confidentially, the public token balance must

--- a/content/docs/en/tokens/extensions/confidential-transfer/index.mdx
+++ b/content/docs/en/tokens/extensions/confidential-transfer/index.mdx
@@ -5,6 +5,13 @@ description:
   optional features to token mints and accounts.
 ---
 
+<Callout type="warn">
+  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
+  undergoes a security audit. This means that confidential transfers extension
+  is currently unavailable. While the concepts are still valid, the code
+  examples will not run.
+</Callout>
+
 ## What are Confidential Transfers?
 
 Confidential transfers enable you to transfer tokens between token accounts

--- a/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
+++ b/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
@@ -4,6 +4,13 @@ description:
   Learn how to transfer tokens privately from one token account to another.
 ---
 
+<Callout type="warn">
+  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
+  undergoes a security audit. This means that confidential transfers extension
+  is currently unavailable. While the concepts are still valid, the code
+  examples will not run.
+</Callout>
+
 ## How to confidentially transfer tokens from one token account to another
 
 To confidentially transfer tokens from one token account to another, both the

--- a/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
+++ b/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
@@ -3,6 +3,13 @@ title: Withdraw Tokens
 description: Learn how to withdraw tokens from confidential state.
 ---
 
+<Callout type="warn">
+  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
+  undergoes a security audit. This means that confidential transfers extension
+  is currently unavailable. While the concepts are still valid, the code
+  examples will not run.
+</Callout>
+
 ## How to withdraw tokens from confidential available balance
 
 To withdraw tokens from confidential available balance to public balance:


### PR DESCRIPTION
ZK Elgamal program currently disabled as it undergoes security audit.
Add warning to docs pages.