### PR TITLE
Fix/i18n arr

### DIFF
--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -1438,7 +1438,7 @@
           "description": "See how Solana’s speed and composability is allowing users on Decaf to fight inflation and take control of their financial future."
         },
         {
-          "name": "DR<lowercase>i</lowercase>P",
+          "name": "DRiP",
           "title": "Changing the way we consume, own and distribute online with DRiP",
           "description": "See how artists, creators and fans are owning their work and supporting each other on DRiP."
         }

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -1238,20 +1238,7 @@
         "note": "*second in raw numbers only to Ethereum."
       },
       "open-source": {
-        "title": [
-          {
-            "phrase": "Fully open-sourced code."
-          },
-          {
-            "phrase": "All activity on-chain."
-          },
-          {
-            "phrase": "Self-custody."
-          },
-          {
-            "phrase": "Community-owned."
-          }
-        ],
+        "title": "Fully open-sourced code.|All activity on-chain.|Self-custody.|Community-owned.",
         "description": "Decentralization is the heart of web3 — and to truly embrace web3’s promise, it needs to be the uncompromising core of everything a project does."
       }
     },

--- a/apps/web/src/components/ecdr/ECDRStats.js
+++ b/apps/web/src/components/ecdr/ECDRStats.js
@@ -23,9 +23,7 @@ const StatCard = ({ value, description = "", note = "", className }) => (
 
 const ECDRStats = () => {
   const t = useTranslations();
-  const openSourceTitle = t("ecdr.stats.open-source.title", {
-    returnObjects: true,
-  });
+  const openSourceTitle = t("ecdr.stats.open-source.title").split("|");
   return (
     <div
       className={classNames("mt-4 container", styles["ecdr-stats__container"])}
@@ -80,14 +78,14 @@ const ECDRStats = () => {
       </div>
       <div className="row">
         <h2 className={styles["ecdr-stats__open-source--title"]}>
-          <span className="d-block">{openSourceTitle[0].phrase}</span>
+          <span className="d-block">{openSourceTitle[0]}</span>
           <span className="d-block d-md-inline-block">
-            {openSourceTitle[1].phrase}
+            {openSourceTitle[1]}
           </span>{" "}
           <span className="d-block d-md-inline-block">
-            {openSourceTitle[2].phrase}
+            {openSourceTitle[2]}
           </span>
-          <span className="d-block">{openSourceTitle[3].phrase}</span>
+          <span className="d-block">{openSourceTitle[3]}</span>
         </h2>
         <p className="col-md-6 mt-4 mx-auto text-center">
           {t("ecdr.stats.open-source.description")}

--- a/apps/web/src/components/possible/PossibleVisionaries.js
+++ b/apps/web/src/components/possible/PossibleVisionaries.js
@@ -55,7 +55,7 @@ const PossibleVisionaries = () => {
           <div className="col-12 col-md-5 d-flex flex-row d-md-block mb-8 mb-md-0 ps-lg-0 align-items-center">
             <h2 className="h2 pe-5 flex-grow-1 flex-shrink-1 mb-0">
               {t.rich("possible.visionaries.title", {
-                italic: (chunks) => <em className="fst-italic">{chunks}</em>,
+                italic: (chunks) => <em>{chunks}</em>,
               })}
             </h2>
           </div>
@@ -191,11 +191,13 @@ const PossibleEpisodeSelection = ({
                 )}
                 onClick={() => selectEpisode(index)}
               >
-                {t.rich(item.name, {
-                  lowercase: (chunks) => (
-                    <span className="text-lowercase">{chunks}</span>
-                  ),
-                })}
+                {item.name === "DRiP" ? (
+                  <>
+                    DR<span className="lowercase">I</span>P
+                  </>
+                ) : (
+                  item.name
+                )}
               </button>
             ))}
           </div>
@@ -223,11 +225,13 @@ const PossibleEpisodeSelection = ({
                     styles[`visionaries-episodeDropdownBtn--possible`],
                   )}
                 >
-                  {t.rich(item.name, {
-                    lowercase: (chunks) => (
-                      <span className="text-lowercase">{chunks}</span>
-                    ),
-                  })}
+                  {item.name === "DRiP" ? (
+                    <>
+                      DR<span className="lowercase">I</span>P
+                    </>
+                  ) : (
+                    item.name
+                  )}
                 </Dropdown.Item>
               ))}
             </Dropdown.Menu>


### PR DESCRIPTION
### Problem
- i18n key shape caused rendering coupling.
- DRiP casing relied on translation markup.
- Italic used utility class instead of semantic tag.

### Changes
- Flattened `ecdr.stats.open-source.title` to a `|`-delimited string and split in code.
- Render DRiP casing in UI (lowercase “i”).
- Use `<em>` for italics.

Fixes #

Files: `apps/web/public/locales/en/common.json`, `apps/web/src/components/ecdr/ECDRStats.js`, `apps/web/src/components/possible/PossibleVisionaries.js`