### PR TITLE
fix: remove i18n url segment from opengraph images

### DIFF
--- a/src/components/developers/DevelopersContentPage/DevelopersContentPage.tsx
+++ b/src/components/developers/DevelopersContentPage/DevelopersContentPage.tsx
@@ -66,7 +66,10 @@ export function HeroTitle({
           <Link href={record.href || "#"}>
             <Image
               alt={record.title}
-              src={`/opengraph${record.href}` || defaultImg}
+              src={
+                `/opengraph${record.href.replace(/^\/[a-z]{2}(?:-[a-z]{2})?\//, "/")}` ||
+                defaultImg
+              }
               loading="lazy"
               fill
               sizes="100vw"


### PR DESCRIPTION
### Problem

Small fix to update opengraph images which are failing to load if the URL contains i18n path segment - eg. `/en/`
