### PR TITLE
Add Gill tokens Second half examples to cookbook

### DIFF
--- a/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/approve-token-delegate.mdx
@@ -12,6 +12,153 @@ is like an another owner of your token account.
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  generateKeyPairSigner,
+  createTransaction,
+  signTransactionMessageWithSigners,
+  getExplorerLink,
+  getSignatureFromTransaction,
+  generateKeyPairSigner
+} from "gill";
+import {
+  getMintSize,
+  getCreateAccountInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getInitializeMintInstruction,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  getMintToCheckedInstruction,
+  getApproveCheckedInstruction,
+} from "gill/programs";
+
+const { rpc, rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "localnet",
+});
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const DELEGATE = await generateKeyPairSigner();
+
+let { mint, authorityATA } = await setup();
+
+const delegateInstruction = getApproveCheckedInstruction({
+  source: authorityATA,
+  mint,
+  delegate: DELEGATE.address,
+  owner: MINT_AUTHORITY,
+  amount: 1_000_000_000n, // 1 token
+  decimals: 9,
+});
+
+const tx = createTransaction({
+    feePayer:MINT_AUTHORITY,
+    version:'legacy',
+    instructions:[delegateInstruction],
+    latestBlockhash
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx)
+
+
+/*
+ * The setup function initializes the mint and associated token accounts,
+ *
+ */
+async function setup() {
+   await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+    });
+
+  const mint = await generateKeyPairSigner();
+
+  const space = BigInt(getMintSize());
+
+  const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+  // create & initialize mint account
+  const createAccountInstruction = getCreateAccountInstruction({
+    payer: MINT_AUTHORITY,
+    newAccount: mint,
+    lamports: rent,
+    space,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const initializeMintInstruction = getInitializeMintInstruction({
+    mint: mint.address,
+    decimals: 9,
+    mintAuthority: MINT_AUTHORITY.address,
+  });
+
+  // create token account
+  const [authorityATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: MINT_AUTHORITY.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const createAuthorityATAInstruction =
+    await getCreateAssociatedTokenInstructionAsync({
+      payer: MINT_AUTHORITY,
+      mint: mint.address,
+      owner: MINT_AUTHORITY.address,
+    });
+
+  // mintTo token account
+  const mintToInstruction = await getMintToCheckedInstruction({
+    mint: mint.address,
+    token: authorityATA,
+    mintAuthority: MINT_AUTHORITY,
+    amount: 1_000_000_000_000n, // 1000
+    decimals: 9,
+  });
+
+  const instructions = [
+    createAccountInstruction,
+    initializeMintInstruction,
+    createAuthorityATAInstruction,
+    mintToInstruction,
+  ];
+
+  const tx = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions,
+    latestBlockhash,
+  });
+
+  const signedTx = await signTransactionMessageWithSigners(tx);
+
+  console.log(
+    `Explorer ${getExplorerLink({
+      cluster: "devnet",
+      transaction: getSignatureFromTransaction(signedTx),
+    })}`
+  );
+
+  await sendAndConfirmTransaction(signedTx);
+
+  return {
+    mint: mint.address,
+    authorityATA,
+  };
+}
+```
+
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {

--- a/apps/web/content/cookbook/tokens/burn-tokens.mdx
+++ b/apps/web/content/cookbook/tokens/burn-tokens.mdx
@@ -7,6 +7,151 @@ You can burn tokens if you are the token account authority.
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  generateKeyPairSigner,
+  createTransaction,
+  signTransactionMessageWithSigners,
+  getExplorerLink,
+  getSignatureFromTransaction,
+} from "gill";
+import {
+  getMintSize,
+  getCreateAccountInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getInitializeMintInstruction,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  getMintToCheckedInstruction,
+  getBurnCheckedInstruction,
+} from "gill/programs";
+
+const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "localnet",
+});
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+let { mint, authorityATA } = await setup();
+
+const burnTokenIx = getBurnCheckedInstruction({
+  account: authorityATA,
+  mint: mint,
+  authority: MINT_AUTHORITY,
+  amount: 100_000_000_000n, // 100 tokens
+  decimals: 9,
+});
+
+
+const tx = createTransaction({
+  feePayer: MINT_AUTHORITY,
+  version: "legacy",
+  instructions: [burnTokenIx],
+  latestBlockhash,
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx);
+
+/*
+ * The setup function initializes the mint and associated token accounts,
+ *
+ */
+
+async function setup() {
+
+   await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+    });
+
+  const mint = await generateKeyPairSigner();
+
+  const space = BigInt(getMintSize());
+
+  const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+  // create & initialize mint account
+  const createAccountInstruction = getCreateAccountInstruction({
+    payer: MINT_AUTHORITY,
+    newAccount: mint,
+    lamports: rent,
+    space,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const initializeMintInstruction = getInitializeMintInstruction({
+    mint: mint.address,
+    decimals: 9,
+    mintAuthority: MINT_AUTHORITY.address,
+  });
+
+  // create token account
+  const [authorityATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: MINT_AUTHORITY.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const createAuthorityATAInstruction =
+    await getCreateAssociatedTokenInstructionAsync({
+      payer: MINT_AUTHORITY,
+      mint: mint.address,
+      owner: MINT_AUTHORITY.address,
+    });
+
+  // mintTo token account
+  const mintToInstruction = await getMintToCheckedInstruction({
+    mint: mint.address,
+    token: authorityATA,
+    mintAuthority: MINT_AUTHORITY,
+    amount: 1_000_000_000_000n, // 1000
+    decimals: 9,
+  });
+
+  const instructions = [
+    createAccountInstruction,
+    initializeMintInstruction,
+    createAuthorityATAInstruction,
+    mintToInstruction,
+  ];
+
+  const tx = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions,
+    latestBlockhash,
+  });
+
+  const signedTx = await signTransactionMessageWithSigners(tx);
+
+  console.log(
+    `Explorer ${getExplorerLink({
+      cluster: "devnet",
+      transaction: getSignatureFromTransaction(signedTx),
+    })}`
+  );
+
+  await sendAndConfirmTransaction(signedTx);
+
+  return {
+    mint: mint.address,
+    authorityATA,
+  };
+}
+```
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {

--- a/apps/web/content/cookbook/tokens/close-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/close-token-accounts.mdx
@@ -13,6 +13,159 @@ situations:
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  generateKeyPairSigner,
+  createTransaction,
+  signTransactionMessageWithSigners,
+  getExplorerLink,
+  getSignatureFromTransaction,
+} from "gill";
+import {
+  getMintSize,
+  getCreateAccountInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getInitializeMintInstruction,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  getMintToCheckedInstruction,
+  getCloseAccountInstruction,
+  getBurnInstruction,
+  getBurnCheckedInstruction,
+} from "gill/programs";
+
+const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+let { mint, authorityATA } = await setup();
+
+const burnTokenIx = getBurnCheckedInstruction({
+  account: authorityATA,
+  mint: mint,
+  authority: MINT_AUTHORITY,
+  amount: 1000000000000n,
+  decimals: 9,
+});
+
+// Non-native account can only be closed if its balance is zero' hence why thr butn token instruction
+const closeTokenAccountIx = getCloseAccountInstruction({
+  account: authorityATA,
+  destination: MINT_AUTHORITY.address,
+  owner: MINT_AUTHORITY,
+});
+
+const tx = createTransaction({
+  feePayer: MINT_AUTHORITY,
+  version: "legacy",
+  instructions: [burnTokenIx, closeTokenAccountIx],
+  latestBlockhash,
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx);
+
+/*
+ * The setup function initializes the mint and associated token accounts,
+ *
+ */
+
+async function setup() {
+
+   await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+  });
+
+  const mint = await generateKeyPairSigner();
+
+  const space = BigInt(getMintSize());
+
+  const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+  // create & initialize mint account
+  const createAccountInstruction = getCreateAccountInstruction({
+    payer: MINT_AUTHORITY,
+    newAccount: mint,
+    lamports: rent,
+    space,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const initializeMintInstruction = getInitializeMintInstruction({
+    mint: mint.address,
+    decimals: 9,
+    mintAuthority: MINT_AUTHORITY.address,
+  });
+
+  // create token account
+  const [authorityATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: MINT_AUTHORITY.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const createAuthorityATAInstruction =
+    await getCreateAssociatedTokenInstructionAsync({
+      payer: MINT_AUTHORITY,
+      mint: mint.address,
+      owner: MINT_AUTHORITY.address,
+    });
+
+  // mintTo token account
+  const mintToInstruction = await getMintToCheckedInstruction({
+    mint: mint.address,
+    token: authorityATA,
+    mintAuthority: MINT_AUTHORITY,
+    amount: 1_000_000_000_000n, // 1000
+    decimals: 9,
+  });
+
+  const instructions = [
+    createAccountInstruction,
+    initializeMintInstruction,
+    createAuthorityATAInstruction,
+    mintToInstruction,
+  ];
+
+  const tx = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions,
+    latestBlockhash,
+  });
+
+  const signedTx = await signTransactionMessageWithSigners(tx);
+
+  console.log(
+    `Explorer ${getExplorerLink({
+      cluster: "devnet",
+      transaction: getSignatureFromTransaction(signedTx),
+    })}`
+  );
+
+  await sendAndConfirmTransaction(signedTx);
+
+  return {
+    mint: mint.address,
+    authorityATA,
+  };
+}
+```
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {

--- a/apps/web/content/cookbook/tokens/get-all-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/get-all-token-accounts.mdx
@@ -11,6 +11,38 @@ You can fetch token accounts by owner. There are two ways to do it.
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import { address, createSolanaClient } from "gill";
+import { TOKEN_PROGRAM_ADDRESS } from "gill/programs/token";
+
+const { rpc } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+let owner = address("4kg8oh3jdNtn7j2wcS7TrUua31AgbLzDVkBZgTAe44aF");
+
+let response = await rpc
+  .getTokenAccountsByOwner(
+    owner,
+    { programId: TOKEN_PROGRAM_ADDRESS },
+    { encoding: "jsonParsed" }
+  )
+  .send();
+
+response.value.forEach((accountInfo) => {
+  console.log(`pubkey:${accountInfo.pubkey}`);
+  console.log(`Mint:${accountInfo.account.data["parsed"]["info"]["mint"]}`);
+  console.log(`Owner:${accountInfo.account.data["parsed"]["info"]["owner"]}`);
+  console.log(
+    `Decimals:${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["decimals"]}`
+  );
+  console.log(
+    `Amount:${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["amount"]}`
+  );
+  console.log("=====================");
+});
+```
+
 ```ts !! title="Kit"
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
 import { address, createSolanaRpc } from "@solana/kit";

--- a/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
+++ b/apps/web/content/cookbook/tokens/manage-wrapped-sol.mdx
@@ -27,6 +27,101 @@ There are two ways to add balance for Wrapped SOL
 
 <CodeTabs storage="cookbook">
 
+```ts !! title="Gill"
+import {
+  address,
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getExplorerLink,
+  getSignatureFromTransaction,
+  lamports,
+  signTransactionMessageWithSigners,
+} from "gill";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  TOKEN_PROGRAM_ADDRESS,
+} from "gill/programs/token";
+import {getTransferSolInstruction} from "gill/programs"
+import { getSyncNativeInstruction } from "@solana-program/token";
+
+const { rpc, rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "devnet",
+  }
+);
+
+// Generate key pairs for fee payer
+const feePayer = await generateKeyPairSigner();
+
+// Native mint (Wrapped SOL) address
+const NATIVE_MINT = address("So11111111111111111111111111111111111111112");
+
+// Use findAssociatedTokenPda to derive the ATA address for WSOL
+const [associatedTokenAddress] = await findAssociatedTokenPda({
+  mint: NATIVE_MINT,
+  owner: feePayer.address,
+  tokenProgram: TOKEN_PROGRAM_ADDRESS,
+});
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+await requestAirdrop()
+
+// Create instructions to create the WSOL associated token account
+const createAtaInstruction = await getCreateAssociatedTokenInstructionAsync({
+  payer: feePayer,
+  mint: NATIVE_MINT,
+  owner: feePayer.address,
+  tokenProgram:TOKEN_PROGRAM_ADDRESS
+});
+
+// Amount to wrap (1 SOL = 1,000,000,000 lamports)
+const amountToSync = 1_000_000_000n;
+
+const transferSolInstruction = getTransferSolInstruction({
+    source: feePayer,
+    destination: associatedTokenAddress,
+    amount: amountToSync,
+});
+
+const syncNativeInstruction = getSyncNativeInstruction({
+  account: associatedTokenAddress,
+});
+
+const instructions = [
+  createAtaInstruction,
+  transferSolInstruction,
+  syncNativeInstruction,
+];
+
+const tx = createTransaction({
+  feePayer,
+  version: "legacy",
+  instructions,
+  latestBlockhash,
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(`Explorer ${
+    getExplorerLink({
+        cluster:'devnet',
+        transaction:getSignatureFromTransaction(signedTx)
+    })
+}`);
+
+await sendAndConfirmTransaction(signedTx)
+
+async function  requestAirdrop () {
+  await  airdropFactory ({ rpc, rpcSubscriptions })({
+    recipientAddress:  feePayer.address,
+    lamports:  lamports ( 5_000_000_000 n ),  // 5 SOL
+    commitment:  "confirmed"
+  });
+}
+```
+
 ```ts !! title="Kit"
 import { getTransferSolInstruction } from "@solana-program/system";
 import {
@@ -252,6 +347,135 @@ async fn main() -> anyhow::Result<()> {
 ### 2. By Token Transfer
 
 <CodeTabs storage="cookbook">
+
+```ts !! title = "Gill"
+import {
+  address,
+  createSolanaClient,
+  createTransaction,
+  getExplorerLink,
+  getSignatureFromTransaction,
+  generateKeyPairSigner,
+  signTransactionMessageWithSigners,
+  airdropFactory,
+  lamports,
+} from "gill";
+import {
+  findAssociatedTokenPda,
+  getTokenSize,
+  TOKEN_PROGRAM_ADDRESS,
+} from "gill/programs/token";
+import { getCreateAccountInstruction } from "gill/programs";
+import { getCloseAccountInstruction, getCreateAssociatedTokenInstructionAsync, getInitializeAccountInstruction, getSyncNativeInstruction, getTransferCheckedInstruction } from "@solana-program/token";
+
+const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+
+/* constants */
+const SENDER = await generateKeyPairSigner();
+const SENDER_TEMPORARY_TOKEN_ACCOUNT = await generateKeyPairSigner();
+const RECIPIENT = await generateKeyPairSigner();
+
+// Native mint (Wrapped SOL) address
+const NATIVE_MINT = address("So11111111111111111111111111111111111111112");
+
+// Use findAssociatedTokenPda to derive the ATA address for WSOL
+const [recipientATA] = await findAssociatedTokenPda({
+  mint: NATIVE_MINT,
+  owner: RECIPIENT.address,
+  tokenProgram: TOKEN_PROGRAM_ADDRESS,
+});
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+await requestAirdrop();
+
+// Amount to wrap (1 SOL = 1,000,000,000 lamports)
+const amount = 1_000_000_000n;
+
+const tokenAccountLen = getTokenSize();
+const tokenAccountRent = await rpc
+  .getMinimumBalanceForRentExemption(BigInt(tokenAccountLen))
+  .send();
+
+// create temporary token account
+// adds extra transfer amount lamports to token account
+const createAccountInstruction = getCreateAccountInstruction({
+  payer: SENDER,
+  newAccount: SENDER_TEMPORARY_TOKEN_ACCOUNT,
+  lamports: tokenAccountRent + amount,
+  programAddress: TOKEN_PROGRAM_ADDRESS,
+  space: tokenAccountLen
+});
+
+// initialize temporary token account
+const initAccountInstruction = getInitializeAccountInstruction({
+  account: SENDER_TEMPORARY_TOKEN_ACCOUNT.address,
+  mint: NATIVE_MINT,
+  owner: SENDER.address,
+});
+
+// create recipient wrapped sol token account
+const createRecipientATAInstruction =
+  await getCreateAssociatedTokenInstructionAsync({
+    payer: SENDER,
+    mint: NATIVE_MINT,
+    owner: RECIPIENT.address,
+  });
+
+// transfer WSOL
+const transferTokenInstruction = getTransferCheckedInstruction({
+  source: SENDER_TEMPORARY_TOKEN_ACCOUNT.address,
+  mint: NATIVE_MINT,
+  destination: recipientATA,
+  authority: SENDER,
+  amount: amount, // 1 WSOL
+  decimals: 9
+});
+
+// close temp account
+const closeTokenAccountInstruction = getCloseAccountInstruction({
+  account: SENDER_TEMPORARY_TOKEN_ACCOUNT.address,
+  destination: SENDER.address,
+  owner: SENDER
+});
+
+const instructions = [
+  createAccountInstruction,
+  initAccountInstruction,
+  createRecipientATAInstruction,
+  transferTokenInstruction,
+  closeTokenAccountInstruction
+];
+
+const tx = createTransaction({
+  feePayer:SENDER,
+  version: "legacy",
+  instructions,
+  latestBlockhash,
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx);
+
+async function requestAirdrop() {
+  await airdropFactory({ rpc, rpcSubscriptions })({
+    recipientAddress: SENDER.address,
+    lamports: lamports(5_000_000_000n), // 5 SOL
+    commitment: "confirmed"
+  });
+}
+```
 
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";

--- a/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
+++ b/apps/web/content/cookbook/tokens/revoke-token-delegate.mdx
@@ -9,6 +9,148 @@ Revoke will set delegate to null and set delegated amount to 0.
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getExplorerLink,
+  getSignatureFromTransaction,
+  signTransactionMessageWithSigners,
+} from "gill";
+import {
+  findAssociatedTokenPda,
+  getCreateAccountInstruction,
+  getCreateAssociatedTokenInstructionAsync,
+  getInitializeMintInstruction,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getRevokeInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+} from "gill/programs";
+
+const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+let { authorityATA } = await setup();
+
+const revokeDelegateIx = getRevokeInstruction({
+  source: authorityATA,
+  owner: MINT_AUTHORITY,
+});
+
+const tx = createTransaction({
+  feePayer: MINT_AUTHORITY,
+  version: "legacy",
+  instructions: [revokeDelegateIx],
+  latestBlockhash,
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx);
+
+/*
+ * The setup function initializes the mint and associated token accounts,
+ *
+ */
+
+async function setup() {
+
+  await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+  });
+
+  const mint = await generateKeyPairSigner();
+
+  const space = BigInt(getMintSize());
+
+  const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+  // create & initialize mint account
+  const createAccountInstruction = getCreateAccountInstruction({
+    payer: MINT_AUTHORITY,
+    newAccount: mint,
+    lamports: rent,
+    space,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const initializeMintInstruction = getInitializeMintInstruction({
+    mint: mint.address,
+    decimals: 9,
+    mintAuthority: MINT_AUTHORITY.address,
+  });
+
+  // create token account
+  const [authorityATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: MINT_AUTHORITY.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const createAuthorityATAInstruction =
+    await getCreateAssociatedTokenInstructionAsync({
+      payer: MINT_AUTHORITY,
+      mint: mint.address,
+      owner: MINT_AUTHORITY.address,
+    });
+
+  // mintTo token account
+  const mintToInstruction = await getMintToCheckedInstruction({
+    mint: mint.address,
+    token: authorityATA,
+    mintAuthority: MINT_AUTHORITY,
+    amount: 1_000_000_000_000n, // 1000
+    decimals: 9,
+  });
+
+  const instructions = [
+    createAccountInstruction,
+    initializeMintInstruction,
+    createAuthorityATAInstruction,
+    mintToInstruction,
+  ];
+
+  const tx = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions,
+    latestBlockhash,
+  });
+
+  const signedTx = await signTransactionMessageWithSigners(tx);
+
+  console.log(
+    `Explorer ${getExplorerLink({
+      cluster: "devnet",
+      transaction: getSignatureFromTransaction(signedTx),
+    })}`
+  );
+
+  await sendAndConfirmTransaction(signedTx);
+
+  return {
+    mint: mint.address,
+    authorityATA,
+  };
+}
+```
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {

--- a/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
+++ b/apps/web/content/cookbook/tokens/set-update-token-authority.mdx
@@ -14,6 +14,175 @@ You can set/update authority. There are 4 types:
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getExplorerLink,
+  getSignatureFromTransaction,
+  signTransactionMessageWithSigners,
+} from "gill";
+import {
+  getMintSize,
+  getCreateAccountInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getInitializeMintInstruction,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstructionAsync,
+  getMintToCheckedInstruction,
+  AuthorityType,
+  getSetAuthorityInstruction,
+} from "gill/programs";
+
+const { rpc,rpcSubscriptions,sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet",
+});
+
+const MINT_AUTHORITY = await generateKeyPairSigner();
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const NEW_AUTHORITY = await generateKeyPairSigner();
+
+const { mint } = await setup();
+
+// 1. Change Mint Authority (MintTokens)
+const setMintAuthorityIx = getSetAuthorityInstruction({
+  owned: mint,
+  owner: MINT_AUTHORITY,
+  authorityType: AuthorityType.MintTokens,
+  newAuthority: NEW_AUTHORITY.address,
+});
+
+// 2. Change Freeze Authority
+const setFreezeAuthorityIx = getSetAuthorityInstruction({
+  owned: mint,
+  owner: MINT_AUTHORITY,
+  authorityType: AuthorityType.FreezeAccount,
+  newAuthority: NEW_AUTHORITY.address,
+});
+
+// Example of revoking authority (setting to null)
+const revokeMintAuthorityIx = getSetAuthorityInstruction({
+  owned: mint,
+  owner: NEW_AUTHORITY,
+  authorityType: AuthorityType.MintTokens,
+  newAuthority: null,
+});
+
+const instructions = [
+  setMintAuthorityIx,
+  setFreezeAuthorityIx,
+  revokeMintAuthorityIx,
+];
+
+const tx = createTransaction({
+    feePayer:MINT_AUTHORITY,
+    version:'legacy',
+    instructions,
+    latestBlockhash
+});
+
+const signedTx = await signTransactionMessageWithSigners(tx);
+
+console.log(
+  `Explorer ${getExplorerLink({
+    cluster: "devnet",
+    transaction: getSignatureFromTransaction(signedTx),
+  })}`
+);
+
+await sendAndConfirmTransaction(signedTx)
+
+
+/*
+ * The setup function initializes the mint and associated token accounts,
+ *
+ */
+async function setup() {
+
+  await airdropFactory({ rpc, rpcSubscriptions })({
+        recipientAddress: MINT_AUTHORITY.address,
+        lamports: lamports(1_000_000_000n),
+        commitment: "confirmed"
+  });
+
+  const mint = await generateKeyPairSigner();
+
+  const space = BigInt(getMintSize());
+
+  const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+  // create & initialize mint account
+  const createAccountInstruction = getCreateAccountInstruction({
+    payer: MINT_AUTHORITY,
+    newAccount: mint,
+    lamports: rent,
+    space,
+    programAddress: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const initializeMintInstruction = getInitializeMintInstruction({
+    mint: mint.address,
+    decimals: 9,
+    mintAuthority: MINT_AUTHORITY.address,
+    freezeAuthority:MINT_AUTHORITY.address
+  });
+
+  // create token account
+  const [authorityATA] = await findAssociatedTokenPda({
+    mint: mint.address,
+    owner: MINT_AUTHORITY.address,
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
+  });
+
+  const createAuthorityATAInstruction =
+    await getCreateAssociatedTokenInstructionAsync({
+      payer: MINT_AUTHORITY,
+      mint: mint.address,
+      owner: MINT_AUTHORITY.address,
+    });
+
+  // mintTo token account
+  const mintToInstruction = await getMintToCheckedInstruction({
+    mint: mint.address,
+    token: authorityATA,
+    mintAuthority: MINT_AUTHORITY,
+    amount: 1_000_000_000_000n, // 1000
+    decimals: 9,
+  });
+
+  const instructions = [
+    createAccountInstruction,
+    initializeMintInstruction,
+    createAuthorityATAInstruction,
+    mintToInstruction,
+  ];
+
+  const tx = createTransaction({
+    feePayer: MINT_AUTHORITY,
+    version: "legacy",
+    instructions,
+    latestBlockhash,
+  });
+
+  const signedTx = await signTransactionMessageWithSigners(tx);
+
+  console.log(
+    `Explorer ${getExplorerLink({
+      cluster: "devnet",
+      transaction: getSignatureFromTransaction(signedTx),
+    })}`
+  );
+
+  await sendAndConfirmTransaction(signedTx);
+
+  return {
+    mint: mint.address,
+    authorityATA,
+  };
+}
+```
+
 ```ts !! title="Kit"
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {


### PR DESCRIPTION
### Problem
The Solana cookbook was lacking on gill token examples for burning tokens,closing token accounts,setting and revoking delegate etc


### Summary of Changes
Add Gill to Solana Cookbook for token examples for burning tokens,closing token accounts,setting and revoking delegate on token accounts,how to use wrapped sol by transfer and balance,get all token accounts authority

