### PR TITLE
docs: Fix typo "tokenaccounts" to "token accounts"

### DIFF
--- a/apps/web/content/docs/en/tokens/basics/transfer-tokens.mdx
+++ b/apps/web/content/docs/en/tokens/basics/transfer-tokens.mdx
@@ -5,7 +5,7 @@ description: Learn how to transfer tokens between token accounts.
 
 ## How to Transfer Tokens
 
-Token transfers move tokens between tokenaccounts of the same mint using the
+Token transfers move tokens between token accounts of the same mint using the
 [`TransferChecked`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L268)
 instruction.
 


### PR DESCRIPTION
### Problem
Documentation contains "tokenaccounts" as one word instead of the correct "token accounts" with proper spacing.


### Summary of Changes
Corrected "tokenaccounts" to "token accounts" for proper spacing and readability