### PR TITLE
chore: move husky to repo root

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -96,7 +96,6 @@
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-react": "^7.37.3",
     "eslint-plugin-react-hooks": "^5.0.0",
-    "husky": "^9.1.6",
     "jest": "^30.0.2",
     "jest-environment-jsdom": "^30.0.2",
     "next-sitemap": "^4.2.3",
@@ -118,7 +117,6 @@
     "lint": "next lint",
     "lint:fix": "next lint --fix",
     "postbuild": "next-sitemap",
-    "prepare": "husky",
     "postinstall": "fs-mdx",
     "add:radix": "npx @radix-ui/scripts"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "packages/*"
   ],
   "devDependencies": {
+    "husky": "^9.1.7",
     "turbo": "latest"
   },
   "scripts": {
@@ -17,7 +18,8 @@
     "test": "turbo run test",
     "clean": "turbo run clean && find . -type d \\( -name 'node_modules' -o -name '.next' -o -name '.turbo'  -o -name '.source' \\) -prune -exec rm -rf '{}' +",
     "format:check": "turbo run format:check",
-    "format:all": "turbo run format:all"
+    "format:all": "turbo run format:all",
+    "prepare": "husky"
   },
   "packageManager": "pnpm@10.15.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
       turbo:
         specifier: latest
         version: 2.5.6
@@ -273,9 +276,6 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.0.0
         version: 5.2.0(eslint@9.35.0(jiti@1.21.7))
-      husky:
-        specifier: ^9.1.6
-        version: 9.1.7
       jest:
         specifier: ^30.0.2
         version: 30.1.3(@types/node@22.18.1)(ts-node@10.9.2(@types/node@22.18.1)(typescript@5.9.2))
@@ -12875,6 +12875,7 @@ snapshots:
   '@types/react-dom@19.1.9(@types/react@19.1.12)':
     dependencies:
       '@types/react': 19.1.12
+    optional: true
 
   '@types/react-slick@0.23.13':
     dependencies:


### PR DESCRIPTION
### Problem

Husky was configured in `apps/web` but it's supposed to run in the project root.

Before:
<img width="695" height="313" alt="image" src="https://github.com/user-attachments/assets/6dfe7dde-c0d0-44da-ac13-f620d9c3a29c" />

After:
<img width="423" height="471" alt="image" src="https://github.com/user-attachments/assets/d27de8cc-1747-4aaa-9424-97daf97fe88f" />


### Summary of Changes

- [x] Move `husky` to project root devDependencies
- [x] Run `husky` in the prepare script of the project root.

