### PR TITLE
Fixing a typo in the Solana docs

### DIFF
--- a/apps/web/content/docs/en/core/transactions.mdx
+++ b/apps/web/content/docs/en/core/transactions.mdx
@@ -757,7 +757,7 @@ The structure of a transaction message consists of:
 <WithMentions>
 
 - [Message Header](mention:message-header): Specifies the number of signer and
-  read-only account.
+  read-only accounts.
 - [Account Addresses](mention:account-addresses): An array of account addresses
   required by the instructions on the transaction.
 - [Recent Blockhash](mention:recent-blockhash): Acts as a timestamp for the


### PR DESCRIPTION
### Problem
There was a missing 's'


### Summary of Changes
I added the missing 's'