### PR TITLE
fix: redirect unresolved routes to /developer/courses

### DIFF
--- a/apps/web/src/app/[locale]/developers/courses/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/developers/courses/[...rest]/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function RestPage() {
+  return redirect("/developers/courses");
+}

--- a/apps/web/src/pages/[locale]/[...slug].js
+++ b/apps/web/src/pages/[locale]/[...slug].js
@@ -17,6 +17,9 @@ const Page = ({ page, builderLocale }) => {
   const isPreviewing = useIsPreviewing();
 
   if (useAppRouterNavigation(page)) {
+    if (typeof window === "undefined") {
+      return null;
+    }
     window.location.reload();
     return null;
   }


### PR DESCRIPTION
### Problem

Because of how the routing is set up, any path with more than 2 segments after the base `/developer/courses` like  `/developer/courses/1/2/3` would not get resolved and get into a loop.

### Summary of Changes

Redirect the unresolved routes back to the base.
