### PR TITLE
fix broken contributing link and typo in reading-from-network

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ Repository for [https://solana.com](https://solana.com) - a Turborepo-powered mo
 ## Maintainers
 
 The solana.com website is managed and maintained by the Solana Foundation. Read
-more on [how to contribute](CONTRIBUTING.md).
+more on [how to contribute](apps/web/CONTRIBUTING.md).

--- a/apps/web/content/docs/en/intro/quick-start/reading-from-network.mdx
+++ b/apps/web/content/docs/en/intro/quick-start/reading-from-network.mdx
@@ -379,8 +379,7 @@ account's `data` field.
 
 ## !!steps
 
-Executable program accounts also have a program designated as the `owner` of the
-of the account.
+Executable program accounts also have a program designated as the `owner` of the account.
 
 All program accounts are owned by a Loader program, which is a category of
 built-in programs that own executable program accounts on Solana.


### PR DESCRIPTION
### Problem

The "how to contribute" link is broken.
There is a typo in en/reading-from-network.mdx

### Summary of Changes
Fix the "how to contribute" link
Fix the typo in en/reading-from-network.mdx
