### PR TITLE
Update university tour dates and add MHacks event

### DIFF
--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -1851,13 +1851,13 @@
     },
     "events": {
       "title": "Meet With Us!",
-      "stanford": {
-        "title": "Solana University Workshop",
-        "description": "Solana Foundation and One Piece Lab university tour visits Stanford blockchain club"
-      },
       "berkeley": {
         "title": "Solana University Workshop",
         "description": "Solana Foundation and One Piece Lab university tour visits UC Berkeley blockchain club"
+      },
+      "mhacks": {
+        "title": "MHacks Hackathon",
+        "description": "Join MHacks - one of the world's largest hackathons - and build on Solana"
       },
       "purdue": {
         "title": "Solana University Workshop",

--- a/apps/web/src/components/universities/UniversityEventsGrid.tsx
+++ b/apps/web/src/components/universities/UniversityEventsGrid.tsx
@@ -7,16 +7,6 @@ import GradientOrbs, { orbPresets } from "./GradientOrbs";
 
 const universityEvents = [
   {
-    id: "stanford-2025",
-    titleKey: "stanford",
-    location: "Stanford",
-    university: "Stanford University",
-    date: "Sept 18",
-    href: "https://lu.ma/f25su",
-    image:
-      "https://images.unsplash.com/photo-1681782421891-5088f13466ec?q=80&w=2000",
-  },
-  {
     id: "berkeley-2025",
     titleKey: "berkeley",
     location: "Berkeley",
@@ -25,6 +15,16 @@ const universityEvents = [
     href: "https://lu.ma/f25ucb",
     image:
       "https://images.unsplash.com/photo-1694391505705-7fde96f6f14f?q=80&w=2000",
+  },
+  {
+    id: "mhacks-2025",
+    titleKey: "mhacks",
+    location: "Ann Arbor",
+    university: "MHacks",
+    date: "Sept 27-28",
+    href: "https://www.mhacks.org/",
+    image:
+      "https://images.unsplash.com/photo-1523050854058-8df90110c9f1?q=80&w=2000",
   },
   {
     id: "ucla-2025",


### PR DESCRIPTION
## Summary
- Removed Stanford event from the university tour schedule
- Added MHacks hackathon (September 27-28) in Ann Arbor with link to https://www.mhacks.org/
- Verified and confirmed dates for existing events:
  - UCLA: October 1st
  - USC: October 3rd
  - UT Austin: October 15th
  - MIT & Harvard: October 22nd
  - NYU: October 27th

## Changes
- Updated `UniversityEventsGrid.tsx` to remove Stanford and add MHacks event
- Updated `common.json` translations to remove Stanford entry and add MHacks translation