### PR TITLE
docs: fix guides card to include title

### DIFF
--- a/apps/web/src/components/developers/sections/DevelopersResourcesSection/DevelopersResourceItem.jsx
+++ b/apps/web/src/components/developers/sections/DevelopersResourcesSection/DevelopersResourceItem.jsx
@@ -9,7 +9,7 @@ import { memo } from "react";
 
 export default function DevelopersResourceItem({
   category = "Resource",
-  children,
+  children = null,
   title,
   description,
   url,


### PR DESCRIPTION
### Problem

Cards missing page title

<img width="2452" height="1050" alt="CleanShot 2025-09-11 at 12 33 54@2x" src="https://github.com/user-attachments/assets/25889259-68a9-4fb6-aa42-ba026a5708b5" />

### Summary of Changes

Update component so title displays on card:

<img width="2536" height="1122" alt="CleanShot 2025-09-11 at 12 34 50@2x" src="https://github.com/user-attachments/assets/57528165-4fe7-4360-b4b0-3c902e30f182" />



