### PR TITLE
Update how-to-optimize-compute.mdx

### DIFF
--- a/apps/web/content/guides/advanced/how-to-optimize-compute.mdx
+++ b/apps/web/content/guides/advanced/how-to-optimize-compute.mdx
@@ -41,7 +41,7 @@ ensure it's as efficient as possible.
 
 Solana programs have a few compute limitations to be aware of:
 
-- **Max Compute per block**: 48 million CU
+- **Max Compute per block**: 60 million CU
 - **Max Compute per account per block**: 12 million CU
 - **Max Compute per transaction**: 1.4 million CU
 


### PR DESCRIPTION
### Problem

The documentation currently lists the maximum compute per block as 48 million CU, but this has since been increased to 60 million CU.

### Summary of Changes

Updated the documented maximum compute per block from 48M CU → 60M CU to reflect the latest network limits.

Fixes #