### PR TITLE
docs: fixed missing 'is' in sentence about data persistence

### DIFF
--- a/apps/web/content/docs/en/intro/quick-start/reading-from-network.mdx
+++ b/apps/web/content/docs/en/intro/quick-start/reading-from-network.mdx
@@ -40,7 +40,7 @@ corresponding on-chain data.
 
 Solana accounts contain either:
 
-- **State**: Data that meant to be read from and persisted. For example,
+- **State**: Data that is meant to be read from and persisted. For example,
   information about tokens, user data, or other data defined within a program.
 - **Executable Programs**: Accounts containing the actual code of Solana
   programs. These accounts store instructions that users can invoke.


### PR DESCRIPTION
### Problem
Small grammatical error by missing a word which makes docs seem more unprofessional


### Summary of Changes
Added the missing word 'is' to fix the sentence