### PR TITLE
docs: remove redundant transaction confirmation in accounts guide

### DIFF
--- a/apps/web/content/docs/ar/core/accounts.mdx
+++ b/apps/web/content/docs/ar/core/accounts.mdx
@@ -964,7 +964,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/de/core/accounts.mdx
+++ b/apps/web/content/docs/de/core/accounts.mdx
@@ -992,7 +992,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/el/core/accounts.mdx
+++ b/apps/web/content/docs/el/core/accounts.mdx
@@ -1004,7 +1004,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/en/core/accounts.mdx
+++ b/apps/web/content/docs/en/core/accounts.mdx
@@ -977,7 +977,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/es/core/accounts.mdx
+++ b/apps/web/content/docs/es/core/accounts.mdx
@@ -991,7 +991,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/fi/core/accounts.mdx
+++ b/apps/web/content/docs/fi/core/accounts.mdx
@@ -981,7 +981,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/fr/core/accounts.mdx
+++ b/apps/web/content/docs/fr/core/accounts.mdx
@@ -996,7 +996,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/id/core/accounts.mdx
+++ b/apps/web/content/docs/id/core/accounts.mdx
@@ -983,7 +983,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/it/core/accounts.mdx
+++ b/apps/web/content/docs/it/core/accounts.mdx
@@ -990,7 +990,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/ja/core/accounts.mdx
+++ b/apps/web/content/docs/ja/core/accounts.mdx
@@ -909,7 +909,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/ko/core/accounts.mdx
+++ b/apps/web/content/docs/ko/core/accounts.mdx
@@ -972,7 +972,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/nl/core/accounts.mdx
+++ b/apps/web/content/docs/nl/core/accounts.mdx
@@ -996,7 +996,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/pl/core/accounts.mdx
+++ b/apps/web/content/docs/pl/core/accounts.mdx
@@ -977,7 +977,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/pt/core/accounts.mdx
+++ b/apps/web/content/docs/pt/core/accounts.mdx
@@ -987,7 +987,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/ru/core/accounts.mdx
+++ b/apps/web/content/docs/ru/core/accounts.mdx
@@ -990,7 +990,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/tr/core/accounts.mdx
+++ b/apps/web/content/docs/tr/core/accounts.mdx
@@ -988,7 +988,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/uk/core/accounts.mdx
+++ b/apps/web/content/docs/uk/core/accounts.mdx
@@ -986,7 +986,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/vi/core/accounts.mdx
+++ b/apps/web/content/docs/vi/core/accounts.mdx
@@ -984,7 +984,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;

--- a/apps/web/content/docs/zh/core/accounts.mdx
+++ b/apps/web/content/docs/zh/core/accounts.mdx
@@ -916,7 +916,6 @@ async fn main() -> Result<()> {
     let airdrop_signature = client
         .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
         .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
 
     loop {
         let confirmed = client.confirm_transaction(&airdrop_signature).await?;


### PR DESCRIPTION
 ### Problem

  The Rust code example in the accounts documentation contains a redundant
  `client.confirm_transaction(&airdrop_signature).await?;` call before the loop that already confirms the
  transaction. Since the loop immediately checks and confirms the transaction.

  ### Summary of Changes

  - Removed the redundant `client.confirm_transaction(&airdrop_signature).await?;` line that appears before the
  confirmation loop
  - Updated all 19 language versions of the `accounts.mdx` file to ensure consistency across translations
  - The loop that actually handles transaction confirmation remains unchanged
