### PR TITLE
chore: pin nth-check version to 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,10 @@
     "format:check": "turbo run format:check",
     "format:all": "turbo run format:all"
   },
-  "packageManager": "pnpm@10.15.1"
+  "packageManager": "pnpm@10.15.1",
+  "pnpm": {
+    "overrides": {
+      "nth-check": "2.1.1"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nth-check: 2.1.1
+
 importers:
 
   .:
@@ -6927,9 +6930,6 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
-
-  nth-check@1.0.2:
-    resolution: {integrity: sha512-WeBOdju8SnzPN5vTUJYxYUxLeXpCaVP5i5e0LF8fg7WORF2Wd7wFX/pk0tYZk7s8T+J7VLy0Da6J1+wCT0AtHg==}
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -13879,7 +13879,7 @@ snapshots:
       boolbase: 1.0.0
       css-what: 3.4.2
       domutils: 1.7.0
-      nth-check: 1.0.2
+      nth-check: 2.1.1
 
   css-select@5.2.2:
     dependencies:
@@ -16800,10 +16800,6 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
-
-  nth-check@1.0.2:
-    dependencies:
-      boolbase: 1.0.0
 
   nth-check@2.1.1:
     dependencies:


### PR DESCRIPTION
### Problem

We depend on [seti-icons](https://www.npmjs.com/package/seti-icons) to render the filetype icons in the RPC docs. Somewhere down it's dependencies it pulls in `nth-check@1.0.2`.

### Summary of Changes

Pin the version so we only depend on `nth-check@2.1.1`:

```diff
$ pnpm why -r nth-check
Legend: production dependency, optional only, dev only

solana-com@3.0.0 /Users/beeman/dev/solana-foundation/solana-com/apps/web

dependencies:
cheerio 1.1.2
└─┬ cheerio-select 2.1.0
  └─┬ css-select 5.2.2
    └── nth-check 2.1.1
seti-icons 0.0.4
└─┬ svgo 1.3.2
  └─┬ css-select 2.1.0
-    └── nth-check 1.0.2
+    └── nth-check 2.1.1

devDependencies:
@svgr/webpack 8.1.0
└─┬ @svgr/plugin-svgo 8.1.0
  └─┬ svgo 3.3.2
    └─┬ css-select 5.2.2
      └── nth-check 2.1.1
```


Fixes https://github.com/solana-foundation/solana-com/security/dependabot/33