### PR TITLE
docs: disable runnable component for python code

### DIFF
--- a/src/app/components/code/code.runnable.tsx
+++ b/src/app/components/code/code.runnable.tsx
@@ -155,6 +155,11 @@ export function RunnableLayout({
 }) {
   const state = useRunnableCode(code, language);
 
+  // disable runnable for python, server does not support python code
+  if (language === "py") {
+    return <div className={className}>{children}</div>;
+  }
+
   return (
     <>
       <div className="md:hidden">


### PR DESCRIPTION
disable runnable component for python related to https://github.com/solana-foundation/solana-com/pull/622, server does not support python code