### PR TITLE
Update intro-to-anchor-frontend.mdx

### DIFF
--- a/apps/web/content/courses/onchain-development/intro-to-anchor-frontend.mdx
+++ b/apps/web/content/courses/onchain-development/intro-to-anchor-frontend.mdx
@@ -537,7 +537,7 @@ const accounts = await program.account.counter.all([
   {
     memcmp: {
       offset: 8,
-      bytes: bs58.encode(new BN(0, "le").toArray()),
+      bytes: bs58.encode(new BN(0).toArray("le", 8)),
     },
   },
 ]);


### PR DESCRIPTION
### What I did

Corrected BN (Big Number) usage in memcmp filters to ensure proper 8-byte little-endian encoding for `u64` values

-----

### Problem

The current documentation shows:

```javascript
bytes: bs58.encode(new BN(0, "le").toArray()),
```

This is problematic for two reasons:

1.  **Incorrect use of BN constructor:** The second argument to `BN` is the numeric base, not the endianness. Passing `"le"` is misleading and may behave inconsistently across `bn.js` versions.
2.  **Variable-length encoding:** `.toArray()` without an explicit length produces a variable number of bytes. For example, `new BN(5).toArray("le")` yields `[5]`, but Solana accounts store `u64` values in 8-byte little-endian format. Using shorter arrays may still match as a prefix in `memcmp` filters, but it’s unsafe and can produce false positives or fail unexpectedly.

-----

### Fixes

Updated example to:

```javascript
bytes: bs58.encode(new BN(0).toArray("le", 8)),
```

Ensures numbers are serialized as fixed-length 8-byte little-endian arrays, consistent with Solana’s on-chain `u64` layout. This makes `memcmp` filters deterministic and avoids misleading or unsafe BN usage.

-----

### Example Failure

Suppose an on-chain account has a `u64` field set to `65536`.

**On-chain bytes (u64 LE):**

```
[0, 0, 1, 0, 0, 0, 0, 0]
```

**Current doc version (`new BN(65536, "le").toArray()`):**

```
[1] // only 1 byte
```

→ Encodes incorrectly, does not match the on-chain value.

**Correct version (`new BN(65536).toArray("le", 8)`):**

```
[0, 0, 1, 0, 0, 0, 0, 0]
```

→ Matches exactly as expected.