### PR TITLE
Added comprehensive documentation for Token 2022 metadata extensions

### DIFF
--- a/content/docs/en/tokens/extensions/meta.json
+++ b/content/docs/en/tokens/extensions/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Extensions",
-  "pages": ["confidential-transfer", "scaled-ui-amount"]
+  "pages": ["confidential-transfer", "scaled-ui-amount", "metadata"]
 }

--- a/content/docs/en/tokens/extensions/metadata/anchor.mdx
+++ b/content/docs/en/tokens/extensions/metadata/anchor.mdx
@@ -1,0 +1,637 @@
+---
+title: Anchor Implementation
+description: Implement Token 2022 metadata extensions using the Anchor framework with best practices.
+---
+
+> **Previous:** [TypeScript Implementation](./typescript) | **Next:** [Native Rust Implementation](./native-rust)
+
+With a solid understanding of the TypeScript client-side implementation, let's explore how to build the same functionality using Anchor. You'll see how Anchor simplifies many aspects while still requiring deep understanding of the underlying mechanics.
+
+## Anchor Rust Implementation: Framework Convenience with Power
+
+Anchor abstracts away much of the boilerplate code we wrote manually, but it's
+crucial to understand what it's doing under the hood.
+
+Think of Anchor as a powerful code generator that writes the tedious account
+validation, serialization, and CPI boilerplate for you. But you still need to
+understand the underlying Token 2022 concepts we covered in the TypeScript
+section.
+
+Anchor also provides several advantages for Token 2022 development:
+
+- **Type-safe CPIs**: Compile-time verification of cross-program calls
+- **IDL generation**: Automatic client SDK generation
+- **Space calculation helpers**: Built-in rent and space management
+- **Extension support**: First-class Token 2022 extension handling
+
+However, Anchor also has limitations that we'll address:
+
+- **Complex type restrictions**: IDL generator doesn't support all Rust types
+- **Less granular control**: Some advanced Token 2022 features require manual
+  implementation
+- **Framework overhead**: Additional dependencies and compilation complexity
+
+### Step 1: Project Setup
+
+Navigate back to the project root and create the Anchor workspace:
+
+```bash
+cd ..  # Back to dev_cert_token directory root
+
+# Create anchor directory
+mkdir anchor
+cd anchor
+
+# Initialize an Anchor project
+anchor init metadata
+```
+
+This creates a **complete Anchor workspace with program structure, tests, and
+deployment configuration** so we can start building our Token 2022 metadata
+program.
+
+check into the metadata directory
+
+```bash
+cd metadata
+```
+
+### Step 2: Configure your Dependencies
+
+Edit your `Cargo.toml` in the `programs/metadata/` directory:
+
+```toml
+[package]
+name = "metadata"
+version = "0.1.0"
+description = "Token-2022 metadata extension with Anchor"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+name = "metadata"
+
+[features]
+no-entrypoint = []
+no-log-ix-name = []
+cpi = ["no-entrypoint"]
+default = []
+idl-build = ["anchor-lang/idl-build", "anchor-spl/idl-build"]
+
+[dependencies]
+anchor-lang = { version = "0.31.0", features = ["init-if-needed"] }
+anchor-spl = { version = "0.31.0", features = ["memo", "metadata"] }
+spl-token-2022 = { version = "7.0.0", features = ["no-entrypoint"] }
+spl-token-metadata-interface = "0.7.0"
+spl-type-length-value = "0.8.0"
+```
+
+- **`anchor-lang`**: Core Anchor framework for Solana programs
+- **`anchor-spl`** with `metadata` and `memo` features: Access to Token 2022
+  metadata CPIs and SPL helpers
+- **`spl-token-2022`**: The Token 2022 program logic and types
+- **`spl-token-metadata-interface`**: Provides the metadata state structures
+- **`spl-type-length-value`**: For TLV data length calculations
+
+### Step 3: Understanding the Account Structure
+
+If you navigate into the lib.rs file in the program src directory, what you will
+see is the essential structure of a minimal Anchor program.
+
+```rust
+
+// imports
+use anchor_lang::prelude::*;
+
+// program id
+declare_id!("5jQMJupEr8cSALhadjwWri1CyFxZ4UBcMwgkuaxKupFh");
+
+// program module
+#[program]
+pub mod metadata {
+    use super::*;
+
+    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
+        msg!("Greetings from: {:?}", ctx.program_id);
+        Ok(())
+    }
+}
+
+// Account Context
+#[derive(Accounts)]
+pub struct Initialize {}
+
+```
+
+- **Imports**: Bring in the Anchor framework and any dependencies.
+- **Program ID Declaration**: Uniquely identifies your Solana program.
+- **Program Module**: Contains your program's entrypoints (instructions).
+- **Account Contexts**: Define the accounts required for each instruction.
+
+In our TypeScript implementation, we manually managed five accounts:
+
+1. **Payer**: Pays for account creation and signs transactions
+2. **Mint**: The Token 2022 mint account (with extensions)
+3. **System Program**: Creates the initial account
+4. **Token 2022 Program**: Manages all token operations
+5. **Rent Sysvar**: Provides rent calculation data
+
+Anchor simplifies this through its account constraint system. For example, this
+is how our InitializeWithMetadata Account context would look like:
+
+```rust
+#[derive(Accounts)]
+pub struct InitializeWithMetadata<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    #[account(
+        init,                                    // Create new account
+        payer = payer,                          // Payer funds creation
+        mint::decimals = 0,                     // Token decimals
+        mint::authority = payer,                // Mint authority
+        mint::token_program = token_2022_program, // Use Token 2022
+        extensions::metadata_pointer::authority = payer,        // Metadata authority
+        extensions::metadata_pointer::metadata_address = mint   // Self-referential
+    )]
+    pub mint: InterfaceAccount<'info, Mint>,
+
+    pub token_2022_program: Program<'info, Token2022>,
+    pub system_program: Program<'info, System>,
+}
+```
+
+**What Anchor does automatically:**
+
+- Validates that `payer` is a signer
+- Calculates required space for mint + metadata pointer extension
+- Creates the account with proper ownership
+- Initializes the metadata pointer extension
+- Initializes the basic mint structure
+
+### Step 4: Custom Types for IDL Compatibility
+
+One challenge with Anchor is that its IDL (Interface Definition Language)
+generator doesn't support complex Rust types like `Vec<(String, String)>`. So
+what we will do is create a custom struct:
+
+```rust
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+pub struct MetadataField {
+    pub key: String,
+    pub value: String,
+}
+```
+
+This allows us to pass additional metadata as `Vec<MetadataField>` instead of
+tuples. This makes it IDL-compatible while maintaining the same functionality.
+You might resolve that issue in another way.
+
+### Step 5: The Core Implementation
+
+The following section provides a complete, production-ready Rust implementation
+for initializing a Token-2022 mint with metadata using the Anchor framework.
+This code is intended for your `/src/lib.rs` file and demonstrates how to
+leverage Anchor's account validation, CPI helpers, and custom types to manage
+on-chain metadata efficiently and securely.
+
+The implementation includes dynamic rent calculation for TLV-encoded metadata,
+proper handling of additional metadata fields, and clear separation of
+responsibilities within the program. All critical steps are annotated for
+clarity and to highlight Anchor-specific best practices.
+
+Replace your entire `lib.rs` file with the following:
+
+```rust
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::rent::{
+    DEFAULT_EXEMPTION_THRESHOLD,
+    DEFAULT_LAMPORTS_PER_BYTE_YEAR,
+};
+use anchor_lang::system_program::{transfer, Transfer};
+use anchor_spl::token_interface::{
+    Mint,
+    TokenMetadataInitialize,
+    TokenMetadataUpdateField,
+    token_metadata_initialize,
+    token_metadata_update_field,
+    spl_token_metadata_interface::state::Field,
+};
+use anchor_spl::token_2022::Token2022;
+use spl_token_metadata_interface::state::TokenMetadata;
+use spl_type_length_value::variable_len_pack::VariableLenPack;
+
+declare_id!("CPJ9XPMV8ubUEAqCxV3MvuncBsufghTyT22hoCxzZQGe");
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+pub struct MetadataField {
+    pub key: String,
+    pub value: String,
+}
+
+#[program]
+pub mod metadata {
+    use super::*;
+
+    /// Initialize a Token-2022 mint with metadata extension
+    pub fn initialize_with_metadata(
+        ctx: Context<InitializeWithMetadata>,
+        name: String,
+        symbol: String,
+        uri: String,
+        additional_metadata: Option<Vec<MetadataField>>
+    ) -> Result<()> {
+        msg!("Initializing Token-2022 mint with metadata");
+        msg!("Name: {}", name);
+        msg!("Symbol: {}", symbol);
+        msg!("URI: {}", uri);
+        msg!("Mint: {}", ctx.accounts.mint.key());
+        msg!("Authority: {}", ctx.accounts.payer.key());
+
+        // Step 1: Calculate space needed for metadata TLV data
+        let mut token_metadata = TokenMetadata {
+            name: name.clone(),
+            symbol: symbol.clone(),
+            uri: uri.clone(),
+            ..Default::default()
+        };
+
+        // Add additional metadata fields if provided
+        if let Some(ref additional_fields) = additional_metadata {
+            token_metadata.additional_metadata = additional_fields
+                .iter()
+                .map(|field| (field.key.clone(), field.value.clone()))
+                .collect();
+        }
+
+        // Step 2: Calculate exact lamports needed for metadata storage
+        // TLV (Type-Length-Value) encoding: TYPE_SIZE (2) + LENGTH_SIZE (2) + packed data
+        const TYPE_SIZE: usize = 2;
+        const LENGTH_SIZE: usize = 2;
+        const TLV_HEADER_SIZE: usize = TYPE_SIZE + LENGTH_SIZE;
+
+        let data_len = TLV_HEADER_SIZE + token_metadata.get_packed_len()?;
+        let additional_lamports = (data_len as u64) *
+            DEFAULT_LAMPORTS_PER_BYTE_YEAR *
+            (DEFAULT_EXEMPTION_THRESHOLD as u64);
+
+        // Step 3: Transfer lamports for metadata storage
+        transfer(
+            CpiContext::new(
+                ctx.accounts.system_program.to_account_info(),
+                Transfer {
+                    from: ctx.accounts.payer.to_account_info(),
+                    to: ctx.accounts.mint.to_account_info(),
+                }
+            ),
+            additional_lamports
+        )?;
+
+        // Step 4: Initialize basic metadata (name, symbol, uri)
+        token_metadata_initialize(
+            CpiContext::new(
+                ctx.accounts.token_2022_program.to_account_info(),
+                TokenMetadataInitialize {
+                    program_id: ctx.accounts.token_2022_program.to_account_info(),
+                    mint: ctx.accounts.mint.to_account_info(),
+                    metadata: ctx.accounts.mint.to_account_info(), // Self-referential
+                    mint_authority: ctx.accounts.payer.to_account_info(),
+                    update_authority: ctx.accounts.payer.to_account_info(),
+                }
+            ),
+            name,
+            symbol,
+            uri
+        )?;
+
+        // Step 5: Add additional metadata fields
+        // Each field requires a separate CPI call, just like in TypeScript
+        if let Some(additional_fields) = additional_metadata {
+            for field in additional_fields.iter() {
+                token_metadata_update_field(
+                    CpiContext::new(
+                        ctx.accounts.token_2022_program.to_account_info(),
+                        TokenMetadataUpdateField {
+                            program_id: ctx.accounts.token_2022_program.to_account_info(),
+                            metadata: ctx.accounts.mint.to_account_info(),
+                            update_authority: ctx.accounts.payer.to_account_info(),
+                        }
+                    ),
+                    Field::Key(field.key.clone()),
+                    field.value.clone()
+                )?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(name: String, symbol: String, uri: String, additional_metadata: Option<Vec<MetadataField>>)]
+pub struct InitializeWithMetadata<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+
+    #[account(
+        init,
+        payer = payer,
+        mint::decimals = 9,
+        mint::authority = payer,
+        mint::token_program = token_2022_program,
+        extensions::metadata_pointer::authority = payer,
+        extensions::metadata_pointer::metadata_address = mint
+    )]
+    pub mint: InterfaceAccount<'info, Mint>,
+
+    pub token_2022_program: Program<'info, Token2022>,
+    pub system_program: Program<'info, System>,
+}
+```
+
+### Now, let's Break Down Each Step:
+
+#### **Step 1: Metadata Structure Creation**
+
+We create a `TokenMetadata` struct that mirrors what we did in TypeScript:
+
+```rust
+let mut token_metadata = TokenMetadata {
+    name: name.clone(),
+    symbol: symbol.clone(),
+    uri: uri.clone(),
+    ..Default::default()
+};
+```
+
+This struct will be used to calculate the exact space needed for TLV storage.
+
+#### **Step 2: Dynamic Space Calculation**
+
+Now that we have our metadata structure, we need to calculate the exact space
+required for storage. Unlike the TypeScript version where we calculated Metadata
+Pointer space explicitly, Anchor already did that part for us.
+
+So we can move to the Metadata Space Calculation stage;
+
+1. Build the complete metadata structure
+2. Calculate its packed length using `get_packed_len()`
+3. Add TLV header overhead (4 bytes: 2 for type, 2 for length)
+4. Calculate exact rent needed
+
+```rust
+const TLV_HEADER_SIZE: usize = TYPE_SIZE + LENGTH_SIZE;
+let data_len = TLV_HEADER_SIZE + token_metadata.get_packed_len()?;
+```
+
+#### **Step 3: Rent Transfer**
+
+With the space calculated, we need to ensure the mint account has enough
+lamports to cover the metadata storage. We transfer the exact lamports needed:
+
+```rust
+transfer(
+    CpiContext::new(ctx.accounts.system_program.to_account_info(), Transfer {
+        from: ctx.accounts.payer.to_account_info(),
+        to: ctx.accounts.mint.to_account_info(),
+    }),
+    additional_lamports
+)?;
+```
+
+This is similar to our TypeScript implementation but uses Anchor's CPI helpers.
+
+#### **Step 4: Basic Metadata Initialization**
+
+Once the account is properly funded, we can initialize the core metadata fields
+(name, symbol, uri) using Anchor's token metadata CPI:
+
+```rust
+token_metadata_initialize(
+    CpiContext::new(
+        ctx.accounts.token_2022_program.to_account_info(),
+        TokenMetadataInitialize { /* accounts */ }
+    ),
+    name, symbol, uri
+)?;
+```
+
+#### **Step 5: Additional Fields Update**
+
+After the basic metadata is initialized, we can add any additional custom
+fields. Just like in TypeScript, each additional metadata field requires a
+separate instruction because the way the metadata is updated is that they are
+first unpacked, updated, then packed using byte level instructions:
+
+```rust
+for field in additional_fields.iter() {
+    token_metadata_update_field(
+        CpiContext::new(/* accounts */),
+        Field::Key(field.key.clone()),
+        field.value.clone()
+    )?;
+}
+```
+
+### **Step 6: Account Constraints Deep Dive**
+
+The `#[account]` constraints deserve special attention because they replace all
+the manual validation we did in TypeScript:
+
+```rust
+#[account(
+    init,                                           // Creates new account
+    payer = payer,                                 // Funding source
+    mint::decimals = 0,                            // Token decimals
+    mint::authority = payer,                       // Mint authority
+    mint::token_program = token_2022_program,      // Use Token 2022
+    extensions::metadata_pointer::authority = payer,        // Metadata authority
+    extensions::metadata_pointer::metadata_address = mint   // Self-referential metadata
+)]
+pub mint: InterfaceAccount<'info, Mint>,
+```
+
+**What each constraint does:**
+
+- **`init`**: Creates a new account (calls SystemProgram::create_account)
+- **`payer = payer`**: Specifies who pays for account creation
+- **`mint::decimals = 9`**: Sets token decimals
+- **`mint::authority = payer`**: Sets the mint authority
+- **`mint::token_program = token_2022_program`**: Uses Token 2022 instead of
+  original Token program
+- **`extensions::metadata_pointer::authority = payer`**: Sets metadata update
+  authority
+- **`extensions::metadata_pointer::metadata_address = mint`**: Points metadata
+  to the mint itself (self-referential)
+
+### **Step 7: Building and Deployment**
+
+Now that we have our complete Anchor program, we need to build and deploy it:
+
+```bash
+
+# Optional (sometimes the program id is out of sync)
+# So run the following command just to be sure
+anchor keys sync
+
+# Then build the program
+anchor build
+
+# Deploy to devnet
+anchor deploy --provider.cluster devnet
+```
+
+### **Step 8: Client Implementation and Testing**
+
+With our program deployed, we can now create a client to interact with it. The
+client code is much simpler than our manual TypeScript implementation because
+the beautiful thing about Anchor other than it's Account Validation is its
+generated client:
+
+So paste the following code in your `tests/metadata.ts`:
+
+```typescript
+import { expect } from "chai";
+import * as anchor from "@coral-xyz/anchor";
+import { Program } from "@coral-xyz/anchor";
+import { Metadata } from "../target/types/metadata";
+import {
+  getMint,
+  getTokenMetadata,
+  TOKEN_2022_PROGRAM_ID
+} from "@solana/spl-token";
+import { Keypair, LAMPORTS_PER_SOL, SystemProgram } from "@solana/web3.js";
+
+describe("Token Metadata Tutorial", () => {
+  // Configure the client to use the local cluster
+  const provider = anchor.AnchorProvider.env();
+  anchor.setProvider(provider);
+
+  // Load the program
+
+  const program = anchor.workspace.metadata as Program<Metadata>;
+  const connection = provider.connection;
+
+  // Test wallets
+  const payer = (provider.wallet as anchor.Wallet).payer;
+  let mintKeypair: Keypair;
+  let metadataAccount: Keypair;
+
+  beforeEach(async () => {
+    // Generate new keypairs for each test
+    mintKeypair = Keypair.generate();
+    metadataAccount = Keypair.generate();
+
+    // Airdrop SOL to payer if needed
+    const balance = await connection.getBalance(payer.publicKey);
+    if (balance < 10 * LAMPORTS_PER_SOL) {
+      const sig = await connection.requestAirdrop(
+        payer.publicKey,
+        2 * LAMPORTS_PER_SOL
+      );
+      await connection.confirmTransaction(sig);
+      // Wait a bit to ensure the airdrop is fully processed
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  });
+  it("Should initialize a mint with metadata extension", async () => {
+    const name = "Developer Certification";
+    const symbol = "DEVCERT";
+    const uri = "https://example.com/metadata.json";
+    const additionalMetadata = [
+      { key: "level", value: "1" },
+      { key: "Issuer", value: "Solana Foundation" },
+      {
+        key: "Description",
+        value: "Certification for Solana developer proficiency"
+      },
+      { key: "Website", value: "https://solana.com" }
+    ];
+
+    const tx = await program.methods
+      .initializeWithMetadata(name, symbol, uri, additionalMetadata)
+      .accounts({
+        payer: payer.publicKey,
+        mint: mintKeypair.publicKey,
+        token_2022_program: TOKEN_2022_PROGRAM_ID,
+        systemProgram: SystemProgram.programId
+      })
+      .signers([payer, mintKeypair])
+      .rpc();
+
+    console.log("transaction", tx);
+
+    // Verify the mint was created
+    const mintInfo = await getMint(
+      connection,
+      mintKeypair.publicKey,
+      undefined,
+      TOKEN_2022_PROGRAM_ID
+    );
+
+    expect(mintInfo.decimals).to.equal(9);
+    expect(mintInfo.mintAuthority?.toBase58()).to.equal(
+      payer.publicKey.toBase58()
+    );
+
+    // Verify metadata was added
+    const metadata = await getTokenMetadata(
+      connection,
+      mintKeypair.publicKey,
+      undefined,
+      TOKEN_2022_PROGRAM_ID
+    );
+
+    expect(metadata.name).to.equal("Developer Certification");
+    expect(metadata.symbol).to.equal("DEVCERT");
+    expect(metadata.uri).to.equal("https://example.com/metadata.json");
+  });
+});
+```
+
+### Step 9: Run the Tests
+
+```bash
+# Anchor doesn't come packaged with "@solana/spl-token"
+# So add it
+yarn add @solana/spl-token
+
+Oh You You
+# Run all tests
+
+anchor test --skip-deploy --provider.cluster devnet
+```
+
+If everything goes well, we should get
+
+```bash
+  Token Metadata Tutorial
+transaction 4jrBYHjm2BrExd6J6hzdza3b9kyDG9Kiji7r1ogMqSPYDiVf8r1rHLvWoQjFotxnv23ScGsXgvKTVxans17UDsWc
+    ✔ Should initialize a mint with metadata extension (4264ms)
+  1 passing (6s)
+```
+
+You can examine the transaction on the
+[Solana Explorer](https://explorer.solana.com/tx/4jrBYHjm2BrExd6J6hzdza3b9kyDG9Kiji7r1ogMqSPYDiVf8r1rHLvWoQjFotxnv23ScGsXgvKTVxans17UDsWc?cluster=devnet)
+
+The approach we've shown here handles the same use case as our TypeScript
+implementation but with significantly less code and automatic safety checks.
+
+While Anchor provides excellent abstractions for most use cases, there are
+scenarios where you need the ultimate level of control such as extensions of
+features that Anchor doesn't yet support. This is where **native Rust
+implementation** comes into play. And we will get into it in next section.
+
+---
+
+## What's Next?
+
+You've mastered Token 2022 metadata extensions using the Anchor framework. You understand how Anchor simplifies development while still requiring deep knowledge of Solana's account model and extension architecture.
+
+**Continue to:** [**Native Rust Implementation →**](./native-rust)
+
+In the final implementation guide, we'll build the same functionality using pure Rust, giving you:
+- Complete control over every aspect of the implementation
+- Deep understanding of what Anchor abstracts away
+- The ability to handle edge cases and custom requirements
+- Maximum performance and flexibility for production systems

--- a/content/docs/en/tokens/extensions/metadata/how-extensions-work.mdx
+++ b/content/docs/en/tokens/extensions/metadata/how-extensions-work.mdx
@@ -17,29 +17,41 @@ extensions.
 
 ## Core Concepts
 
-Before diving into the technical details, let's establish two fundamental concepts that are crucial for understanding Token 2022 metadata extensions:
+Before diving into the technical details, let's establish two fundamental
+concepts that are crucial for understanding Token 2022 metadata extensions:
 
 ### What is Account Initialization?
 
-On Solana, **accounts are just raw data buffers** when first created. They contain unstructured bytes with no inherent meaning. **Initialization** is the process that gives this raw data structure and semantic meaning, allowing programs to interpret and use the data correctly.
+On Solana, **accounts are just raw data buffers** when first created. They
+contain unstructured bytes with no inherent meaning. **Initialization** is the
+process that gives this raw data structure and semantic meaning, allowing
+programs to interpret and use the data correctly.
 
 Think of it like formatting a hard drive:
+
 - **Before initialization**: Raw storage space with no file system
-- **After initialization**: Structured data that the operating system can understand and use
+- **After initialization**: Structured data that the operating system can
+  understand and use
 
 For Token 2022 mints:
+
 - **Before initialization**: A blank account owned by the Token 2022 program
-- **After initialization**: A structured mint account with defined fields (supply, decimals, authority, extensions)
+- **After initialization**: A structured mint account with defined fields
+  (supply, decimals, authority, extensions)
 
 ### TLV (Type-Length-Value) Encoding
 
-Token 2022 uses **TLV encoding** to store extension data efficiently and flexibly. TLV is a standardized way to serialize data where each piece of information is stored as:
+Token 2022 uses **TLV encoding** to store extension data efficiently and
+flexibly. TLV is a standardized way to serialize data where each piece of
+information is stored as:
 
-- **Type** (2 bytes): Identifies what kind of data this is (e.g., MetadataPointer = 18, TokenMetadata = 19)
+- **Type** (2 bytes): Identifies what kind of data this is (e.g.,
+  MetadataPointer = 18, TokenMetadata = 19)
 - **Length** (2 bytes): Specifies how many bytes the data occupies
 - **Value** (variable): The actual data content
 
 This structure allows Token 2022 to:
+
 - Support multiple extensions in any combination
 - Parse extension data without knowing the complete schema upfront
 - Add new extension types without breaking existing code
@@ -52,23 +64,36 @@ Example TLV structure:
 
 ### Account Reallocation
 
-Based on the Token 2022 source code, **account reallocation** is the mechanism used to handle variable-sized extensions like metadata within the existing account structure.
+Based on the Token 2022 source code, **account reallocation** is the mechanism
+used to handle variable-sized extensions like metadata within the existing
+account structure.
 
 **Key facts from the implementation:**
-- Token 2022 can reallocate account space to accommodate variable-length extensions
-- The `alloc_and_serialize_variable_len_extension` function handles both allocation and serialization of metadata
-- When metadata is initialized or updated, the account may be reallocated to fit the new data size
-- The reallocation process adjusts the TLV structure within the account to accommodate size changes
+
+- Token 2022 can reallocate account space to accommodate variable-length
+  extensions
+- The `alloc_and_serialize_variable_len_extension` function handles both
+  allocation and serialization of metadata
+- When metadata is initialized or updated, the account may be reallocated to fit
+  the new data size
+- The reallocation process adjusts the TLV structure within the account to
+  accommodate size changes
 
 **From the source code comments:**
-> "allocate a TLV entry for the space and write it in, assumes that there's enough SOL for the new rent-exemption"
+
+> "allocate a TLV entry for the space and write it in, assumes that there's
+> enough SOL for the new rent-exemption"
 
 **Space allocation:**
-- The initial account is created with space for the base mint and metadata pointer extension
-- Additional rent is calculated and paid for the metadata extension when it's added
+
+- The initial account is created with space for the base mint and metadata
+  pointer extension
+- Additional rent is calculated and paid for the metadata extension when it's
+  added
 - Updates to metadata can cause reallocation if the size changes
 
-This reallocation mechanism enables the flexibility of variable-sized metadata while maintaining the structured TLV format within the account.
+This reallocation mechanism enables the flexibility of variable-sized metadata
+while maintaining the structured TLV format within the account.
 
 Now let's see how these concepts apply to the actual account structure.
 
@@ -80,44 +105,18 @@ traditional token program plus some additional stuff, which we call extensions
 and And this is how it looks like in memory:
 
 ```mermaid
-block-beta
-    columns 3
-
-    block:mint["Base Mint Data"]:1
-        a["Mint Authority: 32 bytes"]
-        b["Supply: 8 bytes"]
-        c["Decimals: 1 byte"]
-        d["Other fields: 41 bytes"]
-    end
-
-    block:padding["Padding"]:1
-        e["Reserved: 83 bytes"]
-    end
-
-    block:type["Account Type"]:1
-        f["Type: 1 byte"]
-    end
-
-    block:ext1["Extension 1"]:3
-        g["Metadata Pointer Extension"]
-        h["Authority: 32 bytes"]
-        i["Address: 32 bytes (optional)"]
-    end
-
-    block:ext2["Extension 2"]:3
-        j["Token Metadata Extension"]
-        k["Update Authority: 32 bytes"]
-        l["Mint: 32 bytes"]
-        m["Name: Variable length"]
-        n["Symbol: Variable length"]
-        o["URI: Variable length"]
-    end
-
-    style mint fill:#e3f2fd
-    style padding fill:#f5f5f5
-    style type fill:#f5f5f5
-    style ext1 fill:#e8f5e8
-    style ext2 fill:#fff3e0
+flowchart LR
+    Base["Base Mint<br/>82 bytes"] --> 
+    Padding["Padding<br/>83 bytes"] --> 
+    Type["Type<br/>1 byte"] --> 
+    MetaPtr["Metadata Pointer<br/>33 bytes"] --> 
+    MetaData["Token Metadata<br/>Variable size"]
+    
+    style Base fill:#e3f2fd
+    style Padding fill:#f5f5f5
+    style Type fill:#f5f5f5
+    style MetaPtr fill:#e8f5e8
+    style MetaData fill:#fff3e0
 ```
 
 ### Extension Dependencies Flowchart
@@ -175,9 +174,11 @@ flowchart TD
 
 #### Fixed Components (for mint with MetadataPointer):
 
-Based on the Token 2022 test suite, `getMintLen([ExtensionType.MetadataPointer])` returns **234 bytes**.
+Based on the Token 2022 test suite,
+`getMintLen([ExtensionType.MetadataPointer])` returns **234 bytes**.
 
 This includes:
+
 - Base mint data and required extensions infrastructure
 - Metadata Pointer extension data
 - Proper alignment and padding
@@ -185,19 +186,25 @@ This includes:
 #### Variable Components (Token Metadata Extension):
 
 When adding the Token Metadata extension, additional space is calculated as:
-- **TYPE_SIZE** (2 bytes) + **LENGTH_SIZE** (2 bytes) + **packed metadata length**
+
+- **TYPE_SIZE** (2 bytes) + **LENGTH_SIZE** (2 bytes) + **packed metadata
+  length**
 
 The packed metadata includes:
+
 - Update Authority: 32 bytes
-- Mint: 32 bytes  
+- Mint: 32 bytes
 - Name: 4 bytes (length) + N bytes (content)
 - Symbol: 4 bytes (length) + N bytes (content)
 - URI: 4 bytes (length) + N bytes (content)
 - Additional fields: Variable
 
-_Total Space = 234 bytes (base with MetadataPointer) + Variable Metadata Extension Size_
+_Total Space = 234 bytes (base with MetadataPointer) + Variable Metadata
+Extension Size_
 
-> **⚠️ Critical Rule**: You must allocate all space upfront based on your requirements. Account space cannot be increased later for the account structure.
+> **⚠️ Critical Rule**: You must allocate all space upfront based on your
+> requirements. Account space cannot be increased later for the account
+> structure.
 
 ### The Initialization Order That Matters
 
@@ -266,20 +273,32 @@ official." Here's why this matters:
 
 ```mermaid
 flowchart TD
-    A[Malicious Actor] --> B[Creates Fake Metadata Account]
-    B --> C[Claims: "This belongs to Popular Token XYZ"]
-
-    D[Wallet/Explorer] --> E{Check Metadata Pointer}
-    E -->|Mint points to fake account| F[❌ Reject - Not official metadata]
-    E -->|Mint points to real account| G[✅ Accept - Official metadata]
-
-    H[Token Mint XYZ] --> I[Metadata Pointer Extension]
-    I --> J[Points to Official Metadata]
-
+    subgraph Attack["Potential Attack Scenario"]
+        A[Malicious Actor] --> B[Creates Fake Metadata Account]
+        B --> C["Claims: 'This belongs to Popular Token XYZ'"]
+    end
+    
+    subgraph Verification["Verification Process"]
+        D[Wallet/Explorer] --> E{Check Metadata Pointer}
+        E -->|Mint points to fake account| F["❌ Reject - Not official metadata"]
+        E -->|Mint points to real account| G["✅ Accept - Official metadata"]
+    end
+    
+    subgraph Official["Official Token Structure"]
+        H[Token Mint XYZ] --> I[Metadata Pointer Extension]
+        I --> J[Points to Official Metadata]
+    end
+    
+    Attack -.-> Verification
+    Official --> Verification
+    
     style F fill:#ffebee
     style G fill:#e8f5e8
     style A fill:#ffebee
     style B fill:#ffebee
+    style Attack fill:#ffebee,stroke:#d32f2f
+    style Official fill:#e8f5e8,stroke:#388e3c
+    style Verification fill:#fff3e0,stroke:#f57c00
 ```
 
 **Without the pointer**: Anyone could create metadata claiming to belong to your

--- a/content/docs/en/tokens/extensions/metadata/how-extensions-work.mdx
+++ b/content/docs/en/tokens/extensions/metadata/how-extensions-work.mdx
@@ -1,0 +1,341 @@
+---
+title: How Token Extensions Work Technically
+description:
+  A deep technical dive into how Token 2022 extensions—especially metadata and
+  metadata pointer—are structured and function at the account level, with
+  practical insights for developers working in Rust or other languages.
+---
+
+> **Previous:** [Token Extensions Overview](./) | **Next:** >
+> [TypeScript Implementation](./typescript)
+
+This section provides the technical foundation you need to understand Token 2022
+extensions at the byte level. We'll cover account structures, space
+calculations, and the critical initialization sequences—plus address the most
+common questions and pitfalls developers encounter when working with metadata
+extensions.
+
+## Core Concepts
+
+Before diving into the technical details, let's establish two fundamental concepts that are crucial for understanding Token 2022 metadata extensions:
+
+### What is Account Initialization?
+
+On Solana, **accounts are just raw data buffers** when first created. They contain unstructured bytes with no inherent meaning. **Initialization** is the process that gives this raw data structure and semantic meaning, allowing programs to interpret and use the data correctly.
+
+Think of it like formatting a hard drive:
+- **Before initialization**: Raw storage space with no file system
+- **After initialization**: Structured data that the operating system can understand and use
+
+For Token 2022 mints:
+- **Before initialization**: A blank account owned by the Token 2022 program
+- **After initialization**: A structured mint account with defined fields (supply, decimals, authority, extensions)
+
+### TLV (Type-Length-Value) Encoding
+
+Token 2022 uses **TLV encoding** to store extension data efficiently and flexibly. TLV is a standardized way to serialize data where each piece of information is stored as:
+
+- **Type** (2 bytes): Identifies what kind of data this is (e.g., MetadataPointer = 18, TokenMetadata = 19)
+- **Length** (2 bytes): Specifies how many bytes the data occupies
+- **Value** (variable): The actual data content
+
+This structure allows Token 2022 to:
+- Support multiple extensions in any combination
+- Parse extension data without knowing the complete schema upfront
+- Add new extension types without breaking existing code
+
+```
+Example TLV structure:
+[Type: 18][Length: 33][Value: Metadata Pointer data...]
+[Type: 19][Length: 188][Value: Token Metadata data...]
+```
+
+### Account Reallocation
+
+Based on the Token 2022 source code, **account reallocation** is the mechanism used to handle variable-sized extensions like metadata within the existing account structure.
+
+**Key facts from the implementation:**
+- Token 2022 can reallocate account space to accommodate variable-length extensions
+- The `alloc_and_serialize_variable_len_extension` function handles both allocation and serialization of metadata
+- When metadata is initialized or updated, the account may be reallocated to fit the new data size
+- The reallocation process adjusts the TLV structure within the account to accommodate size changes
+
+**From the source code comments:**
+> "allocate a TLV entry for the space and write it in, assumes that there's enough SOL for the new rent-exemption"
+
+**Space allocation:**
+- The initial account is created with space for the base mint and metadata pointer extension
+- Additional rent is calculated and paid for the metadata extension when it's added
+- Updates to metadata can cause reallocation if the size changes
+
+This reallocation mechanism enables the flexibility of variable-sized metadata while maintaining the structured TLV format within the account.
+
+Now let's see how these concepts apply to the actual account structure.
+
+## Account Structure Deep Dive
+
+The first thing to understand is that a Token 2022 mint account is a superset of
+an SPL Token Mint Account. So it has all the bells and whistles of the
+traditional token program plus some additional stuff, which we call extensions
+and And this is how it looks like in memory:
+
+```mermaid
+block-beta
+    columns 3
+
+    block:mint["Base Mint Data"]:1
+        a["Mint Authority: 32 bytes"]
+        b["Supply: 8 bytes"]
+        c["Decimals: 1 byte"]
+        d["Other fields: 41 bytes"]
+    end
+
+    block:padding["Padding"]:1
+        e["Reserved: 83 bytes"]
+    end
+
+    block:type["Account Type"]:1
+        f["Type: 1 byte"]
+    end
+
+    block:ext1["Extension 1"]:3
+        g["Metadata Pointer Extension"]
+        h["Authority: 32 bytes"]
+        i["Address: 32 bytes (optional)"]
+    end
+
+    block:ext2["Extension 2"]:3
+        j["Token Metadata Extension"]
+        k["Update Authority: 32 bytes"]
+        l["Mint: 32 bytes"]
+        m["Name: Variable length"]
+        n["Symbol: Variable length"]
+        o["URI: Variable length"]
+    end
+
+    style mint fill:#e3f2fd
+    style padding fill:#f5f5f5
+    style type fill:#f5f5f5
+    style ext1 fill:#e8f5e8
+    style ext2 fill:#fff3e0
+```
+
+### Extension Dependencies Flowchart
+
+```mermaid
+flowchart TD
+    A[Start: Create Token with Metadata] --> B[Calculate Required Space]
+    B --> C[Create Account with Exact Space]
+    C --> D{Want Token Metadata Extension?}
+    D -->|Yes| E[Initialize Metadata Pointer Extension]
+    D -->|No| F[Initialize Base Mint]
+    E --> G[Initialize Base Mint]
+    G --> H[Initialize Token Metadata Extension]
+    H --> I[Done: Token with Rich Metadata]
+    F --> J[Done: Basic Token]
+
+    style E fill:#e8f5e8
+    style H fill:#fff3e0
+    style I fill:#e8f5e8
+    style J fill:#e3f2fd
+```
+
+### Space Calculation Formula
+
+**How to Calculate the Space Needed for a Token 2022 Mint with Metadata**
+
+```mermaid
+flowchart TD
+    A[Token 2022 Mint Account] --> B[Base Mint: 82 bytes]
+    A --> C[Padding: 83 bytes]
+    A --> D[Account Type: 1 byte]
+    A --> E[Metadata Pointer Extension: 33 bytes]
+    A --> F[Token Metadata Extension: Variable]
+
+    F --> G[Update Authority: 32 bytes]
+    F --> H[Mint: 32 bytes]
+    F --> I[Name: 4 bytes length + N bytes content]
+    F --> J[Symbol: 4 bytes length + N bytes content]
+    F --> K[URI: 4 bytes length + N bytes content]
+    F --> L[Additional Fields: Variable]
+
+    style A fill:#e1f5fe
+    style B fill:#f3e5f5
+    style C fill:#f3e5f5
+    style D fill:#f3e5f5
+    style E fill:#f3e5f5
+    style F fill:#fff3e0
+    style G fill:#e8f5e8
+    style H fill:#e8f5e8
+    style I fill:#e8f5e8
+    style J fill:#e8f5e8
+    style K fill:#e8f5e8
+    style L fill:#e8f5e8
+```
+
+#### Fixed Components (for mint with MetadataPointer):
+
+Based on the Token 2022 test suite, `getMintLen([ExtensionType.MetadataPointer])` returns **234 bytes**.
+
+This includes:
+- Base mint data and required extensions infrastructure
+- Metadata Pointer extension data
+- Proper alignment and padding
+
+#### Variable Components (Token Metadata Extension):
+
+When adding the Token Metadata extension, additional space is calculated as:
+- **TYPE_SIZE** (2 bytes) + **LENGTH_SIZE** (2 bytes) + **packed metadata length**
+
+The packed metadata includes:
+- Update Authority: 32 bytes
+- Mint: 32 bytes  
+- Name: 4 bytes (length) + N bytes (content)
+- Symbol: 4 bytes (length) + N bytes (content)
+- URI: 4 bytes (length) + N bytes (content)
+- Additional fields: Variable
+
+_Total Space = 234 bytes (base with MetadataPointer) + Variable Metadata Extension Size_
+
+> **⚠️ Critical Rule**: You must allocate all space upfront based on your requirements. Account space cannot be increased later for the account structure.
+
+### The Initialization Order That Matters
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant System Program
+    participant Token 2022 Program
+
+    Note over Client: Step 1: Calculate Space
+    Client->>Client: mintLen = getMintLen([MetadataPointer])
+    Client->>Client: metadataLen = TYPE_SIZE + LENGTH_SIZE + pack(metadata).length
+
+    Note over Client: Step 2: Create Account
+    Client->>System Program: createAccount(space: mintLen, lamports: mintLen + metadataLen)
+    System Program-->>Client: Account created
+
+    Note over Client: Step 3: Initialize Extensions (ORDER MATTERS!)
+    Client->>Token 2022 Program: initializeMetadataPointer()
+    Token 2022 Program-->>Client: Metadata Pointer ready
+
+    Client->>Token 2022 Program: initializeMint()
+    Token 2022 Program-->>Client: Basic mint ready
+
+    Client->>Token 2022 Program: initializeTokenMetadata()
+    Note over Token 2022 Program: Checks for Metadata Pointer ✓
+    Token 2022 Program-->>Client: Metadata added
+
+    rect rgb(255, 243, 224)
+        Note over Client, Token 2022 Program: ⚠️ If you try Token Metadata before Metadata Pointer, it fails!
+    end
+```
+
+## Why Do We Need Both Metadata Pointer AND Token Metadata?
+
+This is the **#1 question** developers ask, and for good reason. It seems
+redundant at first glance.
+
+### The Design Rationale
+
+The Token Metadata Interface supports **two approaches**:
+
+1. **Self-referential**: A mint can carry metadata itself AND point to itself
+2. **External reference**: A mint points to another account for metadata
+
+```mermaid
+graph LR
+    A[Mint Account] --> B{Metadata Pointer Extension}
+
+    B --> C[Points to SELF]
+    B --> D[Points to EXTERNAL account]
+
+    C --> E[Token Metadata Extension<br/>in same account]
+    D --> F[Custom Metadata Program<br/>in different account]
+
+    style C fill:#e8f5e8
+    style E fill:#e8f5e8
+    style D fill:#fff3e0
+    style F fill:#fff3e0
+```
+
+### The Security Pattern
+
+**The Metadata Pointer acts as a digital signature** that says "this metadata is
+official." Here's why this matters:
+
+```mermaid
+flowchart TD
+    A[Malicious Actor] --> B[Creates Fake Metadata Account]
+    B --> C[Claims: "This belongs to Popular Token XYZ"]
+
+    D[Wallet/Explorer] --> E{Check Metadata Pointer}
+    E -->|Mint points to fake account| F[❌ Reject - Not official metadata]
+    E -->|Mint points to real account| G[✅ Accept - Official metadata]
+
+    H[Token Mint XYZ] --> I[Metadata Pointer Extension]
+    I --> J[Points to Official Metadata]
+
+    style F fill:#ffebee
+    style G fill:#e8f5e8
+    style A fill:#ffebee
+    style B fill:#ffebee
+```
+
+**Without the pointer**: Anyone could create metadata claiming to belong to your
+token.  
+**With the pointer**: Only the mint authority can set which metadata is
+official.
+
+This design enables clients to verify a token's official metadata by checking
+that the mint and metadata reference each other—providing a built-in anti-scam
+mechanism.
+
+## Ecosystem Support and Display Considerations
+
+### Wallet and Explorer Integration
+
+Token 2022 metadata extensions represent a newer standard that required
+ecosystem-wide adoption. Initially, many wallets and explorers displayed tokens
+with these extensions as "Unknown Token" because they lacked built-in support
+for the new metadata format.
+
+The ecosystem has evolved to support Token 2022 metadata natively. Modern
+explorers and wallets can now read and display metadata directly from the mint
+account extensions, eliminating the dependency on external metadata accounts.
+
+### Unified Metadata Access
+
+The **Metaplex Digital Asset Standard (DAS) API** provides a standardized
+interface for accessing metadata regardless of whether it uses the traditional
+Metaplex format or Token 2022 extensions. This abstraction layer allows
+applications to work with both metadata formats seamlessly.
+
+## Understanding Extension Status Indicators
+
+User interfaces often display labels like "Token Extensions: False" or "Token
+Extensions: True" to indicate the technical characteristics of a token.
+
+This flag indicates whether the token was created using the Token 2022 program
+and has any extensions enabled:
+
+- **"False"**: Token created with the original Token Program, or Token 2022 with
+  no extensions
+- **"True"**: Token created with Token 2022 program with at least one extension
+  enabled
+
+A token can be created with the Token 2022 program but still show "Extensions:
+False" if no extensions are actually utilized. The program supports both
+traditional token functionality and extended capabilities.
+
+## What's Next?
+
+Now that you understand the technical architecture and common pitfalls, you're
+ready to start building. The initialization order, space calculations, and
+security patterns we've covered form the foundation for everything that follows.
+
+**Continue to:** [**TypeScript Implementation →**](./typescript)
+
+In the next section, we'll put this knowledge into practice by building a
+complete token with metadata using TypeScript/JavaScript, handling all the edge
+cases and pitfalls we've discussed here.

--- a/content/docs/en/tokens/extensions/metadata/index.mdx
+++ b/content/docs/en/tokens/extensions/metadata/index.mdx
@@ -1,0 +1,282 @@
+## A Practical Guide to Token 2022 Metadata Pointer and Metadata Token Extensions
+
+Solana's [Token 2022 program](https://spl.solana.com/token-2022) introduces a
+powerful new architecture: **Token Extensions**.
+
+These extensions – especially the Metadata Extension addresses the core
+challenge of the digital trust problem: **how do you attach rich, verifiable,
+and updatable information to a token, in a way that's cryptographically secure,
+natively accessible, and impossible to fake or lose?**
+
+Unlike older approaches (where metadata lived in a separate account or off-chain
+database), Token 2022 lets you store metadata _inside_ the token mint account
+itself through a flexible and extensible data layout. This means wallets,
+explorers, and programs can always find and trust your token's metadata – no
+more "unknown token" errors, no more fragile links, and no more custom smart
+contracts just to add a name or an image.
+
+### What This Guide Covers
+
+This guide is a **step-by-step, code-level walkthrough** of how to build, use,
+and understand Token 2022 metadata extensions – across the full stack:
+
+- **TypeScript Client Implementation**: You'll learn how to manually construct
+  and serialize instructions for Token 2022 extensions using
+  [@solana/web3.js](https://solana-labs.github.io/solana-web3.js/), including
+  the details of byte layout, discriminators, and matching Rust-side
+  expectations.
+- **[Anchor Framework](https://www.anchor-lang.com/) Approach**: We'll show how
+  the Anchor framework can simplify some aspects of extension management, but
+  also where you need to understand the underlying mechanics for full control
+  and security.
+- **Native Rust Program Implementation**: You'll see how to implement everything
+  from scratch using the
+  [Solana Program Library](https://github.com/solana-labs/solana-program-library),
+  including manual account validation, TLV (Type-Length-Value) data management,
+  [rent](https://docs.solana.com/implemented-proposals/rent) handling, and
+  [cross-program invocations](/docs/intro/quick-start/cross-program-invocation),
+  giving you a deep understanding of Solana's internals.
+
+Throughout, we will highlight real-world errors, debugging strategies, and best
+practices for Solana programs.
+
+### What You'll Learn (and What You'll Build)
+
+By following this guide, you will:
+
+1. **Understand the two main types of Token Extensions** (Mint and Account) and
+   how they fit into the
+   [Solana account model](/docs/intro/quick-start/reading-from-network).
+2. **Learn when and why to use the Metadata Pointer extension** – and how it
+   enables dynamic, updatable metadata directly in the mint account.
+3. **Master TLV (Type-Length-Value) data structures**: how Token 2022 stores
+   extension data, how to calculate space, and how to read/write TLV fields.
+   Learn more about
+   [TLV in the SPL docs](https://spl.solana.com/token-2022/extension-guide#type-length-value).
+4. **See the full lifecycle of a Token 2022 mint with metadata**: from account
+   creation, through extension initialization, to dynamic metadata updates.
+5. **Write and debug TypeScript clients** that serialize instructions _exactly_
+   as the Rust program expects (no more "invalid instruction data" errors).
+   Build on [Solana Web3.js](https://solana-labs.github.io/solana-web3.js/)
+   foundations.
+6. **Implement and validate Rust programs** (both
+   [Anchor](https://www.anchor-lang.com/) and native) that handle all the edge
+   cases: account validation,
+   [rent](https://docs.solana.com/implemented-proposals/rent),
+   [CPI](/docs/intro/quick-start/cross-program-invocation), and more.
+7. **Avoid common pitfalls**: account order mismatches, missing signer checks,
+   space miscalculations, and rent errors.
+8. **Gain a deep understanding of Solana's extension architecture** – knowledge
+   that will make you a better Solana developer, whether you use
+   [Anchor](https://www.anchor-lang.com/) or not.
+
+### Prerequisites & Knowledge Required
+
+This guide is designed for developers who:
+
+- Have a basic understanding of
+  [Solana accounts, programs](/docs/intro/quick-start), and the
+  [SPL Token standard](/docs/tokens).
+- Are comfortable reading and writing both
+  [TypeScript](https://www.typescriptlang.org/) and
+  [Rust](https://www.rust-lang.org/) (no need to be an expert, but you should
+  know the basics).
+- Want to go beyond "copy-paste" and actually understand _why_ things work (and
+  why they sometimes don't).
+
+If you're new to Solana, it's helpful to review the
+[Solana Programming Model](/docs/intro/quick-start) and
+[Token 2022 documentation](https://spl.solana.com/token-2022) first. If you're
+already comfortable with [Anchor](https://www.anchor-lang.com/), this guide will
+show you what's happening "under the hood" – and how to go native when you need
+maximum control.
+
+### How This Guide Is Structured
+
+This comprehensive guide is organized into focused sections:
+
+1. **[How Extensions Work](./how-extensions-work)**: Deep dive into the
+   technical architecture, TLV structures, and space calculations
+2. **[TypeScript Implementation](./typescript)**: Build tokens with metadata
+   using JavaScript/TypeScript clients
+3. **[Anchor Implementation](./anchor)**: Leverage the Anchor framework for
+   streamlined development
+4. **[Native Rust Implementation](./native-rust)**: Master complete control with
+   native Solana programming
+5. **[Real-World Use Cases](./usecases)**: Explore practical applications and
+   production patterns
+
+Each section builds on the previous, starting with foundational concepts and
+progressing to advanced implementations. You can jump to specific sections based
+on your needs, but we recommend following the sequence for the fullest
+understanding.
+
+**Ready to start?** Let's begin with understanding how Token 2022 extensions
+work under the hood.
+
+## What Are Token Extensions? (And Why Do They Matter?)
+
+Think of a traditional [SPL token](/docs/tokens/basics) like a basic bank note –
+it has a value, you can transfer it, but that's about it. You can't write on it,
+you can't update it, and you certainly can't attach a photo or certificate to
+it.
+
+If you wanted to add metadata to your token, you had to:
+
+1. **Create your SPL token** (using the
+   [original token program](/docs/tokens/basics))
+2. **Create a separate metadata account** (using
+   [Metaplex's program](https://docs.metaplex.com/programs/token-metadata/))
+3. **Hope wallets and explorers knew how to connect them**
+
+This created several problems:
+
+- First, you are relying on separate programs (more dependencies and
+  complexity).
+- Then, Wallets had to guess the connections so your token might show up as
+  "Unknown Token" in wallets because they couldn't reliably find or trust the
+  metadata connection.
+
+```mermaid
+graph TD
+    A[SPL Token Mint] -.->|"Guess connection"| B[Metaplex Metadata Account]
+    C[Wallet] --> A
+    C -.->|"May not find"| B
+    D[Explorer] --> A
+    D -.->|"Shows warnings"| B
+
+    style B fill:#fff3e0
+    style A fill:#e3f2fd
+```
+
+More than that, there was no form of verification and things were often stored
+on centralized storage which may get corrupted or deleted. This is why
+[decentralized storage solutions](https://arweave.org/) became important for NFT
+metadata.
+
+### Token Extensions change this completely.
+
+They're like upgrading from a basic bank note to a smart card that can store
+photos, certificates, update history, and even enforce rules about how it can be
+used.
+
+With Token 2022, everything lives in one place:
+
+```
+Token Mint Address: ABC123...
+├── Basic token data (balance, decimals)
+├── Metadata Extension (name, symbol, image)
+├── Transfer Fee Extension (optional)
+└── Other Extensions (as needed)
+```
+
+The result? Wallets and explorers get all the information they need from one
+source they can trust.
+
+```mermaid
+graph TD
+    A[Token 2022 Mint] --> B[Built-in Metadata Extensions]
+    B --> C[Metadata Pointer Extension]
+    B --> D[Token Metadata Extension]
+
+    E[Wallet] --> A
+    E --> C
+    E --> D
+
+    F[Explorer] --> A
+    F --> C
+    F --> D
+
+    G[DApp] --> A
+    G --> C
+    G --> D
+
+    style A fill:#e8f5e8
+    style C fill:#e8f5e8
+    style D fill:#e8f5e8
+    style B fill:#e8f5e8
+```
+
+## Token Extensions are like Lego Blocks
+
+They work like modular components that you can snap together. Each extension
+adds specific functionality, and they fall into **two distinct categories**:
+
+- **Mint Account Extensions**
+- **Token Account Extensions**
+
+Mint Account Extensions are attached to the
+**[Mint Account](/docs/tokens#mint-account)** itself (the "template" for the
+token). So it's shared by all token holders. While Token Account Extensions are
+attached to **individual [Token Accounts](/docs/tokens#token-account)** (where
+users hold the tokens). So it means it could be different for each token holder.
+
+```mermaid
+graph TD
+    A[Token 2022 Extensions] --> B[Mint Account Extensions]
+    A --> C[Token Account Extensions]
+
+    B --> D[Metadata Pointer]
+    B --> E[Token Metadata]
+    B --> F[Mint Close Authority]
+    B --> G[Transfer Fee Config]
+    B --> H[Interest Bearing Config]
+
+    C --> I[Transfer Hook]
+    C --> J[Immutable Owner]
+    C --> K[Memo Transfer]
+    C --> L[CPI Guard]
+
+    style B fill:#e1f5fe
+    style C fill:#f3e5f5
+```
+
+### Metadata Pointer and Token Metadata Extensions will be used in this guide
+
+As shown earlier, they are Mint Account Extensions and so affect **all tokens**
+made from their Mint.
+
+- **Metadata Pointer** Extension points to where the metadata lives
+- **Token Metadata** Extension stores the actual metadata (name, symbol, image
+  URL) and any additional information.
+
+They are always used together for security patterns. The Metadata Pointer acts
+like a digital signature that says "this metadata is official." Without it,
+anyone could claim their metadata belongs to your token.
+
+```mermaid
+flowchart TD
+    A[Token Mint: MyToken] --> B{Has Metadata Pointer?}
+    B -->|No| C[❌ Anyone can attach fake metadata]
+    B -->|Yes| D[✅ Only official metadata is trusted]
+
+    C --> E[Scammer creates fake metadata]
+    E --> F[Users can't tell what's real]
+
+    D --> G[Metadata Pointer → Official Metadata]
+    G --> H[Users can verify authenticity]
+
+    style C fill:#ffebee
+    style E fill:#ffebee
+    style F fill:#ffebee
+    style D fill:#e8f5e8
+    style G fill:#e8f5e8
+    style H fill:#e8f5e8
+```
+
+## What's Next?
+
+Now that you understand the motivation and basic concepts behind Token 2022
+metadata extensions, it's time to dive deeper into the technical implementation.
+
+**Continue to:** [**How Extensions Work →**](./metadata/how-extensions-work)
+
+In the next section, we'll explore the technical architecture, including:
+
+- Account structure and TLV (Type-Length-Value) encoding
+- Space calculations and rent considerations
+- The critical initialization order that prevents common errors
+- Extension dependencies and security patterns
+
+This foundation will prepare you for the hands-on implementation guides that
+follow.

--- a/content/docs/en/tokens/extensions/metadata/meta.json
+++ b/content/docs/en/tokens/extensions/metadata/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Metadata and Metadata Pointer",
+  "pages": ["how-extensions-work", "typescript", "anchor", "native-rust", "usecases"]
+}

--- a/content/docs/en/tokens/extensions/metadata/native-rust.mdx
+++ b/content/docs/en/tokens/extensions/metadata/native-rust.mdx
@@ -1,0 +1,1035 @@
+---
+title: Native Rust Implementation
+description: Master Token 2022 metadata extensions with complete control using native Rust programming.
+---
+
+> **Previous:** [Anchor Implementation](./anchor) | **Next:** [Real-World Use Cases](./usecases)
+>
+> **Quick Navigation:** [How Extensions Work](./how-extensions-work) | [TypeScript](./typescript) | [Anchor](./anchor)
+
+Ready for the ultimate level of control? This section shows you how to implement [Token 2022 metadata extensions](./how-extensions-work) using pure Rust, giving you complete control over every aspect of the implementation. You'll understand exactly what [Anchor](./anchor) abstracts away.
+
+## **Native Rust Implementation: Complete Control**
+
+With this method, you gain complete control over every aspect of the Token 2022
+metadata system. However, this power comes at the cost of having to understand
+and manually handle all the details that frameworks like Anchor usually abstract
+away.
+
+Think of it as building a house from scratch, rather than assembling one from
+prefabricated components. In this approach, you'll need to reimplement many of
+the conveniences that Anchor provides for you for free, such as:
+
+- Manual account management and validation
+- Custom instruction data serialization
+- Cross Program Invocation (CPI) complexity
+- Token 2022's [TLV data structures](./how-extensions-work#tlv-type-length-value-encoding)
+- [Dynamic account reallocation](./how-extensions-work#account-reallocation) for metadata
+
+But it will give you:
+
+- **Complete control** over every instruction and validation
+- **Maximum performance** with minimal overhead
+- **Deep understanding** of Solana's internals
+- **Custom logic** that frameworks can't express
+
+### Step 1: Project Setup
+
+First, navigate back to our Project's root directory.
+
+```bash
+cd ../..
+
+# Then create a new directory for native implementation
+mkdir native
+cd native
+
+# After that, initialize a new Rust project
+cargo init --lib
+```
+
+### Step 2: Dependencies Configuration
+
+Edit `Cargo.toml` with the required dependencies:
+
+```toml
+[package]
+name = "native"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[dependencies]
+solana-program = "1.18"
+spl-token-2022 = { version = "3.0", features = ["no-entrypoint"] }
+spl-token-metadata-interface = "0.3"
+spl-associated-token-account = { version = "3.0", features = ["no-entrypoint"] }
+spl-pod = "0.2"
+borsh = "0.10"
+thiserror = "1.0"
+
+[features]
+no-entrypoint = []
+```
+
+**Critical Note**: The `no-entrypoint` feature prevents global allocator
+conflicts when multiple SPL programs are used together in a single program. This
+is essential for native implementations.
+
+Without it you will be getting errors like:
+
+```bash
+multiple declaration of global allocator
+```
+
+### Step 3: Program Structure
+
+Replace the boilerplate code generated into `src/lib.rs` with the following
+library imports:
+
+```rust
+;use solana_program::{
+    account_info::{next_account_info, AccountInfo},
+    entrypoint,
+    entrypoint::ProgramResult,
+    msg,
+    program::invoke,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    rent::Rent,
+    system_instruction,
+    sysvar::Sysvar,
+};
+
+use spl_token_2022::{
+    extension::{
+        metadata_pointer::{self},
+        ExtensionType,
+    },
+    instruction as token_instruction,
+    state::Mint,
+};
+
+use spl_token_metadata_interface::{
+    instruction as metadata_instruction,
+};
+
+use borsh::{BorshDeserialize, BorshSerialize}
+```
+
+The imports we're using here provide the core building blocks for Solana program
+development:
+
+- **`solana_program`**: Core Solana program framework (accounts, instructions,
+  entrypoints)
+- **`spl_token_2022`**: Token 2022 program extensions and instructions
+- **`spl_token_metadata_interface`**: Metadata interface for Token 2022
+- **`borsh`**: Binary serialization for instruction data
+- **`thiserror`**: Custom error handling utilities
+
+#### Every Solana Program requires an entry point.
+
+You can think of an entry point as similar to an API handler in a traditional
+web2 server—it's the function that gets called whenever your program receives an
+instruction from the client.
+
+It then handles the instruction and dispatches it to the appropriate logic.
+
+So let's create one.
+
+```rust
+// preceeding code excluded for brevity
+
+// Program entrypoint
+entrypoint!(process_instruction);
+
+// Program ID - will be updated after deployment
+solana_program::declare_id!("11111111111111111111111111111111");
+
+// Main program processor
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8],
+) -> ProgramResult {
+
+    // Does absolutely nothing for now
+    // except return back to the caller
+    Ok(())
+}
+```
+
+**Process Instruction Function Overview**
+
+The `process_instruction` function receives three parameters:
+
+- **`program_id`**: The address of your deployed program
+- **`accounts`**: Array of accounts that the instruction needs to work with
+- **`instruction_data`**: Raw bytes containing the instruction to call and it's
+  data sent by the client
+
+It's acts as a router and deserializes the instruction data to determine what
+operation to perform, then calls the appropriate handler function. For now, it
+just returns `Ok(())` as a placeholder.
+
+#### Ensure that everything works fine
+
+```bash
+cargo build-sbf
+```
+
+That command is telling Cargo (Rust's package manager) to build your Solana
+program into a SBF (Solana Byte Format) binary that can run on the Solana
+blockchain.
+
+If this is the first time, your program will pull your dependencies then compile
+them into a deployable binary.
+
+You may get a lot of warnings in the console regarding unused imports and
+variables -- it's because Rust is very strict about unused code but at the end
+of it you should get a
+`Finished`release` profile [optimized] target(s) in {57.04}s` message
+
+### Step 4: Implement the Instruction Data Structures
+
+Since we already know the Instructions we need from our [previous TypeScript implementation](./typescript), let's quickly map them out:
+
+1. **CreateTokenWithMetadata** - Creates a new Token 2022 mint with metadata
+2. **UpdateMetadataField** - Updates a specific metadata field
+
+We will define our Instruction set as an Enum since our Program only has a
+Finite Set of Instructions. This makes it easy to serialize/deserialize
+instruction data and provides type safety.
+
+```rust
+#[derive(BorshSerialize, BorshDeserialize, Debug)]
+pub enum TokenCertInstruction {
+    /// Create a Token 2022 mint with metadata
+    ///
+    /// Accounts expected:
+    /// 0. `[signer, writable]` Payer account
+    /// 1. `[signer, writable]` Mint account (to be created)
+    /// 2. `[]` System program
+    /// 3. `[]` Token 2022 program
+    /// 4. `[]` Rent sysvar
+    CreateTokenWithMetadata {
+        /// Token name
+        name: String,
+        /// Token symbol
+        symbol: String,
+        /// Token URI
+        uri: String,
+    },
+
+    /// Update a metadata field
+    UpdateMetadataField {
+        /// Field name to update
+        field: String,
+        /// New value for the field
+        value: String,
+    },
+
+
+}
+```
+
+The `#[derive(BorshSerialize, BorshDeserialize, Debug)]` line automatically
+generates code for our enum:
+
+- **`BorshSerialize`**: Converts our enum into binary bytes for sending to the
+  blockchain
+- **`BorshDeserialize`**: Converts binary bytes back into our enum when the
+  program receives them
+- **`Debug`**: Allows us to print the enum for debugging purposes
+
+This is Rust's way of automatically implementing these traits without us having
+to write the tedious serialization/deserialization code manually.
+
+Following the patterns we established in our [TypeScript](./typescript) and [Anchor](./anchor) implementations, let's define some custom types:
+
+### Step 5: Custom Error Types
+
+Writing Native code is already difficult, so it's crucial to create custom error
+types and messages to help us identify exactly what went wrong (unauthorized
+access, invalid data, etc.) when a transaction fails.
+
+It also helps clients catch and handle specific error types appropriately. Also
+they are often more CU efficient that plain string error messages;
+
+```rust
+#[derive(thiserror::Error, Debug)]
+pub enum TokenCertError {
+    #[error("Invalid instruction")]
+    InvalidInstruction,
+    #[error("Invalid metadata")]
+    InvalidMetadata,
+    #[error("Unauthorized")]
+    Unauthorized,
+    #[error("Invalid mint")]
+    InvalidMint,
+}
+
+impl From<TokenCertError> for ProgramError {
+    fn from(e: TokenCertError) -> Self {
+        ProgramError::Custom(e as u32)
+    }
+}
+```
+
+The `#[derive(thiserror::Error, Debug)]` line automatically generates custom
+error code. The `impl From<TokenCertError> for ProgramError` block is useful for
+converting our custom errors into Solana's standard error format.
+
+### Step 6: Implement the Create Mint with Metadata
+
+Now we'll implement the core functionality - creating a Token 2022 Mint Account
+with metadata. We can focus on the native Rust details since we already
+understand the [correct sequence](./how-extensions-work#the-initialization-order-that-matters) from our [TypeScript implementation](./typescript).
+
+This is where the complexity of native programming becomes apparent - we need to
+manually handle every step that Anchor would do automatically.
+
+For now, I'll give you the whole instruction then explain it later;
+
+```rust
+fn process_create_token_with_metadata(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    name: String,
+    symbol: String,
+    uri: String,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    // Parse accounts in exact order expected by the instruction
+    let payer = next_account_info(account_info_iter)?;
+    let mint_account = next_account_info(account_info_iter)?;
+    let system_program = next_account_info(account_info_iter)?;
+    let token_program = next_account_info(account_info_iter)?;
+    let rent_sysvar = next_account_info(account_info_iter)?;
+
+    // Manual validation (Anchor does this automatically)
+    if !payer.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+    if !mint_account.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    msg!("Creating mint with metadata: name={}, symbol={}, uri={}", name, symbol, uri);
+
+    // Step 1: Calculate space for mint with metadata pointer extension
+    let space = spl_token_2022::extension::ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MetadataPointer])
+        .map_err(|_| ProgramError::InvalidAccountData)?;
+
+    // Step 2: Calculate rent
+    let rent = Rent::from_account_info(rent_sysvar)?;
+    let minimum_balance = rent.minimum_balance(space);
+
+    // Step 3: Create mint account
+    invoke(
+        &system_instruction::create_account(
+            payer.key,
+            mint_account.key,
+            minimum_balance,
+            space as u64,
+            token_program.key,
+        ),
+        &[payer.clone(), mint_account.clone(), system_program.clone()],
+    )?;
+
+    // Step 4: Initialize metadata pointer extension
+    invoke(
+        &metadata_pointer::instruction::initialize(
+            token_program.key,
+            mint_account.key,
+            Some(*payer.key),
+            Some(*mint_account.key),
+        )?,
+        &[mint_account.clone(), token_program.clone()],
+    )?;
+
+    // Step 5: Initialize mint
+    invoke(
+        &token_instruction::initialize_mint2(
+            token_program.key,
+            mint_account.key,
+            payer.key,
+            None,
+            4, // decimals
+        )?,
+        &[mint_account.clone(), rent_sysvar.clone(), token_program.clone()],
+    )?;
+
+    // Step 6: Calculate additional rent for metadata TLV data
+    use spl_token_metadata_interface::state::TokenMetadata;
+    let metadata = TokenMetadata {
+        name: name.clone(),
+        symbol: symbol.clone(),
+        uri: uri.clone(),
+        mint: *mint_account.key,
+        update_authority: spl_pod::optional_keys::OptionalNonZeroPubkey::try_from(Some(*payer.key))
+            .map_err(|_| ProgramError::InvalidAccountData)?,
+        additional_metadata: vec![],
+    };
+
+    // Calculate current account size and required size for metadata
+    let current_len = mint_account.data_len();
+    let metadata_len = metadata.tlv_size_of().map_err(|_| ProgramError::InvalidAccountData)?;
+    let required_len = current_len + metadata_len;
+
+    // Calculate additional rent needed
+    let current_balance = mint_account.lamports();
+    let required_balance = rent.minimum_balance(required_len);
+    let additional_lamports = required_balance.saturating_sub(current_balance);
+
+    if additional_lamports > 0 {
+        msg!("Transferring {} lamports for metadata storage", additional_lamports);
+        invoke(
+            &system_instruction::transfer(payer.key, mint_account.key, additional_lamports),
+            &[payer.clone(), mint_account.clone(), system_program.clone()],
+        )?;
+    }
+
+    // Step 7: Initialize metadata - Token 2022 will reallocate the account
+    invoke(
+        &metadata_instruction::initialize(
+            token_program.key,   // program_id (Token 2022)
+            mint_account.key,    // metadata_address (same as mint for self-referential)
+            payer.key,           // update_authority
+            mint_account.key,    // mint_address
+            payer.key,           // mint_authority (must be the signer)
+            name.clone(),
+            symbol.clone(),
+            uri.clone(),
+        ),
+        &[mint_account.clone(), payer.clone(), token_program.clone()],
+    )?;
+
+    msg!("Successfully initialized metadata in mint account");
+    msg!("Metadata pointer: {}", mint_account.key);
+    msg!("Metadata stored in mint account TLV data");
+    msg!("Name: {}, Symbol: {}, URI: {}", name, symbol, uri);
+
+    msg!("Successfully created Token 2022 mint with metadata");
+    msg!("Mint address: {}", mint_account.key);
+
+    Ok(())
+}
+```
+
+### Let's break down what's happening in each step:
+
+First, the instruction accepts the program_id, accounts array, and
+instruction_data as parameters
+
+Then we parsed the Accounts by manually iterate through the accounts array. The
+order is very important here and must must match exactly what the TypeScript
+client sends.
+
+```rust
+let account_info_iter = &mut accounts.iter();
+let payer = next_account_info(account_info_iter)?;
+```
+
+After that we did some manual validation checks which Anchor would have
+naturally done for us. Missing these creates security vulnerabilities.
+
+```rust
+if !payer.is_signer {
+    return Err(ProgramError::MissingRequiredSignature);
+}
+if !mint_account.is_signer {
+    return Err(ProgramError::MissingRequiredSignature);
+}
+```
+
+These are standard security practices for any given Solana Native Rust program.
+We validate that:
+
+- The payer is a signer (required to pay for account creation)
+- The mint account is a signer (required for account creation)
+- Account ownership and program IDs are validated implicitly through CPI calls
+
+Now lets go into our own specific program implementation;
+
+#### **In Step 1, we did Space Calculation**
+
+As with our [TypeScript implementation](./typescript), we calculated the initial space needed for
+the mint account with the metadata pointer extension included. This is
+critical - too little space and the transaction fails. Note that Token 2022 will
+[dynamically reallocate](./how-extensions-work#account-reallocation) the account when metadata is initialized.
+
+```rust
+let space = spl_token_2022::extension::ExtensionType::try_calculate_account_len::<Mint>(&[ExtensionType::MetadataPointer])
+    .map_err(|_| ProgramError::InvalidAccountData)?;
+```
+
+#### **Then in Step 2: We calculated the minimum balance required for Rent Exemption**
+
+Solana requires accounts to pay rent to stay on-chain. The rent exemption is the
+minimum balance needed to keep an account alive indefinitely. We calculate this
+based on the space we determined in Step 1:
+
+```rust
+let rent = Rent::get()?;
+let minimum_balance = rent.minimum_balance(space);
+```
+
+This ensures the mint account has enough SOL to stay on-chain for 2 years (the
+current rent exemption period). If the account runs out of rent, it becomes
+inactive, but the SOL can be recovered by closing the account.
+
+#### **For Step 3, we created the Mint Account**
+
+We use Cross Program Invocation (CPI) to call the System Program to create the
+account. The account will be owned by the Token 2022 program.
+
+```rust
+invoke(
+    &system_instruction::create_account(
+        payer.key,
+        mint_account.key,
+        minimum_balance,
+        space as u64,
+        token_program.key,
+    ),
+    &[payer.clone(), mint_account.clone(), system_program.clone()],
+)?;
+```
+
+#### **Step 4: Metadata Pointer Initialization**
+
+Next, we initialize the metadata pointer extension. This tells the mint where to
+find its metadata (in our case, self-referential since the metadata is stored in
+the mint account itself)
+
+```rust
+invoke(
+    &metadata_pointer::instruction::initialize(
+        token_program.key,
+        mint_account.key,
+        Some(*payer.key),
+        Some(*mint_account.key),
+    )?,
+    &[mint_account.clone(), token_program.clone()],
+)?;
+```
+
+#### **In Step 5: Mint Initialization**
+
+Then we initialize the mint with basic token properties (decimals, authority,
+etc.)
+
+```rust
+invoke(
+    &token_instruction::initialize_mint2(
+        token_program.key,
+        mint_account.key,
+        payer.key,
+        None,
+        4, // decimals
+    )?,
+    &[mint_account.clone(), rent_sysvar.clone(), token_program.clone()],
+)?;
+```
+
+#### **Step 6: Dynamic Rent Transfer**
+
+Remember we pointed out that **[Token 2022 uses dynamic account reallocation](./how-extensions-work#account-reallocation)**.
+We calculate how much additional rent is needed for the metadata and transfer it
+to the mint account.
+
+```rust
+let current_balance = mint_account.lamports();
+let required_balance = rent.minimum_balance(required_len);
+let additional_lamports = required_balance.saturating_sub(current_balance);
+
+if additional_lamports > 0 {
+    invoke(
+        &system_instruction::transfer(payer.key, mint_account.key, additional_lamports),
+        &[payer.clone(), mint_account.clone(), system_program.clone()],
+    )?;
+}
+```
+
+#### **Step 7: Metadata Initialization**
+
+We initialize the actual metadata. Token 2022 will automatically reallocate the
+account to fit the TLV data.
+
+```rust
+invoke(
+    &metadata_instruction::initialize(
+        token_program.key,
+        mint_account.key,
+        payer.key,
+        mint_account.key,
+        payer.key,
+        name.clone(),
+        symbol.clone(),
+        uri.clone(),
+    ),
+    &[mint_account.clone(), payer.clone(), token_program.clone()],
+)?;
+```
+
+### Step 8: Expose the Instructions through the Entry Point function
+
+Head back to your entry function and replace it with:
+
+```rust
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8]
+) -> ProgramResult {
+    let instruction = TokenCertInstruction::try_from_slice(instruction_data).map_err(
+        |_| TokenCertError::InvalidInstruction
+    )?;
+
+    match instruction {
+        TokenCertInstruction::CreateTokenWithMetadata { name, symbol, uri } => {
+            msg!("Creating Token 2022 mint with metadata");
+            process_create_token_with_metadata(program_id, accounts, name, symbol, uri)
+        }
+        _ => {
+            msg!("Invalid instruction");
+            return Err(TokenCertError::InvalidInstruction.into());
+        }
+    }
+}
+```
+
+### Step 9: Compile your Program then Deploy
+
+```bash
+cargo build-sbf
+
+solana program deploy target/deploy/native.so --program-id target/deploy/native-keypair.json --url devnet
+
+```
+
+Command Result
+
+```bash
+
+Program Id: sPicfnhP1RAAqcRWWMyh3kDLE6KZ19PB2fuXaaCbwEa
+
+Signature: 25jSVywDucHXdrhHYUpdzVbp6zLUGWquy8gQuTTM2qb9etna7rd6yZwTATRTrTDXDj36k5gBZduSUbrRbRhH3bzC
+
+```
+
+Update the program ID in your Rust code with the deployed address.
+
+### Step 10: test the program with a TypeScript Client Implementation
+
+The TypeScript client for native Rust is significantly more complex than our [previous TypeScript implementation](./typescript) because
+there are no generated client code so you must manually handle everything; But
+since this isn't a client tutorial, we've prepared a ready made sample client
+for you to copy and paste.
+
+First, Initialize your directory
+
+```bash
+yarn init
+```
+
+Install the required packages;
+
+```bash
+yarn add @solana/web3.js @solana/spl-token borsh typescript @types/node @solana-developers/helpers
+```
+
+Create a `client.ts` file and paste the following inside:
+
+```typescript
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction,
+  sendAndConfirmTransaction
+} from "@solana/web3.js";
+import {
+  TOKEN_2022_PROGRAM_ID,
+  getAssociatedTokenAddressSync,
+  ASSOCIATED_TOKEN_PROGRAM_ID
+} from "@solana/spl-token";
+
+// Program ID - updated after deployment
+const PROGRAM_ID = new PublicKey("sPicfnhP1RAAqcRWWMyh3kDLE6KZ19PB2fuXaaCbwEa");
+
+// Instruction data structures matching the Rust implementation
+export enum TokenCertInstruction {
+  CreateTokenWithMetadata = 0,
+  UpdateMetadataField = 1
+}
+
+export class TokenCertClient {
+  constructor(
+    private connection: Connection,
+    private programId: PublicKey = PROGRAM_ID
+  ) {}
+
+  async createTokenWithMetadata(
+    payer: Keypair,
+    mint: Keypair,
+    name: string,
+    symbol: string,
+    uri: string
+  ): Promise<string> {
+    console.log("Creating Token 2022 mint with metadata...");
+
+    // Manual instruction data serialization
+    const nameBuffer = Buffer.from(name, "utf-8");
+    const symbolBuffer = Buffer.from(symbol, "utf-8");
+    const uriBuffer = Buffer.from(uri, "utf-8");
+
+    const instructionData = Buffer.alloc(
+      1 + // instruction discriminator
+        4 +
+        nameBuffer.length + // name length + name
+        4 +
+        symbolBuffer.length + // symbol length + symbol
+        4 +
+        uriBuffer.length // uri length + uri
+    );
+
+    let offset = 0;
+
+    // Write instruction discriminator
+    instructionData.writeUInt8(
+      TokenCertInstruction.CreateTokenWithMetadata,
+      offset
+    );
+    offset += 1;
+
+    // Write name
+    instructionData.writeUInt32LE(nameBuffer.length, offset);
+    offset += 4;
+    nameBuffer.copy(instructionData, offset);
+    offset += nameBuffer.length;
+
+    // Write symbol
+    instructionData.writeUInt32LE(symbolBuffer.length, offset);
+    offset += 4;
+    symbolBuffer.copy(instructionData, offset);
+    offset += symbolBuffer.length;
+
+    // Write URI
+    instructionData.writeUInt32LE(uriBuffer.length, offset);
+    offset += 4;
+    uriBuffer.copy(instructionData, offset);
+
+    // Create instruction with exact account order
+    const instruction = new TransactionInstruction({
+      keys: [
+        { pubkey: payer.publicKey, isSigner: true, isWritable: true },
+        { pubkey: mint.publicKey, isSigner: true, isWritable: true },
+        { pubkey: SystemProgram.programId, isSigner: false, isWritable: false },
+        { pubkey: TOKEN_2022_PROGRAM_ID, isSigner: false, isWritable: false },
+        { pubkey: SYSVAR_RENT_PUBKEY, isSigner: false, isWritable: false }
+      ],
+      programId: this.programId,
+      data: Buffer.from(instructionData)
+    });
+
+    // Create and send transaction
+    const transaction = new Transaction().add(instruction);
+    const signature = await sendAndConfirmTransaction(
+      this.connection,
+      transaction,
+      [payer, mint]
+    );
+
+    console.log(`✅ Token created successfully!`);
+    console.log(`Mint address: ${mint.publicKey.toBase58()}`);
+    console.log(`Transaction signature: ${signature}`);
+
+    return signature;
+  }
+}
+
+// Export the rent sysvar
+export const SYSVAR_RENT_PUBKEY = new PublicKey(
+  "SysvarRent111111111111111111111111111111111"
+);
+```
+
+Next, create a test script:
+
+```typescript
+import { createConnection, generateKeypair } from "./client";
+import { TokenCertClient } from "./client";
+
+async function testNativeImplementation() {
+  const connection = createConnection("devnet");
+  const client = new TokenCertClient(connection);
+
+  // Generate keypairs
+  const payer = generateKeypair();
+  const mint = generateKeypair();
+
+  // Create token with metadata
+  const signature = await client.createTokenWithMetadata(
+    payer,
+    mint,
+    "Developer Certification",
+    "DEVCERT",
+    "https://example.com/metadata.json"
+  );
+
+  console.log("✅ Native implementation test completed!");
+  console.log("Transaction signature:", signature);
+}
+
+testNativeImplementation().catch(console.error);
+```
+
+Now that we are certain that instruction works lets move on to
+
+```bash
+
+Connected to Solana devnet
+Payer: GE2McNXDwPa1VsC1nDi3JWTfoH6mshSoGFEDunbUyKvn
+Mint: 3WHEgXT6hx79iNqifrCSmi5GeEbbEAD96pPR3P5GuShz
+Token Owner: J7sRCmXK5DRYgdjxyWaV5iCv6daoG75TTEn57kXFb9jX
+
+💰 Step 0: Funding payer account...
+✅ Payer funded! Airdrop signature: 21vJp7DNrRBaqLpHeWsZviv1NE6YjwDSznF6iHB4cvsuGE4Sr8smjTup6gWPzvnyze1xSh5BixhYXsh3XxjJdE7a
+
+📝 Step 1: Creating token with metadata...
+Creating Token 2022 mint with metadata...
+Name: My Test Token, Symbol: MTT, URI: https://example.com/metadata.json
+✅ Token created successfully!
+Mint address: 3WHEgXT6hx79iNqifrCSmi5GeEbbEAD96pPR3P5GuShz
+Transaction signature: VFEh5N5zaKapsdrfz5R1caQ48Pv4GZKyCbn2NprdkBNmVhqnptzxNqYMQbx5V74HwAkTTUPxS2vzCTEiyYDgshr
+✅ Token created! Signature: VFEh5N5zaKapsdrfz5R1caQ48Pv4GZKyCbn2NprdkBNmVhqnptzxNqYMQbx5V74HwAkTTUPxS2vzCTEiyYDgshr
+```
+
+If you scroll down a little, you will also observe that we have an error
+
+```bash
+📝 Step 2: Updating metadata field...
+Updating metadata field: description = This is an updated description for the token
+❌ Error during execution: SendTransactionError: Simulation failed.
+Message: Transaction simulation failed: Error processing Instruction 0: custom program error: 0x0.
+Logs:
+[
+  "Program J3oRgfsUUjfrEgYqwSq418oDYjyHQcbpzr8VMBaH2ZJx invoke [1]",
+  "Program log: Invalid instruction",
+  "Program J3oRgfsUUjfrEgYqwSq418oDYjyHQcbpzr8VMBaH2ZJx consumed 1444 of 200000 compute units",
+  "Program J3oRgfsUUjfrEgYqwSq418oDYjyHQcbpzr8VMBaH2ZJx failed: custom program error: 0x0"
+].
+Catch the `SendTransactionError` and call `getLogs()` on it for full details...
+```
+
+The reason is because we haven't implemented the Update Metadata
+
+### Step 11: Implement the Update Metadata Field
+
+```rust
+/// Process update metadata field instruction
+fn process_update_metadata_field(
+    _program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    field: String,
+    value: String,
+) -> ProgramResult {
+    let account_info_iter = &mut accounts.iter();
+
+    let update_authority = next_account_info(account_info_iter)?;
+    let mint_account = next_account_info(account_info_iter)?;
+    let token_program = next_account_info(account_info_iter)?;
+
+    // Validate accounts
+    if !update_authority.is_signer {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    msg!("Updating metadata field: {} = {}", field, value);
+
+    // Update metadata field using Token 2022 metadata interface
+    // This updates the TLV data stored directly in the mint account
+    use spl_token_metadata_interface::state::Field;
+    let metadata_field = Field::Key(field.clone());
+
+    invoke(
+        &metadata_instruction::update_field(
+            token_program.key,
+            mint_account.key,
+            update_authority.key,
+            metadata_field,
+            value.clone(),
+        ),
+        &[mint_account.clone(), update_authority.clone(), token_program.clone()],
+    )?;
+
+    msg!("Successfully updated metadata field: {} = {}", field, value);
+    msg!("Metadata TLV data updated in mint account");
+
+    Ok(())
+}
+```
+
+This one is fairly simple instruction. What we did in essence is **delegate the
+actual metadata update to the Token 2022 program's built-in metadata
+interface**.
+
+As we've mentioned severally, the Token 2022 metadata is stored as TLV
+(Type-Length-Value) data directly in the mint account. Manually manipulating
+this TLV data is extremely error-prone because:
+
+1. **Complex serialization**: TLV data requires precise byte-level manipulation
+   with specific type codes, length calculations, and value encoding
+2. **Security risks**: Incorrect TLV manipulation can corrupt the entire mint
+   account or create invalid metadata that breaks token functionality
+3. **Version compatibility**: The TLV format can change between Token 2022
+   versions, requiring constant updates
+4. **Validation complexity**: You need to validate field names, value formats,
+   and ensure the metadata remains consistent
+
+Instead of manually manipulating [TLV data](./how-extensions-work#tlv-type-length-value-encoding), we use the
+`spl_token_metadata_interface` to create the proper instruction and invoke it
+through the Token 2022 program. This ensures we're using the official, tested
+metadata update mechanism that handles all the complex TLV manipulation,
+validation, and security checks for us.
+
+Now lets update our entry point function marching arms:
+
+```rust
+
+// Main program processor
+pub fn process_instruction(
+    program_id: &Pubkey,
+    accounts: &[AccountInfo],
+    instruction_data: &[u8]
+) -> ProgramResult {
+    let instruction = TokenCertInstruction::try_from_slice(instruction_data).map_err(
+        |_| TokenCertError::InvalidInstruction
+    )?;
+
+    match instruction {
+        TokenCertInstruction::CreateTokenWithMetadata { name, symbol, uri } => {
+            msg!("Creating Token 2022 mint with metadata");
+            process_create_token_with_metadata(program_id, accounts, name, symbol, uri)
+        }
+        // new match arm
+        TokenCertInstruction::UpdateMetadataField { field, value } => {
+            msg!("Updating metadata field: {} = {}", field, value);
+            process_update_metadata_field(program_id, accounts, field, value)
+        }
+        _ => {
+            msg!("Invalid instruction");
+            return Err(TokenCertError::InvalidInstruction.into());
+        }
+    }
+}
+```
+
+Now, recompile and redeploy as we did earlier
+
+### Step 12: Lets test our new addition from the Typescript Client
+
+It's as simple as running our previous test again.
+
+```bash
+
+🚀 Starting TokenCert client test...
+
+Connected to Solana devnet
+Payer: tutR66FySadZpzRHLju2MXArJgsxmWu12nCGvBAx4vK
+Mint: HKdNyaV5GFdRipFmKL9fvrMNTJAbgGqsMKFbsQJSivqy
+Token Owner: wf9g2f4Mtt1mk71wZh6x2NWSjSRQZNdzRxDFdfd6iqQ
+
+📝 Step 1: Creating token with metadata...
+Creating Token 2022 mint with metadata...
+Name: My Test Token, Symbol: MTT, URI: https://example.com/metadata.json
+✅ Token created successfully!
+Mint address: HKdNyaV5GFdRipFmKL9fvrMNTJAbgGqsMKFbsQJSivqy
+Transaction signature: 5dzAQJJhUvdzh2U29z6Jc4nCUcuUSTEgTYR9nPsBmDPZVATfjNuHzQdbtSobRPMqs5rk2CCSkYSAkXW71BBnePGk
+✅ Token created! Signature: 5dzAQJJhUvdzh2U29z6Jc4nCUcuUSTEgTYR9nPsBmDPZVATfjNuHzQdbtSobRPMqs5rk2CCSkYSAkXW71BBnePGk
+
+📝 Step 2: Updating metadata field...
+Updating metadata field: description = This is an updated description for the token
+Transferring 382800 lamports for rent
+✅ Metadata field updated successfully!
+Transaction signature: 3XwPLaLAp8hTAxip9XYm1GpcFQgJrzfYhrDszqmvzrC1B6CFDdfzmWQHQGgBYtAyNW2r9CBmrzjpb7x9Pcd9rgvc
+✅ Metadata updated! Signature: 3XwPLaLAp8hTAxip9XYm1GpcFQgJrzfYhrDszqmvzrC1B6CFDdfzmWQHQGgBYtAyNW2r9CBmrzjpb7x9Pcd9rgvc
+```
+
+Do note though that sometimes that our current metadata update instruction could
+fail
+
+```bash
+..
+...
+....
+📝 Step 2: Updating metadata field...
+Updating metadata field: description = This is an updated description for the token
+❌ Error during execution: SendTransactionError: Simulation failed.
+Message: Transaction simulation failed: Transaction results in an account (1) with insufficient funds for rent.
+Logs:
+[
+  "Program log: Updating metadata field: description = This is an updated description for the token",
+  "Program log: Updating metadata field: description = This is an updated description for the token",
+  "Program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb invoke [2]",
+  "Program log: TokenMetadataInstruction: UpdateField",
+  "Program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb consumed 6395 of 195271 compute units",
+  "Program TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb success",
+  "Program log: Successfully updated metadata field: description = This is an updated description for the token",
+  "Program log: Metadata TLV data updated in mint account",
+  "Program J3oRgfsUUjfrEgYqwSq418oDYjyHQcbpzr8VMBaH2ZJx consumed 12057 of 200000 compute units",
+  "Program J3oRgfsUUjfrEgYqwSq418oDYjyHQcbpzr8VMBaH2ZJx success"
+].
+
+```
+
+Do you know why? Because our new update **metadata field value** could be larger
+than **the original metadata field value** and that would necessitate [additional payment for extra storage space](./how-extensions-work#account-reallocation)? Can you resolve that?
+
+And friends, that's how to create a Mint Token with [Token 2022 Metadata Pointer and Metadata Extension](./how-extensions-work). Hopefully, from here on you can mint tokens with rich,
+verifiable metadata that can't be faked or lost.
+
+## The Hard Part Starts Now
+
+You've got the code working. You understand the concepts. You can deploy to
+devnet.
+
+Now comes the real challenge: building something that actually matters.
+
+You could build another JPEG collection and hope it sells. Or you could build a
+certification system that universities actually trust. A collectible that proves
+its authenticity beyond doubt. A credential that travels with the token and
+can't be compromised.
+
+The technology is the same. The impact is completely different.
+
+_The hard part isn't the code. It's deciding what to build with it._
+
+---
+
+## What's Next?
+
+Congratulations! You've mastered Token 2022 metadata extensions across the full spectrum—from TypeScript clients to Anchor frameworks to native Rust implementation. You now have complete control over Solana's most powerful token architecture.
+
+**Continue to:** [**Real-World Use Cases →**](./usecases)
+
+In the final section, explore how these technical skills apply to real-world problems:
+
+**Review Previous Sections:**
+- [How Extensions Work](./how-extensions-work) - Technical architecture and concepts
+- [TypeScript Implementation](./typescript) - Client-side development
+- [Anchor Implementation](./anchor) - Framework-based approach
+- Digital credentials and certifications
+- Supply chain verification
+- Gaming assets and achievements  
+- Financial instruments and compliance
+- Art authentication and provenance
+
+See how the technical foundation you've built across [all three implementation approaches](./how-extensions-work) enables solutions to some of the world's most pressing trust and verification challenges.

--- a/content/docs/en/tokens/extensions/metadata/typescript.mdx
+++ b/content/docs/en/tokens/extensions/metadata/typescript.mdx
@@ -1,0 +1,504 @@
+---
+title: TypeScript Implementation
+description:
+  Build Token 2022 metadata extensions using TypeScript/JavaScript with
+  step-by-step examples.
+---
+
+> **Previous:** [How Extensions Work](./how-extensions-work) | **Next:** >
+> [Anchor Implementation](./anchor)
+
+Now that you understand the [technical architecture](./how-extensions-work),
+let's build a real token with metadata using TypeScript. This hands-on
+implementation will apply the concepts from the previous section.
+
+## Building Your First Token with Metadata
+
+We'll create a "Developer Certification Token" that proves someone completed a
+coding bootcamp and demonstrates the complete workflow of Token 2022 metadata
+extensions. This example shows how to properly handle space calculations,
+initialization order, and metadata management.
+
+Then we will walk our way up implementing the same functionality in Anchor Rust,
+and then in Native Rust.
+
+### Step 1: Project Setup
+
+```bash
+# Create project directory
+mkdir dev_cert_token && cd dev_cert_token
+
+# Generate a keypair (avoids rate limiting from airdrops)
+solana-keygen grind --starts-with tut:1
+
+# Initialize TypeScript project
+mkdir ts && cd ts
+yarn init -y
+
+# Add required dependencies
+yarn add @solana/web3.js @solana/spl-token @solana/spl-token-metadata @solana-developers/helpers
+```
+
+### Step 2: Token Design
+
+Our token will represent a developer certification with these properties:
+
+- **Name**: "Developer Certification"
+- **Symbol**: "DEVCERT"
+- **URI**: Link to metadata JSON
+- **Additional Metadata**: Level, issuer, and other certification details
+
+### Step 3: Implementation Setup
+
+Create the main implementation file and add the necessary imports. As covered in
+[How Extensions Work](./how-extensions-work), space calculation is critical—get
+it wrong and everything fails.
+
+```bash
+touch mint.ts
+```
+
+```typescript
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  clusterApiUrl,
+  sendAndConfirmTransaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  createInitializeInstruction,
+  createUpdateFieldInstruction,
+  pack,
+  TokenMetadata
+} from "@solana/spl-token-metadata";
+import { getKeypairFromFile } from "@solana-developers/helpers";
+import { writeFileSync, appendFileSync } from "fs";
+import {
+  createInitializeMetadataPointerInstruction,
+  createInitializeMintInstruction,
+  ExtensionType,
+  getMintLen,
+  getTokenMetadata,
+  getMint,
+  getExtensionData,
+  getExtensionTypes,
+  LENGTH_SIZE,
+  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
+  TYPE_SIZE
+} from "@solana/spl-token";
+
+// Create a connection with Devnet cluster
+const connection = new Connection(clusterApiUrl("devnet"));
+```
+
+Now let's define our Mint keypair and Metadata structure:
+
+```typescript
+//preceeding code excluded for brevity
+
+// Then generate a keypair for the Mint Account;
+const mint = Keypair.generate();
+
+const metadata: TokenMetadata = {
+  mint: mint.publicKey,
+  name: "Developer Certification",
+  symbol: "DEVCERT",
+  uri: "https://example.com/metadata.json", // reach out for this
+  additionalMetadata: [
+    ["Level", "1"],
+    ["Issuer", "Solana Foundation"], // You can add the issuer or creator
+    ["Description", "Certification for Solana developer proficiency"], // Add a description
+    ["Website", "https://solana.com"] // Add a website or project link
+    // You can add any other custom key-value pairs as needed
+  ]
+};
+```
+
+### Step 4: Account Creation
+
+Before creating the mint, we must calculate the exact space needed. Remember
+from [How Extensions Work](./how-extensions-work#space-calculation-formula): we
+need the Metadata Pointer extension first, then the mint can be initialized, and
+finally the Token Metadata extension can be added.
+
+> **Initialization Order**:
+> [Metadata Pointer → Mint → Token Metadata](./how-extensions-work#the-initialization-order-that-matters)
+
+```typescript
+// preceeding code removed for brevity
+const mintSpace = getMintLen([
+  ExtensionType.MetadataPointer
+  // ExtensionType.TokenMetadata,
+]);
+
+// We need a different way to calculate Metadata length
+// because unlike MetadataPointer, it has a variable length,
+const metadataSpace =
+  TYPE_SIZE +
+  LENGTH_SIZE +
+  // What this does is it packs the metadata into a buffer
+  // and then returns the length of the buffer
+  // so we can know how much space we need to allocate
+  // for the metadata
+  pack(metadata).length;
+```
+
+This uses the
+[TLV (Type-Length-Value) encoding](./how-extensions-work#account-structure-deep-dive)
+scheme covered in the technical overview:
+
+- **TYPE_SIZE** (2 bytes): Extension type identifier
+- **LENGTH_SIZE** (2 bytes): Total length of the metadata buffer
+- **pack(metadata).length**: The serialized metadata data
+
+Now, lets log how much space we need to allocate on the Blockchain and what it
+will cost us to the console.
+
+```typescript
+//  preceeding code excluded for clarity
+
+console.log("metadataSpace is", metadataSpace, "bytes in size");
+
+const lamportsNeeded = await connection.getMinimumBalanceForRentExemption(
+  metadataSpace + mintSpace
+);
+
+console.log(
+  "It will cost you",
+  lamportsNeeded,
+  "lamports to store your metadata onchain",
+  `That is ${lamportsNeeded / LAMPORTS_PER_SOL} sol`
+);
+```
+
+In your command line, run the mint.ts script
+
+```bash
+# I use esrun run to execute typescript modules
+esrun mint.ts
+```
+
+I got
+
+```
+It will cost you 2909280 lamports to store your metadata onchain That is 0.00290928 sol
+```
+
+Do note that this will vary with the content in your metadata.
+
+#### Step 4b: Fix missing Payer
+
+We are about to create an Account and allocate space on the Blockchain, so you
+will observe that something is missing: The Transaction payer. So lets import
+the key pair we generated earlier into our code
+
+```typescript
+// This is mine, yours could be different address
+const payer = await getKeypairFromFile(
+  "./tutqVnneherRKvd1rfiCsiGSrJx1azXA7a6vQGwGkLY.json"
+);
+```
+
+After that, lets create an account then transfer it's ownership to the Token 22
+program
+
+```typescript
+// Then lets create the account
+const createAccountIx = SystemProgram.createAccount({
+  fromPubkey: payer.publicKey,
+  newAccountPubkey: mint.publicKey,
+  space: mintSpace, // any observation  ???
+  lamports: lamportsNeeded,
+  programId: TOKEN_2022_PROGRAM_ID
+});
+```
+
+If you examine the Create Account Transaction, you will observe that although
+the Metadata is not included in the space allocated at Account reation, it's
+space is paid for upfront... why is this so?
+
+Dynamically sized Extensions like Metadata Extensions are added through a form
+of Account reallocation but the Account must have enough lamport to cover Rent;
+
+### Step 5: Verify Account Creation
+
+At this point, it's important to note that the created Account is not a Mint but
+just an Account owned by the Token program. We can confirm this by executing the
+transaction for example:
+
+```typescript
+// preceeding code removed for brevity
+
+const transaction = new Transaction().add(createAccountIx);
+
+const signature = await sendAndConfirmTransaction(connection, transaction, [
+  payer,
+  mint
+]);
+
+console.log("Signature: ", signature);
+
+const mintAccount = await connection.getAccountInfo(mint.publicKey);
+
+console.log("Mint Account: ", mintAccount);
+```
+
+Here's what I got:
+
+```bash
+metadataSpace is 290 bytes in size
+It will cost you 2909280 lamports to store your metadata onchain That is 0.00290928 sol
+Signature:  3SRckqtg2BNtBizu3mKtbPRrFVWNMA25gMuFtA65wRQSXGVte8Jk6obfgEgkaQWoj2BseoHyPLrSeBVPhzoMjZ4H
+Mint Account:  null
+```
+
+The `null` response confirms the account exists but contains no structured data
+yet. You can verify this on
+[Solana Explorer](https://explorer.solana.com/address/C5ermvKhV6eqxut7j9iB2cutmFte8WgC7tyTwdQEBPFY?cluster=devnet).
+
+### Step 6: Initialize Metadata Pointer Extension
+
+Now we follow the critical
+[initialization order](./how-extensions-work#the-initialization-order-that-matters):
+Metadata Pointer → Mint → Token Metadata.
+
+```typescript
+const initializeMetadataPointerIx = createInitializeMetadataPointerInstruction(
+  mint.publicKey, // mint address
+  payer.publicKey,
+  mint.publicKey, // metadata address (self-referential)
+  TOKEN_2022_PROGRAM_ID
+);
+```
+
+It's also worth pointing out that you can choose to reference an External
+Metadata Account other than the Mint; Self referencing the Mint is just
+cost-saving advantage.
+
+---
+
+### Step 7: Initialize the Mint Account
+
+With the metadata pointer in place, we can now initialize the mint account. This
+step gives the account its identity as a Mint, setting its decimals, authority,
+and other core properties.
+
+```typescript
+const initializeMintIx = createInitializeMintInstruction(
+  mint.publicKey,
+  0, // decimals
+  payer.publicKey, // mint authority
+  null, // freeze authority (optional)
+  TOKEN_2022_PROGRAM_ID
+);
+```
+
+**Order matters!** If you try to initialize the mint before setting up the
+metadata pointer, the transaction will fail. This ordering is a security
+feature: it guarantees that the mint's metadata location is locked in before the
+mint becomes active.
+
+---
+
+### Step 8: Initialize the Metadata
+
+Now that the mint is fully initialized and knows where to find its metadata, we
+can actually create and store the metadata itself. This step writes the name,
+symbol, URI, and other fields into the mint account using the metadata
+extension.
+
+```typescript
+const initializeMetadataIx = createInitializeInstruction({
+  mint: mint.publicKey,
+  metadata: mint.publicKey,
+  mintAuthority: payer.publicKey,
+  name: metadata.name,
+  symbol: metadata.symbol,
+  uri: metadata.uri,
+  programId: TOKEN_2022_PROGRAM_ID,
+  updateAuthority: payer.publicKey
+
+  //  why are we not using the additionalMetadata?
+  // because additionalMetadata requires separate update instructions
+  // and we handle them individually below
+});
+```
+
+You will observe that Additional metadata fields are not added in this
+instruction.
+
+This is because Additional metadata fields require separate update instructions
+due to the variable-length nature of the extension. Images are referenced via
+URI following the
+[Solana NFT metadata standard](https://docs.metaplex.com/programs/token-metadata/token-standard).
+
+```typescript
+const updateMetadataFieldIx = createUpdateFieldInstruction({
+  metadata: mint.publicKey,
+  updateAuthority: payer.publicKey,
+  programId: TOKEN_2022_PROGRAM_ID,
+  field: metadata.additionalMetadata[0][0],
+  value: metadata.additionalMetadata[0][1]
+});
+```
+
+And you will call this same instruction as much times as each fields you have.
+
+### Step 9: Transaction Construction
+
+Combine all instructions following the
+[mandatory initialization sequence](./how-extensions-work#the-initialization-order-that-matters):
+
+```typescript
+const transaction = new Transaction().add(
+  createAccountIx,
+  initializeMetadataPointerIx,
+  initializeMintIx,
+  initializeMetadataIx,
+  updateMetadataFieldIx,
+  updateMetadataFieldIx2
+);
+```
+
+### Step 10: Execute Transaction
+
+```typescript
+//
+const signature = await sendAndConfirmTransaction(connection, transaction, [
+  payer,
+  mint
+]);
+
+console.log("Signature: ", signature);
+```
+
+You can examine the transaction on
+[Solana Explorer](https://explorer.solana.com/tx/4NRQHN95t17nnt5qDpv6FFfsNisCqLsSfi8wPxFNAYmqmKJeGczxeb2B2dLM99dTVk5Eqsb6SGNVWur8dBqEXYWQ?cluster=devnet).
+
+### Step 11: Verify the Implementation
+
+Retrieve and verify the metadata using Token 2022 specific functions:
+
+```typescript
+// For Token 2022 mints, we need to use the Token 2022 program's getMint function
+// This returns the full mint data including all extensions (metadata, transfer fees, etc.)
+console.log("\n=== READING TOKEN 2022 METADATA ===");
+
+try {
+  // Get the full mint data from Token 2022 program
+  const mintInfo = await getMint(
+    connection,
+    mint.publicKey,
+    "confirmed",
+    TOKEN_2022_PROGRAM_ID
+  );
+
+  console.log("✅ Mint Info Retrieved Successfully!");
+  console.log("Mint Address:", mint.publicKey.toBase58());
+  console.log("Decimals:", mintInfo.decimals);
+  console.log("Mint Authority:", mintInfo.mintAuthority?.toBase58() || "None");
+  console.log(
+    "Freeze Authority:",
+    mintInfo.freezeAuthority?.toBase58() || "None"
+  );
+  console.log("Supply:", mintInfo.supply.toString());
+
+  // Check if metadata extension is present
+  if (mintInfo.tlvData && mintInfo.tlvData.length > 0) {
+    console.log("✅ Token 2022 Extensions Found!");
+
+    // Get all extension types from the TLV data
+    const extensionTypes = getExtensionTypes(mintInfo.tlvData);
+    console.log("Extension Types:", extensionTypes);
+
+    // Look for metadata extension
+    const metadataData = getExtensionData(
+      ExtensionType.TokenMetadata,
+      mintInfo.tlvData
+    );
+    if (metadataData) {
+      console.log("✅ Metadata Extension Found!");
+      console.log("Metadata Extension Data Length:", metadataData.length);
+
+      // The metadata is stored in the extension data
+      // You can deserialize it using the spl-token-metadata package
+      console.log(
+        "Metadata Extension Data (hex):",
+        metadataData.toString("hex")
+      );
+
+      // Try to unpack the metadata using the spl-token-metadata package
+      try {
+        const { unpack } = await import("@solana/spl-token-metadata");
+        const unpackedMetadata = unpack(metadataData);
+        console.log("✅ Unpacked Metadata:", unpackedMetadata);
+      } catch (error) {
+        console.log("❌ Could not unpack metadata:", error);
+      }
+    } else {
+      console.log("❌ No metadata extension found in mint data");
+    }
+  } else {
+    console.log("❌ No Token 2022 extensions found");
+  }
+} catch (error) {
+  console.log("❌ Error reading Token 2022 mint data:", error);
+}
+```
+
+The verification confirms successful creation of a Token 2022 mint with both
+Metadata Pointer (type 18) and Token Metadata (type 19) extensions. The metadata
+includes:
+
+```bash
+=== READING TOKEN 2022 METADATA ===
+✅ Mint Info Retrieved Successfully!
+Mint Address: Ba5XVwMyLcLeDsng8nrfrDrtHXvgC1uVeL86XfAbLZ8V
+Decimals: 0
+Mint Authority: tutqVnneherRKvd1rfiCsiGSrJx1azXA7a6vQGwGkLY
+Freeze Authority: None
+Supply: 0
+✅ Token 2022 Extensions Found!
+Extension Types: [ 18, 19 ]
+✅ Metadata Extension Found!
+Metadata Extension Data Length: 188
+Metadata Extension Data (hex): 0d4c6daafac5479d37e02b1cd97d7b56b7440e37658a793305ba676ac8c722d19d0e2741f9f90c119f80613cfd44cca59d0dbf2a013e9c1ecb0460c4a26ced6a17000000446576656c6f7065722043657274696669636174696f6e07000000444556434552542100000068747470733a2f2f6578616d706c652e636f6d2f6d657461646174612e6a736f6e02000000050000004c6576656c01000000310600000049737375657211000000536f6c616e6120466f756e646174696f6e
+✅ Unpacked Metadata: {
+  updateAuthority: PublicKey [PublicKey(tutqVnneherRKvd1rfiCsiGSrJx1azXA7a6vQGwGkLY)] {
+    _bn: <BN: d4c6daafac5479d37e02b1cd97d7b56b7440e37658a793305ba676ac8c722d1>
+  },
+  mint: PublicKey [PublicKey(Ba5XVwMyLcLeDsng8nrfrDrtHXvgC1uVeL86XfAbLZ8V)] {
+    _bn: <BN: 9d0e2741f9f90c119f80613cfd44cca59d0dbf2a013e9c1ecb0460c4a26ced6a>
+  },
+  name: 'Developer Certification',
+  symbol: 'DEVCERT',
+  uri: 'https://example.com/metadata.json',
+  additionalMetadata: [ ['Level', '1'], ['Issuer', 'Solana Foundation'] ]
+}
+```
+
+You've successfully implemented a complete Token 2022 mint with metadata
+extensions using pure TypeScript, handling all the low-level details of space
+calculation, initialization order, and instruction serialization.
+
+---
+
+## What's Next?
+
+You've now learned how to create Token 2022 metadata extensions from the client
+side using TypeScript. You understand the byte-level serialization, space
+calculations, and instruction building.
+
+**Continue to:** [**Anchor Implementation →**](./anchor)
+
+In the next section, we'll implement the same functionality using the Anchor
+framework, showing you:
+
+- How Anchor simplifies instruction building and account validation
+- What abstractions Anchor provides and what you still need to handle manually
+- When to use Anchor vs. pure TypeScript approaches

--- a/content/docs/en/tokens/extensions/metadata/usecases.mdx
+++ b/content/docs/en/tokens/extensions/metadata/usecases.mdx
@@ -1,0 +1,275 @@
+---
+title: Challenge Yourself - Real-World Metadata Problems to Solve
+description: Put your Token 2022 metadata skills to the test by building solutions to real-world trust and verification challenges across industries.
+---
+
+> **Previous:** [Native Rust Implementation](./native-rust) | **Back to:** [Overview](./index)
+>
+> **Review Your Arsenal:** [How Extensions Work](./how-extensions-work) | [TypeScript](./typescript) | [Anchor](./anchor) | [Native Rust](./native-rust)
+
+You've learned Token 2022 metadata extensions through TypeScript, Anchor, and native Rust. Now put that knowledge to work on real problems.
+
+Each challenge gives you:
+- A real problem costing billions annually
+- What you need to build to solve it
+- Technical hints pointing to specific tutorial concepts
+- Extra challenges if you want to go deeper
+
+---
+
+## Challenge 1: The Credential Verification Crisis
+
+### The Problem
+
+In January 2023, [federal agents dismantled a $100 million nursing diploma scheme](https://www.justice.gov/usao-sdfl/pr/fraudulent-nursing-diploma-scheme-leads-federal-charges-against-25-defendants) that sold fake credentials to thousands of people. Hospitals unknowingly hired unqualified individuals, putting patient safety at risk. The fundamental issue: no reliable way to verify educational credentials in real-time.
+
+**Current systems rely on:**
+- Phone calls to schools (slow, unreliable)
+- PDF certificates (easily forged)  
+- Third-party databases (expensive, often outdated)
+- Manual verification processes (error-prone)
+
+### Your Mission
+
+Build a credential verification system with Token 2022 metadata extensions.
+
+**What it needs to do:**
+- Schools mint credential tokens
+- Credentials store degree/certification details in metadata
+- Employers verify credentials without calling schools
+- Credentials can be updated for continuing education
+- No way to forge credentials
+
+### Technical Implementation Hints
+
+**Metadata Structure Design:**
+```
+- Institution Name & ID
+- Student Name & ID  
+- Degree/Certification Type
+- Completion Date
+- GPA/Honors
+- Accreditation Body
+- Verification URL
+- Digital Signature Hash
+```
+
+**Questions to Solve:**
+1. How would you structure the [metadata fields](./how-extensions-work#tlv-type-length-value-encoding) to store institution verification data?
+2. Which [implementation approach](./typescript) would you use for the institutional minting interface?
+3. How would you handle [metadata updates](./anchor#step-5-additional-fields-update) for continuing education credits?
+4. What [account validation](./native-rust#step-6-custom-error-types) would prevent unauthorized credential minting?
+
+**Extra Credit:**
+- Joint degrees from multiple schools
+- Expiring certifications that update automatically
+- Hide grades but show degree completion
+- Connect to existing student databases
+
+---
+
+## Challenge 2: Supply Chain Authenticity
+
+### The Problem
+
+[U.S. Customs seized $2.7 billion in counterfeit goods in 2023](https://www.cbp.gov/newsroom/stats/trade). Despite anti-counterfeiting measures, luxury brands like [Louis Vuitton are frequently counterfeited](https://www.cbp.gov/newsroom/local-media-release/almost-half-million-counterfeit-louis-vuitton-belts-seized-ky). The core issue: no single source of truth that travels with the product throughout its lifecycle.
+
+**Current problems:**
+- Serial numbers can be duplicated
+- Certificates of authenticity are forgeable  
+- No way to track ownership history
+- Expensive third-party authentication services
+- No real-time verification at point of sale
+
+### Your Mission
+
+Build a product authenticity system with Token 2022 metadata extensions.
+
+**What it needs to do:**
+- Manufacturers mint tokens for physical products
+- Metadata stores manufacturing details, materials, history
+- Ownership transfers are tracked
+- Anyone can verify authenticity instantly
+- Updates for repairs, certifications, recalls
+
+### Technical Implementation Hints
+
+**Metadata Structure Design:**
+```
+- Manufacturer Details
+- Product Specifications
+- Serial Number/SKU
+- Manufacturing Date & Location
+- Materials Composition
+- Quality Certifications
+- Ownership History
+- Service Records
+```
+
+**Questions to Solve:**
+1. How would you design [TLV data structures](./how-extensions-work#tlv-type-length-value-encoding) for complex product specifications?
+2. Which [space calculations](./how-extensions-work#space-calculation-formula) would accommodate variable-length warranty information?
+3. How would you implement [metadata updates](./typescript#step-4-updating-additional-metadata-fields) for service records and repairs?
+4. What [account reallocation](./how-extensions-work#account-reallocation) strategy handles growing ownership histories?
+
+**Extra Credit:**
+- Track carbon footprint through entire supply chain
+- Handle products with thousands of components
+- Automatic recall notifications
+- Connect to insurance systems
+
+---
+
+## Challenge 3: Digital Asset Authenticity
+
+### The Problem
+
+The [March 2022 Ronin Bridge hack drained $625 million from Axie Infinity](https://www.coindesk.com/tech/2022/03/29/axie-infinitys-ronin-network-suffers-625m-exploit), making players' digital assets worthless overnight. The issue wasn't duplication—it was infrastructure compromise. Players lost trust because they couldn't verify what was authentic in the collapsed ecosystem.
+
+**Current problems:**
+- Off-chain metadata can disappear
+- No verifiable creation history
+- Centralized services create single points of failure
+- No way to prove rarity or authenticity independently
+- Metadata updates require centralized control
+
+### Your Mission
+
+Build a gaming asset system with Token 2022 metadata extensions.
+
+**What it needs to do:**
+- Game devs mint tokens for in-game assets
+- All metadata stored on-chain
+- Players can prove ownership without the game company
+- Assets keep value even if servers shut down
+- Assets work across different games
+
+### Technical Implementation Hints
+
+**Metadata Structure Design:**
+```
+- Asset Type & Category
+- Rarity Level & Statistics
+- Creation Block/Timestamp
+- Original Creator/Artist
+- Game Integration Data
+- Visual/Audio Asset Hashes
+- Gameplay Mechanics Data
+- Trading History
+```
+
+**Questions to Solve:**
+1. How would you structure [metadata initialization](./how-extensions-work#the-initialization-order-that-matters) for complex gaming assets?
+2. Which [client implementation](./typescript#step-2-the-complete-implementation) would handle real-time gameplay integration?
+3. How would you design [update mechanisms](./anchor#step-4-basic-metadata-initialization) for evolving asset statistics?
+4. What [error handling](./native-rust#step-5-custom-error-types) prevents unauthorized asset modifications?
+
+**Extra Credit:**
+- Move assets between different blockchains
+- Generate assets with provably fair algorithms
+- Assets that level up and evolve
+- Connect to Unity or Unreal Engine
+
+---
+
+## Challenge 4: Financial Compliance & Reporting
+
+### The Problem
+
+Traditional financial systems struggle with real-time compliance reporting and audit trails. Regulators require detailed information about financial instruments, but current systems rely on batch processing, manual reporting, and fragmented data sources that can't provide real-time visibility.
+
+**Current problems:**
+- Compliance data scattered across multiple systems
+- Manual regulatory reporting (slow, error-prone)
+- No real-time audit capabilities
+- Difficulty tracking instrument lifecycle
+- Complex reconciliation processes
+
+### Your Mission
+
+Build a financial compliance system with Token 2022 metadata extensions.
+
+**What it needs to do:**
+- Banks mint tokens for financial instruments (bonds, loans, derivatives)
+- Metadata contains all regulatory information
+- Real-time compliance monitoring
+- Complete audit trails
+- Automated regulatory reports
+
+### Technical Implementation Hints
+
+**Metadata Structure Design:**
+```
+- Instrument Classification
+- Regulatory Jurisdiction
+- Risk Ratings & Categories
+- Counterparty Information
+- Maturity & Terms
+- Compliance Status
+- Audit Trail References
+- Regulatory Filings
+```
+
+**Questions to Solve:**
+1. How would you handle [large metadata structures](./how-extensions-work#space-calculation-formula) for complex financial instruments?
+2. Which [implementation approach](./native-rust) provides the control needed for financial regulations?
+3. How would you design [metadata updates](./anchor#step-5-additional-fields-update) for changing regulatory requirements?
+4. What [validation mechanisms](./native-rust#step-6-custom-error-types) ensure compliance data integrity?
+
+**Extra Credit:**
+- Handle different regulations across countries
+- Calculate and report risk in real-time
+- Connect to existing bank systems
+- Keep sensitive data private while staying compliant
+
+---
+
+## Your Next Steps
+
+### Pick Your Challenge
+
+Choose one problem, then:
+
+1. **Design your metadata structure** - What fields do you need?
+2. **Pick your approach** - [TypeScript](./typescript) for quick builds, [Anchor](./anchor) for framework help, or [Native Rust](./native-rust) for full control
+3. **Plan your space** - How much data? How will it grow?
+4. **Build and test** - Start simple, add complexity
+5. **Share it** - Others can learn from your work
+
+### How You Know You Won
+
+Your system works when:
+- It solves a real trust problem
+- Metadata is complete and verifiable
+- It handles edge cases
+- It scales to real usage
+- Others can build on it
+
+### The Real Test
+
+Would someone trust your system with something valuable? Would a hospital use your credential checker? Would luxury brands use your authenticity system? Would gamers trust your asset platform?
+
+That's what matters.
+
+---
+
+## Beyond These Challenges
+
+Once you solve these, you'll see problems everywhere:
+
+**Healthcare**: Patient records with verified doctors  
+**Real Estate**: Property titles with full ownership history  
+**Identity**: Control your own identity data  
+**Carbon Credits**: Prove environmental impact  
+**Research**: Track peer reviews and citations  
+**Voting**: Transparent, verifiable elections  
+
+You know [TLV encoding](./how-extensions-work#tlv-type-length-value-encoding), [space calculations](./how-extensions-work#space-calculation-formula), [metadata updates](./anchor#step-5-additional-fields-update), and [account management](./native-rust). These are the tools for solving trust problems.
+
+You can build these systems. You have the knowledge.
+
+Which problem will you solve first?
+
+---
+
+**Go build.** Share what you make. Others need to see how this works in practice.

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import NextError from "next/error";
+import { useEffect } from "react";
+
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html>
+      <body>
+        {/* `NextError` is the default Next.js error page component. Its type
+        definition requires a `statusCode` prop. However, since the App Router
+        does not expose status codes for errors, we simply pass 0 to render a
+        generic error message. */}
+        <NextError statusCode={0} />
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
This commit adds a complete guide covering how to use Token 2022's metadata pointer and metadata token extensions. The docs include:

- **Overview section** explaining why these extensions matter (solves the "unknown token" problem in wallets)
- **Technical deep dive** into how TLV encoding works and account structure
- **Three implementation approaches**: TypeScript client, Anchor framework, and native Rust
- **Real-world use cases** like credential verification and supply chain authenticity

The guide walks through building a "Developer Certification Token" as an example, showing the complete workflow from space calculations to metadata updates. It's basically a full tutorial that teaches developers how to attach rich, verifiable metadata directly to tokens instead of relying on separate metadata accounts.

The docs are structured progressively - starts with concepts, then TypeScript (easiest), then Anchor (middle ground), then native Rust (full control). Each section builds on the previous one.

This fills a major gap in the Solana docs since Token 2022 metadata extensions are powerful but complex to implement correctly.
