### PR TITLE
Fix Anchor documentation links in journal.mdx

### DIFF
--- a/apps/web/content/guides/dapps/journal.mdx
+++ b/apps/web/content/guides/dapps/journal.mdx
@@ -86,7 +86,7 @@ npm run dev
 ## Writing a Solana program with Anchor
 
 If you're new to Anchor,
-[The Anchor Book](https://book.anchor-lang.com/introduction/introduction.html)
+[The Anchor Book](https://book.anchor-lang.com/docs)
 and [Anchor Examples](https://examples.anchor-lang.com/) are great references to
 help you learn.
 


### PR DESCRIPTION
This pull request makes a minor documentation update to the `apps/web/content/guides/dapps/journal.mdx` file, updating the link to the Anchor Book to point to the latest documentation.

- Updated the Anchor Book reference link to use the current documentation URL for improved accuracy and user experience.