### PR TITLE
Replaced coral-xyz with solana-foundation in repo references

### DIFF
--- a/content/docs/en/intro/installation.mdx
+++ b/content/docs/en/intro/installation.mdx
@@ -386,7 +386,7 @@ Anchor versions on your system and easily update Anchor versions in the future.
 Install AVM with the following command:
 
 ```terminal
-$ cargo install --git https://github.com/coral-xyz/anchor avm --force
+$ cargo install --git https://github.com/solana-foundation/anchor avm --force
 ```
 
 Confirm that AVM installed successfully:
@@ -427,7 +427,7 @@ version to run on your system.
 Install a specific version of the Anchor CLI with the following command:
 
 ```terminal
-$ cargo install --git https://github.com/coral-xyz/anchor --tag v0.30.1 anchor-cli
+$ cargo install --git https://github.com/solana-foundation/anchor --tag v0.30.1 anchor-cli
 ```
 
 </Tab>
@@ -562,7 +562,7 @@ You can fix this by changing the version field of `Cargo.lock` file from 4 to 3:
 +version = 3
 ```
 
-See [this issue](https://github.com/coral-xyz/anchor/issues/3392) for more
+See [this issue](https://github.com/solana-foundation/anchor/issues/3392) for more
 information.
 
 </Accordion>


### PR DESCRIPTION
### Problem
coral-xyz references in documentation might raise alarm for new developers.


### Summary of Changes



Fixes #