### PR TITLE
feat: add styling for LTR enforcement of all code blocks

### DIFF
--- a/src/app/components/code/code.tsx
+++ b/src/app/components/code/code.tsx
@@ -122,7 +122,7 @@ export async function toCodeGroup(props: {
         pre: (
           <Pre
             code={highlighted}
-            className="overflow-auto px-0 py-3 m-0 rounded-none !bg-ch-background font-mono selection:bg-ch-selection text-sm max-h-full"
+            className="overflow-auto px-0 py-3 m-0 rounded-none !bg-ch-background font-mono selection:bg-ch-selection text-sm max-h-full direction-ltr text-left"
             style={highlighted.style}
             handlers={handlers}
           />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -37,6 +37,7 @@
 }
 
 @media (min-width: 767px) {
+
   /* docs pages have a wider container */
   body:has(.container-docs) .container-xl {
     max-width: 120rem !important;
@@ -60,9 +61,8 @@
 .fumadocs .prose :is(h1, h2, h3, h4, h5, h6) a {
   color: inherit;
 }
-.fumadocs
-  .prose
-  :where(h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+
+.fumadocs .prose :where(h4):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   font-size: 1.25em;
 }
 
@@ -145,17 +145,17 @@
   color: hsl(var(--fd-muted-foreground) / 1);
 }
 
-.prose-no-margin > :first-child {
+.prose-no-margin> :first-child {
   margin-top: 0 !important;
 }
 
-.prose-no-margin > :last-child {
+.prose-no-margin> :last-child {
   margin-bottom: 0 !important;
 }
 
 /* previous/next links */
 
-.fumadocs article > div:not(.prose) p {
+.fumadocs article>div:not(.prose) p {
   margin-bottom: 0;
 }
 
@@ -181,6 +181,12 @@
 
 .fumadocs .group:hover .group-hover\:opacity-100 {
   opacity: 1 !important;
+}
+
+.fumadocs pre,
+.fumadocs code {
+  direction: ltr !important;
+  text-align: left !important;
 }
 
 html.dark {


### PR DESCRIPTION
### Problem

In Arabic where RTL lang format is used for i18n this PR enforces LTR for semantically correct codeblocks.

### Summary of Changes

- fumadocs styles for all `code` and `pre` codeblocks
- Tailwind styling in `<Code />` component 