### PR TITLE
docs: exclude rpc pages in i18n.json

### DIFF
--- a/i18n.json
+++ b/i18n.json
@@ -33,6 +33,11 @@
         "content/docs/[locale]/*/*/*.mdx",
         "content/docs/[locale]/*/*/*/*.mdx",
         "content/learn/[locale]/*.mdx"
+      ],
+      "exclude": [
+        "content/docs/[locale]/rpc/*.mdx",
+        "content/docs/[locale]/rpc/*/*.mdx",
+        "content/docs/[locale]/rpc/*/*/*.mdx"
       ]
     },
     "json": {
@@ -43,6 +48,11 @@
         "content/docs/[locale]/*/meta.json",
         "content/docs/[locale]/*/*/meta.json",
         "content/docs/[locale]/*/*/*/meta.json"
+      ],
+      "exclude": [
+        "content/docs/[locale]/rpc/meta.json",
+        "content/docs/[locale]/rpc/*/meta.json",
+        "content/docs/[locale]/rpc/*/*/meta.json"
       ]
     }
   }


### PR DESCRIPTION
- update i18n.json to exclude `/rpc` paes
- lingo github actions reverts the codehike annotation spacing corrections made in the translated files https://github.com/solana-foundation/solana-com/pull/658 https://github.com/solana-foundation/solana-com/pull/656
