### PR TITLE
fix: Grammar mistake in accouts.mdx

### DIFF
--- a/apps/web/content/docs/en/core/accounts.mdx
+++ b/apps/web/content/docs/en/core/accounts.mdx
@@ -201,7 +201,7 @@ commonly called "account data."
 - For program accounts (smart contracts), this field contains either the
   executable program code itself or the address of another account that stores
   the executable program code.
-- For non-executable accounts, this generally stores state that's meant be read
+- For non-executable accounts, this generally stores state that's meant to be read
   from.
 
 Reading data from a Solana account involves two steps:


### PR DESCRIPTION
### Problem
Small grammar mistake in the Accounts doc: 
_"For non-executable accounts, this generally stores state that's meant be read from."_

Missing "to" after "meant"


### Summary of Changes

Added missing "to"