### PR TITLE
docs: fix broken lingo translated pages

### DIFF
--- a/apps/web/content/docs/ar/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/ar/tokens/basics/create-mint.mdx
@@ -1,12 +1,12 @@
 ---
 title: إنشاء عملة رمزية
-description: تعلم كيفية إنشاء عملة SPL Token.
+description: تعلم كيفية إنشاء عملة رمزية SPL.
 ---
 
-## ما هو حساب العملة؟
+## ما هو حساب Mint؟
 
-حساب العملة (mint account) يمثل بشكل فريد رمزًا على سولانا ويخزن البيانات
-الوصفية العالمية الخاصة به.
+حساب mint يمثل بشكل فريد رمزًا على سولانا ويخزن البيانات الوصفية العالمية الخاصة
+به.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -32,21 +32,21 @@ pub struct Mint {
 <Callout type="info">
   لاحظ أن كلاً من [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30)
-  و[Token Extension
+  و[Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
-  يشتركان في نفس التنفيذ الأساسي لحساب العملة.
+  يشتركان في نفس التنفيذ الأساسي لحساب Mint.
 </Callout>
 
-كل رمز على سولانا لديه حساب mint، وعنوان الـ mint يعمل كمعرف فريد للرمز.
+كل رمز على سولانا لديه حساب mint، وعنوان mint يعمل كمعرف فريد للرمز.
 
 على سبيل المثال، USD Coin (USDC) لديه عنوان mint
 `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. هذا العنوان يحدد USDC بشكل فريد
 في جميع أنحاء نظام سولانا البيئي. يمكنك عرض هذا الـ mint على
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
-## كيفية إنشاء حساب عملة
+## كيفية إنشاء حساب Mint
 
-إنشاء حساب mint يتطلب تعليمة
+يتطلب إنشاء حساب mint تعليمة
 [`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37).
 انظر
 [تفاصيل التنفيذ هنا](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
@@ -55,7 +55,7 @@ pub struct Mint {
 
 1. System Program: إنشاء حساب بمساحة مخصصة لحساب mint ونقل الملكية إلى Token
    Program.
-2. Token Program: تهيئة بيانات حساب الـ mint
+2. Token Program: تهيئة بيانات حساب mint
 
 ### تايبسكريبت
 

--- a/apps/web/content/docs/ar/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/ar/tokens/basics/create-token-account.mdx
@@ -5,8 +5,8 @@ description: تعلم كيفية إنشاء حسابات SPL Token.
 
 ## ما هو حساب Token؟
 
-يخزن حساب الرمز المميز (token account) رصيدك من رمز مميز محدد. يرتبط كل حساب رمز
-مميز بعملة واحدة فقط ويتتبع رصيد الرمز المميز الخاص بك والتفاصيل الإضافية.
+يخزن token account رصيدك من توكن محدد. يرتبط كل token account بعملة واحدة فقط
+ويتتبع رصيد التوكن الخاص بك والتفاصيل الإضافية.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -37,61 +37,60 @@ pub struct Account {
 ```
 
 <Callout type="info">
-  لاحظ أنه في الكود المصدري، يطلق المطورون على حساب Token اسم `Account` كنوع. كل
+  لاحظ أنه في الكود المصدري، يطلق المطورون على حساب Token اسم `Account` type. كل
   من [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)
-  و[Token Extension
+  و [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
   يشتركان في نفس التنفيذ الأساسي لحساب Token.
 </Callout>
 
-للاحتفاظ بالرموز المميزة، تحتاج إلى حساب رمز مميز (token account) لتلك العملة
-المحددة. يتتبع كل حساب رمز مميز:
+للاحتفاظ بالتوكنات، تحتاج إلى token account لتلك العملة المحددة. كل token
+account يتتبع:
 
-1. **العملة (Mint)**: نوع الرمز المميز المحدد الذي يحتفظ به
-2. **المالك (Owner)**: السلطة التي يمكنها تحويل الرموز المميزة من هذا الحساب
+1. **العملة (Mint)**: نوع التوكن المحدد الذي يحتفظ به
+2. **المالك (Owner)**: السلطة التي يمكنها تحويل التوكنات من هذا الحساب
 
 ### مثال: عملة الدولار الأمريكي (USDC)
 
 - عنوان العملة: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- حساب الرمز المميز لشركة Circle: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-- يحتفظ هذا الحساب برموز USDC فقط
-- تتحكم Circle في الرمز المميز من خلال سلطة مالك حساب الرمز المميز:
+- token account الخاص بـ Circle: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- هذا الحساب يحتفظ فقط بتوكنات USDC
+- تتحكم Circle في التوكن من خلال سلطة مالك token account:
   `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
 يمكنك عرض تفاصيل token account هذا على
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  **فهم مصطلح "المالك"**
+  **فهم مصطلح "المالك (Owner)"**
 
 يمكن استخدام مصطلح "المالك" في سياقين مختلفين:
 
-1. **مالك حساب الرمز المميز**: السلطة التي يمكنها تحويل أو حرق أو تفويض الرموز
-   المميزة. يتم تخزين هذا في بيانات حساب الرمز المميز.
+1. **مالك token account**: السلطة التي يمكنها تحويل أو حرق أو تفويض التوكنات.
+   يتم تخزين هذا في بيانات token account.
 
 2. **مالك البرنامج**: البرنامج الذي يملك الحساب (دائمًا Token Program أو Token
-   Extension Program لحسابات الرموز المميزة).
+   Extension Program لحسابات التوكن).
 
-عند العمل مع حسابات الرموز المميزة، يشير "المالك" عادةً إلى السلطة التي يمكنها
-تحويل الرموز المميزة، وليس البرنامج الذي يملك الحساب.
+عند العمل مع token accounts، يشير "المالك" عادةً إلى السلطة التي يمكنها تحويل
+التوكنات، وليس البرنامج الذي يملك الحساب.
 
 </Callout>
 
-## ما هو حساب الرمز المميز المرتبط؟
+## ما هو associated token account؟
 
-حساب الرمز المميز المرتبط (associated token account - ATA) هو حساب الرمز المميز
-الافتراضي للمحفظة للاحتفاظ برمز مميز محدد. يستخدم عنوانًا حتميًا (PDA) تم إنشاؤه
-بواسطة
+associated token account (ATA) هو token account الافتراضي للمحفظة للاحتفاظ بتوكن
+محدد. يستخدم عنوانًا محددًا (PDA) تم إنشاؤه بواسطة
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
 
 <Callout type="info">
-  فقط حسابات الرموز المميزة التي تم إنشاؤها بواسطة Associated Token Program تسمى
-  "حسابات الرموز المميزة المرتبطة".
+  فقط حسابات الـtoken التي تم إنشاؤها بواسطة Associated Token Program تسمى
+  "associated token accounts."
 </Callout>
 
-تستخدم حسابات الرموز المميزة المرتبطة (ATAs) عناوين حتمية، مما يسهل العثور على
-حساب الرمز المميز لأي محفظة لعملة معينة. انظر
+تستخدم حسابات ATAs عناوين محددة مسبقاً، مما يسهل العثور على حساب token لأي محفظة
+لـmint معين. انظر
 [تنفيذ الاشتقاق هنا](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
@@ -112,14 +111,13 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-لأي مجموعة محفظة ورمز مميز، هناك عنوان واحد فقط لحساب الرمز المميز المرتبط
-(ATA). هذا يلغي الحاجة إلى تتبع عناوين حسابات الرموز المميزة يدويًا - يمكنك
-دائمًا aاشتقاق العنوان الصحيح.
+لأي محفظة وتوكن، هناك عنوان ATA واحد فقط. هذا يلغي الحاجة إلى تتبع عناوين حسابات
+الـtoken يدوياً—يمكنك دائماً اشتقاق العنوان الصحيح.
 
 <Callout type="info">
   **كيف يعمل Associated Token Program**
 
-Associated Token Program هو مساعد يقوم بما يلي:
+الـAssociated Token Program هو مساعد يقوم بـ:
 
 - إنشاء حسابات token في عناوين محددة مسبقاً (PDAs)
 - إجراء Cross-Program Invocations (CPIs) إلى Token Program
@@ -475,7 +473,7 @@ console.log("Token Account Address:", tokenAccount.toBase58());
 
 </CodeTabs>
 
-### راست
+### Rust
 
 <CodeTabs storage="token-rs" flags="r">
 
@@ -703,15 +701,15 @@ async fn main() -> Result<()> {
 
 </CodeTabs>
 
-## كيفية إنشاء associated token account
+## كيفية إنشاء Associated Token Account
 
-يتطلب إنشاء Associated Token Account (ATA) تعليمة
-[`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18).
+إنشاء حساب توكن مرتبط (ATA) يتطلب التعليمة
+[---INLINE-CODE-PLACEHOLDER-85c08564ca556b926744bf94497c4af2---](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
 انظر
 [التنفيذ هنا](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-تتعامل هذه التعليمة الواحدة تلقائيًا مع إنشاء حساب الـtoken وتهيئته من خلال
-Cross Program Invocations (CPI).
+تتعامل هذه التعليمة الواحدة تلقائيًا مع إنشاء حساب التوكن وتهيئته من خلال
+استدعاءات البرامج المتقاطعة (CPI).
 
 ### تايبسكريبت
 
@@ -1035,7 +1033,7 @@ console.log(
 
 </CodeTabs>
 
-### Rust
+### راست
 
 <CodeTabs storage="token-rs" flags="r">
 

--- a/apps/web/content/docs/de/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/de/tokens/basics/create-mint.mdx
@@ -1,12 +1,12 @@
 ---
 title: Einen Token Mint erstellen
-description: Erfahren Sie, wie Sie einen SPL Token mint erstellen.
+description: Erfahren Sie, wie Sie einen SPL Token Mint erstellen.
 ---
 
 ## Was ist ein Mint Account?
 
 Ein mint account repräsentiert eindeutig einen Token auf Solana und speichert
-seine globalen Metadaten.
+dessen globale Metadaten.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -37,28 +37,28 @@ pub struct Mint {
   die gleiche Basisimplementierung für den Mint Account teilen.
 </Callout>
 
-Jeder Token auf Solana hat ein mint account, und die Adresse des mints dient als
-eindeutige Kennung des Tokens.
+Jeder Token auf Solana hat einen Mint Account, und die Adresse des Mints dient
+als eindeutige Kennung des Tokens.
 
-Zum Beispiel hat USD Coin (USDC) die mint-Adresse
+Zum Beispiel hat USD Coin (USDC) die Mint-Adresse
 `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Diese Adresse identifiziert USDC
-eindeutig im gesamten Solana-Ökosystem. Sie können diesen mint auf
+eindeutig im gesamten Solana-Ökosystem. Sie können diesen Mint auf
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)
 ansehen.
 
 ## Wie man einen Mint Account erstellt
 
-Das Erstellen eines mint account erfordert die
+Das Erstellen eines Mint Accounts erfordert die
 [`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37)
 Anweisung. Siehe die
 [Implementierungsdetails hier](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-Sie müssen zwei Anweisungen ausführen, um ein mint account zu erstellen:
+Sie müssen zwei Anweisungen aufrufen, um einen Mint Account zu erstellen:
 
 1. System Program: Erstellen Sie ein Konto mit zugewiesenem Speicherplatz für
-   ein mint account und übertragen Sie die Eigentümerschaft an das Token
+   einen Mint Account und übertragen Sie die Eigentümerschaft an das Token
    Program.
-2. Token Program: Initialisieren Sie die mint account-Daten
+2. Token Program: Initialisieren Sie die Mint Account-Daten
 
 ### Typescript
 

--- a/apps/web/content/docs/de/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/de/tokens/basics/create-token-account.mdx
@@ -5,8 +5,8 @@ description: Erfahren Sie, wie Sie SPL Token Accounts erstellen.
 
 ## Was ist ein Token Account?
 
-Ein token account speichert dein Guthaben eines bestimmten Tokens. Jeder token
-account ist mit genau einem Mint verknüpft und verfolgt dein Token-Guthaben und
+Ein Token Account speichert Ihr Guthaben eines bestimmten Tokens. Jeder Token
+Account ist mit genau einem Mint verknüpft und verfolgt Ihr Token-Guthaben und
 zusätzliche Details.
 
 ```rust title="Token Account Type"
@@ -38,29 +38,29 @@ pub struct Account {
 ```
 
 <Callout type="info">
-  Beachten Sie, dass Entwickler im Quellcode einen Token Account als `Account`
-  Typ bezeichnen. Sowohl das [Token
+  Beachten Sie, dass Entwickler in der Codebasis einen Token Account als
+  `Account` Typ bezeichnen. Sowohl das [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)
   als auch das [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
   teilen sich dieselbe Basisimplementierung für den Token Account.
 </Callout>
 
-Um Tokens zu halten, benötigst du einen token account für diesen spezifischen
-Mint. Jeder token account verfolgt:
+Um Tokens zu halten, benötigen Sie einen Token Account für diesen spezifischen
+Mint. Jeder Token Account verfolgt:
 
 1. **Mint**: Der spezifische Token-Typ, den er enthält
-2. **Owner**: Die Autorität, die Tokens von diesem Konto überweisen kann
+2. **Owner**: Die Autorität, die Tokens von diesem Konto übertragen kann
 
 ### Beispiel: USD Coin (USDC)
 
 - Mint-Adresse: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- Circles token account: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- Circles Token Account: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
 - Dieses Konto enthält nur USDC-Tokens
-- Circle kontrolliert Token durch die token account owner-Autorität:
+- Circle kontrolliert Tokens durch die Token Account Owner-Autorität:
   `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
-Sie können die Details dieses token accounts im
+Sie können die Details dieses Token Accounts im
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa)
 einsehen.
 
@@ -69,14 +69,14 @@ einsehen.
 
 Der Begriff "Owner" kann in zwei verschiedenen Kontexten verwendet werden:
 
-1. **Token Account Owner**: Die Autorität, die Tokens überweisen, verbrennen
-   oder delegieren kann. Dies wird in den Daten des token accounts gespeichert.
+1. **Token Account Owner**: Die Autorität, die Tokens übertragen, verbrennen
+   oder delegieren kann. Dies wird in den Daten des Token Accounts gespeichert.
 
 2. **Program Owner**: Das Programm, das das Konto besitzt (immer das Token
-   Program oder Token Extensions Program für token accounts).
+   Program oder Token Extensions Program für Token Accounts).
 
-Bei der Arbeit mit token accounts bezieht sich "Owner" typischerweise auf die
-Autorität, die Tokens überweisen kann, nicht auf das Programm, das das Konto
+Bei der Arbeit mit Token Accounts bezieht sich "Owner" typischerweise auf die
+Autorität, die Tokens übertragen kann, nicht auf das Programm, das das Konto
 besitzt.
 
 </Callout>
@@ -90,12 +90,12 @@ um einen bestimmten Token zu halten. Es verwendet eine deterministische Adresse
 erstellt wird.
 
 <Callout type="info">
-  Nur token accounts, die vom Associated Token Program erstellt wurden, werden
+  Nur Token Accounts, die vom Associated Token Program erstellt wurden, werden
   "associated token accounts" genannt.
 </Callout>
 
-ATAs verwenden deterministische Adressen, wodurch es einfach ist, den token
-account einer Wallet für einen bestimmten Mint zu finden. Siehe die
+ATAs verwenden deterministische Adressen, wodurch es einfach ist, das Token
+Konto einer Wallet für einen bestimmten Mint zu finden. Siehe die
 [Ableitungsimplementierung hier](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
@@ -117,8 +117,8 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 ```
 
 Für jede Wallet- und Token-Kombination gibt es genau eine ATA-Adresse. Dies
-beseitigt die Notwendigkeit, token account-Adressen manuell zu verfolgen – du
-kannst immer die korrekte Adresse ableiten.
+macht es überflüssig, Token-Kontoadressen manuell zu verfolgen – Sie können
+immer die korrekte Adresse ableiten.
 
 <Callout type="info">
   **Wie das Associated Token Program funktioniert**
@@ -130,22 +130,22 @@ Das Associated Token Program ist ein Hilfsprogramm, das:
 - Selbst keinen Zustand verwaltet
 
 Die resultierenden Token Konten gehören dem Token Program und verwenden die
-Standard `Account` Struktur.
+Standardstruktur `Account`.
 
 </Callout>
 
 ## Wie man ein Token Account erstellt
 
-Das Erstellen eines token account erfordert die
+Das Erstellen eines Token Accounts erfordert die
 [`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63)
 Anweisung. Siehe die
 [Implementierung hier](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
-Du benötigst zwei Anweisungen, um ein token account zu erstellen:
+Sie benötigen zwei Anweisungen, um ein Token Account zu erstellen:
 
-1. System Program: Erstelle ein Konto mit zugewiesenem Speicherplatz für ein
-   token account und übertrage die Eigentümerschaft an das Token Program
-2. Token Program: Initialisiere die token account Daten
+1. System Program: Erstellen eines Kontos mit zugewiesenem Speicherplatz für ein
+   Token Account und Übertragung der Eigentümerschaft an das Token Program
+2. Token Program: Initialisierung der Token Account-Daten
 
 ### Typescript
 
@@ -709,13 +709,13 @@ async fn main() -> Result<()> {
 
 ## Wie man ein Associated Token Account erstellt
 
-Das Erstellen eines associated token account (ATA) erfordert die
+Das Erstellen eines Associated Token Account (ATA) erfordert die
 [`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
 Anweisung. Siehe die
 [Implementierung hier](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
 Diese einzelne Anweisung übernimmt automatisch die Erstellung des token account
-und initialisiert es durch Cross Program Invocations (CPI).
+und initialisiert ihn durch Cross Program Invocation (CPI).
 
 ### Typescript
 

--- a/apps/web/content/docs/el/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/el/tokens/basics/create-mint.mdx
@@ -5,8 +5,8 @@ description: Μάθετε πώς να δημιουργήσετε ένα SPL Toke
 
 ## Τι είναι ένας Mint Account;
 
-Ένας λογαριασμός mint αντιπροσωπεύει μοναδικά ένα token στο Solana και
-αποθηκεύει τα παγκόσμια μεταδεδομένα του.
+Ένας mint account αντιπροσωπεύει μοναδικά ένα token στο Solana και αποθηκεύει τα
+παγκόσμια μεταδεδομένα του.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -37,8 +37,8 @@ pub struct Mint {
   μοιράζονται την ίδια βασική υλοποίηση για τον Mint account.
 </Callout>
 
-Κάθε token στο Solana έχει έναν λογαριασμό mint, και η διεύθυνση του mint
-λειτουργεί ως μοναδικό αναγνωριστικό του token.
+Κάθε token στο Solana έχει έναν mint account, και η διεύθυνση του mint
+λειτουργεί ως ο μοναδικός αναγνωριστικός κωδικός του token.
 
 Για παράδειγμα, το USD Coin (USDC) έχει τη διεύθυνση mint
 `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Αυτή η διεύθυνση προσδιορίζει
@@ -46,18 +46,18 @@ pub struct Mint {
 το mint στον
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
-## Πώς να δημιουργήσετε ένα Mint Account
+## Πώς να δημιουργήσετε έναν Mint Account
 
-Η δημιουργία ενός λογαριασμού mint απαιτεί την εντολή
+Η δημιουργία ενός mint account απαιτεί την εντολή
 [`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37).
 Δείτε τις
 [λεπτομέρειες υλοποίησης εδώ](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-Χρειάζεται να εκτελέσετε δύο εντολές για να δημιουργήσετε έναν λογαριασμό mint:
+Πρέπει να εκτελέσετε δύο εντολές για να δημιουργήσετε έναν mint account:
 
 1. System Program: Δημιουργία ενός λογαριασμού με κατανεμημένο χώρο για έναν
-   λογαριασμό mint και μεταφορά ιδιοκτησίας στο Token Program.
-2. Token Program: Αρχικοποίηση των δεδομένων του λογαριασμού mint
+   mint account και μεταφορά της ιδιοκτησίας στο Token Program.
+2. Token Program: Αρχικοποίηση των δεδομένων του mint account
 
 ### Typescript
 

--- a/apps/web/content/docs/el/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/el/tokens/basics/create-token-account.mdx
@@ -72,28 +72,27 @@ mint. Κάθε token account παρακολουθεί:
    αναθέσει tokens. Αυτό αποθηκεύεται στα δεδομένα του token account.
 
 2. **Program Owner**: Το πρόγραμμα που κατέχει τον λογαριασμό (πάντα το Token
-   Program ή το Token Extension Program για token accounts).
+   Program ή το Token Extension Program για τα token accounts).
 
-Όταν εργάζεστε με token accounts, ο "owner" συνήθως αναφέρεται στην αρχή που
-μπορεί να μεταφέρει tokens, όχι στο πρόγραμμα που κατέχει τον λογαριασμό.
+Όταν εργάζεστε με token accounts, ο όρος "owner" συνήθως αναφέρεται στην αρχή
+που μπορεί να μεταφέρει tokens, όχι στο πρόγραμμα που κατέχει τον λογαριασμό.
 
 </Callout>
 
 ## Τι είναι ένα Associated Token Account;
 
 Ένα associated token account (ATA) είναι το προεπιλεγμένο token account για ένα
-πορτοφόλι για τη διατήρηση ενός συγκεκριμένου token. Χρησιμοποιεί μια
-ντετερμινιστική διεύθυνση (PDA) που δημιουργείται από το
+πορτοφόλι που διατηρεί ένα συγκεκριμένο token. Χρησιμοποιεί μια ντετερμινιστική
+διεύθυνση (PDA) που δημιουργείται από το
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
 
 <Callout type="info">
-  Μόνο τα token accounts που δημιουργούνται από το Associated Token Program
+  Μόνο οι token accounts που δημιουργούνται από το Associated Token Program
   ονομάζονται "associated token accounts."
 </Callout>
 
-Τα ATAs χρησιμοποιούν ντετερμινιστικές διευθύνσεις, καθιστώντας εύκολη την
-εύρεση του token account οποιουδήποτε πορτοφολιού για ένα δεδομένο mint. Δείτε
-την
+Τα ATAs χρησιμοποιούν ντετερμινιστικές διευθύνσεις, διευκολύνοντας την εύρεση
+του token account οποιουδήποτε πορτοφολιού για ένα συγκεκριμένο mint. Δείτε την
 [υλοποίηση παραγωγής εδώ](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
@@ -115,20 +114,20 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 ```
 
 Για οποιονδήποτε συνδυασμό πορτοφολιού και token, υπάρχει ακριβώς μία διεύθυνση
-ATA. Αυτό εξαλείφει την ανάγκη χειροκίνητης παρακολούθησης των διευθύνσεων token
-account—μπορείτε πάντα να παράγετε τη σωστή διεύθυνση.
+ATA. Αυτό εξαλείφει την ανάγκη χειροκίνητης παρακολούθησης των διευθύνσεων των
+token accounts—μπορείτε πάντα να παράγετε τη σωστή διεύθυνση.
 
 <Callout type="info">
   **Πώς λειτουργεί το Associated Token Program**
 
 Το Associated Token Program είναι ένα βοηθητικό πρόγραμμα που:
 
-- Δημιουργεί token accounts σε προκαθορισμένες διευθύνσεις (PDAs)
-- Πραγματοποιεί Cross-Program Invocations (CPIs) στο Token Program
+- Δημιουργεί token accounts σε ντετερμινιστικές διευθύνσεις (PDAs)
+- Πραγματοποιεί Cross Program Invocation (CPIs) στο Token Program
 - Δεν διατηρεί καμία κατάσταση από μόνο του
 
-Τα token accounts που δημιουργούνται ανήκουν στο Token Program και χρησιμοποιούν
-την τυπική δομή `Account`.
+Τα token accounts που προκύπτουν ανήκουν στο Token Program και χρησιμοποιούν την
+τυπική `Account` δομή.
 
 </Callout>
 
@@ -712,8 +711,8 @@ async fn main() -> Result<()> {
 Δείτε την
 [υλοποίηση εδώ](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-Αυτή η μοναδική εντολή διαχειρίζεται αυτόματα τη δημιουργία του token account
-και την αρχικοποίησή του μέσω Cross Program Invocations (CPI).
+Αυτή η μεμονωμένη εντολή χειρίζεται αυτόματα τη δημιουργία του token account και
+την αρχικοποίησή του μέσω Cross Program Invocation (CPI).
 
 ### Typescript
 

--- a/apps/web/content/docs/es/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/es/tokens/basics/create-mint.mdx
@@ -5,9 +5,8 @@ description: Aprende cómo crear un mint de SPL Token.
 
 ## ¿Qué es una Mint Account?
 
-Una mint account es un tipo de cuenta en los Token Programs de Solana que
-representa de manera única un token en la red y almacena metadatos globales
-sobre el token.
+Una mint account representa de manera única un token en Solana y almacena sus
+metadatos globales.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -35,30 +34,29 @@ pub struct Mint {
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30)
   como el [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
-  comparten la misma implementación base para la Mint account.
+  comparten la misma implementación base para la mint account.
 </Callout>
 
-Cada token en Solana existe como una mint account donde la dirección de la mint
-account es su identificador único en la red.
+Cada token en Solana tiene una mint account, y la dirección del mint sirve como
+identificador único del token.
 
-Por ejemplo, el USD Coin (USDC) o dólar digital en Solana tiene la dirección de
-mint `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Esta dirección de mint
-sirve como identificador único de USD Coin en todo el ecosistema de Solana.
-Puedes ver los detalles sobre esta mint account en
+Por ejemplo, USD Coin (USDC) tiene la dirección de mint
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Esta dirección identifica de
+manera única a USDC en todo el ecosistema de Solana. Puedes ver este mint en
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
 ## Cómo crear una Mint Account
 
-Para crear una Mint Account, invoca la instrucción
-[`InitializeMint`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L65).
-Puedes encontrar implementaciones de esta instrucción
-[aquí](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L79).
+La creación de una mint account requiere la instrucción
+[`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37).
+Consulta los
+[detalles de implementación aquí](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-La transacción para crear una mint account necesita dos instrucciones:
+Necesitas invocar dos instrucciones para crear una mint account:
 
-1. Invocar al System Program para crear y asignar espacio para una mint account
-   y transferir la propiedad al Token Program.
-2. Invocar al Token Program para inicializar los datos de la mint account.
+1. System Program: Crear una cuenta con espacio asignado para una mint account y
+   transferir la propiedad al Token Program.
+2. Token Program: Inicializar los datos de la mint account
 
 ### Typescript
 
@@ -84,8 +82,8 @@ import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -110,18 +108,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 9,
@@ -155,7 +153,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
 console.log("Mint Address:", mint.address);
-console.log("Transaction Signature:", transactionSignature);
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy"
@@ -169,14 +167,14 @@ import {
 } from "@solana/web3.js";
 import {
   createInitializeMintInstruction,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint
 } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -187,8 +185,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -200,15 +198,15 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: await getMinimumBalanceForRentExemptMint(connection),
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 const initializeMintInstruction = createInitializeMintInstruction(
-  mint.publicKey, // mint pubkey
-  9, // decimals
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  mint.publicKey,
+  9, // Decimals
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  TOKEN_PROGRAM_ID
 );
 
 const transaction = new Transaction().add(
@@ -222,17 +220,17 @@ const transactionSignature = await sendAndConfirmTransaction(
   [feePayer, mint] // Signers
 );
 
-console.log("Mint Address: ", mint.publicKey.toBase58());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { createMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import { createMint, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -243,24 +241,24 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
 const mintPubkey = await createMint(
-  connection, // connection
-  feePayer, // fee payer
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  9, // decimals
-  Keypair.generate(), // keypair
+  connection,
+  feePayer,
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  9, // Decimals
+  Keypair.generate(),
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 ```
 
 </CodeTabs>
@@ -268,82 +266,6 @@ console.log(`Mint Address: ${mintPubkey.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    let mint_space = Mint::LEN;
-    let rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Create account instruction for mint
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(), // program id
-        &mint.pubkey(),           // mint address
-        &fee_payer.pubkey(),      // mint authority
-        Some(&fee_payer.pubkey()),// freeze authority
-        9,                        // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -355,7 +277,7 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
+use spl_token::{id as token_program_id, instruction::initialize_mint, state::Mint};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -364,7 +286,7 @@ async fn main() -> Result<()> {
         String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -390,16 +312,16 @@ async fn main() -> Result<()> {
 
     // Create account instruction
     let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // fee payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        space as u64,             // space
-        &token_2022_program_id(), // program id
+        &fee_payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &token_program_id(),
     );
 
     // Initialize mint instruction
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint address
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -411,14 +333,14 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
     let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }
@@ -431,7 +353,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -464,7 +386,6 @@ async fn main() -> Result<()> {
 
     // Generate keypair to use as address of mint
     let mint = Keypair::new();
-    println!("Mint keypair generated: {}", mint.pubkey());
 
     // Set up program client for Token client
     let program_client =
@@ -473,10 +394,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 9;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -495,7 +416,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }

--- a/apps/web/content/docs/es/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/es/tokens/basics/create-token-account.mdx
@@ -5,9 +5,9 @@ description: Aprende cómo crear SPL Token Accounts.
 
 ## ¿Qué es una token account?
 
-Una token account almacena tu saldo de un token específico. Cada token account
-está asociada con exactamente un mint y realiza un seguimiento de tu saldo de
-tokens y detalles adicionales.
+Una token account almacena tu balance de un token específico. Cada token account
+está asociada exactamente con un mint y hace seguimiento de tu balance de tokens
+y detalles adicionales.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -39,15 +39,15 @@ pub struct Account {
 
 <Callout type="info">
   Ten en cuenta que en el código fuente, los desarrolladores llaman a una Token
-  account un tipo `Account` . Tanto el [Token
+  account un `Account` type. Tanto el [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)
   como el [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
-  comparten la misma implementación base para la token account.
+  comparten la misma implementación base para la Token account.
 </Callout>
 
 Para mantener tokens, necesitas una token account para ese mint específico. Cada
-token account realiza un seguimiento de:
+token account hace seguimiento de:
 
 1. **Mint**: El tipo específico de token que contiene
 2. **Owner**: La autoridad que puede transferir tokens desde esta cuenta
@@ -64,11 +64,11 @@ Puedes ver los detalles de esta token account en
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  **Entendiendo la terminología de "Owner"
+  **Entendiendo la terminología de "Owner"**
 
 El término "owner" puede usarse en dos contextos diferentes:
 
-1. **Owner de la Token Account**: La autoridad que puede transferir, quemar o
+1. **Owner de la token account**: La autoridad que puede transferir, quemar o
    delegar tokens. Esto se almacena en los datos de la token account.
 
 2. **Program Owner**: El programa que posee la cuenta (siempre el Token Program
@@ -79,7 +79,7 @@ autoridad que puede transferir tokens, no al programa que posee la cuenta.
 
 </Callout>
 
-## ¿Qué es una Associated Token Account?
+## ¿Qué es una associated token account?
 
 Una associated token account (ATA) es la token account predeterminada para que
 una wallet mantenga un token específico. Utiliza una dirección determinista
@@ -92,7 +92,7 @@ una wallet mantenga un token específico. Utiliza una dirección determinista
 </Callout>
 
 Las ATAs utilizan direcciones deterministas, lo que facilita encontrar la token
-account de cualquier wallet para un mint dado. Consulta la
+account de cualquier wallet para un mint específico. Consulta la
 [implementación de derivación aquí](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
@@ -113,18 +113,17 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-Para cualquier combinación de wallet y token, hay exactamente una dirección ATA.
-Esto elimina la necesidad de rastrear manualmente las direcciones de token
+Para cualquier combinación de wallet y token, existe exactamente una dirección
+ATA. Esto elimina la necesidad de rastrear manualmente las direcciones de token
 account—siempre puedes deducir la dirección correcta.
 
 <Callout type="info">
   **Cómo funciona el Associated Token Program**
 
-El Associated Token Program es un ayudante que:
+El Associated Token Program es un asistente que:
 
 - Crea token accounts en direcciones deterministas (PDAs)
-- Realiza Invocaciones entre Programas (Cross Program Invocation o CPIs) al
-  Token Program
+- Realiza Cross-Program Invocations (CPIs) al Token Program
 - No mantiene ningún estado por sí mismo
 
 Las token accounts resultantes son propiedad del Token Program y utilizan la
@@ -713,8 +712,7 @@ Consulta la
 [implementación aquí](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
 Esta única instrucción maneja automáticamente la creación de la token account y
-su inicialización a través de Invocaciones entre Programas (Cross Program
-Invocation o CPI).
+su inicialización a través de Cross Program Invocation (CPI).
 
 ### Typescript
 

--- a/apps/web/content/docs/fi/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/fi/tokens/basics/create-mint.mdx
@@ -5,8 +5,8 @@ description: Opi luomaan SPL Token mint.
 
 ## Mikä on Mint Account?
 
-Mint account on tilityypppi Solanan Token Programs -ohjelmissa, joka edustaa
-yksilöllisesti tokenia verkossa ja tallentaa globaalia metatietoa tokenista.
+Mint account edustaa yksilöllisesti tokenia Solanassa ja tallentaa sen globaalit
+metatiedot.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -37,27 +37,26 @@ pub struct Mint {
   jakavat saman perusimplementaation Mint-tilille.
 </Callout>
 
-Jokainen token Solanassa on olemassa mint account -tilinä, jossa mint accountin
-osoite toimii sen yksilöllisenä tunnisteena verkossa.
+Jokaisella Solanan tokenilla on mint account, ja mintin osoite toimii tokenin
+yksilöllisenä tunnisteena.
 
-Esimerkiksi USD Coin (USDC) -digitaalidollarilla Solanassa on mint-osoite
-`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Tämä mint-osoite toimii USD
-Coinin yksilöllisenä tunnisteena koko Solana-ekosysteemissä. Voit tarkastella
-tämän mint accountin tietoja
+Esimerkiksi USD Coinilla (USDC) on mint-osoite
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Tämä osoite yksilöi USDC:n koko
+Solana-ekosysteemissä. Voit tarkastella tätä mintiä
 [Solana Explorerissa](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
 ## Miten luoda Mint Account
 
-Luodaksesi Mint Accountin, kutsu
-[`InitializeMint`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L65)
--ohjetta. Tämän ohjeen toteutukset löytyvät
-[täältä](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L79).
+Mint accountin luominen vaatii
+[`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37)
+-ohjeen. Katso
+[toteutuksen yksityiskohdat täältä](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-Mint accountin luomiseen tarvittava transaktio vaatii kaksi ohjetta:
+Sinun täytyy kutsua kahta ohjetta mint accountin luomiseksi:
 
-1. Kutsu System Program -ohjelmaa luomaan ja allokoimaan tilaa mint accountille
-   ja siirtämään omistajuus Token Program -ohjelmalle.
-2. Kutsu Token Program -ohjelmaa alustamaan mint accountin data.
+1. System Program: Luo tili, jossa on varattu tila mint accountille ja siirrä
+   omistajuus Token Programille.
+2. Token Program: Alusta mint accountin tiedot
 
 ### Typescript
 
@@ -83,11 +82,11 @@ import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Generate keypairs for fee payer
@@ -109,18 +108,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 9,
@@ -154,7 +153,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
 console.log("Mint Address:", mint.address);
-console.log("Transaction Signature:", transactionSignature);
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy"
@@ -168,14 +167,14 @@ import {
 } from "@solana/web3.js";
 import {
   createInitializeMintInstruction,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -186,8 +185,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -199,15 +198,15 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: await getMinimumBalanceForRentExemptMint(connection),
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 const initializeMintInstruction = createInitializeMintInstruction(
-  mint.publicKey, // mint pubkey
-  9, // decimals
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  mint.publicKey,
+  9, // Decimals
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  TOKEN_PROGRAM_ID
 );
 
 const transaction = new Transaction().add(
@@ -221,17 +220,17 @@ const transactionSignature = await sendAndConfirmTransaction(
   [feePayer, mint] // Signers
 );
 
-console.log("Mint Address: ", mint.publicKey.toBase58());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { createMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import { createMint, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -242,24 +241,24 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
 const mintPubkey = await createMint(
-  connection, // connection
-  feePayer, // fee payer
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  9, // decimals
-  Keypair.generate(), // keypair
+  connection,
+  feePayer,
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  9, // Decimals
+  Keypair.generate(),
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 ```
 
 </CodeTabs>
@@ -267,82 +266,6 @@ console.log(`Mint Address: ${mintPubkey.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    let mint_space = Mint::LEN;
-    let rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Create account instruction for mint
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(), // program id
-        &mint.pubkey(),           // mint address
-        &fee_payer.pubkey(),      // mint authority
-        Some(&fee_payer.pubkey()),// freeze authority
-        9,                        // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -354,16 +277,16 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
+use spl_token::{id as token_program_id, instruction::initialize_mint, state::Mint};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create connection to local validator
     let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -389,16 +312,16 @@ async fn main() -> Result<()> {
 
     // Create account instruction
     let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // fee payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        space as u64,             // space
-        &token_2022_program_id(), // program id
+        &fee_payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &token_program_id(),
     );
 
     // Initialize mint instruction
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint address
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -410,14 +333,14 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
     let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }
@@ -430,7 +353,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -441,7 +364,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     // Create connection to local validator
     let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
 
@@ -463,7 +386,6 @@ async fn main() -> Result<()> {
 
     // Generate keypair to use as address of mint
     let mint = Keypair::new();
-    println!("Mint keypair generated: {}", mint.pubkey());
 
     // Set up program client for Token client
     let program_client =
@@ -472,10 +394,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 9;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -494,7 +416,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }

--- a/apps/web/content/docs/fi/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/fi/tokens/basics/create-token-account.mdx
@@ -5,9 +5,9 @@ description: Opi luomaan SPL token accounteja.
 
 ## Mikä on token account?
 
-Token account tallentaa saldosi tietystä tokenista. Jokainen token account on
+Token account säilyttää saldosi tietystä tokenista. Jokainen token account on
 yhdistetty täsmälleen yhteen minttiin ja seuraa token-saldoasi sekä muita
-tietoja.
+yksityiskohtia.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -39,24 +39,24 @@ pub struct Account {
 
 <Callout type="info">
   Huomaa, että lähdekoodissa kehittäjät kutsuvat token accountia `Account`
-  -tyypiksi. Sekä [Token
+  tyypiksi. Sekä [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)
-  että [Token Extension
+  että [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
   jakavat saman perusimplementaation token accountille.
 </Callout>
 
-Pitääksesi hallussasi tokeneita tarvitset token accountin kyseiselle mintille.
-Jokainen token account seuraa:
+Pitääksesi tokeneita tarvitset token accountin kyseiselle mintille. Jokainen
+token account seuraa:
 
-1. **Mint**: Tietty tokenityyppi, jota se sisältää
-2. **Owner**: Auktoriteetti, joka voi siirtää tokeneita tältä tililtä
+1. **Mint**: Tietty tokentyyppi, jota se pitää hallussaan
+2. **Omistaja**: Auktoriteetti, joka voi siirtää tokeneita tältä tililtä
 
 ### Esimerkki: USD Coin (USDC)
 
 - Mint-osoite: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
 - Circlen token account: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-- Tämä tili sisältää vain USDC-tokeneita
+- Tämä tili pitää hallussaan vain USDC-tokeneita
 - Circle hallitsee tokeneita token accountin omistajan auktoriteetin kautta:
   `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
@@ -64,34 +64,34 @@ Voit tarkastella tämän token accountin tietoja
 [Solana Explorerissa](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  **"Owner"-terminologian ymmärtäminen**
+  **"Omistaja"-terminologian ymmärtäminen**
 
-Termiä "owner" voidaan käyttää kahdessa eri yhteydessä:
+Termiä "omistaja" voidaan käyttää kahdessa eri yhteydessä:
 
-1. **Token Account Owner**: Auktoriteetti, joka voi siirtää, polttaa tai
+1. **Token accountin omistaja**: Auktoriteetti, joka voi siirtää, polttaa tai
    delegoida tokeneita. Tämä on tallennettu token accountin tietoihin.
 
-2. **Program Owner**: Ohjelma, joka omistaa tilin (aina Token Program tai Token
-   Extension Program token accountien kohdalla).
+2. **Ohjelman omistaja**: Ohjelma, joka omistaa tilin (aina Token Program tai
+   Token Extensions Program token accounteille).
 
-Kun työskennellään token accountien kanssa, "owner" viittaa tyypillisesti
+Kun työskennellään token accountien kanssa, "omistaja" viittaa tyypillisesti
 auktoriteettiin, joka voi siirtää tokeneita, ei ohjelmaan, joka omistaa tilin.
 
 </Callout>
 
-## Mikä on Associated Token Account?
+## Mikä on associated token account?
 
 Associated token account (ATA) on lompakon oletusarvoinen token account tietyn
 tokenin säilyttämiseen. Se käyttää determinististä osoitetta (PDA), jonka luo
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
 
 <Callout type="info">
-  Vain Associated Token Programin luomia token accounteja kutsutaan "associated
-  token accounteiksi."
+  Vain Associated Token Program -ohjelman luomia token accounteja kutsutaan
+  "associated token accounteiksi."
 </Callout>
 
-ATA:t käyttävät deterministisiä osoitteita, mikä tekee minkä tahansa lompakon
-token accountin löytämisestä helppoa tietylle mintille. Katso
+ATA:t käyttävät deterministisiä osoitteita, mikä tekee helpoksi löytää minkä
+tahansa lompakon token account tietylle mintille. Katso
 [johtamisen toteutus täältä](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
@@ -113,8 +113,8 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 ```
 
 Jokaiselle lompakko- ja token-yhdistelmälle on täsmälleen yksi ATA-osoite. Tämä
-poistaa tarpeen seurata token account -osoitteita manuaalisesti—voit aina johtaa
-oikean osoitteen.
+poistaa tarpeen seurata token account -osoitteita manuaalisesti – voit aina
+johtaa oikean osoitteen.
 
 <Callout type="info">
   **Miten Associated Token Program toimii**
@@ -122,11 +122,11 @@ oikean osoitteen.
 Associated Token Program on apuohjelma, joka:
 
 - Luo token accounteja deterministisiin osoitteisiin (PDA:t)
-- Tekee Cross-Program Invocation -kutsuja (CPI:t) Token Programille
-- Ei ylläpidä mitään tilaa itsessään
+- Tekee Cross-Program Invocation (CPI) -kutsuja Token Programiin
+- Ei ylläpidä mitään tilaa itse
 
-Luodut token accountit ovat Token Programin omistamia ja käyttävät standardia
-`Account` rakennetta.
+Tuloksena syntyvät token accountit ovat Token Programin omistamia ja käyttävät
+standardia `Account` rakennetta.
 
 </Callout>
 
@@ -134,14 +134,14 @@ Luodut token accountit ovat Token Programin omistamia ja käyttävät standardia
 
 Token accountin luominen vaatii
 [`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63)
-ohjeen. Katso
+-ohjeen. Katso
 [toteutus täältä](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
 Tarvitset kaksi ohjetta token accountin luomiseen:
 
 1. System Program: Luo tili, jossa on varattu tila token accountille ja siirrä
    omistajuus Token Programille
-2. Token Program: Alusta token accountin tiedot
+2. Token Program: Alusta token accountin data
 
 ### Typescript
 
@@ -705,13 +705,13 @@ async fn main() -> Result<()> {
 
 ## Miten luoda associated token account
 
-Associated Token Accountin (ATA) luominen vaatii
-[`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
-ohjeen. Katso
+Associated Token Account (ATA) -tilin luominen vaatii
+[---INLINE-CODE-PLACEHOLDER-85c08564ca556b926744bf94497c4af2---](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
+-ohjeen. Katso
 [toteutus täältä](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-Tämä yksittäinen ohje käsittelee automaattisesti token accountin luomisen ja sen
-alustamisen Cross Program Invocation (CPI) -kutsujen kautta.
+Tämä yksittäinen ohje käsittelee automaattisesti token account -tilin luomisen
+ja sen alustamisen Cross Program Invocation (CPI) -kutsujen kautta.
 
 ### Typescript
 

--- a/apps/web/content/docs/fr/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/fr/tokens/basics/create-mint.mdx
@@ -5,7 +5,7 @@ description: Apprenez à créer un mint de token SPL.
 
 ## Qu'est-ce qu'un Mint Account ?
 
-Un compte mint représente de manière unique un jeton sur Solana et stocke ses
+Un mint account représente de manière unique un token sur Solana et stocke ses
 métadonnées globales.
 
 ```rust title="Mint Account Type"
@@ -37,27 +37,27 @@ pub struct Mint {
   partagent la même implémentation de base pour le Mint account.
 </Callout>
 
-Chaque jeton sur Solana possède un compte mint, et l'adresse du mint sert
-d'identifiant unique pour le jeton.
+Chaque token sur Solana possède un mint account, et l'adresse du mint sert
+d'identifiant unique pour le token.
 
-Par exemple, USD Coin (USDC) a l'adresse mint
+Par exemple, USD Coin (USDC) a l'adresse de mint
 `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Cette adresse identifie de
-manière unique l'USDC dans tout l'écosystème Solana. Vous pouvez consulter ce
-mint sur
+manière unique USDC dans tout l'écosystème Solana. Vous pouvez consulter ce mint
+sur
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
 ## Comment créer un Mint Account
 
-La création d'un compte mint nécessite l'instruction
+La création d'un mint account nécessite l'instruction
 [`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37).
 Consultez les
 [détails d'implémentation ici](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-Vous devez invoquer deux instructions pour créer un compte mint :
+Vous devez invoquer deux instructions pour créer un mint account :
 
-1. System Program : créer un compte avec l'espace alloué pour un compte mint et
+1. System Program : Créer un compte avec l'espace alloué pour un mint account et
    transférer la propriété au Token Program.
-2. Token Program : initialiser les données du compte mint
+2. Token Program : Initialiser les données du mint account
 
 ### Typescript
 

--- a/apps/web/content/docs/fr/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/fr/tokens/basics/create-token-account.mdx
@@ -1,13 +1,13 @@
 ---
 title: Créer un compte de jetons
-description: Apprenez comment créer des comptes de jetons SPL.
+description: Apprenez à créer des comptes de jetons SPL.
 ---
 
-## Qu'est-ce qu'un token account ?
+## Qu'est-ce qu'un compte de jetons ?
 
-Un token account stocke votre solde d'un jeton spécifique. Chaque token account
-est associé à exactement un mint et suit votre solde de jetons ainsi que des
-détails supplémentaires.
+Un compte de jetons stocke votre solde d'un jeton spécifique. Chaque compte de
+jetons est associé à exactement une émission et suit votre solde de jetons et
+des détails supplémentaires.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -43,58 +43,58 @@ pub struct Account {
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)
   et le [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
-  partagent la même implémentation de base pour le token account.
+  partagent la même implémentation de base pour le compte de jetons.
 </Callout>
 
-Pour détenir des jetons, vous avez besoin d'un token account pour ce mint
-spécifique. Chaque token account suit :
+Pour détenir des jetons, vous avez besoin d'un compte de jetons pour cette
+émission spécifique. Chaque compte de jetons suit :
 
-1. **Mint** : Le type de jeton spécifique qu'il contient
-2. **Owner** : L'autorité qui peut transférer des jetons depuis ce compte
+1. **Émission** : Le type de jeton spécifique qu'il détient
+2. **Propriétaire** : L'autorité qui peut transférer des jetons depuis ce compte
 
 ### Exemple : USD Coin (USDC)
 
-- Adresse du mint : `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- Token account de Circle : `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-- Ce compte ne contient que des jetons USDC
-- Circle contrôle les jetons via l'autorité propriétaire du token account :
+- Adresse d'émission : `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- Compte de jetons de Circle : `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- Ce compte ne détient que des jetons USDC
+- Circle contrôle les jetons via l'autorité propriétaire du compte de jetons :
   `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
-Vous pouvez consulter les détails de ce token account sur
+Vous pouvez consulter les détails de ce compte de jetons sur
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  **Comprendre la terminologie "Owner"**
+  **Comprendre la terminologie "Propriétaire"**
 
-Le terme "owner" peut être utilisé dans deux contextes différents :
+Le terme "propriétaire" peut être utilisé dans deux contextes différents :
 
-1. **Propriétaire du token account** : L'autorité qui peut transférer, brûler ou
-   déléguer des jetons. Ceci est stocké dans les données du token account.
+1. **Propriétaire du compte de jetons** : L'autorité qui peut transférer, brûler
+   ou déléguer des jetons. Ceci est stocké dans les données du compte de jetons.
 
 2. **Programme propriétaire** : Le programme qui possède le compte (toujours le
-   Token Program ou Token Extension Program pour les token accounts).
+   Token Program ou le Token Extensions Program pour les comptes de jetons).
 
-Lorsqu'on travaille avec des token accounts, "owner" fait généralement référence
-à l'autorité qui peut transférer des jetons, et non au programme qui possède le
-compte.
+Lorsqu'on travaille avec des comptes de jetons, "propriétaire" fait généralement
+référence à l'autorité qui peut transférer des jetons, et non au programme qui
+possède le compte.
 
 </Callout>
 
-## Qu'est-ce qu'un associated token account ?
+## Qu'est-ce qu'un compte de jetons associé ?
 
-Un associated token account (ATA) est le token account par défaut pour un
+Un compte de jetons associé (ATA) est le compte de jetons par défaut pour un
 portefeuille destiné à détenir un jeton spécifique. Il utilise une adresse
-déterministe (PDA) créée par l'
+déterministe (PDA) créée par le
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
 
 <Callout type="info">
-  Seuls les token accounts créés par l'Associated Token Program sont appelés
+  Seuls les comptes de jetons créés par l'Associated Token Program sont appelés
   "associated token accounts."
 </Callout>
 
 Les ATA utilisent des adresses déterministes, ce qui facilite la recherche du
-token account de n'importe quel portefeuille pour un mint donné. Voir
-[l'implémentation de la dérivation ici](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
+compte de jetons de n'importe quel portefeuille pour un mint donné. Voir
+[l'implémentation de dérivation ici](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -116,15 +116,15 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 
 Pour toute combinaison de portefeuille et de jeton, il existe exactement une
 adresse ATA. Cela élimine la nécessité de suivre manuellement les adresses des
-token accounts—vous pouvez toujours dériver l'adresse correcte.
+comptes de jetons — vous pouvez toujours dériver l'adresse correcte.
 
 <Callout type="info">
   **Comment fonctionne l'Associated Token Program**
 
 L'Associated Token Program est un assistant qui :
 
-- Crée des comptes de jetons à des adresses déterministes (PDAs)
-- Effectue des Cross Program Invocations (CPIs) vers le Token Program
+- Crée des comptes de jetons à des adresses déterministes (PDA)
+- Effectue des Cross Program Invocation (CPI) vers le Token Program
 - Ne maintient aucun état par lui-même
 
 Les comptes de jetons résultants appartiennent au Token Program et utilisent la
@@ -141,9 +141,9 @@ Voir
 
 Vous avez besoin de deux instructions pour créer un compte de jetons :
 
-1. System Program : Créer un compte avec l'espace alloué pour un compte de
+1. System Program : créer un compte avec l'espace alloué pour un compte de
    jetons et transférer la propriété au Token Program
-2. Token Program : Initialiser les données du compte de jetons
+2. Token Program : initialiser les données du compte de jetons
 
 ### Typescript
 
@@ -707,12 +707,12 @@ async fn main() -> Result<()> {
 
 ## Comment créer un associated token account
 
-La création d'un Associated Token Account (ATA) nécessite l'instruction
+La création d'un compte de token associé (ATA) nécessite l'instruction
 [`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18).
-Voir
+Consultez
 [l'implémentation ici](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-Cette instruction unique gère automatiquement la création du compte de jetons et
+Cette instruction unique gère automatiquement la création du token account et
 son initialisation via des Cross Program Invocations (CPI).
 
 ### Typescript

--- a/apps/web/content/docs/id/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/id/tokens/basics/create-mint.mdx
@@ -5,7 +5,8 @@ description: Pelajari cara membuat SPL Token mint.
 
 ## Apa itu Mint Account?
 
-Akun mint secara unik mewakili token di Solana dan menyimpan metadata globalnya.
+Mint account secara unik mewakili token di Solana dan menyimpan metadata
+globalnya.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -31,13 +32,13 @@ pub struct Mint {
 <Callout type="info">
   Perhatikan bahwa baik [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30)
-  maupun [Token Extension
+  dan [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
   berbagi implementasi dasar yang sama untuk akun Mint.
 </Callout>
 
-Setiap token di Solana memiliki akun mint, dan alamat mint berfungsi sebagai
-pengidentifikasi unik token tersebut.
+Setiap token di Solana memiliki mint account, dan alamat mint berfungsi sebagai
+pengenal unik token.
 
 Sebagai contoh, USD Coin (USDC) memiliki alamat mint
 `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Alamat ini secara unik
@@ -47,20 +48,20 @@ di
 
 ## Cara Membuat Mint Account
 
-Membuat akun mint memerlukan instruksi
+Membuat mint account memerlukan instruksi
 [`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37).
 Lihat
 [detail implementasi di sini](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-Anda perlu menjalankan dua instruksi untuk membuat akun mint:
+Anda perlu menjalankan dua instruksi untuk membuat mint account:
 
-1. System Program: Membuat akun dengan ruang yang dialokasikan untuk akun mint
-   dan mentransfer kepemilikan ke Token Program.
-2. Token Program: Menginisialisasi data akun mint
+1. System Program: Membuat akun dengan ruang yang dialokasikan untuk mint
+   account dan mentransfer kepemilikan ke Token Program.
+2. Token Program: Menginisialisasi data mint account
 
 ### Typescript
 
-<CodeTabs storage="token-ts">
+<CodeTabs storage="token-ts" flags="r">
 
 ```ts !! title="Kit"
 import {
@@ -265,7 +266,7 @@ console.log("Mint Address:", mintPubkey.toBase58());
 
 ### Rust
 
-<CodeTabs storage="token-rs">
+<CodeTabs storage="token-rs" flags="r">
 
 ```rust !! title="Rust Async"
 use anyhow::Result;

--- a/apps/web/content/docs/id/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/id/tokens/basics/create-token-account.mdx
@@ -6,7 +6,7 @@ description: Pelajari cara membuat SPL Token Accounts.
 ## Apa itu Token Account?
 
 Token account menyimpan saldo Anda untuk token tertentu. Setiap token account
-terkait dengan tepat satu mint dan melacak saldo token Anda serta detail
+terhubung dengan tepat satu mint dan melacak saldo token Anda serta detail
 tambahan lainnya.
 
 ```rust title="Token Account Type"
@@ -46,8 +46,8 @@ pub struct Account {
   berbagi implementasi dasar yang sama untuk Token account.
 </Callout>
 
-Untuk menyimpan token, Anda membutuhkan token account untuk mint tertentu
-tersebut. Setiap token account melacak:
+Untuk menyimpan token, Anda memerlukan token account untuk mint tertentu. Setiap
+token account melacak:
 
 1. **Mint**: Jenis token spesifik yang disimpan
 2. **Owner**: Otoritas yang dapat mentransfer token dari akun ini
@@ -57,7 +57,7 @@ tersebut. Setiap token account melacak:
 - Alamat mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
 - Token account Circle: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
 - Akun ini hanya menyimpan token USDC
-- Circle mengendalikan token melalui otoritas pemilik token account:
+- Circle mengontrol token melalui otoritas pemilik token account:
   `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
 Anda dapat melihat detail token account ini di
@@ -91,8 +91,8 @@ oleh
   "associated token accounts."
 </Callout>
 
-ATA menggunakan alamat deterministik, memudahkan untuk menemukan token account
-dompet mana pun untuk mint tertentu. Lihat
+ATA menggunakan alamat deterministik, sehingga mudah untuk menemukan token
+account wallet manapun untuk mint tertentu. Lihat
 [implementasi derivasi di sini](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
@@ -113,18 +113,18 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-Untuk kombinasi dompet dan token apa pun, hanya ada satu alamat ATA. Ini
+Untuk setiap kombinasi wallet dan token, terdapat tepat satu alamat ATA. Ini
 menghilangkan kebutuhan untuk melacak alamat token account secara manual—Anda
 selalu dapat menurunkan alamat yang benar.
 
 <Callout type="info">
   **Bagaimana Associated Token Program Bekerja**
 
-Associated Token Program adalah program pembantu yang:
+Associated Token Program adalah pembantu yang:
 
 - Membuat token account di alamat deterministik (PDA)
-- Melakukan Cross-Program Invocation (CPI) ke Token Program
-- Tidak menyimpan state apapun
+- Membuat Cross Program Invocation (CPI) ke Token Program
+- Tidak memelihara status apapun sendiri
 
 Token account yang dihasilkan dimiliki oleh Token Program dan menggunakan
 struktur `Account` standar.
@@ -140,7 +140,7 @@ Lihat
 
 Anda memerlukan dua instruksi untuk membuat token account:
 
-1. System Program: Membuat account dengan ruang yang dialokasikan untuk token
+1. System Program: Membuat akun dengan ruang yang dialokasikan untuk token
    account dan mentransfer kepemilikan ke Token Program
 2. Token Program: Menginisialisasi data token account
 

--- a/apps/web/content/docs/it/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/it/tokens/basics/create-mint.mdx
@@ -34,13 +34,13 @@ pub struct Mint {
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30)
   che il [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
-  condividono la stessa implementazione di base per il Mint account.
+  condividono la stessa implementazione di base per il mint account.
 </Callout>
 
-Ogni token su Solana ha un mint account, e l'indirizzo del mint funge da
+Ogni token su Solana ha un mint account, e l'indirizzo del mint serve come
 identificatore univoco del token.
 
-Ad esempio, USD Coin (USDC) ha l'indirizzo mint
+Per esempio, USD Coin (USDC) ha l'indirizzo mint
 `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Questo indirizzo identifica in
 modo univoco USDC in tutto l'ecosistema Solana. Puoi visualizzare questo mint su
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
@@ -52,11 +52,11 @@ La creazione di un mint account richiede l'istruzione
 Vedi i
 [dettagli di implementazione qui](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-È necessario invocare due istruzioni per creare un mint account:
+Devi invocare due istruzioni per creare un mint account:
 
-1. System Program: crea un account con spazio allocato per un mint account e
+1. System Program: Crea un account con spazio allocato per un mint account e
    trasferisci la proprietà al Token Program.
-2. Token Program: inizializza i dati del mint account
+2. Token Program: Inizializza i dati del mint account
 
 ### Typescript
 

--- a/apps/web/content/docs/it/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/it/tokens/basics/create-token-account.mdx
@@ -6,8 +6,8 @@ description: Impara come creare gli SPL Token Account.
 ## Cos'è un token account?
 
 Un token account memorizza il tuo saldo di un token specifico. Ogni token
-account è associato a esattamente una mint e tiene traccia del tuo saldo token e
-di dettagli aggiuntivi.
+account è associato esattamente a una mint e tiene traccia del tuo saldo di
+token e di ulteriori dettagli.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -39,9 +39,9 @@ pub struct Account {
 
 <Callout type="info">
   Nota che nel codice sorgente, gli sviluppatori chiamano un Token account un
-  tipo `Account` . Sia il [Token
+  tipo `Account`. Sia il [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)
-  che il [Token Extension
+  che il [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
   condividono la stessa implementazione di base per il token account.
 </Callout>
@@ -64,15 +64,15 @@ Puoi visualizzare i dettagli di questo token account su
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  **Comprendere la terminologia "Owner"
+  **Comprendere la terminologia "Owner"**
 
 Il termine "owner" può essere utilizzato in due contesti diversi:
 
 1. **Owner del token account**: L'autorità che può trasferire, bruciare o
    delegare token. Questo è memorizzato nei dati del token account.
 
-2. **Program Owner**: Il programma che possiede l'account (sempre il Token
-   Program o Token Extension Program per i token account).
+2. **Program owner**: Il programma che possiede l'account (sempre il Token
+   Program o il Token Extensions Program per i token account).
 
 Quando si lavora con i token account, "owner" si riferisce tipicamente
 all'autorità che può trasferire token, non al programma che possiede l'account.
@@ -83,16 +83,16 @@ all'autorità che può trasferire token, non al programma che possiede l'account
 
 Un associated token account (ATA) è il token account predefinito per un wallet
 per detenere un token specifico. Utilizza un indirizzo deterministico (PDA)
-creato dall'
+creato dal
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
 
 <Callout type="info">
   Solo i token account creati dall'Associated Token Program sono chiamati
-  "associated token account."
+  "associated token accounts."
 </Callout>
 
 Gli ATA utilizzano indirizzi deterministici, rendendo facile trovare il token
-account di qualsiasi wallet per una data mint. Vedi
+account di qualsiasi wallet per un dato mint. Vedi
 [l'implementazione della derivazione qui](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
@@ -123,7 +123,7 @@ dei token account—puoi sempre derivare l'indirizzo corretto.
 L'Associated Token Program è un helper che:
 
 - Crea token account a indirizzi deterministici (PDA)
-- Effettua Cross-Program Invocation (CPI) verso il Token Program
+- Effettua Cross Program Invocation (CPI) verso il Token Program
 - Non mantiene alcuno stato proprio
 
 I token account risultanti sono di proprietà del Token Program e utilizzano la
@@ -136,13 +136,13 @@ struttura standard `Account`.
 La creazione di un token account richiede l'istruzione
 [`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63).
 Vedi
-l'[implementazione qui](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
+[l'implementazione qui](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
 Sono necessarie due istruzioni per creare un token account:
 
-1. System Program: crea un account con spazio allocato per un token account e
-   trasferisce la proprietà al Token Program
-2. Token Program: inizializza i dati del token account
+1. System Program: Crea un account con spazio allocato per un token account e
+   trasferisci la proprietà al Token Program
+2. Token Program: Inizializza i dati del token account
 
 ### Typescript
 

--- a/apps/web/content/docs/ja/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/ja/tokens/basics/create-mint.mdx
@@ -1,11 +1,12 @@
 ---
-title: トークンミントを作成する
+title: トークンミントの作成
 description: SPLトークンミントの作成方法を学びましょう。
 ---
 
 ## ミントアカウントとは？
 
-ミントアカウントはSolana上のトークンを一意に表し、そのグローバルメタデータを保存します。
+mint
+accountはSolana上でトークンを一意に表し、そのグローバルメタデータを保存します。
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -31,9 +32,9 @@ pub struct Mint {
 <Callout type="info">
   [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30)
-  と [Token Extension
+  と[Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
-  の両方がミントアカウントに対して同じ基本実装を共有していることに注意してください。
+  の両方が、ミントアカウントに対して同じ基本実装を共有していることに注意してください。
 </Callout>
 
 Solana上のすべてのトークンにはミントアカウントがあり、ミントのアドレスがトークンの一意の識別子として機能します。

--- a/apps/web/content/docs/ja/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/ja/tokens/basics/create-token-account.mdx
@@ -36,10 +36,11 @@ pub struct Account {
 ```
 
 <Callout type="info">
-  ソースコードでは、開発者はトークンアカウントを`Account`タイプと呼んでいることに注意してください。[Token
+  ソースコードでは、開発者はトークンアカウントを `Account`
+  型と呼んでいることに注意してください。[Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)と[Token
-  Extension
-  Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)は、トークンアカウントに対して同じ基本実装を共有しています。
+  Extensions
+  Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)は両方ともトークンアカウントの同じ基本実装を共有しています。
 </Callout>
 
 トークンを保有するには、その特定のミント用のトークンアカウントが必要です。各トークンアカウントは以下を追跡します：
@@ -55,8 +56,7 @@ pub struct Account {
 - Circleはトークンアカウントオーナー権限を通じてトークンを管理：
   `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
-このtoken
-accountの詳細は[Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa)で確認できます。
+このトークンアカウントの詳細は[Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa)で確認できます。
 
 <Callout type="info">
   **「オーナー」という用語の理解**
@@ -72,17 +72,17 @@ accountの詳細は[Solana Explorer](https://explorer.solana.com/address/3emsAVd
 
 </Callout>
 
-## associated token accountとは？
+## アソシエイテッドトークンアカウントとは？
 
-associated token
-account（ATA）は、ウォレットが特定のトークンを保有するためのデフォルトのトークンアカウントです。[Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program)によって作成された決定論的なアドレス（PDA）を使用します。
+アソシエイテッドトークンアカウント（ATA）は、ウォレットが特定のトークンを保持するためのデフォルトのトークンアカウントです。これは[Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program)によって作成された決定論的なアドレス（PDA）を使用します。
 
 <Callout type="info">
-  Associated Token Programによって作成されたトークンアカウントのみが「associated
-  token accounts」と呼ばれます。
+  Associated Token Programによって作成されたトークンアカウントのみが "associated
+  token accounts"と呼ばれます。
 </Callout>
 
-ATAは決定論的なアドレスを使用するため、特定のミントに対する任意のウォレットのトークンアカウントを簡単に見つけることができます。[派生実装はこちら](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56)をご覧ください。
+ATAは決定論的なアドレスを使用するため、特定のミントに対する任意のウォレットのトークンアカウントを簡単に見つけることができます。
+[導出の実装はこちら](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56)をご覧ください。
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -102,16 +102,16 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-任意のウォレットとトークンの組み合わせに対して、正確に1つのATAアドレスが存在します。これによりトークンアカウントアドレスを手動で追跡する必要がなくなり、常に正しいアドレスを導出できます。
+任意のウォレットとトークンの組み合わせに対して、正確に1つのATAアドレスが存在します。これにより、トークンアカウントのアドレスを手動で追跡する必要がなくなります—常に正しいアドレスを導出することができます。
 
 <Callout type="info">
   **Associated Token Programの仕組み**
 
-Associated Token Programは以下を行うヘルパープログラムです：
+Associated Token Programは以下を行うヘルパーです：
 
 - 決定論的なアドレス（PDA）でトークンアカウントを作成する
 - Token Programへのクロスプログラム呼び出し（CPI）を行う
-- 自身では状態を保持しない
+- 自身では状態を維持しない
 
 作成されたトークンアカウントはToken Programによって所有され、標準的な
 `Account`構造を使用します。
@@ -692,14 +692,15 @@ async fn main() -> Result<()> {
 
 </CodeTabs>
 
-## Associated Token Accountの作成方法
+## associated token accountの作成方法
 
-Associated Token Account（ATA）の作成には
-[`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
-instruction が必要です。
+Associated Token Account（ATA）を作成するには、
+[---INLINE-CODE-PLACEHOLDER-85c08564ca556b926744bf94497c4af2---](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
+instructionsが必要です。
 [実装はこちら](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66)をご覧ください。
 
-この単一のinstructionは、クロスプログラム呼び出し（CPI）を通じて、トークンアカウントの作成と初期化を自動的に処理します。
+この単一のinstructionsは、Cross Program Invocation（CPI）を通じてtoken
+accountの作成と初期化を自動的に処理します。
 
 ### Typescript
 

--- a/apps/web/content/docs/ko/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/ko/tokens/basics/create-mint.mdx
@@ -5,7 +5,7 @@ description: SPL 토큰 민트를 생성하는 방법을 알아보세요.
 
 ## 민트 계정이란 무엇인가요?
 
-민트 계정은 솔라나에서 토큰을 고유하게 나타내며 해당 토큰의 전역 메타데이터를
+민트 계정은 Solana에서 토큰을 고유하게 나타내며 토큰의 전역 메타데이터를
 저장합니다.
 
 ```rust title="Mint Account Type"
@@ -32,28 +32,28 @@ pub struct Mint {
 <Callout type="info">
   [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30)과
-  [Token Extension
+  [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
   모두 민트 계정에 대해 동일한 기본 구현을 공유한다는 점에 유의하세요.
 </Callout>
 
-솔라나의 모든 토큰은 민트 계정을 가지고 있으며, 민트의 주소는 토큰의 고유 식별자
+Solana의 모든 토큰은 민트 계정을 가지고 있으며, 민트의 주소는 토큰의 고유 식별자
 역할을 합니다.
 
 예를 들어, USD 코인(USDC)은 민트 주소
 `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`를 가지고 있습니다. 이 주소는
-솔라나 생태계 전체에서 USDC를 고유하게 식별합니다. 이 민트는
-[솔라나 익스플로러](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)에서
-확인할 수 있습니다.
+Solana 생태계 전체에서 USDC를 고유하게 식별합니다.
+[Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)에서
+이 민트를 볼 수 있습니다.
 
-## 민트 계정 생성 방법
+## 민트 계정을 생성하는 방법
 
 민트 계정을 생성하려면
 [`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37)
 명령어가 필요합니다.
 [여기에서 구현 세부 정보를 확인하세요](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-민트 계정을 생성하려면 두 가지 명령어를 실행해야 합니다:
+민트 계정을 생성하려면 두 가지 명령어를 호출해야 합니다:
 
 1. System Program: 민트 계정을 위한 공간이 할당된 계정을 생성하고 소유권을 Token
    Program으로 이전합니다.
@@ -61,7 +61,7 @@ pub struct Mint {
 
 ### 타입스크립트
 
-<CodeTabs storage="token-ts">
+<CodeTabs storage="token-ts" flags="r">
 
 ```ts !! title="Kit"
 import {
@@ -266,7 +266,7 @@ console.log("Mint Address:", mintPubkey.toBase58());
 
 ### 러스트
 
-<CodeTabs storage="token-rs">
+<CodeTabs storage="token-rs" flags="r">
 
 ```rust !! title="Rust Async"
 use anyhow::Result;

--- a/apps/web/content/docs/ko/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/ko/tokens/basics/create-token-account.mdx
@@ -5,9 +5,8 @@ description: SPL 토큰 계정을 생성하는 방법을 알아보세요.
 
 ## 토큰 계정이란 무엇인가요?
 
-토큰 계정은 Solana의 Token Programs에서 특정 토큰(민트)에 대한 개인의 소유권
-정보를 저장하는 계정 유형입니다. 각 토큰 계정은 하나의 민트와 연결되어 토큰 잔액
-및 소유자와 같은 세부 정보를 추적합니다.
+토큰 계정은 특정 토큰의 잔액을 저장합니다. 각 토큰 계정은 정확히 하나의 민트와
+연결되어 있으며 토큰 잔액과 추가 세부 정보를 추적합니다.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -38,68 +37,61 @@ pub struct Account {
 ```
 
 <Callout type="info">
-  소스 코드에서 개발자들은 토큰 계정을 `Account` 유형이라고 부릅니다. [Token
+  소스 코드에서 개발자들은 토큰 계정을 `Account` 타입이라고 부릅니다. [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)과
-  [Token Extension
+  [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
   모두 토큰 계정에 대해 동일한 기본 구현을 공유합니다.
 </Callout>
 
-특정 민트의 토큰을 보유하려면 사용자는 먼저 토큰 계정을 생성해야 합니다. 각 토큰
-계정은 다음 사항을 추적합니다:
+토큰을 보유하려면 해당 민트에 대한 토큰 계정이 필요합니다. 각 토큰 계정은 다음을
+추적합니다:
 
-1. 특정 민트(토큰 계정이 보유하는 토큰 유형)
-2. 소유자(계정에서 토큰을 전송할 수 있는 권한을 가진 주체)
+1. **민트**: 보유하는 특정 토큰 유형
+2. **소유자**: 이 계정에서 토큰을 전송할 수 있는 권한을 가진 주체
 
-다음은 Solana에서 USD Coin(USDC)을 사용하는 예시입니다:
+### 예시: USD 코인 (USDC)
 
-- USD Coin 민트 주소: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- Circle(USD Coin 발행자)은 `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-  주소에 토큰 계정을 가지고 있습니다
-- 이 토큰 계정은 USD Coin 토큰(민트) 단위만 보유합니다
-- Circle은 `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE` 주소에 소유자 권한을
-  가지고 있으며 이 토큰들을 전송할 수 있습니다
+- 민트 주소: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- Circle의 토큰 계정: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- 이 계정은 USDC 토큰만 보유합니다
+- Circle은 토큰 계정 소유자 권한을 통해 토큰을 제어합니다:
+  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
-[Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa)에서
+[솔라나 익스플로러](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa)에서
 이 토큰 계정의 세부 정보를 볼 수 있습니다.
 
 <Callout type="info">
-  "소유자"라는 용어는 두 가지 다른 맥락에서 사용됩니다:
+  **"소유자" 용어 이해하기**
 
-1. 토큰 계정 "소유자" - 이는 Token Program에서 정의한
-   [Account](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L106)
-   유형의 "소유자" 필드로 토큰 계정의 데이터에 저장된 주소입니다. 소유자는
-   계정에서 토큰을 전송, 소각 또는 위임할 수 있습니다. 이 주소는 프로그램
-   소유자와 구별하기 위해 때때로 토큰 계정의 "권한자"라고도 불립니다.
+"소유자"라는 용어는 두 가지 다른 맥락에서 사용될 수 있습니다:
 
-2. 프로그램 "owner" - 이는 Solana에서 계정 데이터를 소유한 프로그램을
-   의미합니다. 토큰 계정의 경우, 이는 항상 Token Program 또는 Token Extension
-   Program 중 하나이며, 기본 Solana
-   [Account](https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/account/src/lib.rs#L51)
-   타입의 "owner" 필드에 명시되어 있습니다.
+1. **토큰 계정 소유자**: 토큰을 전송, 소각 또는 위임할 수 있는 권한을 가진
+   주체입니다. 이는 토큰 계정의 데이터에 저장됩니다.
 
-토큰 계정을 다룰 때, "owner"는 일반적으로 계정을 소유한 프로그램이 아니라 토큰을
-사용할 수 있는 권한을 가진 주체를 의미합니다.
+2. **프로그램 소유자**: 계정을 소유한 프로그램(토큰 계정의 경우 항상 Token
+   Program 또는 Token Extensions Program)입니다.
+
+토큰 계정을 다룰 때 "소유자"는 일반적으로 계정을 소유한 프로그램이 아닌 토큰을
+전송할 수 있는 권한을 가진 주체를 의미합니다.
 
 </Callout>
 
 ## Associated Token Account란 무엇인가요?
 
-Associated token account는
+Associated token account(ATA)는 지갑이 특정 토큰을 보유하기 위한 기본 토큰
+계정입니다. 이는
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program)에
-의해 생성된 Program Derived Address(PDA)를 주소로 가진 토큰 계정입니다.
-Associated token account는 사용자가 특정 토큰(민트)의 단위를 보유하기 위한 기본
-토큰 계정이라고 생각할 수 있습니다.
+의해 생성된 결정론적 주소(PDA)를 사용합니다.
 
 <Callout type="info">
-  "associated token accounts"라는 용어는 Associated Token Program이 생성한 토큰
-  계정에만 적용됩니다.
+  Associated Token Program에 의해 생성된 토큰 계정만이 "associated token
+  accounts"라고 불립니다.
 </Callout>
 
-Associated token account는 주어진 민트에 대한 사용자의 토큰 계정을 결정적으로
-찾을 수 있는 방법을 제공합니다. 파생 구현은
-[여기](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56)에서
-확인할 수 있습니다.
+ATA는 결정론적 주소를 사용하여 주어진 민트에 대한 지갑의 토큰 계정을 쉽게 찾을
+수 있게 합니다.
+[여기에서 파생 구현을 확인하세요](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -119,34 +111,36 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-이러한 결정적 파생은 지갑 주소와 토큰 민트의 모든 조합에 대해 정확히 하나의
-associated token account 주소가 존재함을 보장합니다. 이 접근 방식은 주어진 토큰
-민트에 대한 사용자의 토큰 계정을 쉽게 찾을 수 있게 해주어, 토큰 계정 주소를
-별도로 추적할 필요성을 제거합니다.
+모든 지갑과 토큰 조합에 대해 정확히 하나의 ATA 주소가 있습니다. 이로 인해 토큰
+계정 주소를 수동으로 추적할 필요가 없어집니다—항상 올바른 주소를 도출할 수
+있습니다.
 
 <Callout type="info">
-  Associated Token Program은 결정적 주소(PDA)를 가진 토큰 계정을 생성하는 헬퍼
-  프로그램으로 기능합니다. Associated token account를 생성할 때, Associated
-  Token Program은 Token Program 또는 Token Extension Program에 CPI(Cross-Program
-  Invocation)를 수행합니다. 토큰 프로그램은 생성된 계정을 소유하며, 이 계정은
-  토큰 프로그램에 정의된 것과 동일한 `Account` 타입 구조를 가집니다. Associated
-  Token Program은 상태를 유지하지 않으며, 단순히 PDA인 결정적 주소에서 토큰
-  계정을 생성하는 표준화된 방법을 제공합니다.
+  **Associated Token Program의 작동 방식**
+
+Associated Token Program은 다음과 같은 도우미 역할을 합니다:
+
+- 결정론적 주소(PDA)에 토큰 계정 생성
+- Token Program에 Cross-Program Invocation(CPI) 수행
+- 자체적으로 상태를 유지하지 않음
+
+결과적으로 생성된 토큰 계정은 Token Program이 소유하며 표준 `Account` 구조를
+사용합니다.
+
 </Callout>
 
-## 토큰 계정 생성 방법
+## 토큰 계정을 생성하는 방법
 
 토큰 계정을 생성하려면
-[`InitializeAccount`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L93)
-명령어를 호출하세요. 이 명령어의 구현은
-[여기](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L145)에서
-찾을 수 있습니다.
+[`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63)
+명령이 필요합니다.
+[여기에서 구현을 확인하세요](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
-토큰 계정을 생성하는 트랜잭션에는 두 가지 명령어가 필요합니다:
+토큰 계정을 생성하려면 두 가지 명령이 필요합니다:
 
-1. System Program을 호출하여 토큰 계정을 생성하고 공간을 할당한 다음 소유권을
-   Token Program으로 이전합니다.
-2. Token Program을 호출하여 토큰 계정 데이터를 초기화합니다.
+1. System Program: 토큰 계정을 위한 공간이 할당된 계정을 생성하고 소유권을 Token
+   Program에 이전
+2. Token Program: 토큰 계정 데이터 초기화
 
 ### Typescript
 
@@ -174,8 +168,8 @@ import {
   getInitializeMintInstruction,
   getMintSize,
   getTokenSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -203,18 +197,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -244,8 +238,8 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address);
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", transactionSignature);
 
 // Generate keypair to use as address of token account
 const tokenAccount = await generateKeyPairSigner();
@@ -258,18 +252,18 @@ const tokenAccountRent = await rpc
   .getMinimumBalanceForRentExemption(tokenAccountSpace)
   .send();
 
-// Instruction to create new account for token account (token 2022 program)
+// Instruction to create new account for token account (token program)
 // Invokes the system program
 const createTokenAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: tokenAccount,
   lamports: tokenAccountRent,
   space: tokenAccountSpace,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize token account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeTokenAccountInstruction = getInitializeAccount2Instruction({
   account: tokenAccount.address,
   mint: mint.address,
@@ -300,11 +294,10 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 );
 
 // Get transaction signature
-const tokenAccountTxSignature =
-  getSignatureFromTransaction(signedTokenAccountTx);
+const transactionSignature2 = getSignatureFromTransaction(signedTokenAccountTx);
 
 console.log("Token Account Address:", tokenAccount.address);
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -323,12 +316,12 @@ import {
   getMinimumBalanceForRentExemptMint,
   getMinimumBalanceForRentExemptAccount,
   ACCOUNT_SIZE,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -339,8 +332,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -356,7 +349,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -365,14 +358,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -398,7 +391,7 @@ const createTokenAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: tokenAccount.publicKey,
   space: ACCOUNT_SIZE,
   lamports: tokenAccountRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize token account instruction
@@ -406,14 +399,14 @@ const initializeTokenAccountInstruction = createInitializeAccountInstruction(
   tokenAccount.publicKey, // token account
   mint.publicKey, // mint
   feePayer.publicKey, // owner
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for token account
 let tokenAccountTransaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createTokenAccountInstruction, initializeTokenAccountInstruction);
 
 // Sign and send transaction
@@ -424,20 +417,16 @@ const tokenAccountTxSignature = await sendAndConfirmTransaction(
 );
 
 console.log("Token Account Address:", tokenAccount.publicKey.toBase58());
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import {
-  createMint,
-  createAccount,
-  TOKEN_2022_PROGRAM_ID
-} from "@solana/spl-token";
+import { createMint, createAccount, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -448,8 +437,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -464,9 +453,9 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create token account using helper function
 const tokenAccount = await createAccount(
@@ -478,9 +467,9 @@ const tokenAccount = await createAccount(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
+console.log("Token Account Address:", tokenAccount.toBase58());
 ```
 
 </CodeTabs>
@@ -488,128 +477,6 @@ console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{
-    id as token_2022_program_id,
-    instruction::{initialize_account, initialize_mint},
-    state::{Account, Mint},
-};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Generate keypair to use as address of token account
-    let token_account = Keypair::new();
-
-    // Get token account size (in bytes)
-    let token_account_space = Account::LEN;
-    let token_account_rent = client.get_minimum_balance_for_rent_exemption(token_account_space)?;
-
-    // Instruction to create new account for token account (token 2022 program)
-    let create_token_account_instruction = create_account(
-        &fee_payer.pubkey(),        // payer
-        &token_account.pubkey(),    // new account (token account)
-        token_account_rent,         // lamports
-        token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
-    );
-
-    // Instruction to initialize token account data
-    let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
-        &token_account.pubkey(), // account
-        &mint.pubkey(),          // mint
-        &fee_payer.pubkey(),     // owner
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[
-            create_token_account_instruction,
-            initialize_token_account_instruction,
-        ],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &token_account],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Token Account Address: {}", token_account.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -621,8 +488,8 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{
-    id as token_2022_program_id,
+use spl_token::{
+    id as token_program_id,
     instruction::{initialize_account, initialize_mint},
     state::{Account, Mint},
 };
@@ -634,7 +501,7 @@ async fn main() -> Result<()> {
         String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -661,18 +528,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(mint_space)
         .await?;
 
-    // Instruction to create new account for mint (token 2022 program)
+    // Instruction to create new account for mint (token program)
     let create_account_instruction = create_account(
         &fee_payer.pubkey(),      // payer
         &mint.pubkey(),           // new account (mint)
         mint_rent,                // lamports
         mint_space as u64,        // space
-        &token_2022_program_id(), // program id
+        &token_program_id(), // program id
     );
 
     // Instruction to initialize mint account data
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -684,7 +551,7 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -702,18 +569,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(token_account_space)
         .await?;
 
-    // Instruction to create new account for token account (token 2022 program)
+    // Instruction to create new account for token account (token program)
     let create_token_account_instruction = create_account(
         &fee_payer.pubkey(),        // payer
         &token_account.pubkey(),    // new account (token account)
         token_account_rent,         // lamports
         token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
+        &token_program_id(),   // program id
     );
 
     // Instruction to initialize token account data
     let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
+        &token_program_id(),
         &token_account.pubkey(), // account
         &mint.pubkey(),          // mint
         &fee_payer.pubkey(),     // owner
@@ -727,7 +594,7 @@ async fn main() -> Result<()> {
         ],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &token_account],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -747,7 +614,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -793,10 +660,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 2;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -829,24 +696,21 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
     Ok(())
 }
 ```
 
 </CodeTabs>
 
-## associated token account 생성 방법
+## Associated Token Account를 생성하는 방법
 
-associated token account를 생성하려면
+Associated Token Account(ATA)를 생성하려면
 [`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
-명령어를 호출하세요. 이 명령어의 구현은
-[여기](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66)에서
-찾을 수 있습니다.
+명령어가 필요합니다.
+[여기에서 구현을 확인하세요](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-associated token account를 생성하는 명령어는 자동으로 System Program을 호출하여
-토큰 계정을 생성하고 Token Program을 호출하여 토큰 계정 데이터를 초기화합니다.
-이 과정은 Cross Program Invocation(CPI)을 통해 이루어집니다.
+이 단일 명령어는 Cross Program Invocation(CPI)을 통해 토큰 계정 생성과 초기화를
+자동으로 처리합니다.
 
 ### Typescript
 
@@ -873,9 +737,9 @@ import {
   getCreateAssociatedTokenInstructionAsync,
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda
-} from "@solana-program/token-2022";
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -903,18 +767,18 @@ const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 // Get latest blockhash to include in transaction
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -944,18 +808,18 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address.toString());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address.toString());
+console.log("Transaction Signature:", transactionSignature);
 
 // Use findAssociatedTokenPda to derive the ATA address
 const [associatedTokenAddress] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: feePayer.address,
-  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
 });
 
 console.log(
-  "Associated Token Account Address: ",
+  "Associated Token Account Address:",
   associatedTokenAddress.toString()
 );
 
@@ -989,7 +853,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 
 // Get transaction signature
 const transactionSignature2 = getSignatureFromTransaction(signedTransaction2);
-console.log("Transaction Signature: ", transactionSignature2);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -1005,7 +869,7 @@ import {
   createInitializeMintInstruction,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountInstruction,
   ASSOCIATED_TOKEN_PROGRAM_ID
@@ -1013,7 +877,7 @@ import {
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1024,8 +888,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1041,7 +905,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -1050,14 +914,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -1075,7 +939,7 @@ const associatedTokenAccount = getAssociatedTokenAddressSync(
   mint.publicKey,
   feePayer.publicKey,
   false, // allowOwnerOffCurve
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
@@ -1085,15 +949,15 @@ const createAssociatedTokenAccountIx = createAssociatedTokenAccountInstruction(
   associatedTokenAccount, // associated token account address
   feePayer.publicKey, // owner
   mint.publicKey, // mint
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for associated token account
 let transaction2 = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAssociatedTokenAccountIx);
 
 // Sign and send transaction
@@ -1115,12 +979,12 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import {
   createMint,
   createAssociatedTokenAccount,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1131,8 +995,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1147,365 +1011,32 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create associated token account using helper function
 const associatedTokenAccount = await createAssociatedTokenAccount(
-  connection, // connection
-  feePayer, // fee payer
-  mintPubkey, // mint
-  feePayer.publicKey, // owner
+  connection,
+  feePayer,
+  mintPubkey,
+  feePayer.publicKey,
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
 console.log(
-  `Associated Token Account Address: ${associatedTokenAccount.toBase58()}`
+  "Associated Token Account Address:",
+  associatedTokenAccount.toBase58()
 );
 ```
 
 </CodeTabs>
 
-### 러스트
+### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction and add instruction
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Rust Async"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client
-        .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
-        .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client
-        .get_minimum_balance_for_rent_exemption(mint_space)
-        .await?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address (owner)
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction for associated token account creation
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account.to_string()
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://localhost:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Derive the associated token account address
-    let associated_token_address = token.get_associated_token_address(&payer.pubkey());
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_address
-    );
-
-    // Create associated token account for the payer
-    let result = token
-        .create_associated_token_account(
-            &payer.pubkey(), // owner
-        )
-        .await?;
-
-    println!(" {}", result);
-
-    Ok(())
-}
-```
-
-</CodeTabs>
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -1724,3 +1255,4 @@ async fn main() -> Result<()> {
 }
 ```
 
+</CodeTabs>

--- a/apps/web/content/docs/nl/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/nl/tokens/basics/create-mint.mdx
@@ -5,9 +5,8 @@ description: Leer hoe je een SPL Token mint aanmaakt.
 
 ## Wat is een mint account?
 
-Een mint account is een account type in Solana's Token Programs dat op unieke
-wijze een token op het netwerk vertegenwoordigt en globale metadata over het
-token opslaat.
+Een mint account vertegenwoordigt uniek een token op Solana en slaat de globale
+metadata ervan op.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -38,28 +37,26 @@ pub struct Mint {
   dezelfde basisimplementatie delen voor het mint account.
 </Callout>
 
-Elke token op Solana bestaat als een mint account waarbij het adres van het mint
-account de unieke identificatie op het netwerk is.
+Elke token op Solana heeft een mint account, en het adres van de mint dient als
+unieke identificatie van de token.
 
-Bijvoorbeeld, de USD Coin (USDC) digitale dollar op Solana heeft het mint adres
-`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Dit mint adres dient als de
-unieke identificatie van USD Coin in het hele Solana ecosysteem. Je kunt details
-over dit mint account bekijken op
+USD Coin (USDC) heeft bijvoorbeeld het mint adres
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Dit adres identificeert USDC
+uniek in het hele Solana ecosysteem. Je kunt deze mint bekijken op
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
 ## Hoe maak je een mint account aan
 
-Om een mint account aan te maken, roep je de
-[`InitializeMint`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L65)
-instructie aan. Je kunt implementaties van deze instructie
-[hier](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L79)
-vinden.
+Voor het aanmaken van een mint account is de
+[`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37)
+instructie nodig. Bekijk de
+[implementatiedetails hier](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-De transactie om een mint account aan te maken heeft twee instructies nodig:
+Je moet twee instructies uitvoeren om een mint account aan te maken:
 
-1. Roep het System Program aan om een mint account te creëren en ruimte toe te
-   wijzen en de eigendom over te dragen aan het Token Program.
-2. Roep het Token Program aan om de mint account data te initialiseren.
+1. System Program: Maak een account aan met gereserveerde ruimte voor een mint
+   account en draag het eigendom over aan het Token Program.
+2. Token Program: Initialiseer de mint account data
 
 ### Typescript
 
@@ -85,11 +82,11 @@ import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Generate keypairs for fee payer
@@ -111,18 +108,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 9,
@@ -156,7 +153,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
 console.log("Mint Address:", mint.address);
-console.log("Transaction Signature:", transactionSignature);
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy"
@@ -170,14 +167,14 @@ import {
 } from "@solana/web3.js";
 import {
   createInitializeMintInstruction,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -188,8 +185,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -201,15 +198,15 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: await getMinimumBalanceForRentExemptMint(connection),
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 const initializeMintInstruction = createInitializeMintInstruction(
-  mint.publicKey, // mint pubkey
-  9, // decimals
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  mint.publicKey,
+  9, // Decimals
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  TOKEN_PROGRAM_ID
 );
 
 const transaction = new Transaction().add(
@@ -223,17 +220,17 @@ const transactionSignature = await sendAndConfirmTransaction(
   [feePayer, mint] // Signers
 );
 
-console.log("Mint Address: ", mint.publicKey.toBase58());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { createMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import { createMint, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -244,24 +241,24 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
 const mintPubkey = await createMint(
-  connection, // connection
-  feePayer, // fee payer
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  9, // decimals
-  Keypair.generate(), // keypair
+  connection,
+  feePayer,
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  9, // Decimals
+  Keypair.generate(),
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 ```
 
 </CodeTabs>
@@ -269,82 +266,6 @@ console.log(`Mint Address: ${mintPubkey.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    let mint_space = Mint::LEN;
-    let rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Create account instruction for mint
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(), // program id
-        &mint.pubkey(),           // mint address
-        &fee_payer.pubkey(),      // mint authority
-        Some(&fee_payer.pubkey()),// freeze authority
-        9,                        // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -356,16 +277,16 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
+use spl_token::{id as token_program_id, instruction::initialize_mint, state::Mint};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create connection to local validator
     let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -391,16 +312,16 @@ async fn main() -> Result<()> {
 
     // Create account instruction
     let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // fee payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        space as u64,             // space
-        &token_2022_program_id(), // program id
+        &fee_payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &token_program_id(),
     );
 
     // Initialize mint instruction
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint address
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -412,14 +333,14 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
     let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }
@@ -432,7 +353,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -443,7 +364,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     // Create connection to local validator
     let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
 
@@ -465,7 +386,6 @@ async fn main() -> Result<()> {
 
     // Generate keypair to use as address of mint
     let mint = Keypair::new();
-    println!("Mint keypair generated: {}", mint.pubkey());
 
     // Set up program client for Token client
     let program_client =
@@ -474,10 +394,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 9;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -496,7 +416,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }

--- a/apps/web/content/docs/nl/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/nl/tokens/basics/create-token-account.mdx
@@ -1,14 +1,13 @@
 ---
 title: Een token account aanmaken
-description: Leer hoe je SPL token accounts aanmaakt.
+description: Leer hoe je SPL Token Accounts kunt aanmaken.
 ---
 
 ## Wat is een token account?
 
-Een token account is een accounttype in Solana's Token Programs dat informatie
-opslaat over het eigendom van een specifieke token (mint) door een individu. Elk
-token account is gekoppeld aan een enkele mint en houdt details bij zoals het
-tokensaldo en de eigenaar.
+Een token account bewaart je saldo van een specifieke token. Elk token account
+is gekoppeld aan precies één mint en houdt je tokensaldo en aanvullende details
+bij.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -39,74 +38,64 @@ pub struct Account {
 ```
 
 <Callout type="info">
-  Merk op dat in de broncode ontwikkelaars een token account een `Account` type
+  Merk op dat in de broncode ontwikkelaars een Token account een `Account` type
   noemen. Zowel het [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)
-  als het [Token Extension
+  als het [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
-  delen dezelfde basisimplementatie voor het token account.
+  delen dezelfde basisimplementatie voor het Token account.
 </Callout>
 
-Om tokens voor een specifieke mint te bewaren, moeten gebruikers eerst een token
-account aanmaken. Elk token account houdt bij:
+Om tokens te bewaren, heb je een token account nodig voor die specifieke mint.
+Elk token account houdt bij:
 
-1. Een specifieke mint (het tokentype waarvan het token account eenheden bevat)
-2. Een eigenaar (de autoriteit die tokens van het account kan overmaken)
+1. **Mint**: Het specifieke tokentype dat het bevat
+2. **Eigenaar**: De autoriteit die tokens van dit account kan overmaken
 
-Hier is een voorbeeld met USD Coin (USDC) op Solana:
+### Voorbeeld: USD Coin (USDC)
 
-- Het USD Coin mint-adres: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- Circle (de uitgever van USD Coin) heeft een token account op
-  `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-- Dit token account bevat alleen eenheden van de USD Coin token (mint)
-- Circle heeft eigenaarsbevoegdheid op
-  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE` en kan deze tokens overmaken
+- Mint-adres: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- Circle's token account: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- Dit account bevat alleen USDC tokens
+- Circle beheert tokens via de token account eigenaar autoriteit:
+  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
 Je kunt de details van dit token account bekijken op
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  De term "eigenaar" wordt in twee verschillende contexten gebruikt:
+  **De terminologie van "Eigenaar" begrijpen**
 
-1. De "eigenaar" van het token account - Dit is een adres dat is opgeslagen in
-   de gegevens van het token account als het "owner"-veld van het
-   [Account](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L106)
-   type gedefinieerd door het Token Program. De eigenaar kan tokens van het
-   account overmaken, verbranden of delegeren. Dit adres wordt soms aangeduid
-   als de "autoriteit" van het token account om het te onderscheiden van de
-   programma-eigenaar.
+De term "eigenaar" kan in twee verschillende contexten worden gebruikt:
 
-2. De programma "owner" - Dit verwijst naar het programma dat eigenaar is van de
-   accountgegevens op Solana. Voor token accounts is dit altijd ofwel het Token
-   Program of Token Extension Program, zoals gespecificeerd in het "owner" veld
-   van het basis Solana
-   [Account](https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/account/src/lib.rs#L51)
-   type.
+1. **Token Account Eigenaar**: De autoriteit die tokens kan overmaken,
+   verbranden of delegeren. Dit wordt opgeslagen in de gegevens van het token
+   account.
 
-Bij het werken met token accounts verwijst "owner" meestal naar de autoriteit
-die de tokens kan uitgeven, niet naar het programma dat eigenaar is van het
+2. **Programma Eigenaar**: Het programma dat eigenaar is van het account (altijd
+   het Token Program of Token Extensions Program voor token accounts).
+
+Bij het werken met token accounts verwijst "eigenaar" meestal naar de autoriteit
+die tokens kan overmaken, niet naar het programma dat eigenaar is van het
 account.
 
 </Callout>
 
-## Wat is een Associated Token Account?
+## Wat is een associated token account?
 
-Een associated token account is een token account met een adres dat een Program
-Derived Address (PDA) is, aangemaakt door het
+Een associated token account (ATA) is het standaard token account voor een
+wallet om een specifieke token te bewaren. Het gebruikt een deterministisch
+adres (PDA) gemaakt door het
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
-Je kunt een associated token account zien als het standaard token account voor
-een gebruiker om eenheden van een specifieke token (mint) te bewaren.
 
 <Callout type="info">
-  De term "associated token accounts" is alleen van toepassing op token accounts
-  die door het Associated Token Program worden aangemaakt.
+  Alleen token accounts die zijn aangemaakt door het Associated Token Program
+  worden "associated token accounts" genoemd.
 </Callout>
 
-Associated token accounts bieden een deterministische manier om het token
-account van een gebruiker voor elke gegeven mint te vinden. Je kunt de
-implementatie van de afleiding
-[hier](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56)
-bekijken.
+ATA's gebruiken deterministische adressen, waardoor het gemakkelijk is om het
+token account van een wallet voor een bepaalde mint te vinden. Bekijk de
+[implementatie van de afleiding hier](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -126,37 +115,36 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-Deze deterministische afleiding zorgt ervoor dat er voor elke combinatie van
-walletadres en token mint precies één associated token account adres bestaat.
-Deze aanpak maakt het eenvoudig om het token account van een gebruiker voor elke
-gegeven token mint te vinden, waardoor het niet meer nodig is om token account
-adressen apart bij te houden.
+Voor elke combinatie van wallet en token is er precies één ATA-adres. Dit maakt
+het handmatig bijhouden van token account adressen overbodig—je kunt altijd het
+juiste adres afleiden.
 
 <Callout type="info">
-  Het Associated Token Program fungeert als een hulpprogramma dat token accounts
-  aanmaakt met deterministische adressen (PDAs). Bij het aanmaken van een
-  associated token account, maakt het Associated Token Program een CPI (Cross
-  Program Invocation) naar ofwel het Token Program of Token Extensions Program.
-  Het token program is eigenaar van het aangemaakte account dat dezelfde
-  `Account` typestructuur heeft zoals gedefinieerd in het token program. Het
-  Associated Token Program bewaart geen status - het biedt simpelweg een
-  gestandaardiseerde manier om token accounts aan te maken op een
-  deterministisch adres dat een PDA is.
+  **Hoe het Associated Token Program werkt**
+
+Het Associated Token Program is een hulpprogramma dat:
+
+- Token accounts aanmaakt op deterministische adressen (PDA's)
+- Cross-Program Invocations (CPI's) uitvoert naar het Token Program
+- Zelf geen status bijhoudt
+
+De resulterende token accounts zijn eigendom van het Token Program en gebruiken
+de standaard `Account` structuur.
+
 </Callout>
 
-## Hoe een token account aanmaken
+## Hoe maak je een token account aan
 
-Om een token account aan te maken, roep je de
-[`InitializeAccount`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L93)
-instructie aan. Je kunt implementaties van deze instructie
-[hier](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L145)
-vinden.
+Voor het aanmaken van een token account is de
+[`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63)
+instructie nodig. Bekijk de
+[implementatie hier](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
-De transactie om een token account aan te maken heeft twee instructies nodig:
+Je hebt twee instructies nodig om een token account aan te maken:
 
-1. Roep de System Program aan om een token account aan te maken, ruimte toe te
-   wijzen en het eigendom over te dragen aan het Token Program.
-2. Roep het Token Program aan om de token account gegevens te initialiseren.
+1. System Program: Maak een account aan met gereserveerde ruimte voor een token
+   account en draag het eigendom over aan het Token Program
+2. Token Program: Initialiseer de token account gegevens
 
 ### Typescript
 
@@ -184,11 +172,11 @@ import {
   getInitializeMintInstruction,
   getMintSize,
   getTokenSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Get latest blockhash to include in transaction
@@ -213,18 +201,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -254,8 +242,8 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address);
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", transactionSignature);
 
 // Generate keypair to use as address of token account
 const tokenAccount = await generateKeyPairSigner();
@@ -268,18 +256,18 @@ const tokenAccountRent = await rpc
   .getMinimumBalanceForRentExemption(tokenAccountSpace)
   .send();
 
-// Instruction to create new account for token account (token 2022 program)
+// Instruction to create new account for token account (token program)
 // Invokes the system program
 const createTokenAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: tokenAccount,
   lamports: tokenAccountRent,
   space: tokenAccountSpace,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize token account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeTokenAccountInstruction = getInitializeAccount2Instruction({
   account: tokenAccount.address,
   mint: mint.address,
@@ -310,11 +298,10 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 );
 
 // Get transaction signature
-const tokenAccountTxSignature =
-  getSignatureFromTransaction(signedTokenAccountTx);
+const transactionSignature2 = getSignatureFromTransaction(signedTokenAccountTx);
 
 console.log("Token Account Address:", tokenAccount.address);
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -333,12 +320,12 @@ import {
   getMinimumBalanceForRentExemptMint,
   getMinimumBalanceForRentExemptAccount,
   ACCOUNT_SIZE,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -349,8 +336,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -366,7 +353,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -375,14 +362,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -408,7 +395,7 @@ const createTokenAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: tokenAccount.publicKey,
   space: ACCOUNT_SIZE,
   lamports: tokenAccountRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize token account instruction
@@ -416,14 +403,14 @@ const initializeTokenAccountInstruction = createInitializeAccountInstruction(
   tokenAccount.publicKey, // token account
   mint.publicKey, // mint
   feePayer.publicKey, // owner
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for token account
 let tokenAccountTransaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createTokenAccountInstruction, initializeTokenAccountInstruction);
 
 // Sign and send transaction
@@ -434,20 +421,16 @@ const tokenAccountTxSignature = await sendAndConfirmTransaction(
 );
 
 console.log("Token Account Address:", tokenAccount.publicKey.toBase58());
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import {
-  createMint,
-  createAccount,
-  TOKEN_2022_PROGRAM_ID
-} from "@solana/spl-token";
+import { createMint, createAccount, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -458,8 +441,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -474,9 +457,9 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create token account using helper function
 const tokenAccount = await createAccount(
@@ -488,9 +471,9 @@ const tokenAccount = await createAccount(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
+console.log("Token Account Address:", tokenAccount.toBase58());
 ```
 
 </CodeTabs>
@@ -498,128 +481,6 @@ console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{
-    id as token_2022_program_id,
-    instruction::{initialize_account, initialize_mint},
-    state::{Account, Mint},
-};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Generate keypair to use as address of token account
-    let token_account = Keypair::new();
-
-    // Get token account size (in bytes)
-    let token_account_space = Account::LEN;
-    let token_account_rent = client.get_minimum_balance_for_rent_exemption(token_account_space)?;
-
-    // Instruction to create new account for token account (token 2022 program)
-    let create_token_account_instruction = create_account(
-        &fee_payer.pubkey(),        // payer
-        &token_account.pubkey(),    // new account (token account)
-        token_account_rent,         // lamports
-        token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
-    );
-
-    // Instruction to initialize token account data
-    let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
-        &token_account.pubkey(), // account
-        &mint.pubkey(),          // mint
-        &fee_payer.pubkey(),     // owner
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[
-            create_token_account_instruction,
-            initialize_token_account_instruction,
-        ],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &token_account],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Token Account Address: {}", token_account.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -631,8 +492,8 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{
-    id as token_2022_program_id,
+use spl_token::{
+    id as token_program_id,
     instruction::{initialize_account, initialize_mint},
     state::{Account, Mint},
 };
@@ -641,10 +502,10 @@ use spl_token_2022::{
 async fn main() -> Result<()> {
     // Create connection to local validator
     let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -671,18 +532,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(mint_space)
         .await?;
 
-    // Instruction to create new account for mint (token 2022 program)
+    // Instruction to create new account for mint (token program)
     let create_account_instruction = create_account(
         &fee_payer.pubkey(),      // payer
         &mint.pubkey(),           // new account (mint)
         mint_rent,                // lamports
         mint_space as u64,        // space
-        &token_2022_program_id(), // program id
+        &token_program_id(), // program id
     );
 
     // Instruction to initialize mint account data
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -694,7 +555,7 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -712,18 +573,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(token_account_space)
         .await?;
 
-    // Instruction to create new account for token account (token 2022 program)
+    // Instruction to create new account for token account (token program)
     let create_token_account_instruction = create_account(
         &fee_payer.pubkey(),        // payer
         &token_account.pubkey(),    // new account (token account)
         token_account_rent,         // lamports
         token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
+        &token_program_id(),   // program id
     );
 
     // Instruction to initialize token account data
     let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
+        &token_program_id(),
         &token_account.pubkey(), // account
         &mint.pubkey(),          // mint
         &fee_payer.pubkey(),     // owner
@@ -737,7 +598,7 @@ async fn main() -> Result<()> {
         ],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &token_account],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -757,7 +618,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -768,7 +629,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     // Create connection to local validator
     let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
 
@@ -794,7 +655,7 @@ async fn main() -> Result<()> {
     // Create a new program client
     let program_client = ProgramRpcClient::new(
         Arc::new(RpcClient::new_with_commitment(
-            String::from("http://127.0.0.1:8899"),
+            String::from("http://localhost:8899"),
             CommitmentConfig::confirmed(),
         )),
         ProgramRpcClientSendTransaction,
@@ -803,10 +664,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 2;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -839,25 +700,21 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
     Ok(())
 }
 ```
 
 </CodeTabs>
 
-## Hoe een associated token account aanmaken
+## Hoe maak je een associated token account aan
 
-Om een associated token account aan te maken, roep je de
-[`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
-instructie aan. Je kunt implementaties van deze instructie
-[hier](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66)
-vinden.
+Het aanmaken van een Associated Token Account (ATA) vereist de
+[---INLINE-CODE-PLACEHOLDER-85c08564ca556b926744bf94497c4af2---](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
+instructie. Bekijk de
+[implementatie hier](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-De instructie om een associated token account aan te maken roept automatisch de
-System Program aan om het token account aan te maken en roept het Token Program
-aan om de token account gegevens te initialiseren. Dit gebeurt via Cross Program
-Invocations (CPI).
+Deze enkele instructie zorgt automatisch voor het aanmaken van het token account
+en het initialiseren ervan via Cross Program Invocation (CPI).
 
 ### Typescript
 
@@ -884,12 +741,12 @@ import {
   getCreateAssociatedTokenInstructionAsync,
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda
-} from "@solana-program/token-2022";
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Generate keypairs for fee payer
@@ -914,18 +771,18 @@ const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 // Get latest blockhash to include in transaction
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -955,18 +812,18 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address.toString());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address.toString());
+console.log("Transaction Signature:", transactionSignature);
 
 // Use findAssociatedTokenPda to derive the ATA address
 const [associatedTokenAddress] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: feePayer.address,
-  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
 });
 
 console.log(
-  "Associated Token Account Address: ",
+  "Associated Token Account Address:",
   associatedTokenAddress.toString()
 );
 
@@ -1000,7 +857,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 
 // Get transaction signature
 const transactionSignature2 = getSignatureFromTransaction(signedTransaction2);
-console.log("Transaction Signature: ", transactionSignature2);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -1016,15 +873,15 @@ import {
   createInitializeMintInstruction,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountInstruction,
   ASSOCIATED_TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1035,8 +892,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1052,7 +909,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -1061,14 +918,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -1086,7 +943,7 @@ const associatedTokenAccount = getAssociatedTokenAddressSync(
   mint.publicKey,
   feePayer.publicKey,
   false, // allowOwnerOffCurve
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
@@ -1096,15 +953,15 @@ const createAssociatedTokenAccountIx = createAssociatedTokenAccountInstruction(
   associatedTokenAccount, // associated token account address
   feePayer.publicKey, // owner
   mint.publicKey, // mint
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for associated token account
 let transaction2 = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAssociatedTokenAccountIx);
 
 // Sign and send transaction
@@ -1126,12 +983,12 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import {
   createMint,
   createAssociatedTokenAccount,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1142,8 +999,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1158,23 +1015,24 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create associated token account using helper function
 const associatedTokenAccount = await createAssociatedTokenAccount(
-  connection, // connection
-  feePayer, // fee payer
-  mintPubkey, // mint
-  feePayer.publicKey, // owner
+  connection,
+  feePayer,
+  mintPubkey,
+  feePayer.publicKey,
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
 console.log(
-  `Associated Token Account Address: ${associatedTokenAccount.toBase58()}`
+  "Associated Token Account Address:",
+  associatedTokenAccount.toBase58()
 );
 ```
 
@@ -1183,340 +1041,6 @@ console.log(
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction and add instruction
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Rust Async"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client
-        .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
-        .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client
-        .get_minimum_balance_for_rent_exemption(mint_space)
-        .await?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address (owner)
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction for associated token account creation
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account.to_string()
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://127.0.0.1:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Derive the associated token account address
-    let associated_token_address = token.get_associated_token_address(&payer.pubkey());
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_address
-    );
-
-    // Create associated token account for the payer
-    let result = token
-        .create_associated_token_account(
-            &payer.pubkey(), // owner
-        )
-        .await?;
-
-    println!(" {}", result);
-
-    Ok(())
-}
-```
-
-</CodeTabs>
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -1735,3 +1259,4 @@ async fn main() -> Result<()> {
 }
 ```
 
+</CodeTabs>

--- a/apps/web/content/docs/pl/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/pl/tokens/basics/create-mint.mdx
@@ -1,12 +1,12 @@
 ---
-title: Utwórz mint account
-description: Dowiedz się, jak utworzyć mint account dla tokena SPL.
+title: Utwórz Token Mint
+description: Dowiedz się, jak utworzyć mint tokena SPL.
 ---
 
-## Czym jest mint account?
+## Czym jest konto mint?
 
-Mint account to typ konta w Token Programs Solany, który unikalnie reprezentuje
-token w sieci i przechowuje globalne metadane dotyczące tego tokena.
+Konto mint unikalnie reprezentuje token na Solanie i przechowuje jego globalne
+metadane.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -34,30 +34,29 @@ pub struct Mint {
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30),
   jak i [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
-  korzystają z tej samej podstawowej implementacji dla mint account.
+  korzystają z tej samej podstawowej implementacji dla konta mint.
 </Callout>
 
-Każdy token na Solanie istnieje jako mint account, gdzie adres mint account jest
-jego unikalnym identyfikatorem w sieci.
+Każdy token na Solanie posiada konto mint, a adres tego konta służy jako
+unikalny identyfikator tokena.
 
-Na przykład cyfrowy dolar USD Coin (USDC) na Solanie ma adres mint
-`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Ten adres mint służy jako
-unikalny identyfikator USD Coin w całym ekosystemie Solany. Szczegóły dotyczące
-tego mint account można zobaczyć na stronie
+Na przykład USD Coin (USDC) ma adres mint
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Ten adres unikalnie identyfikuje
+USDC w całym ekosystemie Solany. Możesz zobaczyć ten mint na stronie
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
-## Jak utworzyć mint account
+## Jak utworzyć konto mint
 
-Aby utworzyć mint account, wywołaj instrukcję
-[`InitializeMint`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L65).
-Implementacje tej instrukcji można znaleźć
-[tutaj](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L79).
+Utworzenie konta mint wymaga użycia instrukcji
+[`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37).
+Szczegóły implementacji znajdziesz
+[tutaj](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-Transakcja tworzenia mint account wymaga dwóch instrukcji:
+Musisz wywołać dwie instrukcje, aby utworzyć konto mint:
 
-1. Wywołaj System Program, aby utworzyć i przydzielić przestrzeń dla mint
-   account oraz przenieść własność na Token Program.
-2. Wywołaj Token Program, aby zainicjalizować dane mint account.
+1. System Program: Utwórz konto z przydzieloną przestrzenią dla konta mint i
+   przenieś własność na Token Program.
+2. Token Program: Zainicjalizuj dane konta mint.
 
 ### Typescript
 
@@ -83,11 +82,11 @@ import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Generate keypairs for fee payer
@@ -109,18 +108,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 9,
@@ -154,7 +153,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
 console.log("Mint Address:", mint.address);
-console.log("Transaction Signature:", transactionSignature);
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy"
@@ -168,14 +167,14 @@ import {
 } from "@solana/web3.js";
 import {
   createInitializeMintInstruction,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -186,8 +185,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -199,15 +198,15 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: await getMinimumBalanceForRentExemptMint(connection),
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 const initializeMintInstruction = createInitializeMintInstruction(
-  mint.publicKey, // mint pubkey
-  9, // decimals
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  mint.publicKey,
+  9, // Decimals
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  TOKEN_PROGRAM_ID
 );
 
 const transaction = new Transaction().add(
@@ -221,17 +220,17 @@ const transactionSignature = await sendAndConfirmTransaction(
   [feePayer, mint] // Signers
 );
 
-console.log("Mint Address: ", mint.publicKey.toBase58());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { createMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import { createMint, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -242,24 +241,24 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
 const mintPubkey = await createMint(
-  connection, // connection
-  feePayer, // fee payer
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  9, // decimals
-  Keypair.generate(), // keypair
+  connection,
+  feePayer,
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  9, // Decimals
+  Keypair.generate(),
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 ```
 
 </CodeTabs>
@@ -267,82 +266,6 @@ console.log(`Mint Address: ${mintPubkey.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    let mint_space = Mint::LEN;
-    let rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Create account instruction for mint
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(), // program id
-        &mint.pubkey(),           // mint address
-        &fee_payer.pubkey(),      // mint authority
-        Some(&fee_payer.pubkey()),// freeze authority
-        9,                        // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -354,16 +277,16 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
+use spl_token::{id as token_program_id, instruction::initialize_mint, state::Mint};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create connection to local validator
     let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -389,16 +312,16 @@ async fn main() -> Result<()> {
 
     // Create account instruction
     let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // fee payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        space as u64,             // space
-        &token_2022_program_id(), // program id
+        &fee_payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &token_program_id(),
     );
 
     // Initialize mint instruction
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint address
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -410,14 +333,14 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
     let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }
@@ -430,7 +353,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -441,7 +364,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     // Create connection to local validator
     let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
 
@@ -463,7 +386,6 @@ async fn main() -> Result<()> {
 
     // Generate keypair to use as address of mint
     let mint = Keypair::new();
-    println!("Mint keypair generated: {}", mint.pubkey());
 
     // Set up program client for Token client
     let program_client =
@@ -472,10 +394,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 9;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -494,7 +416,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }

--- a/apps/web/content/docs/pl/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/pl/tokens/basics/create-token-account.mdx
@@ -5,10 +5,9 @@ description: Dowiedz się, jak tworzyć konta tokenów SPL.
 
 ## Czym jest konto tokena?
 
-Konto tokena to typ konta w programach tokenów Solana, który przechowuje
-informacje o własności konkretnego tokena (mint). Każde konto tokena jest
-powiązane z jednym mintem i śledzi szczegóły, takie jak saldo tokena i
-właściciel.
+Konto tokena przechowuje saldo określonego tokena. Każde konto tokena jest
+powiązane z dokładnie jednym mintem i śledzi twoje saldo tokenów oraz dodatkowe
+dane.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -47,61 +46,54 @@ pub struct Account {
   korzystają z tej samej podstawowej implementacji dla konta tokena.
 </Callout>
 
-Aby przechowywać tokeny dla konkretnego minta, użytkownicy muszą najpierw
-utworzyć konto tokena. Każde konto tokena śledzi:
+Aby przechowywać tokeny, potrzebujesz konta tokena dla określonego minta. Każde
+konto tokena śledzi:
 
-1. Konkretnego minta (typ tokena, którego jednostki przechowuje konto tokena)
-2. Właściciela (autorytet, który może przenosić tokeny z konta)
+1. **Mint**: Określony typ tokena, który przechowuje
+2. **Właściciel**: Autorytet, który może przenosić tokeny z tego konta
 
-Oto przykład z użyciem USD Coin (USDC) na Solanie:
+### Przykład: USD Coin (USDC)
 
-- Adres mint USD Coin: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- Circle (emitent USD Coin) ma konto tokena pod adresem
-  `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-- To konto tokena przechowuje wyłącznie jednostki tokena USD Coin (mint)
-- Circle ma autorytet właściciela pod adresem
-  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE` i może przenosić te tokeny
+- Adres minta: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- Konto tokena Circle: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- To konto przechowuje tylko tokeny USDC
+- Circle kontroluje token za pomocą autorytetu właściciela konta tokena:
+  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
 Możesz zobaczyć szczegóły tego konta tokena na
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  Termin "właściciel" jest używany w dwóch różnych kontekstach:
+  **Zrozumienie terminologii "właściciel"**
 
-1. "Właściciel" konta tokena - Jest to adres przechowywany w danych konta tokena
-   jako pole "owner" typu
-   [Account](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L106)
-   zdefiniowanego przez Token Program. Właściciel może przenosić, spalać lub
-   delegować tokeny z konta. Ten adres jest czasami nazywany "autorytetem" konta
-   tokena, aby odróżnić go od właściciela programu.
+Termin "właściciel" może być używany w dwóch różnych kontekstach:
 
-2. Program "owner" - odnosi się do programu, który jest właścicielem danych
-   konta na Solanie. W przypadku kont tokenów jest to zawsze Token Program lub
-   Token Extensions Program, jak określono w polu "owner" bazowego typu Solana
-   [Account](https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/account/src/lib.rs#L51).
+1. **Właściciel konta tokena**: Autorytet, który może przenosić, spalać lub
+   delegować tokeny. Jest to przechowywane w danych konta tokena.
 
-Podczas pracy z kontami tokenów "owner" zazwyczaj odnosi się do autorytetu,
-który może wydawać tokeny, a nie do programu, który jest właścicielem konta.
+2. **Właściciel programu**: Program, który jest właścicielem konta (zawsze Token
+   Program lub Token Extension Program dla kont tokenów).
+
+Pracując z kontami tokenów, "właściciel" zazwyczaj odnosi się do autorytetu,
+który może przenosić tokeny, a nie do programu, który jest właścicielem konta.
 
 </Callout>
 
-## Co to jest Associated Token Account?
+## Czym jest powiązane konto tokena?
 
-Associated token account to konto tokenów z adresem będącym Program Derived
-Address (PDA) utworzonym przez
+Powiązane konto tokena (ATA) to domyślne konto tokena dla portfela do
+przechowywania określonego tokena. Używa deterministycznego adresu (PDA)
+utworzonego przez
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
-Można je traktować jako domyślne konto tokenów dla użytkownika do przechowywania
-jednostek określonego tokena (mint).
 
 <Callout type="info">
-  Termin "associated token accounts" dotyczy wyłącznie kont tokenów tworzonych
-  przez Associated Token Program.
+  Tylko konta tokenów utworzone przez Associated Token Program nazywane są
+  "associated token accounts."
 </Callout>
 
-Associated token accounts zapewniają deterministyczny sposób znajdowania konta
-tokenów użytkownika dla dowolnego tokena mint. Możesz sprawdzić implementację
-tego procesu
-[tutaj](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
+ATA korzystają z deterministycznych adresów, co ułatwia znalezienie konta tokena
+każdego portfela dla danego tokena. Zobacz
+[implementację wyprowadzenia tutaj](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -121,34 +113,36 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-To deterministyczne podejście zapewnia, że dla dowolnej kombinacji adresu
-portfela i tokena mint istnieje dokładnie jeden adres associated token account.
-Dzięki temu łatwo znaleźć konto tokenów użytkownika dla dowolnego tokena mint,
-eliminując potrzebę osobnego śledzenia adresów kont tokenów.
+Dla każdej kombinacji portfela i tokena istnieje dokładnie jeden adres ATA. To
+eliminuje potrzebę ręcznego śledzenia adresów kont tokenów — zawsze można
+wyprowadzić poprawny adres.
 
 <Callout type="info">
-  Associated Token Program działa jako program pomocniczy, który tworzy konta
-  tokenów z deterministycznymi adresami (PDA). Podczas tworzenia associated
-  token account, Associated Token Program wykonuje CPI (Cross Program
-  Invocation) do Token Program lub Token Extensions Program. Token Program jest
-  właścicielem utworzonego konta, które ma tę samą `Account` strukturę typu, jak
-  zdefiniowano w Token Program. Associated Token Program nie przechowuje stanu -
-  oferuje jedynie ustandaryzowany sposób tworzenia kont tokenów pod
-  deterministycznym adresem będącym PDA.
+  **Jak działa Associated Token Program**
+
+Associated Token Program to narzędzie pomocnicze, które:
+
+- Tworzy konta tokenów na deterministycznych adresach (PDA)
+- Wykonuje Cross-Program Invocations (CPI) do Token Program
+- Nie przechowuje żadnego stanu samodzielnie
+
+Utworzone konta tokenów są własnością Token Program i korzystają ze standardowej
+`Account` struktury.
+
 </Callout>
 
 ## Jak utworzyć konto tokena
 
-Aby utworzyć konto tokena, wywołaj instrukcję
-[`InitializeAccount`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L93).
-Implementacje tej instrukcji można znaleźć
-[tutaj](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L145).
+Utworzenie konta tokena wymaga instrukcji
+[`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63).
+Zobacz
+[implementację tutaj](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
-Transakcja tworzenia konta tokena wymaga dwóch instrukcji:
+Do utworzenia konta tokena potrzebne są dwie instrukcje:
 
-1. Wywołaj System Program, aby utworzyć i przydzielić miejsce na konto tokena
-   oraz przenieść własność na Token Program.
-2. Wywołaj Token Program, aby zainicjalizować dane konta tokena.
+1. System Program: Utwórz konto z przydzieloną przestrzenią dla konta tokena i
+   przenieś własność do Token Program
+2. Token Program: Zainicjalizuj dane konta tokena
 
 ### Typescript
 
@@ -176,11 +170,11 @@ import {
   getInitializeMintInstruction,
   getMintSize,
   getTokenSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Get latest blockhash to include in transaction
@@ -205,18 +199,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -246,8 +240,8 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address);
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", transactionSignature);
 
 // Generate keypair to use as address of token account
 const tokenAccount = await generateKeyPairSigner();
@@ -260,18 +254,18 @@ const tokenAccountRent = await rpc
   .getMinimumBalanceForRentExemption(tokenAccountSpace)
   .send();
 
-// Instruction to create new account for token account (token 2022 program)
+// Instruction to create new account for token account (token program)
 // Invokes the system program
 const createTokenAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: tokenAccount,
   lamports: tokenAccountRent,
   space: tokenAccountSpace,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize token account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeTokenAccountInstruction = getInitializeAccount2Instruction({
   account: tokenAccount.address,
   mint: mint.address,
@@ -302,11 +296,10 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 );
 
 // Get transaction signature
-const tokenAccountTxSignature =
-  getSignatureFromTransaction(signedTokenAccountTx);
+const transactionSignature2 = getSignatureFromTransaction(signedTokenAccountTx);
 
 console.log("Token Account Address:", tokenAccount.address);
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -325,12 +318,12 @@ import {
   getMinimumBalanceForRentExemptMint,
   getMinimumBalanceForRentExemptAccount,
   ACCOUNT_SIZE,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -341,8 +334,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -358,7 +351,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -367,14 +360,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -400,7 +393,7 @@ const createTokenAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: tokenAccount.publicKey,
   space: ACCOUNT_SIZE,
   lamports: tokenAccountRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize token account instruction
@@ -408,14 +401,14 @@ const initializeTokenAccountInstruction = createInitializeAccountInstruction(
   tokenAccount.publicKey, // token account
   mint.publicKey, // mint
   feePayer.publicKey, // owner
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for token account
 let tokenAccountTransaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createTokenAccountInstruction, initializeTokenAccountInstruction);
 
 // Sign and send transaction
@@ -426,20 +419,16 @@ const tokenAccountTxSignature = await sendAndConfirmTransaction(
 );
 
 console.log("Token Account Address:", tokenAccount.publicKey.toBase58());
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import {
-  createMint,
-  createAccount,
-  TOKEN_2022_PROGRAM_ID
-} from "@solana/spl-token";
+import { createMint, createAccount, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -450,8 +439,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -466,9 +455,9 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create token account using helper function
 const tokenAccount = await createAccount(
@@ -480,9 +469,9 @@ const tokenAccount = await createAccount(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
+console.log("Token Account Address:", tokenAccount.toBase58());
 ```
 
 </CodeTabs>
@@ -490,128 +479,6 @@ console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{
-    id as token_2022_program_id,
-    instruction::{initialize_account, initialize_mint},
-    state::{Account, Mint},
-};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Generate keypair to use as address of token account
-    let token_account = Keypair::new();
-
-    // Get token account size (in bytes)
-    let token_account_space = Account::LEN;
-    let token_account_rent = client.get_minimum_balance_for_rent_exemption(token_account_space)?;
-
-    // Instruction to create new account for token account (token 2022 program)
-    let create_token_account_instruction = create_account(
-        &fee_payer.pubkey(),        // payer
-        &token_account.pubkey(),    // new account (token account)
-        token_account_rent,         // lamports
-        token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
-    );
-
-    // Instruction to initialize token account data
-    let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
-        &token_account.pubkey(), // account
-        &mint.pubkey(),          // mint
-        &fee_payer.pubkey(),     // owner
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[
-            create_token_account_instruction,
-            initialize_token_account_instruction,
-        ],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &token_account],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Token Account Address: {}", token_account.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -623,8 +490,8 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{
-    id as token_2022_program_id,
+use spl_token::{
+    id as token_program_id,
     instruction::{initialize_account, initialize_mint},
     state::{Account, Mint},
 };
@@ -633,10 +500,10 @@ use spl_token_2022::{
 async fn main() -> Result<()> {
     // Create connection to local validator
     let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -663,18 +530,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(mint_space)
         .await?;
 
-    // Instruction to create new account for mint (token 2022 program)
+    // Instruction to create new account for mint (token program)
     let create_account_instruction = create_account(
         &fee_payer.pubkey(),      // payer
         &mint.pubkey(),           // new account (mint)
         mint_rent,                // lamports
         mint_space as u64,        // space
-        &token_2022_program_id(), // program id
+        &token_program_id(), // program id
     );
 
     // Instruction to initialize mint account data
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -686,7 +553,7 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -704,18 +571,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(token_account_space)
         .await?;
 
-    // Instruction to create new account for token account (token 2022 program)
+    // Instruction to create new account for token account (token program)
     let create_token_account_instruction = create_account(
         &fee_payer.pubkey(),        // payer
         &token_account.pubkey(),    // new account (token account)
         token_account_rent,         // lamports
         token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
+        &token_program_id(),   // program id
     );
 
     // Instruction to initialize token account data
     let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
+        &token_program_id(),
         &token_account.pubkey(), // account
         &mint.pubkey(),          // mint
         &fee_payer.pubkey(),     // owner
@@ -729,7 +596,7 @@ async fn main() -> Result<()> {
         ],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &token_account],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -749,7 +616,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -760,7 +627,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     // Create connection to local validator
     let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
 
@@ -786,7 +653,7 @@ async fn main() -> Result<()> {
     // Create a new program client
     let program_client = ProgramRpcClient::new(
         Arc::new(RpcClient::new_with_commitment(
-            String::from("http://127.0.0.1:8899"),
+            String::from("http://localhost:8899"),
             CommitmentConfig::confirmed(),
         )),
         ProgramRpcClientSendTransaction,
@@ -795,10 +662,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 2;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -831,24 +698,21 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
     Ok(())
 }
 ```
 
 </CodeTabs>
 
-## Jak utworzyć powiązane konto tokena
+## Jak utworzyć Associated Token Account
 
-Aby utworzyć powiązane konto tokena, wywołaj instrukcję
+Utworzenie powiązanego konta tokena (ATA) wymaga użycia instrukcji
 [`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18).
-Implementacje tej instrukcji można znaleźć
-[tutaj](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
+Zobacz
+[implementację tutaj](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-Instrukcja tworzenia powiązanego konta tokena automatycznie wywołuje System
-Program w celu utworzenia konta tokena oraz wywołuje Token Program w celu
-zainicjalizowania danych konta tokena. Dzieje się to za pomocą Cross Program
-Invocations (CPI).
+Ta pojedyncza instrukcja automatycznie obsługuje tworzenie konta tokena i jego
+inicjalizację za pomocą Cross Program Invocations (CPI).
 
 ### Typescript
 
@@ -875,12 +739,12 @@ import {
   getCreateAssociatedTokenInstructionAsync,
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda
-} from "@solana-program/token-2022";
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Generate keypairs for fee payer
@@ -905,18 +769,18 @@ const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 // Get latest blockhash to include in transaction
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -946,18 +810,18 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address.toString());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address.toString());
+console.log("Transaction Signature:", transactionSignature);
 
 // Use findAssociatedTokenPda to derive the ATA address
 const [associatedTokenAddress] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: feePayer.address,
-  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
 });
 
 console.log(
-  "Associated Token Account Address: ",
+  "Associated Token Account Address:",
   associatedTokenAddress.toString()
 );
 
@@ -991,7 +855,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 
 // Get transaction signature
 const transactionSignature2 = getSignatureFromTransaction(signedTransaction2);
-console.log("Transaction Signature: ", transactionSignature2);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -1007,15 +871,15 @@ import {
   createInitializeMintInstruction,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountInstruction,
   ASSOCIATED_TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1026,8 +890,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1043,7 +907,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -1052,14 +916,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -1077,7 +941,7 @@ const associatedTokenAccount = getAssociatedTokenAddressSync(
   mint.publicKey,
   feePayer.publicKey,
   false, // allowOwnerOffCurve
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
@@ -1087,15 +951,15 @@ const createAssociatedTokenAccountIx = createAssociatedTokenAccountInstruction(
   associatedTokenAccount, // associated token account address
   feePayer.publicKey, // owner
   mint.publicKey, // mint
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for associated token account
 let transaction2 = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAssociatedTokenAccountIx);
 
 // Sign and send transaction
@@ -1117,12 +981,12 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import {
   createMint,
   createAssociatedTokenAccount,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1133,8 +997,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1149,23 +1013,24 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create associated token account using helper function
 const associatedTokenAccount = await createAssociatedTokenAccount(
-  connection, // connection
-  feePayer, // fee payer
-  mintPubkey, // mint
-  feePayer.publicKey, // owner
+  connection,
+  feePayer,
+  mintPubkey,
+  feePayer.publicKey,
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
 console.log(
-  `Associated Token Account Address: ${associatedTokenAccount.toBase58()}`
+  "Associated Token Account Address:",
+  associatedTokenAccount.toBase58()
 );
 ```
 
@@ -1174,340 +1039,6 @@ console.log(
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction and add instruction
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Rust Async"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client
-        .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
-        .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client
-        .get_minimum_balance_for_rent_exemption(mint_space)
-        .await?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address (owner)
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction for associated token account creation
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account.to_string()
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://127.0.0.1:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Derive the associated token account address
-    let associated_token_address = token.get_associated_token_address(&payer.pubkey());
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_address
-    );
-
-    // Create associated token account for the payer
-    let result = token
-        .create_associated_token_account(
-            &payer.pubkey(), // owner
-        )
-        .await?;
-
-    println!(" {}", result);
-
-    Ok(())
-}
-```
-
-</CodeTabs>
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -1726,96 +1257,4 @@ async fn main() -> Result<()> {
 }
 ```
 
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://127.0.0.1:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Generate keypair for token account
-    let token_account_keypair = Keypair::new();
-
-    // Create token account using the keypair
-    let token_account_result = token
-        .create_auxiliary_token_account(
-            &token_account_keypair, // account keypair
-            &payer.pubkey(),        // owner
-        )
-        .await?;
-
-    println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
-    Ok(())
-}
-```
+</CodeTabs>

--- a/apps/web/content/docs/pt/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/pt/tokens/basics/create-mint.mdx
@@ -5,8 +5,8 @@ description: Aprenda como criar um mint de Token SPL.
 
 ## O que é uma Mint Account?
 
-Uma mint account é um tipo de conta nos Token Programs da Solana que representa
-exclusivamente um token na rede e armazena metadados globais sobre o token.
+Uma mint account representa exclusivamente um token na Solana e armazena seus
+metadados globais.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -34,30 +34,30 @@ pub struct Mint {
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30)
   quanto o [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
-  compartilham a mesma implementação base para a Mint account.
+  compartilham a mesma implementação base para a mint account.
 </Callout>
 
-Cada token na Solana existe como uma mint account onde o endereço da mint
-account é seu identificador único na rede.
+Cada token na Solana possui uma mint account, e o endereço do mint serve como
+identificador único do token.
 
-Por exemplo, o USD Coin (USDC), dólar digital na Solana, tem o endereço de mint
-`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Este endereço de mint serve como
-identificador único do USD Coin em todo o ecossistema Solana. Você pode ver
-detalhes sobre esta mint account no
+Por exemplo, o USD Coin (USDC) tem o endereço de mint
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Este endereço identifica
+exclusivamente o USDC em todo o ecossistema Solana. Você pode visualizar este
+mint no
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
 ## Como criar uma Mint Account
 
-Para criar uma Mint Account, invoque a instrução
-[`InitializeMint`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L65).
-Você pode encontrar implementações desta instrução
-[aqui](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L79).
+Criar uma mint account requer a instrução
+[`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37).
+Veja os
+[detalhes de implementação aqui](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-A transação para criar uma mint account precisa de duas instruções:
+Você precisa invocar duas instruções para criar uma mint account:
 
-1. Invocar o System Program para criar e alocar espaço para uma mint account e
+1. System Program: Criar uma conta com espaço alocado para uma mint account e
    transferir a propriedade para o Token Program.
-2. Invocar o Token Program para inicializar os dados da mint account.
+2. Token Program: Inicializar os dados da mint account
 
 ### Typescript
 
@@ -83,8 +83,8 @@ import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -109,18 +109,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 9,
@@ -154,7 +154,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
 console.log("Mint Address:", mint.address);
-console.log("Transaction Signature:", transactionSignature);
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy"
@@ -168,14 +168,14 @@ import {
 } from "@solana/web3.js";
 import {
   createInitializeMintInstruction,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint
 } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -186,8 +186,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -199,15 +199,15 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: await getMinimumBalanceForRentExemptMint(connection),
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 const initializeMintInstruction = createInitializeMintInstruction(
-  mint.publicKey, // mint pubkey
-  9, // decimals
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  mint.publicKey,
+  9, // Decimals
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  TOKEN_PROGRAM_ID
 );
 
 const transaction = new Transaction().add(
@@ -221,17 +221,17 @@ const transactionSignature = await sendAndConfirmTransaction(
   [feePayer, mint] // Signers
 );
 
-console.log("Mint Address: ", mint.publicKey.toBase58());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { createMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import { createMint, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -242,24 +242,24 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
 const mintPubkey = await createMint(
-  connection, // connection
-  feePayer, // fee payer
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  9, // decimals
-  Keypair.generate(), // keypair
+  connection,
+  feePayer,
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  9, // Decimals
+  Keypair.generate(),
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 ```
 
 </CodeTabs>
@@ -267,82 +267,6 @@ console.log(`Mint Address: ${mintPubkey.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    let mint_space = Mint::LEN;
-    let rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Create account instruction for mint
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(), // program id
-        &mint.pubkey(),           // mint address
-        &fee_payer.pubkey(),      // mint authority
-        Some(&fee_payer.pubkey()),// freeze authority
-        9,                        // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -354,7 +278,7 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
+use spl_token::{id as token_program_id, instruction::initialize_mint, state::Mint};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -363,7 +287,7 @@ async fn main() -> Result<()> {
         String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -389,16 +313,16 @@ async fn main() -> Result<()> {
 
     // Create account instruction
     let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // fee payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        space as u64,             // space
-        &token_2022_program_id(), // program id
+        &fee_payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &token_program_id(),
     );
 
     // Initialize mint instruction
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint address
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -410,14 +334,14 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
     let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }
@@ -430,7 +354,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -463,7 +387,6 @@ async fn main() -> Result<()> {
 
     // Generate keypair to use as address of mint
     let mint = Keypair::new();
-    println!("Mint keypair generated: {}", mint.pubkey());
 
     // Set up program client for Token client
     let program_client =
@@ -472,10 +395,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 9;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -494,7 +417,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }

--- a/apps/web/content/docs/pt/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/pt/tokens/basics/create-token-account.mdx
@@ -5,10 +5,9 @@ description: Aprenda como criar SPL Token Accounts.
 
 ## O que é uma Token Account?
 
-Uma token account é um tipo de conta nos Token Programs da Solana que armazena
-informações sobre a propriedade de um token específico (mint) por um indivíduo.
-Cada token account está associada a um único mint e rastreia detalhes como o
-saldo do token e o proprietário.
+Uma token account armazena seu saldo de um token específico. Cada token account
+está associada a exatamente uma mint e rastreia seu saldo de tokens e detalhes
+adicionais.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -42,66 +41,58 @@ pub struct Account {
   Observe que no código-fonte, os desenvolvedores chamam uma Token account de
   tipo `Account`. Tanto o [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)
-  quanto o [Token Extension
+  quanto o [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
   compartilham a mesma implementação base para a Token account.
 </Callout>
 
-Para manter tokens de um mint específico, os usuários devem primeiro criar uma
-token account. Cada token account mantém o controle de:
+Para manter tokens, você precisa de uma token account para aquela mint
+específica. Cada token account rastreia:
 
-1. Um mint específico (o tipo de token que a token account mantém unidades)
-2. Um proprietário (a autoridade que pode transferir tokens da conta)
+1. **Mint**: O tipo específico de token que ela mantém
+2. **Owner**: A autoridade que pode transferir tokens desta conta
 
-Aqui está um exemplo usando USD Coin (USDC) na Solana:
+### Exemplo: USD Coin (USDC)
 
-- O endereço do mint do USD Coin: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- A Circle (emissora do USD Coin) tem uma token account em
-  `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-- Esta token account mantém apenas unidades do token USD Coin (mint)
-- A Circle tem autoridade de proprietário em
-  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE` e pode transferir esses tokens
+- Endereço da mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- Token account da Circle: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- Esta conta mantém apenas tokens USDC
+- A Circle controla o token através da autoridade proprietária da token account:
+  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
 Você pode ver os detalhes desta token account no
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  O termo "proprietário" é usado em dois contextos diferentes:
+  **Entendendo a Terminologia "Owner"**
 
-1. O "proprietário" da token account - Este é um endereço armazenado nos dados
-   da token account como o campo "owner" do tipo
-   [Account](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L106)
-   definido pelo Token Program. O proprietário pode transferir, queimar ou
-   delegar tokens da conta. Este endereço às vezes é referido como a
-   "autoridade" da token account para distingui-lo do proprietário do programa.
+O termo "owner" pode ser usado em dois contextos diferentes:
 
-2. O "owner" do programa - Isso se refere ao programa que possui os dados da
-   conta na Solana. Para token accounts, isso é sempre o Token Program ou Token
-   Extension Program, conforme especificado no campo "owner" do tipo base Solana
-   [Account](https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/account/src/lib.rs#L51).
+1. **Owner da Token Account**: A autoridade que pode transferir, queimar ou
+   delegar tokens. Isso é armazenado nos dados da token account.
 
-Quando trabalhamos com token accounts, "owner" geralmente se refere à autoridade
-que pode gastar os tokens, não ao programa que possui a conta.
+2. **Program Owner**: O programa que possui a conta (sempre o Token Program ou
+   Token Extensions Program para token accounts).
+
+Ao trabalhar com token accounts, "owner" geralmente se refere à autoridade que
+pode transferir tokens, não ao programa que possui a conta.
 
 </Callout>
 
 ## O que é uma Associated Token Account?
 
-Uma associated token account é uma token account com um endereço que é um
-Program Derived Address (PDA) criado pelo
+Uma associated token account (ATA) é a token account padrão para uma carteira
+manter um token específico. Ela usa um endereço determinístico (PDA) criado pelo
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
-Você pode pensar em uma associated token account como a token account padrão
-para um usuário manter unidades de um token específico (mint).
 
 <Callout type="info">
-  O termo "associated token accounts" se aplica apenas às token accounts que o
-  Associated Token Program cria.
+  Apenas as token accounts criadas pelo Associated Token Program são chamadas de
+  "associated token accounts."
 </Callout>
 
-As associated token accounts fornecem uma maneira determinística de encontrar a
-token account de um usuário para qualquer mint. Você pode inspecionar a
-implementação da derivação
-[aqui](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
+As ATAs usam endereços determinísticos, facilitando a localização da token
+account de qualquer carteira para um determinado mint. Veja a
+[implementação da derivação aqui](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -121,35 +112,36 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-Essa derivação determinística garante que para qualquer combinação de endereço
-de carteira e token mint, existe exatamente um endereço de associated token
-account. Esta abordagem torna simples encontrar a token account de um usuário
-para qualquer token mint, eliminando a necessidade de rastrear endereços de
-token account separadamente.
+Para qualquer combinação de carteira e token, existe exatamente um endereço ATA.
+Isso elimina a necessidade de rastrear manualmente os endereços das token
+accounts—você sempre pode derivá-los corretamente.
 
 <Callout type="info">
-  O Associated Token Program funciona como um programa auxiliar que cria token
-  accounts com endereços determinísticos (PDAs). Ao criar uma associated token
-  account, o Associated Token Program faz um CPI (Cross-Program Invocation) para
-  o Token Program ou Token Extension Program. O token program possui a conta
-  criada que tem a mesma estrutura de tipo `Account` conforme definido no token
-  program. O Associated Token Program não mantém estado - ele simplesmente
-  oferece uma maneira padronizada de criar token accounts em um endereço
-  determinístico que é um PDA.
+  **Como o Associated Token Program funciona**
+
+O Associated Token Program é um auxiliar que:
+
+- Cria token accounts em endereços determinísticos (PDAs)
+- Faz Cross Program Invocations (CPIs) para o Token Program
+- Não mantém nenhum estado próprio
+
+As token accounts resultantes são de propriedade do Token Program e usam a
+estrutura padrão `Account`.
+
 </Callout>
 
 ## Como criar uma Token Account
 
-Para criar uma Token Account, invoque a instrução
-[`InitializeAccount`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L93).
-Você pode encontrar implementações desta instrução
-[aqui](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L145).
+Criar uma token account requer a instrução
+[`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63).
+Veja a
+[implementação aqui](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
-A transação para criar uma token account precisa de duas instruções:
+Você precisa de duas instruções para criar uma token account:
 
-1. Invocar o System Program para criar e alocar espaço para uma token account e
-   transferir a propriedade para o Token Program.
-2. Invocar o Token Program para inicializar os dados da token account.
+1. System Program: Criar uma conta com espaço alocado para uma token account e
+   transferir a propriedade para o Token Program
+2. Token Program: Inicializar os dados da token account
 
 ### Typescript
 
@@ -177,8 +169,8 @@ import {
   getInitializeMintInstruction,
   getMintSize,
   getTokenSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -206,18 +198,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -247,8 +239,8 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address);
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", transactionSignature);
 
 // Generate keypair to use as address of token account
 const tokenAccount = await generateKeyPairSigner();
@@ -261,18 +253,18 @@ const tokenAccountRent = await rpc
   .getMinimumBalanceForRentExemption(tokenAccountSpace)
   .send();
 
-// Instruction to create new account for token account (token 2022 program)
+// Instruction to create new account for token account (token program)
 // Invokes the system program
 const createTokenAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: tokenAccount,
   lamports: tokenAccountRent,
   space: tokenAccountSpace,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize token account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeTokenAccountInstruction = getInitializeAccount2Instruction({
   account: tokenAccount.address,
   mint: mint.address,
@@ -303,11 +295,10 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 );
 
 // Get transaction signature
-const tokenAccountTxSignature =
-  getSignatureFromTransaction(signedTokenAccountTx);
+const transactionSignature2 = getSignatureFromTransaction(signedTokenAccountTx);
 
 console.log("Token Account Address:", tokenAccount.address);
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -326,12 +317,12 @@ import {
   getMinimumBalanceForRentExemptMint,
   getMinimumBalanceForRentExemptAccount,
   ACCOUNT_SIZE,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -342,8 +333,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -359,7 +350,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -368,14 +359,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -401,7 +392,7 @@ const createTokenAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: tokenAccount.publicKey,
   space: ACCOUNT_SIZE,
   lamports: tokenAccountRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize token account instruction
@@ -409,14 +400,14 @@ const initializeTokenAccountInstruction = createInitializeAccountInstruction(
   tokenAccount.publicKey, // token account
   mint.publicKey, // mint
   feePayer.publicKey, // owner
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for token account
 let tokenAccountTransaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createTokenAccountInstruction, initializeTokenAccountInstruction);
 
 // Sign and send transaction
@@ -427,20 +418,16 @@ const tokenAccountTxSignature = await sendAndConfirmTransaction(
 );
 
 console.log("Token Account Address:", tokenAccount.publicKey.toBase58());
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import {
-  createMint,
-  createAccount,
-  TOKEN_2022_PROGRAM_ID
-} from "@solana/spl-token";
+import { createMint, createAccount, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -451,8 +438,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -467,9 +454,9 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create token account using helper function
 const tokenAccount = await createAccount(
@@ -481,9 +468,9 @@ const tokenAccount = await createAccount(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
+console.log("Token Account Address:", tokenAccount.toBase58());
 ```
 
 </CodeTabs>
@@ -491,128 +478,6 @@ console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{
-    id as token_2022_program_id,
-    instruction::{initialize_account, initialize_mint},
-    state::{Account, Mint},
-};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Generate keypair to use as address of token account
-    let token_account = Keypair::new();
-
-    // Get token account size (in bytes)
-    let token_account_space = Account::LEN;
-    let token_account_rent = client.get_minimum_balance_for_rent_exemption(token_account_space)?;
-
-    // Instruction to create new account for token account (token 2022 program)
-    let create_token_account_instruction = create_account(
-        &fee_payer.pubkey(),        // payer
-        &token_account.pubkey(),    // new account (token account)
-        token_account_rent,         // lamports
-        token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
-    );
-
-    // Instruction to initialize token account data
-    let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
-        &token_account.pubkey(), // account
-        &mint.pubkey(),          // mint
-        &fee_payer.pubkey(),     // owner
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[
-            create_token_account_instruction,
-            initialize_token_account_instruction,
-        ],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &token_account],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Token Account Address: {}", token_account.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -624,8 +489,8 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{
-    id as token_2022_program_id,
+use spl_token::{
+    id as token_program_id,
     instruction::{initialize_account, initialize_mint},
     state::{Account, Mint},
 };
@@ -637,7 +502,7 @@ async fn main() -> Result<()> {
         String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -664,18 +529,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(mint_space)
         .await?;
 
-    // Instruction to create new account for mint (token 2022 program)
+    // Instruction to create new account for mint (token program)
     let create_account_instruction = create_account(
         &fee_payer.pubkey(),      // payer
         &mint.pubkey(),           // new account (mint)
         mint_rent,                // lamports
         mint_space as u64,        // space
-        &token_2022_program_id(), // program id
+        &token_program_id(), // program id
     );
 
     // Instruction to initialize mint account data
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -687,7 +552,7 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -705,18 +570,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(token_account_space)
         .await?;
 
-    // Instruction to create new account for token account (token 2022 program)
+    // Instruction to create new account for token account (token program)
     let create_token_account_instruction = create_account(
         &fee_payer.pubkey(),        // payer
         &token_account.pubkey(),    // new account (token account)
         token_account_rent,         // lamports
         token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
+        &token_program_id(),   // program id
     );
 
     // Instruction to initialize token account data
     let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
+        &token_program_id(),
         &token_account.pubkey(), // account
         &mint.pubkey(),          // mint
         &fee_payer.pubkey(),     // owner
@@ -730,7 +595,7 @@ async fn main() -> Result<()> {
         ],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &token_account],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -750,7 +615,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -796,10 +661,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 2;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -832,7 +697,6 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
     Ok(())
 }
 ```
@@ -841,15 +705,13 @@ async fn main() -> Result<()> {
 
 ## Como criar uma Associated Token Account
 
-Para criar uma associated token account, invoque a instrução
+Criar uma Associated Token Account (ATA) requer a instrução
 [`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18).
-Você pode encontrar implementações desta instrução
-[aqui](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
+Veja a
+[implementação aqui](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-A instrução para criar uma associated token account invoca automaticamente o
-System Program para criar a token account e invoca o Token Program para
-inicializar os dados da token account. Isso acontece através de Cross Program
-Invocations (CPI).
+Esta única instrução lida automaticamente com a criação da token account e sua
+inicialização através de Cross Program Invocations (CPI).
 
 ### Typescript
 
@@ -876,9 +738,9 @@ import {
   getCreateAssociatedTokenInstructionAsync,
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda
-} from "@solana-program/token-2022";
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -906,18 +768,18 @@ const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 // Get latest blockhash to include in transaction
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -947,18 +809,18 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address.toString());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address.toString());
+console.log("Transaction Signature:", transactionSignature);
 
 // Use findAssociatedTokenPda to derive the ATA address
 const [associatedTokenAddress] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: feePayer.address,
-  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
 });
 
 console.log(
-  "Associated Token Account Address: ",
+  "Associated Token Account Address:",
   associatedTokenAddress.toString()
 );
 
@@ -992,7 +854,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 
 // Get transaction signature
 const transactionSignature2 = getSignatureFromTransaction(signedTransaction2);
-console.log("Transaction Signature: ", transactionSignature2);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -1008,7 +870,7 @@ import {
   createInitializeMintInstruction,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountInstruction,
   ASSOCIATED_TOKEN_PROGRAM_ID
@@ -1016,7 +878,7 @@ import {
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1027,8 +889,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1044,7 +906,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -1053,14 +915,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -1078,7 +940,7 @@ const associatedTokenAccount = getAssociatedTokenAddressSync(
   mint.publicKey,
   feePayer.publicKey,
   false, // allowOwnerOffCurve
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
@@ -1088,15 +950,15 @@ const createAssociatedTokenAccountIx = createAssociatedTokenAccountInstruction(
   associatedTokenAccount, // associated token account address
   feePayer.publicKey, // owner
   mint.publicKey, // mint
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for associated token account
 let transaction2 = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAssociatedTokenAccountIx);
 
 // Sign and send transaction
@@ -1118,12 +980,12 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import {
   createMint,
   createAssociatedTokenAccount,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1134,8 +996,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1150,23 +1012,24 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create associated token account using helper function
 const associatedTokenAccount = await createAssociatedTokenAccount(
-  connection, // connection
-  feePayer, // fee payer
-  mintPubkey, // mint
-  feePayer.publicKey, // owner
+  connection,
+  feePayer,
+  mintPubkey,
+  feePayer.publicKey,
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
 console.log(
-  `Associated Token Account Address: ${associatedTokenAccount.toBase58()}`
+  "Associated Token Account Address:",
+  associatedTokenAccount.toBase58()
 );
 ```
 
@@ -1175,340 +1038,6 @@ console.log(
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction and add instruction
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Rust Async"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client
-        .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
-        .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client
-        .get_minimum_balance_for_rent_exemption(mint_space)
-        .await?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address (owner)
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction for associated token account creation
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account.to_string()
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://localhost:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Derive the associated token account address
-    let associated_token_address = token.get_associated_token_address(&payer.pubkey());
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_address
-    );
-
-    // Create associated token account for the payer
-    let result = token
-        .create_associated_token_account(
-            &payer.pubkey(), // owner
-        )
-        .await?;
-
-    println!(" {}", result);
-
-    Ok(())
-}
-```
-
-</CodeTabs>
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -1727,3 +1256,4 @@ async fn main() -> Result<()> {
 }
 ```
 
+</CodeTabs>

--- a/apps/web/content/docs/ru/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/ru/tokens/basics/create-mint.mdx
@@ -1,12 +1,12 @@
 ---
 title: Создание токенового минта
-description: Узнайте, как создать SPL Token mint.
+description: Узнайте, как создать SPL токеновый минт.
 ---
 
 ## Что такое аккаунт минта?
 
-Аккаунт минта — это тип аккаунта в Token Programs Solana, который уникально
-представляет токен в сети и хранит глобальные метаданные о токене.
+Аккаунт минта уникально представляет токен в Solana и хранит его глобальные
+метаданные.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -37,31 +37,31 @@ pub struct Mint {
   используют одну и ту же базовую реализацию для аккаунта минта.
 </Callout>
 
-Каждый токен в Solana существует как аккаунт минта, где адрес аккаунта минта
-является его уникальным идентификатором в сети.
+Каждый токен в Solana имеет аккаунт минта, а адрес минта служит уникальным
+идентификатором токена.
 
-Например, цифровой доллар USD Coin (USDC) в Solana имеет адрес минта
-`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Этот адрес минта служит
-уникальным идентификатором USD Coin во всей экосистеме Solana. Вы можете
-просмотреть детали об этом аккаунте минта на
+Например, USD Coin (USDC) имеет адрес минта
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Этот адрес уникально
+идентифицирует USDC во всей экосистеме Solana. Вы можете просмотреть этот минт
+на
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
 ## Как создать аккаунт минта
 
-Чтобы создать аккаунт минта, вызовите инструкцию
-[`InitializeMint`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L65).
-Реализации этой инструкции можно найти
-[здесь](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L79).
+Создание аккаунта минта требует использования инструкции
+[`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37).
+Подробнее см. в
+[деталях реализации](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-Транзакция для создания аккаунта минта требует двух инструкций:
+Для создания аккаунта минта необходимо выполнить две инструкции:
 
-1. Вызвать System Program для создания и выделения пространства для аккаунта
-   минта и передачи прав собственности Token Program.
-2. Вызвать Token Program для инициализации данных аккаунта минта.
+1. System Program: Создать аккаунт с выделенным пространством для аккаунта минта
+   и передать права собственности Token Program.
+2. Token Program: Инициализировать данные аккаунта минта.
 
 ### Typescript
 
-<CodeTabs storage="token-ts">
+<CodeTabs storage="token-ts" flags="r">
 
 ```ts !! title="Kit"
 import {
@@ -83,11 +83,11 @@ import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Generate keypairs for fee payer
@@ -109,18 +109,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 9,
@@ -154,7 +154,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
 console.log("Mint Address:", mint.address);
-console.log("Transaction Signature:", transactionSignature);
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy"
@@ -168,14 +168,14 @@ import {
 } from "@solana/web3.js";
 import {
   createInitializeMintInstruction,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -186,8 +186,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -199,15 +199,15 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: await getMinimumBalanceForRentExemptMint(connection),
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 const initializeMintInstruction = createInitializeMintInstruction(
-  mint.publicKey, // mint pubkey
-  9, // decimals
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  mint.publicKey,
+  9, // Decimals
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  TOKEN_PROGRAM_ID
 );
 
 const transaction = new Transaction().add(
@@ -221,17 +221,17 @@ const transactionSignature = await sendAndConfirmTransaction(
   [feePayer, mint] // Signers
 );
 
-console.log("Mint Address: ", mint.publicKey.toBase58());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { createMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import { createMint, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -242,107 +242,31 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
 const mintPubkey = await createMint(
-  connection, // connection
-  feePayer, // fee payer
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  9, // decimals
-  Keypair.generate(), // keypair
+  connection,
+  feePayer,
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  9, // Decimals
+  Keypair.generate(),
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 ```
 
 </CodeTabs>
 
 ### Rust
 
-<CodeTabs storage="token-rs">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    let mint_space = Mint::LEN;
-    let rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Create account instruction for mint
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(), // program id
-        &mint.pubkey(),           // mint address
-        &fee_payer.pubkey(),      // mint authority
-        Some(&fee_payer.pubkey()),// freeze authority
-        9,                        // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
+<CodeTabs storage="token-rs" flags="r">
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -354,16 +278,16 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
+use spl_token::{id as token_program_id, instruction::initialize_mint, state::Mint};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create connection to local validator
     let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -389,16 +313,16 @@ async fn main() -> Result<()> {
 
     // Create account instruction
     let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // fee payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        space as u64,             // space
-        &token_2022_program_id(), // program id
+        &fee_payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &token_program_id(),
     );
 
     // Initialize mint instruction
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint address
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -410,14 +334,14 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
     let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }
@@ -430,7 +354,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -441,7 +365,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     // Create connection to local validator
     let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
 
@@ -463,7 +387,6 @@ async fn main() -> Result<()> {
 
     // Generate keypair to use as address of mint
     let mint = Keypair::new();
-    println!("Mint keypair generated: {}", mint.pubkey());
 
     // Set up program client for Token client
     let program_client =
@@ -472,10 +395,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 9;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -494,7 +417,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }

--- a/apps/web/content/docs/ru/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/ru/tokens/basics/create-token-account.mdx
@@ -5,10 +5,9 @@ description: Узнайте, как создавать SPL токен-аккау
 
 ## Что такое токен-аккаунт?
 
-Токен-аккаунт — это тип аккаунта в Token Program Solana, который хранит
-информацию о владении конкретным токеном (mint) пользователем. Каждый
-токен-аккаунт связан с одним mint и отслеживает такие данные, как баланс токенов
-и владелец.
+Токен-аккаунт хранит ваш баланс определённого токена. Каждый токен-аккаунт
+связан с одним конкретным минтом и отслеживает ваш баланс токенов и
+дополнительные детали.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -40,68 +39,61 @@ pub struct Account {
 
 <Callout type="info">
   Обратите внимание, что в исходном коде разработчики называют токен-аккаунт
-  типом `Account`. И [Token
+  `Account` типом. И [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108),
   и [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
   используют одну и ту же базовую реализацию для токен-аккаунта.
 </Callout>
 
-Чтобы хранить токены для конкретного mint, пользователи должны сначала создать
-токен-аккаунт. Каждый токен-аккаунт отслеживает:
+Чтобы хранить токены, вам нужен токен-аккаунт для конкретного минта. Каждый
+токен-аккаунт отслеживает:
 
-1. Конкретный mint (тип токена, который хранится в токен-аккаунте)
-2. Владельца (авторитет, который может переводить токены с аккаунта)
+1. **Минт**: Тип токена, который он хранит
+2. **Владелец**: Авторитет, который может переводить токены с этого аккаунта
 
-Вот пример с использованием USD Coin (USDC) на Solana:
+### Пример: USD Coin (USDC)
 
-- Адрес mint для USD Coin: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- Circle (эмитент USD Coin) имеет токен-аккаунт по адресу
-  `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-- Этот токен-аккаунт хранит только единицы токена USD Coin (mint)
-- Circle обладает полномочиями владельца по адресу
-  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE` и может переводить эти токены
+- Адрес минта: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- Токен-аккаунт Circle: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- Этот аккаунт хранит только токены USDC
+- Circle управляет токенами через авторитет владельца токен-аккаунта:
+  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
 Вы можете просмотреть детали этого токен-аккаунта на
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  Термин "владелец" используется в двух разных контекстах:
+  **Понимание термина "владелец"**
 
-1. "Владелец" токен-аккаунта — это адрес, хранящийся в данных токен-аккаунта в
-   поле "owner" типа
-   [Account](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L106),
-   определенного в Token Program. Владелец может переводить, сжигать или
-   делегировать токены с аккаунта. Этот адрес иногда называют "авторитетом"
-   токен-аккаунта, чтобы отличить его от владельца программы.
+Термин "владелец" может использоваться в двух разных контекстах:
 
-2. Программа "владелец" - это программа, которая владеет данными аккаунта на
-   Solana. Для токен-аккаунтов это всегда либо Token Program, либо Token
-   Extensions Program, как указано в поле "owner" базового типа Solana
-   [Account](https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/account/src/lib.rs#L51).
+1. **Владелец токен-аккаунта**: Авторитет, который может переводить, сжигать или
+   делегировать токены. Это хранится в данных токен-аккаунта.
 
-При работе с токен-аккаунтами "владелец" обычно относится к полномочию, которое
-может распоряжаться токенами, а не к программе, которая владеет аккаунтом.
+2. **Владелец программы**: Программа, которая владеет аккаунтом (всегда Token
+   Program или Token Extension Program для токен-аккаунтов).
+
+При работе с токен-аккаунтами "владелец" обычно относится к авторитету, который
+может переводить токены, а не к программе, которая владеет аккаунтом.
 
 </Callout>
 
-## Что такое связанный токен-аккаунт?
+## Что такое ассоциированный токен-аккаунт?
 
-Связанный токен-аккаунт — это токен-аккаунт с адресом, который является Program
-Derived Address (PDA), созданным
+Ассоциированный токен-аккаунт (ATA) — это стандартный токен-аккаунт для кошелька
+для хранения определённого токена. Он использует детерминированный адрес (PDA),
+созданный
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
-Вы можете рассматривать связанный токен-аккаунт как основной токен-аккаунт для
-пользователя, чтобы хранить единицы определённого токена (mint).
 
 <Callout type="info">
-  Термин "связанные токен-аккаунты" применяется только к токен-аккаунтам,
-  которые создаёт Associated Token Program.
+  Только токен-аккаунты, созданные с помощью Associated Token Program,
+  называются "связанными токен-аккаунтами."
 </Callout>
 
-Связанные токен-аккаунты предоставляют детерминированный способ найти
-токен-аккаунт пользователя для любого заданного mint. Вы можете ознакомиться с
-реализацией этого процесса
-[здесь](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
+Связанные токен-аккаунты (ATA) используют детерминированные адреса, что упрощает
+поиск токен-аккаунта любого кошелька для заданного токена. См.
+[реализацию вычисления адреса здесь](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -121,35 +113,36 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-Этот детерминированный процесс гарантирует, что для любой комбинации адреса
-кошелька и mint токена существует ровно один адрес связанного токен-аккаунта.
-Такой подход упрощает поиск токен-аккаунта пользователя для любого заданного
-mint токена, устраняя необходимость отдельно отслеживать адреса токен-аккаунтов.
+Для любой комбинации кошелька и токена существует ровно один адрес ATA. Это
+устраняет необходимость вручную отслеживать адреса токен-аккаунтов — вы всегда
+можете вычислить правильный адрес.
 
 <Callout type="info">
-  Associated Token Program функционирует как вспомогательная программа, которая
-  создаёт токен-аккаунты с детерминированными адресами (PDA). При создании
-  связанного токен-аккаунта Associated Token Program выполняет CPI
-  (Cross-Program Invocation) либо в Token Program, либо в Token Extensions
-  Program. Token Program владеет созданным аккаунтом, который имеет ту же
-  `Account` структуру типа, что и определено в Token Program. Associated Token
-  Program не сохраняет состояние - он просто предлагает стандартизированный
-  способ создания токен-аккаунтов по детерминированному адресу, который является
-  PDA.
+  **Как работает Associated Token Program**
+
+Associated Token Program — это вспомогательная программа, которая:
+
+- Создает токен-аккаунты с детерминированными адресами (PDA)
+- Выполняет Cross-Program Invocations (CPI) для Token Program
+- Не хранит собственное состояние
+
+Созданные токен-аккаунты принадлежат Token Program и используют стандартную
+`Account` структуру.
+
 </Callout>
 
 ## Как создать токен-аккаунт
 
-Чтобы создать токен-аккаунт, вызовите инструкцию
-[`InitializeAccount`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L93).
-Реализации этой инструкции можно найти
-[здесь](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L145).
+Создание токен-аккаунта требует инструкции
+[`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63).
+См.
+[реализацию здесь](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
-Транзакция для создания токен-аккаунта требует выполнения двух инструкций:
+Для создания токен-аккаунта требуется выполнить две инструкции:
 
-1. Вызовите System Program для создания и выделения пространства для
-   токен-аккаунта и передачи прав собственности Token Program.
-2. Вызовите Token Program для инициализации данных токен-аккаунта.
+1. System Program: Создать аккаунт с выделенным пространством для токен-аккаунта
+   и передать права собственности Token Program
+2. Token Program: Инициализировать данные токен-аккаунта
 
 ### Typescript
 
@@ -177,8 +170,8 @@ import {
   getInitializeMintInstruction,
   getMintSize,
   getTokenSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -206,18 +199,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -247,8 +240,8 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address);
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", transactionSignature);
 
 // Generate keypair to use as address of token account
 const tokenAccount = await generateKeyPairSigner();
@@ -261,18 +254,18 @@ const tokenAccountRent = await rpc
   .getMinimumBalanceForRentExemption(tokenAccountSpace)
   .send();
 
-// Instruction to create new account for token account (token 2022 program)
+// Instruction to create new account for token account (token program)
 // Invokes the system program
 const createTokenAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: tokenAccount,
   lamports: tokenAccountRent,
   space: tokenAccountSpace,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize token account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeTokenAccountInstruction = getInitializeAccount2Instruction({
   account: tokenAccount.address,
   mint: mint.address,
@@ -303,11 +296,10 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 );
 
 // Get transaction signature
-const tokenAccountTxSignature =
-  getSignatureFromTransaction(signedTokenAccountTx);
+const transactionSignature2 = getSignatureFromTransaction(signedTokenAccountTx);
 
 console.log("Token Account Address:", tokenAccount.address);
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -326,12 +318,12 @@ import {
   getMinimumBalanceForRentExemptMint,
   getMinimumBalanceForRentExemptAccount,
   ACCOUNT_SIZE,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -342,8 +334,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -359,7 +351,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -368,14 +360,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -401,7 +393,7 @@ const createTokenAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: tokenAccount.publicKey,
   space: ACCOUNT_SIZE,
   lamports: tokenAccountRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize token account instruction
@@ -409,14 +401,14 @@ const initializeTokenAccountInstruction = createInitializeAccountInstruction(
   tokenAccount.publicKey, // token account
   mint.publicKey, // mint
   feePayer.publicKey, // owner
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for token account
 let tokenAccountTransaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createTokenAccountInstruction, initializeTokenAccountInstruction);
 
 // Sign and send transaction
@@ -427,20 +419,16 @@ const tokenAccountTxSignature = await sendAndConfirmTransaction(
 );
 
 console.log("Token Account Address:", tokenAccount.publicKey.toBase58());
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import {
-  createMint,
-  createAccount,
-  TOKEN_2022_PROGRAM_ID
-} from "@solana/spl-token";
+import { createMint, createAccount, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -451,8 +439,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -467,9 +455,9 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create token account using helper function
 const tokenAccount = await createAccount(
@@ -481,9 +469,9 @@ const tokenAccount = await createAccount(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
+console.log("Token Account Address:", tokenAccount.toBase58());
 ```
 
 </CodeTabs>
@@ -491,128 +479,6 @@ console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{
-    id as token_2022_program_id,
-    instruction::{initialize_account, initialize_mint},
-    state::{Account, Mint},
-};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Generate keypair to use as address of token account
-    let token_account = Keypair::new();
-
-    // Get token account size (in bytes)
-    let token_account_space = Account::LEN;
-    let token_account_rent = client.get_minimum_balance_for_rent_exemption(token_account_space)?;
-
-    // Instruction to create new account for token account (token 2022 program)
-    let create_token_account_instruction = create_account(
-        &fee_payer.pubkey(),        // payer
-        &token_account.pubkey(),    // new account (token account)
-        token_account_rent,         // lamports
-        token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
-    );
-
-    // Instruction to initialize token account data
-    let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
-        &token_account.pubkey(), // account
-        &mint.pubkey(),          // mint
-        &fee_payer.pubkey(),     // owner
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[
-            create_token_account_instruction,
-            initialize_token_account_instruction,
-        ],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &token_account],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Token Account Address: {}", token_account.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -624,8 +490,8 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{
-    id as token_2022_program_id,
+use spl_token::{
+    id as token_program_id,
     instruction::{initialize_account, initialize_mint},
     state::{Account, Mint},
 };
@@ -637,7 +503,7 @@ async fn main() -> Result<()> {
         String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -664,18 +530,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(mint_space)
         .await?;
 
-    // Instruction to create new account for mint (token 2022 program)
+    // Instruction to create new account for mint (token program)
     let create_account_instruction = create_account(
         &fee_payer.pubkey(),      // payer
         &mint.pubkey(),           // new account (mint)
         mint_rent,                // lamports
         mint_space as u64,        // space
-        &token_2022_program_id(), // program id
+        &token_program_id(), // program id
     );
 
     // Instruction to initialize mint account data
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -687,7 +553,7 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -705,18 +571,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(token_account_space)
         .await?;
 
-    // Instruction to create new account for token account (token 2022 program)
+    // Instruction to create new account for token account (token program)
     let create_token_account_instruction = create_account(
         &fee_payer.pubkey(),        // payer
         &token_account.pubkey(),    // new account (token account)
         token_account_rent,         // lamports
         token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
+        &token_program_id(),   // program id
     );
 
     // Instruction to initialize token account data
     let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
+        &token_program_id(),
         &token_account.pubkey(), // account
         &mint.pubkey(),          // mint
         &fee_payer.pubkey(),     // owner
@@ -730,7 +596,7 @@ async fn main() -> Result<()> {
         ],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &token_account],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -750,7 +616,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -796,10 +662,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 2;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -832,7 +698,6 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
     Ok(())
 }
 ```
@@ -841,14 +706,13 @@ async fn main() -> Result<()> {
 
 ## Как создать связанный токен-аккаунт
 
-Чтобы создать связанный токен-аккаунт, вызовите инструкцию
+Создание связанного токен-аккаунта (ATA) требует использования инструкции
 [`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18).
-Реализации этой инструкции можно найти
-[здесь](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
+См.
+[реализацию здесь](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-Инструкция для создания связанного токен-аккаунта автоматически вызывает System
-Program для создания токен-аккаунта и вызывает Token Program для инициализации
-данных токен-аккаунта. Это происходит через Cross Program Invocations (CPI).
+Эта единственная инструкция автоматически обрабатывает создание токен-аккаунта и
+его инициализацию через Cross Program Invocations (CPI).
 
 ### Typescript
 
@@ -875,9 +739,9 @@ import {
   getCreateAssociatedTokenInstructionAsync,
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda
-} from "@solana-program/token-2022";
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -905,18 +769,18 @@ const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 // Get latest blockhash to include in transaction
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -946,18 +810,18 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address.toString());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address.toString());
+console.log("Transaction Signature:", transactionSignature);
 
 // Use findAssociatedTokenPda to derive the ATA address
 const [associatedTokenAddress] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: feePayer.address,
-  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
 });
 
 console.log(
-  "Associated Token Account Address: ",
+  "Associated Token Account Address:",
   associatedTokenAddress.toString()
 );
 
@@ -991,7 +855,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 
 // Get transaction signature
 const transactionSignature2 = getSignatureFromTransaction(signedTransaction2);
-console.log("Transaction Signature: ", transactionSignature2);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -1007,7 +871,7 @@ import {
   createInitializeMintInstruction,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountInstruction,
   ASSOCIATED_TOKEN_PROGRAM_ID
@@ -1015,7 +879,7 @@ import {
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1026,8 +890,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1043,7 +907,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -1052,14 +916,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -1077,7 +941,7 @@ const associatedTokenAccount = getAssociatedTokenAddressSync(
   mint.publicKey,
   feePayer.publicKey,
   false, // allowOwnerOffCurve
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
@@ -1087,15 +951,15 @@ const createAssociatedTokenAccountIx = createAssociatedTokenAccountInstruction(
   associatedTokenAccount, // associated token account address
   feePayer.publicKey, // owner
   mint.publicKey, // mint
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for associated token account
 let transaction2 = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAssociatedTokenAccountIx);
 
 // Sign and send transaction
@@ -1117,12 +981,12 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import {
   createMint,
   createAssociatedTokenAccount,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1133,8 +997,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1149,23 +1013,24 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create associated token account using helper function
 const associatedTokenAccount = await createAssociatedTokenAccount(
-  connection, // connection
-  feePayer, // fee payer
-  mintPubkey, // mint
-  feePayer.publicKey, // owner
+  connection,
+  feePayer,
+  mintPubkey,
+  feePayer.publicKey,
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
 console.log(
-  `Associated Token Account Address: ${associatedTokenAccount.toBase58()}`
+  "Associated Token Account Address:",
+  associatedTokenAccount.toBase58()
 );
 ```
 
@@ -1174,340 +1039,6 @@ console.log(
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction and add instruction
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Rust Async"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client
-        .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
-        .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client
-        .get_minimum_balance_for_rent_exemption(mint_space)
-        .await?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address (owner)
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction for associated token account creation
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account.to_string()
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://localhost:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Derive the associated token account address
-    let associated_token_address = token.get_associated_token_address(&payer.pubkey());
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_address
-    );
-
-    // Create associated token account for the payer
-    let result = token
-        .create_associated_token_account(
-            &payer.pubkey(), // owner
-        )
-        .await?;
-
-    println!(" {}", result);
-
-    Ok(())
-}
-```
-
-</CodeTabs>
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -1726,96 +1257,4 @@ async fn main() -> Result<()> {
 }
 ```
 
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://localhost:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Generate keypair for token account
-    let token_account_keypair = Keypair::new();
-
-    // Create token account using the keypair
-    let token_account_result = token
-        .create_auxiliary_token_account(
-            &token_account_keypair, // account keypair
-            &payer.pubkey(),        // owner
-        )
-        .await?;
-
-    println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
-    Ok(())
-}
-```
+</CodeTabs>

--- a/apps/web/content/docs/tr/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/tr/tokens/basics/create-mint.mdx
@@ -5,9 +5,8 @@ description: SPL Token mint nasıl oluşturulacağını öğrenin.
 
 ## Mint Account Nedir?
 
-Mint account, Solana'nın Token Programs'ında ağ üzerinde bir tokeni benzersiz
-şekilde temsil eden ve token hakkında global meta verileri depolayan bir hesap
-türüdür.
+Mint account, Solana üzerinde bir tokeni benzersiz şekilde temsil eder ve global
+meta verilerini saklar.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -34,33 +33,33 @@ pub struct Mint {
   [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30)
   ve [Token Extension
-  Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)'ın
-  Mint hesabı için aynı temel uygulamayı paylaştığını unutmayın.
+  Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
+  programlarının her ikisinin de Mint hesabı için aynı temel uygulamayı
+  paylaştığını unutmayın.
 </Callout>
 
-Solana'daki her token, ağ üzerindeki benzersiz tanımlayıcısı mint account'un
-adresi olan bir mint account olarak var olur.
+Solana'daki her tokenin bir mint account'u vardır ve mint'in adresi, tokenin
+benzersiz tanımlayıcısı olarak işlev görür.
 
-Örneğin, Solana üzerindeki USD Coin (USDC) dijital doları
-`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` mint adresine sahiptir. Bu mint
-adresi, tüm Solana ekosisteminde USD Coin'in benzersiz tanımlayıcısı olarak
-işlev görür. Bu mint account hakkındaki detayları
-[Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)'da
-görüntüleyebilirsiniz.
+Örneğin, USD Coin (USDC)'in mint adresi
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`'dir. Bu adres, USDC'yi tüm Solana
+ekosisteminde benzersiz şekilde tanımlar. Bu mint'i
+[Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)
+üzerinde görüntüleyebilirsiniz.
 
 ## Mint Account Nasıl Oluşturulur
 
-Mint Account oluşturmak için
-[`InitializeMint`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L65)
-talimatını çağırın. Bu talimatın uygulamalarını
-[burada](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L79)
-bulabilirsiniz.
+Mint account oluşturmak
+[`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37)
+talimatını gerektirir.
+[Uygulama detaylarını burada](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27)
+görebilirsiniz.
 
-Mint account oluşturmak için işlem iki talimat gerektirir:
+Mint account oluşturmak için iki talimatı çağırmanız gerekir:
 
-1. Mint account için alan oluşturmak ve ayırmak için System Program'ı çağırın ve
+1. System Program: Mint account için ayrılmış alana sahip bir hesap oluşturun ve
    sahipliği Token Program'a aktarın.
-2. Mint account verilerini başlatmak için Token Program'ı çağırın.
+2. Token Program: Mint account verilerini başlatın
 
 ### Typescript
 
@@ -86,8 +85,8 @@ import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -112,18 +111,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 9,
@@ -157,7 +156,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
 console.log("Mint Address:", mint.address);
-console.log("Transaction Signature:", transactionSignature);
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy"
@@ -171,14 +170,14 @@ import {
 } from "@solana/web3.js";
 import {
   createInitializeMintInstruction,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint
 } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -189,8 +188,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -202,15 +201,15 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: await getMinimumBalanceForRentExemptMint(connection),
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 const initializeMintInstruction = createInitializeMintInstruction(
-  mint.publicKey, // mint pubkey
-  9, // decimals
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  mint.publicKey,
+  9, // Decimals
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  TOKEN_PROGRAM_ID
 );
 
 const transaction = new Transaction().add(
@@ -224,17 +223,17 @@ const transactionSignature = await sendAndConfirmTransaction(
   [feePayer, mint] // Signers
 );
 
-console.log("Mint Address: ", mint.publicKey.toBase58());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { createMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import { createMint, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -245,24 +244,24 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
 const mintPubkey = await createMint(
-  connection, // connection
-  feePayer, // fee payer
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  9, // decimals
-  Keypair.generate(), // keypair
+  connection,
+  feePayer,
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  9, // Decimals
+  Keypair.generate(),
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 ```
 
 </CodeTabs>
@@ -270,82 +269,6 @@ console.log(`Mint Address: ${mintPubkey.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    let mint_space = Mint::LEN;
-    let rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Create account instruction for mint
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(), // program id
-        &mint.pubkey(),           // mint address
-        &fee_payer.pubkey(),      // mint authority
-        Some(&fee_payer.pubkey()),// freeze authority
-        9,                        // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -357,7 +280,7 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
+use spl_token::{id as token_program_id, instruction::initialize_mint, state::Mint};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -366,7 +289,7 @@ async fn main() -> Result<()> {
         String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -392,16 +315,16 @@ async fn main() -> Result<()> {
 
     // Create account instruction
     let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // fee payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        space as u64,             // space
-        &token_2022_program_id(), // program id
+        &fee_payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &token_program_id(),
     );
 
     // Initialize mint instruction
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint address
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -413,14 +336,14 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
     let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }
@@ -433,7 +356,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -466,7 +389,6 @@ async fn main() -> Result<()> {
 
     // Generate keypair to use as address of mint
     let mint = Keypair::new();
-    println!("Mint keypair generated: {}", mint.pubkey());
 
     // Set up program client for Token client
     let program_client =
@@ -475,10 +397,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 9;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -497,7 +419,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }

--- a/apps/web/content/docs/tr/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/tr/tokens/basics/create-token-account.mdx
@@ -1,14 +1,13 @@
 ---
-title: Token Account Oluşturma
-description: SPL Token Account'ları nasıl oluşturulacağını öğrenin.
+title: Token Hesabı Oluşturma
+description: SPL Token Hesaplarının nasıl oluşturulacağını öğrenin.
 ---
 
-## Token Account Nedir?
+## Token Hesabı Nedir?
 
-Token account, Solana'nın Token Programları'nda belirli bir token'ın (mint) bir
-kişinin sahipliği hakkında bilgi depolayan bir hesap türüdür. Her token account
-tek bir mint ile ilişkilendirilir ve token bakiyesi ve sahibi gibi detayları
-takip eder.
+Bir token hesabı, belirli bir tokenin bakiyesini saklar. Her token hesabı tam
+olarak bir mint ile ilişkilendirilir ve token bakiyenizi ve ek detayları takip
+eder.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -39,74 +38,63 @@ pub struct Account {
 ```
 
 <Callout type="info">
-  Kaynak kodunda, geliştiricilerin Token account'ı `Account` türü olarak
+  Kaynak kodunda, geliştiricilerin Token hesabını `Account` türü olarak
   adlandırdığını unutmayın. Hem [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)
-  hem de [Token Extension
+  hem de [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
-  Token account için aynı temel uygulamayı paylaşır.
+  Token hesabı için aynı temel uygulamayı paylaşır.
 </Callout>
 
-Belirli bir mint için token tutmak için, kullanıcıların önce bir token account
-oluşturması gerekir. Her token account şunları takip eder:
+Tokenleri tutmak için, o belirli mint için bir token hesabına ihtiyacınız
+vardır. Her token hesabı şunları takip eder:
 
-1. Belirli bir mint (token account'ın tuttuğu token türü)
-2. Bir sahip (hesaptan token aktarma yetkisine sahip olan otorite)
+1. **Mint**: Tuttuğu belirli token türü
+2. **Sahip**: Bu hesaptan tokenleri transfer edebilen yetkili
 
-İşte Solana üzerindeki USD Coin (USDC) kullanarak bir örnek:
+### Örnek: USD Coin (USDC)
 
-- USD Coin mint adresi: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- Circle (USD Coin ihraççısı) `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-  adresinde bir token account'a sahiptir
-- Bu token account sadece USD Coin token (mint) birimlerini tutar
-- Circle, `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE` adresinde sahip
-  yetkisine sahiptir ve bu token'ları transfer edebilir
+- Mint adresi: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- Circle'ın token hesabı: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- Bu hesap sadece USDC tokenleri tutar
+- Circle, token hesabı sahibi yetkisi aracılığıyla tokeni kontrol eder:
+  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
-Bu token account'ın detaylarını
+Bu token hesabının detaylarını
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa)
 üzerinde görüntüleyebilirsiniz.
 
 <Callout type="info">
-  "Sahip" terimi iki farklı bağlamda kullanılır:
+  **"Sahip" Terminolojisini Anlamak**
 
-1. Token account "sahibi" - Bu, token account'ın verilerinde Token Program
-   tarafından tanımlanan
-   [Account](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L106)
-   türünün "owner" alanı olarak saklanan bir adrestir. Sahip, hesaptan token
-   transfer edebilir, yakabilir veya devredebilir. Bu adres, bazen program
-   sahibinden ayırt etmek için token account'ın "yetkisi" olarak da
-   adlandırılır.
+"Sahip" terimi iki farklı bağlamda kullanılabilir:
 
-2. Program "sahibi" - Bu, Solana'daki hesap verilerinin sahibi olan programı
-   ifade eder. Token account'ları için bu, her zaman ya Token Program ya da
-   Token Extension Program'dır ve temel Solana
-   [Account](https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/account/src/lib.rs#L51)
-   tipinin "owner" alanında belirtilir.
+1. **Token Hesabı Sahibi**: Tokenleri transfer edebilen, yakabilen veya
+   devredebilen yetkili. Bu, token hesabının verilerinde saklanır.
 
-Token account'larıyla çalışırken, "owner" genellikle hesabın sahibi olan
-programı değil, tokenleri harcama yetkisine sahip olan otoriteyi ifade eder.
+2. **Program Sahibi**: Hesabın sahibi olan program (token hesapları için her
+   zaman Token Program veya Token Extensions Program).
+
+Token hesaplarıyla çalışırken, "sahip" genellikle hesabın sahibi olan programa
+değil, tokenleri transfer edebilen yetkiliyi ifade eder.
 
 </Callout>
 
-## Associated token account nedir?
+## Associated Token Account Nedir?
 
-Associated token account,
+Associated token account (ATA), bir cüzdanın belirli bir tokeni tutması için
+varsayılan token hesabıdır.
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program)
-tarafından oluşturulan Program Derived Address (PDA) olan bir adrese sahip token
-account'tır. Associated token account'ı, bir kullanıcının belirli bir token'ın
-(mint) birimlerini tutmak için kullandığı varsayılan token account olarak
-düşünebilirsiniz.
+tarafından oluşturulan deterministik bir adres (PDA) kullanır.
 
 <Callout type="info">
-  "Associated token accounts" terimi yalnızca Associated Token Program'ın
-  oluşturduğu token account'ları için geçerlidir.
+  Yalnızca Associated Token Program tarafından oluşturulan token hesapları
+  "associated token accounts" olarak adlandırılır.
 </Callout>
 
-Associated token account'lar, herhangi bir mint için bir kullanıcının token
-account'ını belirleyici bir şekilde bulmanın yolunu sağlar. Türetmenin
-uygulamasını
-[burada](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56)
-inceleyebilirsiniz.
+ATA'lar belirleyici adresler kullanır, bu da herhangi bir cüzdanın belirli bir
+mint için token hesabını bulmanızı kolaylaştırır.
+[Türetme uygulamasını burada görebilirsiniz](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -126,36 +114,36 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-Bu belirleyici türetme, herhangi bir cüzdan adresi ve token mint kombinasyonu
-için tam olarak bir associated token account adresi olduğunu garanti eder. Bu
-yaklaşım, herhangi bir token mint için bir kullanıcının token account'ını bulma
-işlemini basitleştirir ve token account adreslerini ayrıca takip etme ihtiyacını
-ortadan kaldırır.
+Herhangi bir cüzdan ve token kombinasyonu için tam olarak bir ATA adresi vardır.
+Bu, token hesap adreslerini manuel olarak takip etme ihtiyacını ortadan
+kaldırır—her zaman doğru adresi türetebilirsiniz.
 
 <Callout type="info">
-  Associated Token Program, belirleyici adreslerle (PDA'lar) token account'ları
-  oluşturan bir yardımcı program olarak işlev görür. Associated token account
-  oluştururken, Associated Token Program, Token Program veya Token Extension
-  Program'a bir CPI (Cross-Program Invocation) yapar. Token programı, token
-  programında tanımlanan aynı `Account` tip yapısına sahip olan oluşturulan
-  hesabın sahibidir. Associated Token Program hiçbir durum tutmaz - sadece
-  belirleyici bir adreste (PDA olan) token account'ları oluşturmak için
-  standartlaştırılmış bir yol sunar.
+  **Associated Token Program Nasıl Çalışır**
+
+Associated Token Program şunları yapan bir yardımcıdır:
+
+- Belirleyici adreslerde (PDA'lar) token hesapları oluşturur
+- Token Program'a Cross-Program Invocation (CPI) yapar
+- Kendisi herhangi bir durum bilgisi tutmaz
+
+Oluşturulan token hesapları Token Program tarafından sahiplenilir ve standart
+`Account` yapısını kullanır.
+
 </Callout>
 
 ## Token Hesabı Nasıl Oluşturulur
 
-Token Hesabı oluşturmak için
-[`InitializeAccount`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L93)
-talimatını çağırın. Bu talimatın uygulamalarını
-[burada](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L145)
-bulabilirsiniz.
+Token hesabı oluşturmak için
+[`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63)
+talimatı gereklidir.
+[Uygulamayı burada görebilirsiniz](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
-Token hesabı oluşturmak için işlem iki talimat gerektirir:
+Token hesabı oluşturmak için iki talimata ihtiyacınız vardır:
 
-1. Token hesabı için alan oluşturmak ve ayırmak için System Program'ı çağırın ve
-   sahipliği Token Program'a aktarın.
-2. Token hesap verilerini başlatmak için Token Program'ı çağırın.
+1. System Program: Token hesabı için ayrılmış alanı olan bir hesap oluşturun ve
+   sahipliği Token Program'a aktarın
+2. Token Program: Token hesap verilerini başlatın
 
 ### Typescript
 
@@ -183,8 +171,8 @@ import {
   getInitializeMintInstruction,
   getMintSize,
   getTokenSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -212,18 +200,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -253,8 +241,8 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address);
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", transactionSignature);
 
 // Generate keypair to use as address of token account
 const tokenAccount = await generateKeyPairSigner();
@@ -267,18 +255,18 @@ const tokenAccountRent = await rpc
   .getMinimumBalanceForRentExemption(tokenAccountSpace)
   .send();
 
-// Instruction to create new account for token account (token 2022 program)
+// Instruction to create new account for token account (token program)
 // Invokes the system program
 const createTokenAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: tokenAccount,
   lamports: tokenAccountRent,
   space: tokenAccountSpace,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize token account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeTokenAccountInstruction = getInitializeAccount2Instruction({
   account: tokenAccount.address,
   mint: mint.address,
@@ -309,11 +297,10 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 );
 
 // Get transaction signature
-const tokenAccountTxSignature =
-  getSignatureFromTransaction(signedTokenAccountTx);
+const transactionSignature2 = getSignatureFromTransaction(signedTokenAccountTx);
 
 console.log("Token Account Address:", tokenAccount.address);
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -332,12 +319,12 @@ import {
   getMinimumBalanceForRentExemptMint,
   getMinimumBalanceForRentExemptAccount,
   ACCOUNT_SIZE,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -348,8 +335,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -365,7 +352,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -374,14 +361,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -407,7 +394,7 @@ const createTokenAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: tokenAccount.publicKey,
   space: ACCOUNT_SIZE,
   lamports: tokenAccountRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize token account instruction
@@ -415,14 +402,14 @@ const initializeTokenAccountInstruction = createInitializeAccountInstruction(
   tokenAccount.publicKey, // token account
   mint.publicKey, // mint
   feePayer.publicKey, // owner
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for token account
 let tokenAccountTransaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createTokenAccountInstruction, initializeTokenAccountInstruction);
 
 // Sign and send transaction
@@ -433,20 +420,16 @@ const tokenAccountTxSignature = await sendAndConfirmTransaction(
 );
 
 console.log("Token Account Address:", tokenAccount.publicKey.toBase58());
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import {
-  createMint,
-  createAccount,
-  TOKEN_2022_PROGRAM_ID
-} from "@solana/spl-token";
+import { createMint, createAccount, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -457,8 +440,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -473,9 +456,9 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create token account using helper function
 const tokenAccount = await createAccount(
@@ -487,9 +470,9 @@ const tokenAccount = await createAccount(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
+console.log("Token Account Address:", tokenAccount.toBase58());
 ```
 
 </CodeTabs>
@@ -497,128 +480,6 @@ console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{
-    id as token_2022_program_id,
-    instruction::{initialize_account, initialize_mint},
-    state::{Account, Mint},
-};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Generate keypair to use as address of token account
-    let token_account = Keypair::new();
-
-    // Get token account size (in bytes)
-    let token_account_space = Account::LEN;
-    let token_account_rent = client.get_minimum_balance_for_rent_exemption(token_account_space)?;
-
-    // Instruction to create new account for token account (token 2022 program)
-    let create_token_account_instruction = create_account(
-        &fee_payer.pubkey(),        // payer
-        &token_account.pubkey(),    // new account (token account)
-        token_account_rent,         // lamports
-        token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
-    );
-
-    // Instruction to initialize token account data
-    let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
-        &token_account.pubkey(), // account
-        &mint.pubkey(),          // mint
-        &fee_payer.pubkey(),     // owner
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[
-            create_token_account_instruction,
-            initialize_token_account_instruction,
-        ],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &token_account],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Token Account Address: {}", token_account.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -630,8 +491,8 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{
-    id as token_2022_program_id,
+use spl_token::{
+    id as token_program_id,
     instruction::{initialize_account, initialize_mint},
     state::{Account, Mint},
 };
@@ -643,7 +504,7 @@ async fn main() -> Result<()> {
         String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -670,18 +531,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(mint_space)
         .await?;
 
-    // Instruction to create new account for mint (token 2022 program)
+    // Instruction to create new account for mint (token program)
     let create_account_instruction = create_account(
         &fee_payer.pubkey(),      // payer
         &mint.pubkey(),           // new account (mint)
         mint_rent,                // lamports
         mint_space as u64,        // space
-        &token_2022_program_id(), // program id
+        &token_program_id(), // program id
     );
 
     // Instruction to initialize mint account data
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -693,7 +554,7 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -711,18 +572,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(token_account_space)
         .await?;
 
-    // Instruction to create new account for token account (token 2022 program)
+    // Instruction to create new account for token account (token program)
     let create_token_account_instruction = create_account(
         &fee_payer.pubkey(),        // payer
         &token_account.pubkey(),    // new account (token account)
         token_account_rent,         // lamports
         token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
+        &token_program_id(),   // program id
     );
 
     // Instruction to initialize token account data
     let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
+        &token_program_id(),
         &token_account.pubkey(), // account
         &mint.pubkey(),          // mint
         &fee_payer.pubkey(),     // owner
@@ -736,7 +597,7 @@ async fn main() -> Result<()> {
         ],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &token_account],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -756,7 +617,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -802,10 +663,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 2;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -838,7 +699,6 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
     Ok(())
 }
 ```
@@ -847,16 +707,13 @@ async fn main() -> Result<()> {
 
 ## Associated Token Account Nasıl Oluşturulur
 
-Associated Token Account oluşturmak için
-[`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
-talimatını çağırın. Bu talimatın uygulamalarını
-[burada](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66)
-bulabilirsiniz.
+Associated Token Account (ATA) oluşturmak için
+[---INLINE-CODE-PLACEHOLDER-85c08564ca556b926744bf94497c4af2---](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
+talimatı gereklidir.
+[Buradaki uygulamaya bakın](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-Associated token account oluşturmak için talimat, token hesabı oluşturmak için
-System Program'ı ve token hesap verilerini başlatmak için Token Program'ı
-otomatik olarak çağırır. Bu, Cross Program Invocation (CPI) aracılığıyla
-gerçekleşir.
+Bu tek talimat, Cross Program Invocation (CPI) aracılığıyla token hesabını
+oluşturmayı ve başlatmayı otomatik olarak yönetir.
 
 ### Typescript
 
@@ -883,9 +740,9 @@ import {
   getCreateAssociatedTokenInstructionAsync,
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda
-} from "@solana-program/token-2022";
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -913,18 +770,18 @@ const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 // Get latest blockhash to include in transaction
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -954,18 +811,18 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address.toString());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address.toString());
+console.log("Transaction Signature:", transactionSignature);
 
 // Use findAssociatedTokenPda to derive the ATA address
 const [associatedTokenAddress] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: feePayer.address,
-  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
 });
 
 console.log(
-  "Associated Token Account Address: ",
+  "Associated Token Account Address:",
   associatedTokenAddress.toString()
 );
 
@@ -999,7 +856,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 
 // Get transaction signature
 const transactionSignature2 = getSignatureFromTransaction(signedTransaction2);
-console.log("Transaction Signature: ", transactionSignature2);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -1015,7 +872,7 @@ import {
   createInitializeMintInstruction,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountInstruction,
   ASSOCIATED_TOKEN_PROGRAM_ID
@@ -1023,7 +880,7 @@ import {
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1034,8 +891,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1051,7 +908,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -1060,14 +917,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -1085,7 +942,7 @@ const associatedTokenAccount = getAssociatedTokenAddressSync(
   mint.publicKey,
   feePayer.publicKey,
   false, // allowOwnerOffCurve
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
@@ -1095,15 +952,15 @@ const createAssociatedTokenAccountIx = createAssociatedTokenAccountInstruction(
   associatedTokenAccount, // associated token account address
   feePayer.publicKey, // owner
   mint.publicKey, // mint
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for associated token account
 let transaction2 = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAssociatedTokenAccountIx);
 
 // Sign and send transaction
@@ -1125,12 +982,12 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import {
   createMint,
   createAssociatedTokenAccount,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1141,8 +998,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1157,23 +1014,24 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create associated token account using helper function
 const associatedTokenAccount = await createAssociatedTokenAccount(
-  connection, // connection
-  feePayer, // fee payer
-  mintPubkey, // mint
-  feePayer.publicKey, // owner
+  connection,
+  feePayer,
+  mintPubkey,
+  feePayer.publicKey,
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
 console.log(
-  `Associated Token Account Address: ${associatedTokenAccount.toBase58()}`
+  "Associated Token Account Address:",
+  associatedTokenAccount.toBase58()
 );
 ```
 
@@ -1182,340 +1040,6 @@ console.log(
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction and add instruction
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Rust Async"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client
-        .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
-        .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client
-        .get_minimum_balance_for_rent_exemption(mint_space)
-        .await?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address (owner)
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction for associated token account creation
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account.to_string()
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://localhost:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Derive the associated token account address
-    let associated_token_address = token.get_associated_token_address(&payer.pubkey());
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_address
-    );
-
-    // Create associated token account for the payer
-    let result = token
-        .create_associated_token_account(
-            &payer.pubkey(), // owner
-        )
-        .await?;
-
-    println!(" {}", result);
-
-    Ok(())
-}
-```
-
-</CodeTabs>
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -1734,3 +1258,4 @@ async fn main() -> Result<()> {
 }
 ```
 
+</CodeTabs>

--- a/apps/web/content/docs/uk/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/uk/tokens/basics/create-mint.mdx
@@ -1,12 +1,12 @@
 ---
 title: Створення токен-мінту
-description: Дізнайтеся, як створити SPL Token mint.
+description: Дізнайтеся, як створити мінт SPL токена.
 ---
 
 ## Що таке Mint Account?
 
-Mint account — це тип облікового запису в Token Programs мережі Solana, який
-унікально представляє токен у мережі та зберігає глобальні метадані про токен.
+Mint account унікально представляє токен у мережі Solana та зберігає його
+глобальні метадані.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -34,30 +34,29 @@ pub struct Mint {
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30),
   і [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
-  використовують однакову базову реалізацію для облікового запису Mint.
+  використовують однакову базову реалізацію для Mint account.
 </Callout>
 
-Кожен токен у Solana існує як mint account, де адреса mint account є його
-унікальним ідентифікатором у мережі.
+Кожен токен у мережі Solana має mint account, а адреса мінту слугує унікальним
+ідентифікатором токена.
 
-Наприклад, цифровий долар USD Coin (USDC) у Solana має адресу мінту
-`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Ця адреса мінту служить
-унікальним ідентифікатором USD Coin у всій екосистемі Solana. Ви можете
-переглянути деталі про цей mint account на
+Наприклад, USD Coin (USDC) має адресу мінту
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Ця адреса унікально ідентифікує
+USDC у всій екосистемі Solana. Ви можете переглянути цей мінт на
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
 ## Як створити Mint Account
 
-Щоб створити Mint Account, викличте інструкцію
-[`InitializeMint`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L65).
-Ви можете знайти реалізації цієї інструкції
-[тут](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L79).
+Створення mint account потребує інструкції
+[`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37).
+Деталі реалізації можна переглянути
+[тут](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-Транзакція для створення mint account потребує двох інструкцій:
+Для створення mint account потрібно викликати дві інструкції:
 
-1. Викликати System Program для створення та виділення простору для mint account
-   і передачі права власності до Token Program.
-2. Викликати Token Program для ініціалізації даних mint account.
+1. System Program: Створення облікового запису з виділеним простором для mint
+   account та передача права власності до Token Program.
+2. Token Program: Ініціалізація даних mint account
 
 ### Typescript
 
@@ -83,11 +82,11 @@ import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Generate keypairs for fee payer
@@ -109,18 +108,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 9,
@@ -154,7 +153,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
 console.log("Mint Address:", mint.address);
-console.log("Transaction Signature:", transactionSignature);
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy"
@@ -168,14 +167,14 @@ import {
 } from "@solana/web3.js";
 import {
   createInitializeMintInstruction,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -186,8 +185,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -199,15 +198,15 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: await getMinimumBalanceForRentExemptMint(connection),
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 const initializeMintInstruction = createInitializeMintInstruction(
-  mint.publicKey, // mint pubkey
-  9, // decimals
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  mint.publicKey,
+  9, // Decimals
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  TOKEN_PROGRAM_ID
 );
 
 const transaction = new Transaction().add(
@@ -221,17 +220,17 @@ const transactionSignature = await sendAndConfirmTransaction(
   [feePayer, mint] // Signers
 );
 
-console.log("Mint Address: ", mint.publicKey.toBase58());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { createMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import { createMint, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -242,24 +241,24 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
 const mintPubkey = await createMint(
-  connection, // connection
-  feePayer, // fee payer
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  9, // decimals
-  Keypair.generate(), // keypair
+  connection,
+  feePayer,
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  9, // Decimals
+  Keypair.generate(),
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 ```
 
 </CodeTabs>
@@ -267,82 +266,6 @@ console.log(`Mint Address: ${mintPubkey.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    let mint_space = Mint::LEN;
-    let rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Create account instruction for mint
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(), // program id
-        &mint.pubkey(),           // mint address
-        &fee_payer.pubkey(),      // mint authority
-        Some(&fee_payer.pubkey()),// freeze authority
-        9,                        // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -354,16 +277,16 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
+use spl_token::{id as token_program_id, instruction::initialize_mint, state::Mint};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create connection to local validator
     let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -389,16 +312,16 @@ async fn main() -> Result<()> {
 
     // Create account instruction
     let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // fee payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        space as u64,             // space
-        &token_2022_program_id(), // program id
+        &fee_payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &token_program_id(),
     );
 
     // Initialize mint instruction
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint address
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -410,14 +333,14 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
     let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }
@@ -430,7 +353,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -441,7 +364,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     // Create connection to local validator
     let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
 
@@ -463,7 +386,6 @@ async fn main() -> Result<()> {
 
     // Generate keypair to use as address of mint
     let mint = Keypair::new();
-    println!("Mint keypair generated: {}", mint.pubkey());
 
     // Set up program client for Token client
     let program_client =
@@ -472,10 +394,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 9;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -494,7 +416,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }

--- a/apps/web/content/docs/uk/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/uk/tokens/basics/create-token-account.mdx
@@ -1,14 +1,12 @@
 ---
-title: Створення Token Account
+title: Створення токен-акаунта
 description: Дізнайтеся, як створювати SPL Token Accounts.
 ---
 
 ## Що таке Token Account?
 
-Token account — це тип облікового запису в Token Programs Solana, який зберігає
-інформацію про володіння певним токеном (mint) окремою особою. Кожен token
-account пов'язаний з одним mint і відстежує такі деталі, як баланс токенів та
-власник.
+Token account зберігає ваш баланс певного токена. Кожен token account пов'язаний
+з одним конкретним mint і відстежує ваш баланс токенів та додаткові деталі.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -39,69 +37,61 @@ pub struct Account {
 ```
 
 <Callout type="info">
-  Зауважте, що у вихідному коді розробники називають Token account типом
+  Зверніть увагу, що в вихідному коді розробники називають Token account типом
   `Account`. І [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108),
-  і [Token Extension
+  і [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
   використовують однакову базову реалізацію для Token account.
 </Callout>
 
-Щоб зберігати токени для певного mint, користувачі повинні спочатку створити
-token account. Кожен token account відстежує:
+Щоб зберігати токени, вам потрібен token account для конкретного mint. Кожен
+token account відстежує:
 
-1. Конкретний mint (тип токена, одиниці якого зберігає token account)
-2. Власника (повноваження, які можуть переказувати токени з облікового запису)
+1. **Mint**: Конкретний тип токена, який він містить
+2. **Owner**: Власник, який може переказувати токени з цього акаунта
 
-Ось приклад з використанням USD Coin (USDC) на Solana:
+### Приклад: USD Coin (USDC)
 
-- Адреса mint USD Coin: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- Circle (емітент USD Coin) має token account за адресою
-  `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-- Цей token account зберігає лише одиниці токена USD Coin (mint)
-- Circle має повноваження власника за адресою
-  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE` і може переказувати ці токени
+- Адреса mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- Token account Circle: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- Цей акаунт містить лише токени USDC
+- Circle контролює токени через власника token account:
+  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
 Ви можете переглянути деталі цього token account на
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  Термін "власник" використовується у двох різних контекстах:
+  **Розуміння терміну "Owner"**
 
-1. "Власник" token account — це адреса, збережена в даних token account як поле
-   "owner" типу
-   [Account](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L106),
-   визначеного Token Program. Власник може переказувати, спалювати або
-   делегувати токени з облікового запису. Цю адресу іноді називають
-   "повноваженням" token account, щоб відрізнити її від власника програми.
+Термін "owner" може використовуватися у двох різних контекстах:
 
-2. "Власник" програми - це стосується програми, яка володіє даними облікового
-   запису у Solana. Для token account це завжди або Token Program, або Token
-   Extension Program, як зазначено в полі "owner" базового типу Solana
-   [Account](https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/account/src/lib.rs#L51).
+1. **Власник Token Account**: Власник, який може переказувати, спалювати або
+   делегувати токени. Це зберігається в даних token account.
 
-Коли йдеться про token account, "власник" зазвичай означає повноваження, які
-можуть витрачати токени, а не програму, яка володіє обліковим записом.
+2. **Власник програми**: Програма, яка володіє акаунтом (завжди Token Program
+   або Token Extensions Program для token accounts).
+
+Коли йдеться про token accounts, "owner" зазвичай стосується власника, який може
+переказувати токени, а не програми, яка володіє акаунтом.
 
 </Callout>
 
-## Що таке associated token account?
+## Що таке Associated Token Account?
 
-Associated token account - це token account з адресою, яка є Program Derived
-Address (PDA), створеною
+Associated token account (ATA) — це стандартний token account для гаманця для
+зберігання певного токена. Він використовує детерміновану адресу (PDA), створену
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
-Можна розглядати associated token account як типовий token account для
-користувача для зберігання одиниць певного токена (mint).
 
 <Callout type="info">
-  Термін "associated token accounts" застосовується лише до token account, які
-  створює Associated Token Program.
+  Лише token accounts, створені Associated Token Program, називаються
+  "associated token accounts."
 </Callout>
 
-Associated token account забезпечують детермінований спосіб знаходження token
-account користувача для будь-якого заданого mint. Ви можете переглянути
-реалізацію деривації
-[тут](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
+ATA використовують детерміновані адреси, що спрощує пошук token account
+будь-якого гаманця для заданого mint. Дивіться
+[реалізацію деривації тут](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -121,34 +111,36 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-Ця детермінована деривація гарантує, що для будь-якої комбінації адреси гаманця
-та mint токена існує рівно одна адреса associated token account. Цей підхід
-спрощує пошук token account користувача для будь-якого заданого mint токена,
-усуваючи необхідність окремо відстежувати адреси token account.
+Для будь-якої комбінації гаманця та токена існує рівно одна адреса ATA. Це
+усуває необхідність вручну відстежувати адреси token account — ви завжди можете
+вивести правильну адресу.
 
 <Callout type="info">
-  Associated Token Program функціонує як допоміжна програма, яка створює token
-  account з детермінованими адресами (PDA). При створенні associated token
-  account, Associated Token Program робить CPI (Cross-Program Invocation) до
-  Token Program або Token Extension Program. Програма токенів володіє створеним
-  обліковим записом, який має таку ж `Account` структуру типу, як визначено в
-  програмі токенів. Associated Token Program не зберігає стан - вона просто
-  пропонує стандартизований спосіб створення token account за детермінованою
-  адресою, яка є PDA.
+  **Як працює Associated Token Program**
+
+Associated Token Program — це допоміжна програма, яка:
+
+- Створює token accounts за детермінованими адресами (PDA)
+- Виконує Cross-Program Invocations (CPI) до Token Program
+- Не підтримує власний стан
+
+Створені token accounts належать Token Program і використовують стандартну
+`Account` структуру.
+
 </Callout>
 
-## Як створити токен-акаунт
+## Як створити Token Account
 
-Щоб створити токен-акаунт, викличте інструкцію
-[`InitializeAccount`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L93).
-Реалізації цієї інструкції можна знайти
-[тут](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L145).
+Створення token account вимагає інструкції
+[`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63).
+Дивіться
+[реалізацію тут](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
-Транзакція для створення токен-акаунта потребує двох інструкцій:
+Для створення token account потрібні дві інструкції:
 
-1. Викликати System Program для створення та виділення місця для токен-акаунта і
-   передачі права власності до Token Program.
-2. Викликати Token Program для ініціалізації даних токен-акаунта.
+1. System Program: Створення облікового запису з виділеним простором для token
+   account та передача права власності до Token Program
+2. Token Program: Ініціалізація даних token account
 
 ### Typescript
 
@@ -176,11 +168,11 @@ import {
   getInitializeMintInstruction,
   getMintSize,
   getTokenSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Get latest blockhash to include in transaction
@@ -205,18 +197,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -246,8 +238,8 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address);
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", transactionSignature);
 
 // Generate keypair to use as address of token account
 const tokenAccount = await generateKeyPairSigner();
@@ -260,18 +252,18 @@ const tokenAccountRent = await rpc
   .getMinimumBalanceForRentExemption(tokenAccountSpace)
   .send();
 
-// Instruction to create new account for token account (token 2022 program)
+// Instruction to create new account for token account (token program)
 // Invokes the system program
 const createTokenAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: tokenAccount,
   lamports: tokenAccountRent,
   space: tokenAccountSpace,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize token account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeTokenAccountInstruction = getInitializeAccount2Instruction({
   account: tokenAccount.address,
   mint: mint.address,
@@ -302,11 +294,10 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 );
 
 // Get transaction signature
-const tokenAccountTxSignature =
-  getSignatureFromTransaction(signedTokenAccountTx);
+const transactionSignature2 = getSignatureFromTransaction(signedTokenAccountTx);
 
 console.log("Token Account Address:", tokenAccount.address);
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -325,12 +316,12 @@ import {
   getMinimumBalanceForRentExemptMint,
   getMinimumBalanceForRentExemptAccount,
   ACCOUNT_SIZE,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -341,8 +332,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -358,7 +349,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -367,14 +358,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -400,7 +391,7 @@ const createTokenAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: tokenAccount.publicKey,
   space: ACCOUNT_SIZE,
   lamports: tokenAccountRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize token account instruction
@@ -408,14 +399,14 @@ const initializeTokenAccountInstruction = createInitializeAccountInstruction(
   tokenAccount.publicKey, // token account
   mint.publicKey, // mint
   feePayer.publicKey, // owner
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for token account
 let tokenAccountTransaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createTokenAccountInstruction, initializeTokenAccountInstruction);
 
 // Sign and send transaction
@@ -426,20 +417,16 @@ const tokenAccountTxSignature = await sendAndConfirmTransaction(
 );
 
 console.log("Token Account Address:", tokenAccount.publicKey.toBase58());
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import {
-  createMint,
-  createAccount,
-  TOKEN_2022_PROGRAM_ID
-} from "@solana/spl-token";
+import { createMint, createAccount, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -450,8 +437,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -466,9 +453,9 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create token account using helper function
 const tokenAccount = await createAccount(
@@ -480,9 +467,9 @@ const tokenAccount = await createAccount(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
+console.log("Token Account Address:", tokenAccount.toBase58());
 ```
 
 </CodeTabs>
@@ -490,128 +477,6 @@ console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{
-    id as token_2022_program_id,
-    instruction::{initialize_account, initialize_mint},
-    state::{Account, Mint},
-};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Generate keypair to use as address of token account
-    let token_account = Keypair::new();
-
-    // Get token account size (in bytes)
-    let token_account_space = Account::LEN;
-    let token_account_rent = client.get_minimum_balance_for_rent_exemption(token_account_space)?;
-
-    // Instruction to create new account for token account (token 2022 program)
-    let create_token_account_instruction = create_account(
-        &fee_payer.pubkey(),        // payer
-        &token_account.pubkey(),    // new account (token account)
-        token_account_rent,         // lamports
-        token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
-    );
-
-    // Instruction to initialize token account data
-    let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
-        &token_account.pubkey(), // account
-        &mint.pubkey(),          // mint
-        &fee_payer.pubkey(),     // owner
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[
-            create_token_account_instruction,
-            initialize_token_account_instruction,
-        ],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &token_account],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Token Account Address: {}", token_account.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -623,8 +488,8 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{
-    id as token_2022_program_id,
+use spl_token::{
+    id as token_program_id,
     instruction::{initialize_account, initialize_mint},
     state::{Account, Mint},
 };
@@ -633,10 +498,10 @@ use spl_token_2022::{
 async fn main() -> Result<()> {
     // Create connection to local validator
     let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -663,18 +528,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(mint_space)
         .await?;
 
-    // Instruction to create new account for mint (token 2022 program)
+    // Instruction to create new account for mint (token program)
     let create_account_instruction = create_account(
         &fee_payer.pubkey(),      // payer
         &mint.pubkey(),           // new account (mint)
         mint_rent,                // lamports
         mint_space as u64,        // space
-        &token_2022_program_id(), // program id
+        &token_program_id(), // program id
     );
 
     // Instruction to initialize mint account data
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -686,7 +551,7 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -704,18 +569,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(token_account_space)
         .await?;
 
-    // Instruction to create new account for token account (token 2022 program)
+    // Instruction to create new account for token account (token program)
     let create_token_account_instruction = create_account(
         &fee_payer.pubkey(),        // payer
         &token_account.pubkey(),    // new account (token account)
         token_account_rent,         // lamports
         token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
+        &token_program_id(),   // program id
     );
 
     // Instruction to initialize token account data
     let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
+        &token_program_id(),
         &token_account.pubkey(), // account
         &mint.pubkey(),          // mint
         &fee_payer.pubkey(),     // owner
@@ -729,7 +594,7 @@ async fn main() -> Result<()> {
         ],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &token_account],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -749,7 +614,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -760,7 +625,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     // Create connection to local validator
     let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
 
@@ -786,7 +651,7 @@ async fn main() -> Result<()> {
     // Create a new program client
     let program_client = ProgramRpcClient::new(
         Arc::new(RpcClient::new_with_commitment(
-            String::from("http://127.0.0.1:8899"),
+            String::from("http://localhost:8899"),
             CommitmentConfig::confirmed(),
         )),
         ProgramRpcClientSendTransaction,
@@ -795,10 +660,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 2;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -831,23 +696,21 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
     Ok(())
 }
 ```
 
 </CodeTabs>
 
-## Як створити associated token account
+## Як створити Associated Token Account
 
-Щоб створити associated token account, викличте інструкцію
+Створення Associated Token Account (ATA) потребує інструкції
 [`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18).
-Реалізації цієї інструкції можна знайти
-[тут](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
+Дивіться
+[реалізацію тут](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-Інструкція для створення associated token account автоматично викликає System
-Program для створення токен-акаунта та викликає Token Program для ініціалізації
-даних токен-акаунта. Це відбувається через Cross Program Invocations (CPI).
+Ця єдина інструкція автоматично обробляє створення token account та його
+ініціалізацію через Cross Program Invocation (CPI).
 
 ### Typescript
 
@@ -874,12 +737,12 @@ import {
   getCreateAssociatedTokenInstructionAsync,
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda
-} from "@solana-program/token-2022";
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Generate keypairs for fee payer
@@ -904,18 +767,18 @@ const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 // Get latest blockhash to include in transaction
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -945,18 +808,18 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address.toString());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address.toString());
+console.log("Transaction Signature:", transactionSignature);
 
 // Use findAssociatedTokenPda to derive the ATA address
 const [associatedTokenAddress] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: feePayer.address,
-  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
 });
 
 console.log(
-  "Associated Token Account Address: ",
+  "Associated Token Account Address:",
   associatedTokenAddress.toString()
 );
 
@@ -990,7 +853,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 
 // Get transaction signature
 const transactionSignature2 = getSignatureFromTransaction(signedTransaction2);
-console.log("Transaction Signature: ", transactionSignature2);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -1006,15 +869,15 @@ import {
   createInitializeMintInstruction,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountInstruction,
   ASSOCIATED_TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1025,8 +888,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1042,7 +905,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -1051,14 +914,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -1076,7 +939,7 @@ const associatedTokenAccount = getAssociatedTokenAddressSync(
   mint.publicKey,
   feePayer.publicKey,
   false, // allowOwnerOffCurve
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
@@ -1086,15 +949,15 @@ const createAssociatedTokenAccountIx = createAssociatedTokenAccountInstruction(
   associatedTokenAccount, // associated token account address
   feePayer.publicKey, // owner
   mint.publicKey, // mint
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for associated token account
 let transaction2 = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAssociatedTokenAccountIx);
 
 // Sign and send transaction
@@ -1116,12 +979,12 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import {
   createMint,
   createAssociatedTokenAccount,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1132,8 +995,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1148,23 +1011,24 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create associated token account using helper function
 const associatedTokenAccount = await createAssociatedTokenAccount(
-  connection, // connection
-  feePayer, // fee payer
-  mintPubkey, // mint
-  feePayer.publicKey, // owner
+  connection,
+  feePayer,
+  mintPubkey,
+  feePayer.publicKey,
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
 console.log(
-  `Associated Token Account Address: ${associatedTokenAccount.toBase58()}`
+  "Associated Token Account Address:",
+  associatedTokenAccount.toBase58()
 );
 ```
 
@@ -1173,340 +1037,6 @@ console.log(
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction and add instruction
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Rust Async"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client
-        .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
-        .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client
-        .get_minimum_balance_for_rent_exemption(mint_space)
-        .await?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address (owner)
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction for associated token account creation
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account.to_string()
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://127.0.0.1:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Derive the associated token account address
-    let associated_token_address = token.get_associated_token_address(&payer.pubkey());
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_address
-    );
-
-    // Create associated token account for the payer
-    let result = token
-        .create_associated_token_account(
-            &payer.pubkey(), // owner
-        )
-        .await?;
-
-    println!(" {}", result);
-
-    Ok(())
-}
-```
-
-</CodeTabs>
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -1725,3 +1255,4 @@ async fn main() -> Result<()> {
 }
 ```
 
+</CodeTabs>

--- a/apps/web/content/docs/vi/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/vi/tokens/basics/create-mint.mdx
@@ -5,8 +5,8 @@ description: Tìm hiểu cách tạo một SPL Token mint.
 
 ## Mint Account là gì?
 
-Mint account là một loại tài khoản trong Token Programs của Solana, đại diện duy
-nhất cho một token trên mạng và lưu trữ metadata toàn cục về token đó.
+Mint account đại diện duy nhất cho một token trên Solana và lưu trữ metadata
+toàn cục của nó.
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -32,32 +32,31 @@ pub struct Mint {
 <Callout type="info">
   Lưu ý rằng cả [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30)
-  và [Token Extension
+  và [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
   đều chia sẻ cùng một triển khai cơ bản cho tài khoản Mint.
 </Callout>
 
-Mỗi token trên Solana tồn tại dưới dạng mint account, trong đó địa chỉ của mint
-account là định danh duy nhất của nó trên mạng.
+Mỗi token trên Solana đều có một mint account, và địa chỉ của mint đóng vai trò
+như định danh duy nhất của token.
 
-Ví dụ, USD Coin (USDC) - đồng đô la kỹ thuật số trên Solana có địa chỉ mint là
-`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Địa chỉ mint này đóng vai trò là
-định danh duy nhất của USD Coin trong toàn bộ hệ sinh thái Solana. Bạn có thể
-xem chi tiết về mint account này trên
+Ví dụ, USD Coin (USDC) có địa chỉ mint
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`. Địa chỉ này xác định duy nhất
+USDC trong toàn bộ hệ sinh thái Solana. Bạn có thể xem mint này trên
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v).
 
 ## Cách tạo một Mint Account
 
-Để tạo một Mint Account, gọi lệnh
-[`InitializeMint`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L65)
-. Bạn có thể tìm thấy các triển khai của lệnh này
-[tại đây](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L79).
+Việc tạo mint account yêu cầu lệnh
+[`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37).
+Xem
+[chi tiết triển khai tại đây](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27).
 
-Giao dịch để tạo mint account cần hai lệnh:
+Bạn cần thực hiện hai lệnh để tạo một mint account:
 
-1. Gọi System Program để tạo và phân bổ không gian cho mint account và chuyển
-   quyền sở hữu cho Token Program.
-2. Gọi Token Program để khởi tạo dữ liệu mint account.
+1. System Program: Tạo một tài khoản với không gian được cấp phát cho mint
+   account và chuyển quyền sở hữu cho Token Program.
+2. Token Program: Khởi tạo dữ liệu mint account
 
 ### Typescript
 
@@ -83,11 +82,11 @@ import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
+const rpc = createSolanaRpc("http://localhost:8899");
 const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // Generate keypairs for fee payer
@@ -109,18 +108,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 9,
@@ -154,7 +153,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
 console.log("Mint Address:", mint.address);
-console.log("Transaction Signature:", transactionSignature);
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy"
@@ -168,14 +167,14 @@ import {
 } from "@solana/web3.js";
 import {
   createInitializeMintInstruction,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint
 } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -186,8 +185,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -199,15 +198,15 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: await getMinimumBalanceForRentExemptMint(connection),
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 const initializeMintInstruction = createInitializeMintInstruction(
-  mint.publicKey, // mint pubkey
-  9, // decimals
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  mint.publicKey,
+  9, // Decimals
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  TOKEN_PROGRAM_ID
 );
 
 const transaction = new Transaction().add(
@@ -221,17 +220,17 @@ const transactionSignature = await sendAndConfirmTransaction(
   [feePayer, mint] // Signers
 );
 
-console.log("Mint Address: ", mint.publicKey.toBase58());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { createMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import { createMint, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
-const connection = new Connection("http://127.0.0.1:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -242,24 +241,24 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
 const mintPubkey = await createMint(
-  connection, // connection
-  feePayer, // fee payer
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  9, // decimals
-  Keypair.generate(), // keypair
+  connection,
+  feePayer,
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  9, // Decimals
+  Keypair.generate(),
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 ```
 
 </CodeTabs>
@@ -267,82 +266,6 @@ console.log(`Mint Address: ${mintPubkey.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    let mint_space = Mint::LEN;
-    let rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Create account instruction for mint
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(), // program id
-        &mint.pubkey(),           // mint address
-        &fee_payer.pubkey(),      // mint authority
-        Some(&fee_payer.pubkey()),// freeze authority
-        9,                        // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -354,16 +277,16 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
+use spl_token::{id as token_program_id, instruction::initialize_mint, state::Mint};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     // Create connection to local validator
     let client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -389,16 +312,16 @@ async fn main() -> Result<()> {
 
     // Create account instruction
     let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // fee payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        space as u64,             // space
-        &token_2022_program_id(), // program id
+        &fee_payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &token_program_id(),
     );
 
     // Initialize mint instruction
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint address
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -410,14 +333,14 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
     let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }
@@ -430,7 +353,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -441,7 +364,7 @@ use std::sync::Arc;
 async fn main() -> Result<()> {
     // Create connection to local validator
     let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://127.0.0.1:8899"),
+        String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
 
@@ -463,7 +386,6 @@ async fn main() -> Result<()> {
 
     // Generate keypair to use as address of mint
     let mint = Keypair::new();
-    println!("Mint keypair generated: {}", mint.pubkey());
 
     // Set up program client for Token client
     let program_client =
@@ -472,10 +394,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 9;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -494,7 +416,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }

--- a/apps/web/content/docs/vi/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/vi/tokens/basics/create-token-account.mdx
@@ -1,14 +1,13 @@
 ---
-title: Tạo Token Account
+title: Tạo một Token Account
 description: Tìm hiểu cách tạo SPL Token Accounts.
 ---
 
 ## Token Account là gì?
 
-Token account là một loại tài khoản trong Token Programs của Solana, lưu trữ
-thông tin về quyền sở hữu của một cá nhân đối với một token cụ thể (mint). Mỗi
-token account được liên kết với một mint duy nhất và theo dõi các chi tiết như
-số dư token và chủ sở hữu.
+Token account lưu trữ số dư của bạn cho một token cụ thể. Mỗi token account được
+liên kết với chính xác một mint và theo dõi số dư token cùng các thông tin bổ
+sung khác.
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -42,66 +41,58 @@ pub struct Account {
   Lưu ý rằng trong mã nguồn, các nhà phát triển gọi Token account là kiểu
   `Account`. Cả [Token
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L87-L108)
-  và [Token Extension
+  và [Token Extensions
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L102-L123)
   đều chia sẻ cùng một triển khai cơ bản cho Token account.
 </Callout>
 
-Để giữ token cho một mint cụ thể, người dùng trước tiên phải tạo một token
-account. Mỗi token account theo dõi:
+Để giữ token, bạn cần một token account cho mint cụ thể đó. Mỗi token account
+theo dõi:
 
-1. Một mint cụ thể (loại token mà token account giữ các đơn vị của nó)
-2. Một chủ sở hữu (người có quyền chuyển token từ tài khoản)
+1. **Mint**: Loại token cụ thể mà nó chứa
+2. **Owner**: Thẩm quyền có thể chuyển token từ tài khoản này
 
-Dưới đây là một ví dụ sử dụng USD Coin (USDC) trên Solana:
+### Ví dụ: USD Coin (USDC)
 
-- Địa chỉ mint của USD Coin: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- Circle (đơn vị phát hành USD Coin) có một token account tại
-  `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-- Token account này chỉ giữ các đơn vị của token USD Coin (mint)
-- Circle có quyền sở hữu tại `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE` và
-  có thể chuyển các token này
+- Địa chỉ mint: `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- Token account của Circle: `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- Tài khoản này chỉ chứa token USDC
+- Circle kiểm soát token thông qua thẩm quyền chủ sở hữu token account:
+  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
 Bạn có thể xem chi tiết của token account này trên
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa).
 
 <Callout type="info">
-  Thuật ngữ "owner" (chủ sở hữu) được sử dụng trong hai ngữ cảnh khác nhau:
+  **Hiểu thuật ngữ "Owner"**
 
-1. "Owner" của token account - Đây là một địa chỉ được lưu trữ trong dữ liệu của
-   token account như trường "owner" của kiểu
-   [Account](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L106)
-   được định nghĩa bởi Token Program. Owner có thể chuyển, đốt hoặc ủy quyền
-   token từ tài khoản. Địa chỉ này đôi khi được gọi là "authority" của token
-   account để phân biệt nó với program owner.
+Thuật ngữ "owner" có thể được sử dụng trong hai ngữ cảnh khác nhau:
 
-2. "Owner" của chương trình - Đây là chương trình sở hữu dữ liệu tài khoản trên
-   Solana. Đối với token account, đây luôn là Token Program hoặc Token Extension
-   Program, được chỉ định trong trường "owner" của Solana cơ bản
-   [Account](https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/account/src/lib.rs#L51)
-   type.
+1. **Token Account Owner**: Thẩm quyền có thể chuyển, đốt hoặc ủy quyền token.
+   Điều này được lưu trữ trong dữ liệu của token account.
 
-Khi làm việc với token account, "owner" thường đề cập đến quyền hạn có thể chi
-tiêu token, không phải chương trình sở hữu tài khoản.
+2. **Program Owner**: Chương trình sở hữu tài khoản (luôn là Token Program hoặc
+   Token Extensions Program đối với token account).
+
+Khi làm việc với token account, "owner" thường đề cập đến thẩm quyền có thể
+chuyển token, không phải chương trình sở hữu tài khoản.
 
 </Callout>
 
 ## Associated Token Account là gì?
 
-Associated token account là một token account có địa chỉ là Program Derived
-Address (PDA) được tạo bởi
+Associated token account (ATA) là token account mặc định cho một ví để giữ một
+token cụ thể. Nó sử dụng địa chỉ xác định (PDA) được tạo bởi
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program).
-Bạn có thể xem associated token account như token account mặc định cho người
-dùng để lưu giữ các đơn vị của một token cụ thể (mint).
 
 <Callout type="info">
-  Thuật ngữ "associated token accounts" chỉ áp dụng cho các token account được
-  Associated Token Program tạo ra.
+  Chỉ những token account được tạo bởi Associated Token Program mới được gọi là
+  "associated token accounts."
 </Callout>
 
-Associated token account cung cấp cách xác định để tìm token account của người
-dùng cho bất kỳ mint nào. Bạn có thể kiểm tra cách triển khai của quá trình tạo
-[tại đây](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
+ATA sử dụng địa chỉ xác định, giúp dễ dàng tìm token account của bất kỳ ví nào
+cho một mint cụ thể. Xem
+[cách triển khai dẫn xuất tại đây](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56).
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -121,33 +112,36 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-Cách tạo xác định này đảm bảo rằng với bất kỳ sự kết hợp nào giữa địa chỉ ví và
-token mint, sẽ chỉ tồn tại đúng một địa chỉ associated token account. Cách tiếp
-cận này giúp dễ dàng tìm token account của người dùng cho bất kỳ token mint nào,
-loại bỏ nhu cầu theo dõi địa chỉ token account riêng biệt.
+Đối với bất kỳ kết hợp ví và token nào, chỉ có đúng một địa chỉ ATA. Điều này
+loại bỏ nhu cầu theo dõi địa chỉ token account thủ công—bạn luôn có thể tính
+toán ra địa chỉ chính xác.
 
 <Callout type="info">
-  Associated Token Program hoạt động như một chương trình hỗ trợ tạo token
-  account với địa chỉ xác định (PDA). Khi tạo associated token account,
-  Associated Token Program thực hiện CPI (Cross-Program Invocation) đến Token
-  Program hoặc Token Extension Program. Token program sở hữu tài khoản được tạo
-  có cùng cấu trúc kiểu `Account` như được định nghĩa trong token program.
-  Associated Token Program không duy trì trạng thái nào - nó chỉ đơn giản cung
-  cấp cách tiêu chuẩn để tạo token account tại địa chỉ xác định là PDA.
+  **Cách Associated Token Program hoạt động**
+
+Associated Token Program là một trợ giúp để:
+
+- Tạo token account tại các địa chỉ xác định (PDA)
+- Thực hiện Cross Program Invocation (CPI) đến Token Program
+- Không duy trì bất kỳ trạng thái nào
+
+Các token account được tạo ra thuộc sở hữu của Token Program và sử dụng cấu trúc
+`Account` tiêu chuẩn.
+
 </Callout>
 
-## Cách tạo một Token Account
+## Cách tạo Token Account
 
-Để tạo một Token Account, gọi lệnh
-[`InitializeAccount`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L93)
-. Bạn có thể tìm thấy các triển khai của lệnh này
-[tại đây](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L145).
+Việc tạo token account yêu cầu lệnh
+[`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63).
+Xem
+[triển khai tại đây](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83).
 
-Giao dịch để tạo một token account cần hai lệnh:
+Bạn cần hai lệnh để tạo token account:
 
-1. Gọi System Program để tạo và phân bổ không gian cho token account và chuyển
-   quyền sở hữu cho Token Program.
-2. Gọi Token Program để khởi tạo dữ liệu token account.
+1. System Program: Tạo một tài khoản với không gian được phân bổ cho token
+   account và chuyển quyền sở hữu cho Token Program
+2. Token Program: Khởi tạo dữ liệu token account
 
 ### Typescript
 
@@ -175,8 +169,8 @@ import {
   getInitializeMintInstruction,
   getMintSize,
   getTokenSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -204,18 +198,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -245,8 +239,8 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address);
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", transactionSignature);
 
 // Generate keypair to use as address of token account
 const tokenAccount = await generateKeyPairSigner();
@@ -259,18 +253,18 @@ const tokenAccountRent = await rpc
   .getMinimumBalanceForRentExemption(tokenAccountSpace)
   .send();
 
-// Instruction to create new account for token account (token 2022 program)
+// Instruction to create new account for token account (token program)
 // Invokes the system program
 const createTokenAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: tokenAccount,
   lamports: tokenAccountRent,
   space: tokenAccountSpace,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize token account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeTokenAccountInstruction = getInitializeAccount2Instruction({
   account: tokenAccount.address,
   mint: mint.address,
@@ -301,11 +295,10 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 );
 
 // Get transaction signature
-const tokenAccountTxSignature =
-  getSignatureFromTransaction(signedTokenAccountTx);
+const transactionSignature2 = getSignatureFromTransaction(signedTokenAccountTx);
 
 console.log("Token Account Address:", tokenAccount.address);
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -324,12 +317,12 @@ import {
   getMinimumBalanceForRentExemptMint,
   getMinimumBalanceForRentExemptAccount,
   ACCOUNT_SIZE,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -340,8 +333,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -357,7 +350,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -366,14 +359,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -399,7 +392,7 @@ const createTokenAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: tokenAccount.publicKey,
   space: ACCOUNT_SIZE,
   lamports: tokenAccountRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize token account instruction
@@ -407,14 +400,14 @@ const initializeTokenAccountInstruction = createInitializeAccountInstruction(
   tokenAccount.publicKey, // token account
   mint.publicKey, // mint
   feePayer.publicKey, // owner
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for token account
 let tokenAccountTransaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createTokenAccountInstruction, initializeTokenAccountInstruction);
 
 // Sign and send transaction
@@ -425,20 +418,16 @@ const tokenAccountTxSignature = await sendAndConfirmTransaction(
 );
 
 console.log("Token Account Address:", tokenAccount.publicKey.toBase58());
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import {
-  createMint,
-  createAccount,
-  TOKEN_2022_PROGRAM_ID
-} from "@solana/spl-token";
+import { createMint, createAccount, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -449,8 +438,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -465,9 +454,9 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create token account using helper function
 const tokenAccount = await createAccount(
@@ -479,9 +468,9 @@ const tokenAccount = await createAccount(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
+console.log("Token Account Address:", tokenAccount.toBase58());
 ```
 
 </CodeTabs>
@@ -489,128 +478,6 @@ console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{
-    id as token_2022_program_id,
-    instruction::{initialize_account, initialize_mint},
-    state::{Account, Mint},
-};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Generate keypair to use as address of token account
-    let token_account = Keypair::new();
-
-    // Get token account size (in bytes)
-    let token_account_space = Account::LEN;
-    let token_account_rent = client.get_minimum_balance_for_rent_exemption(token_account_space)?;
-
-    // Instruction to create new account for token account (token 2022 program)
-    let create_token_account_instruction = create_account(
-        &fee_payer.pubkey(),        // payer
-        &token_account.pubkey(),    // new account (token account)
-        token_account_rent,         // lamports
-        token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
-    );
-
-    // Instruction to initialize token account data
-    let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
-        &token_account.pubkey(), // account
-        &mint.pubkey(),          // mint
-        &fee_payer.pubkey(),     // owner
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[
-            create_token_account_instruction,
-            initialize_token_account_instruction,
-        ],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &token_account],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Token Account Address: {}", token_account.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -622,8 +489,8 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{
-    id as token_2022_program_id,
+use spl_token::{
+    id as token_program_id,
     instruction::{initialize_account, initialize_mint},
     state::{Account, Mint},
 };
@@ -635,7 +502,7 @@ async fn main() -> Result<()> {
         String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -662,18 +529,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(mint_space)
         .await?;
 
-    // Instruction to create new account for mint (token 2022 program)
+    // Instruction to create new account for mint (token program)
     let create_account_instruction = create_account(
         &fee_payer.pubkey(),      // payer
         &mint.pubkey(),           // new account (mint)
         mint_rent,                // lamports
         mint_space as u64,        // space
-        &token_2022_program_id(), // program id
+        &token_program_id(), // program id
     );
 
     // Instruction to initialize mint account data
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -685,7 +552,7 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -703,18 +570,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(token_account_space)
         .await?;
 
-    // Instruction to create new account for token account (token 2022 program)
+    // Instruction to create new account for token account (token program)
     let create_token_account_instruction = create_account(
         &fee_payer.pubkey(),        // payer
         &token_account.pubkey(),    // new account (token account)
         token_account_rent,         // lamports
         token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
+        &token_program_id(),   // program id
     );
 
     // Instruction to initialize token account data
     let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
+        &token_program_id(),
         &token_account.pubkey(), // account
         &mint.pubkey(),          // mint
         &fee_payer.pubkey(),     // owner
@@ -728,7 +595,7 @@ async fn main() -> Result<()> {
         ],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &token_account],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -748,7 +615,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -794,10 +661,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 2;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -830,23 +697,21 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
     Ok(())
 }
 ```
 
 </CodeTabs>
 
-## Cách tạo một Associated Token Account
+## Cách tạo Associated Token Account
 
-Để tạo một Associated Token Account, gọi lệnh
-[`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
-. Bạn có thể tìm thấy các triển khai của lệnh này
-[tại đây](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
+Việc tạo một Associated Token Account (ATA) yêu cầu lệnh
+[`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18).
+Xem
+[triển khai tại đây](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66).
 
-Lệnh để tạo một associated token account tự động gọi System Program để tạo token
-account và gọi Token Program để khởi tạo dữ liệu token account. Điều này xảy ra
-thông qua Cross Program Invocation (CPI).
+Lệnh đơn này tự động xử lý việc tạo token account và khởi tạo nó thông qua Cross
+Program Invocation (CPI).
 
 ### Typescript
 
@@ -873,9 +738,9 @@ import {
   getCreateAssociatedTokenInstructionAsync,
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda
-} from "@solana-program/token-2022";
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -903,18 +768,18 @@ const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 // Get latest blockhash to include in transaction
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -944,18 +809,18 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address.toString());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address.toString());
+console.log("Transaction Signature:", transactionSignature);
 
 // Use findAssociatedTokenPda to derive the ATA address
 const [associatedTokenAddress] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: feePayer.address,
-  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
 });
 
 console.log(
-  "Associated Token Account Address: ",
+  "Associated Token Account Address:",
   associatedTokenAddress.toString()
 );
 
@@ -989,7 +854,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 
 // Get transaction signature
 const transactionSignature2 = getSignatureFromTransaction(signedTransaction2);
-console.log("Transaction Signature: ", transactionSignature2);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -1005,7 +870,7 @@ import {
   createInitializeMintInstruction,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountInstruction,
   ASSOCIATED_TOKEN_PROGRAM_ID
@@ -1013,7 +878,7 @@ import {
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1024,8 +889,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1041,7 +906,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -1050,14 +915,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -1075,7 +940,7 @@ const associatedTokenAccount = getAssociatedTokenAddressSync(
   mint.publicKey,
   feePayer.publicKey,
   false, // allowOwnerOffCurve
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
@@ -1085,15 +950,15 @@ const createAssociatedTokenAccountIx = createAssociatedTokenAccountInstruction(
   associatedTokenAccount, // associated token account address
   feePayer.publicKey, // owner
   mint.publicKey, // mint
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for associated token account
 let transaction2 = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAssociatedTokenAccountIx);
 
 // Sign and send transaction
@@ -1115,12 +980,12 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import {
   createMint,
   createAssociatedTokenAccount,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1131,8 +996,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1147,23 +1012,24 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create associated token account using helper function
 const associatedTokenAccount = await createAssociatedTokenAccount(
-  connection, // connection
-  feePayer, // fee payer
-  mintPubkey, // mint
-  feePayer.publicKey, // owner
+  connection,
+  feePayer,
+  mintPubkey,
+  feePayer.publicKey,
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
 console.log(
-  `Associated Token Account Address: ${associatedTokenAccount.toBase58()}`
+  "Associated Token Account Address:",
+  associatedTokenAccount.toBase58()
 );
 ```
 
@@ -1172,340 +1038,6 @@ console.log(
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction and add instruction
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Rust Async"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client
-        .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
-        .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client
-        .get_minimum_balance_for_rent_exemption(mint_space)
-        .await?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address (owner)
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction for associated token account creation
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account.to_string()
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://localhost:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Derive the associated token account address
-    let associated_token_address = token.get_associated_token_address(&payer.pubkey());
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_address
-    );
-
-    // Create associated token account for the payer
-    let result = token
-        .create_associated_token_account(
-            &payer.pubkey(), // owner
-        )
-        .await?;
-
-    println!(" {}", result);
-
-    Ok(())
-}
-```
-
-</CodeTabs>
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -1724,3 +1256,4 @@ async fn main() -> Result<()> {
 }
 ```
 
+</CodeTabs>

--- a/apps/web/content/docs/zh/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/zh/tokens/basics/create-mint.mdx
@@ -3,10 +3,9 @@ title: 创建一个 Token Mint
 description: 了解如何创建一个 SPL Token mint。
 ---
 
-## 什么是 Mint Account？
+## 什么是 Mint 账户？
 
-Mint account 是 Solana 的 Token
-Programs 中的一种账户类型，它在网络中唯一地表示一个代币，并存储该代币的全局元数据。
+一个 mint 账户在 Solana 上唯一地代表一个代币，并存储其全局元数据。
 
 ```rust title="Mint Account Type"
 /// Mint data.
@@ -34,31 +33,27 @@ pub struct Mint {
   Program](https://github.com/solana-program/token/blob/6d18ff73b1dd30703a30b1ca941cb0f1d18c2b2a/program/src/state.rs#L13-L30)
   和 [Token Extension
   Program](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L25-L42)
-  在 Mint account 的基础实现上是共享的。
+  对 Mint 账户共享相同的基础实现。
 </Callout>
 
-在 Solana 上，每个代币都以一个 mint account 的形式存在，其中 mint
-account 的地址是其在网络中的唯一标识符。
+在 Solana 上，每个代币都有一个 mint 账户，而 mint 的地址作为该代币的唯一标识符。
 
-例如，Solana 上的数字美元 USD Coin (USDC) 的 mint 地址是
-`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`。这个 mint 地址是 USD
-Coin 在整个 Solana 生态系统中的唯一标识符。您可以在
+例如，USD Coin (USDC) 的 mint 地址是
+`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`。这个地址在整个 Solana 生态系统中唯一标识 USDC。您可以在
 [Solana Explorer](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)
-上查看该 mint account 的详细信息。
+上查看此 mint。
 
-## 如何创建一个 Mint Account
+## 如何创建一个 Mint 账户
 
-要创建一个 Mint Account，请调用
-[`InitializeMint`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L65)
-指令。您可以在
-[这里](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L79)
-找到该指令的实现。
+创建一个 mint 账户需要使用
+[`InitializeMint`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L37)
+指令。请参阅[此处的实现细节](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L27)。
 
-创建一个 mint account 的交易需要两个指令：
+您需要调用两个指令来创建一个 mint 账户：
 
-1. 调用 System Program 来创建并分配 mint account 的空间，并将所有权转移给 Token
+1. System Program：创建一个分配了 mint 账户空间的账户，并将其所有权转移给 Token
    Program。
-2. 调用 Token Program 来初始化 mint account 的数据。
+2. Token Program：初始化 mint 账户数据。
 
 ### Typescript
 
@@ -84,8 +79,8 @@ import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -110,18 +105,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 9,
@@ -155,7 +150,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
 console.log("Mint Address:", mint.address);
-console.log("Transaction Signature:", transactionSignature);
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy"
@@ -169,14 +164,14 @@ import {
 } from "@solana/web3.js";
 import {
   createInitializeMintInstruction,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint
 } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -187,8 +182,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -200,15 +195,15 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: await getMinimumBalanceForRentExemptMint(connection),
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 const initializeMintInstruction = createInitializeMintInstruction(
-  mint.publicKey, // mint pubkey
-  9, // decimals
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  mint.publicKey,
+  9, // Decimals
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  TOKEN_PROGRAM_ID
 );
 
 const transaction = new Transaction().add(
@@ -222,17 +217,17 @@ const transactionSignature = await sendAndConfirmTransaction(
   [feePayer, mint] // Signers
 );
 
-console.log("Mint Address: ", mint.publicKey.toBase58());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nTransaction Signature:", transactionSignature);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import { createMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
+import { createMint, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -243,24 +238,24 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
 const mintPubkey = await createMint(
-  connection, // connection
-  feePayer, // fee payer
-  feePayer.publicKey, // mint authority
-  feePayer.publicKey, // freeze authority
-  9, // decimals
-  Keypair.generate(), // keypair
+  connection,
+  feePayer,
+  feePayer.publicKey, // Mint authority
+  feePayer.publicKey, // Freeze authority
+  9, // Decimals
+  Keypair.generate(),
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 ```
 
 </CodeTabs>
@@ -268,82 +263,6 @@ console.log(`Mint Address: ${mintPubkey.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    let mint_space = Mint::LEN;
-    let rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Create account instruction for mint
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(), // program id
-        &mint.pubkey(),           // mint address
-        &fee_payer.pubkey(),      // mint authority
-        Some(&fee_payer.pubkey()),// freeze authority
-        9,                        // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -355,7 +274,7 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
+use spl_token::{id as token_program_id, instruction::initialize_mint, state::Mint};
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -364,7 +283,7 @@ async fn main() -> Result<()> {
         String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -390,16 +309,16 @@ async fn main() -> Result<()> {
 
     // Create account instruction
     let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // fee payer
-        &mint.pubkey(),           // mint address
-        rent,                     // rent
-        space as u64,             // space
-        &token_2022_program_id(), // program id
+        &fee_payer.pubkey(),
+        &mint.pubkey(),
+        rent,
+        space as u64,
+        &token_program_id(),
     );
 
     // Initialize mint instruction
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint address
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -411,14 +330,14 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
     let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }
@@ -431,7 +350,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -464,7 +383,6 @@ async fn main() -> Result<()> {
 
     // Generate keypair to use as address of mint
     let mint = Keypair::new();
-    println!("Mint keypair generated: {}", mint.pubkey());
 
     // Set up program client for Token client
     let program_client =
@@ -473,10 +391,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 9;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -495,7 +413,7 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
+    println!("\nTransaction Signature: {}", transaction_signature);
 
     Ok(())
 }

--- a/apps/web/content/docs/zh/tokens/basics/create-token-account.mdx
+++ b/apps/web/content/docs/zh/tokens/basics/create-token-account.mdx
@@ -1,13 +1,12 @@
 ---
 title: 创建一个 Token Account
-description: 了解如何创建 SPL Token Accounts。
+description: 学习如何创建 SPL Token Account。
 ---
 
 ## 什么是 Token Account？
 
-Token Account 是 Solana 的 Token
-Programs 中的一种账户类型，用于存储个人对特定代币（mint）的所有权信息。每个 Token
-Account 都与一个 mint 相关联，并跟踪代币余额和所有者等详细信息。
+Token Account 用于存储您特定代币的余额。每个 Token
+Account 都与一个特定的 mint 相关联，并跟踪您的代币余额及其他详细信息。
 
 ```rust title="Token Account Type"
 /// Account data.
@@ -45,58 +44,59 @@ pub struct Account {
   Token Account 都共享相同的基础实现。
 </Callout>
 
-为了持有特定 mint 的代币，用户必须首先创建一个 Token Account。每个 Token
+要持有代币，您需要为该特定 mint 创建一个 Token Account。每个 Token
 Account 跟踪以下内容：
 
-1. 一个特定的 mint（Token Account 持有的代币类型）
-2. 一个所有者（可以从账户中转移代币的权限）
+1. **Mint**：它持有的特定代币类型
+2. **Owner**：可以从该账户转移代币的权限所有者
 
-以下是一个使用 Solana 上的 USD Coin (USDC) 的示例：
+### 示例：USD Coin (USDC)
 
-- USD Coin 的 mint 地址：`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
-- Circle（USD Coin 的发行方）在 `3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
-  处有一个 Token Account
-- 这个 Token Account 仅持有 USD Coin 代币（mint）的单位
-- Circle 在 `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
-  处拥有所有者权限，可以转移这些代币
+- Mint 地址：`EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`
+- Circle 的 Token Account：`3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa`
+- 此账户仅持有 USDC 代币
+- Circle 通过 Token Account 的所有者权限控制代币：
+  `7VHUFJHWu2CuExkJcJrzhQPJ2oygupTWkL2A2For4BmE`
 
 您可以在
 [Solana Explorer](https://explorer.solana.com/address/3emsAVdmGKERbHjmGfQ6oZ1e35dkf5iYcS6U4CPKFVaa)
 上查看此 Token Account 的详细信息。
 
 <Callout type="info">
-  "所有者" 一词在两种不同的上下文中使用：
+  **理解“Owner”术语**
 
-1. Token Account 的 "所有者" - 这是存储在 Token Account 数据中的一个地址，作为
-   [Account](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/state.rs#L106)
-   类型的 "owner" 字段，由 Token
-   Program 定义。所有者可以从账户中转移、销毁或委托代币。为了与程序所有者区分开来，这个地址有时被称为 Token
-   Account 的 "权限"。
+术语“Owner”可以在两种不同的上下文中使用：
 
-2. 程序 "owner" - 这是指拥有 Solana 上账户数据的程序。对于 token
-   account，这通常是 Token Program 或 Token Extension Program，如 base Solana
-   [Account](https://github.com/anza-xyz/solana-sdk/blob/4e30766b8d327f0191df6490e48d9ef521956495/account/src/lib.rs#L51)
-   类型的 "owner" 字段中所指定。
+1. **Token Account Owner**：可以转移、销毁或委托代币的权限所有者。这存储在 Token
+   Account 的数据中。
+2. **Program Owner**：拥有账户的程序（对于 Token Account 来说，总是 Token
+   Program 或 Token Extension Program）。
 
-在处理 token
-account 时，"owner" 通常指的是可以花费这些 token 的权限，而不是拥有账户的程序。
+在处理 Token
+Account 时，“Owner”通常指可以转移代币的权限所有者，而不是拥有账户的程序。
 
 </Callout>
 
-## 什么是关联 token account？
+## 什么是 Associated Token Account？
 
-关联 token account 是一个地址为程序派生地址 (PDA) 的 token account，由
+Associated Token Account (ATA) 是钱包用于持有特定代币的默认 Token
+Account。它使用由
 [Associated Token Program](https://github.com/solana-program/associated-token-account/tree/main/program)
-创建。您可以将关联 token account 视为用户持有特定 token (mint) 单位的默认 token
-account。
+创建的确定性地址 (PDA)。
 
 <Callout type="info">
   "关联 token account" 这一术语仅适用于由 Associated Token Program 创建的 token
   account。
 </Callout>
 
-关联 token account 提供了一种确定性的方式来查找用户针对任何给定 mint 的 token
-account。您可以在[这里](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56)查看派生的实现。
+<Callout type="info">
+  只有通过 Associated Token Program 创建的 token account 才被称为 "关联 token
+  account"。
+</Callout>
+
+ATAs 使用确定性地址，这使得查找任何钱包的特定 mint 的 token
+account 变得简单。请参阅
+[此处的派生实现](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/interface/src/address.rs#L56)。
 
 ```rust title="Associated Token Account Address Derivation"
 pub fn get_associated_token_address_and_bump_seed_internal(
@@ -116,31 +116,34 @@ pub fn get_associated_token_address_and_bump_seed_internal(
 }
 ```
 
-这种确定性的派生确保了对于任何钱包地址和 token
-mint 的组合，始终存在唯一的关联 token
-account 地址。这种方法使得查找用户针对任何给定 token mint 的 token
-account 变得简单，无需单独跟踪 token account 地址。
+对于任何钱包和 token 的组合，都只有一个 ATA 地址。这消除了手动跟踪 token
+account 地址的需要——您始终可以派生出正确的地址。
 
 <Callout type="info">
-  Associated Token Program 作为一个辅助程序，创建具有确定性地址 (PDA) 的 token
-  account。在创建关联 token account 时，Associated Token Program 会对 Token
-  Program 或 Token Extension Program 进行 CPI（跨程序调用）。创建的账户由 token
-  program 拥有，其结构与 token program 中定义的 `Account` 类型相同。Associated
-  Token Program 不维护任何状态 -
-  它仅提供了一种标准化的方式，在确定性地址（PDA）上创建 token account。
+  **Associated Token Program 的工作原理**
+
+Associated Token Program 是一个辅助程序，它：
+
+- 在确定性地址 (PDA) 上创建 token account
+- 对 Token Program 进行 Cross-Program Invocation (CPI)
+- 自身不维护任何状态
+
+生成的 token account 由 Token Program 拥有，并使用标准的 `Account` 结构。
+
 </Callout>
 
-## 如何创建 Token Account
+## 如何创建一个 Token Account
 
-要创建 Token Account，请调用
-[`InitializeAccount`](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/instruction.rs#L93)
-指令。您可以在[这里](https://github.com/solana-program/token-2022/blob/efd0c957fefbd79882d77df5fb2dac88c001249c/program/src/processor.rs#L145)找到该指令的实现。
+创建一个 token account 需要使用
+[`InitializeAccount`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/instruction.rs#L63)
+指令。请参阅
+[此处的实现](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/program/src/processor.rs#L83)。
 
-创建一个 token account 的交易需要两个指令：
+创建一个 token account 需要两个指令：
 
-1. 调用 System Program 创建并分配 token account 的空间，并将所有权转移到 Token
-   Program。
-2. 调用 Token Program 初始化 token account 数据。
+1. System Program：创建一个分配了 token
+   account 空间的账户，并将所有权转移给 Token Program
+2. Token Program：初始化 token account 数据
 
 ### Typescript
 
@@ -168,8 +171,8 @@ import {
   getInitializeMintInstruction,
   getMintSize,
   getTokenSize,
-  TOKEN_2022_PROGRAM_ADDRESS
-} from "@solana-program/token-2022";
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -197,18 +200,18 @@ const space = BigInt(getMintSize());
 // Get minimum balance for rent exemption
 const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -238,8 +241,8 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address);
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", transactionSignature);
 
 // Generate keypair to use as address of token account
 const tokenAccount = await generateKeyPairSigner();
@@ -252,18 +255,18 @@ const tokenAccountRent = await rpc
   .getMinimumBalanceForRentExemption(tokenAccountSpace)
   .send();
 
-// Instruction to create new account for token account (token 2022 program)
+// Instruction to create new account for token account (token program)
 // Invokes the system program
 const createTokenAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: tokenAccount,
   lamports: tokenAccountRent,
   space: tokenAccountSpace,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize token account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeTokenAccountInstruction = getInitializeAccount2Instruction({
   account: tokenAccount.address,
   mint: mint.address,
@@ -294,11 +297,10 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 );
 
 // Get transaction signature
-const tokenAccountTxSignature =
-  getSignatureFromTransaction(signedTokenAccountTx);
+const transactionSignature2 = getSignatureFromTransaction(signedTokenAccountTx);
 
 console.log("Token Account Address:", tokenAccount.address);
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -317,12 +319,12 @@ import {
   getMinimumBalanceForRentExemptMint,
   getMinimumBalanceForRentExemptAccount,
   ACCOUNT_SIZE,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -333,8 +335,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -350,7 +352,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -359,14 +361,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -392,7 +394,7 @@ const createTokenAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: tokenAccount.publicKey,
   space: ACCOUNT_SIZE,
   lamports: tokenAccountRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize token account instruction
@@ -400,14 +402,14 @@ const initializeTokenAccountInstruction = createInitializeAccountInstruction(
   tokenAccount.publicKey, // token account
   mint.publicKey, // mint
   feePayer.publicKey, // owner
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for token account
 let tokenAccountTransaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createTokenAccountInstruction, initializeTokenAccountInstruction);
 
 // Sign and send transaction
@@ -418,20 +420,16 @@ const tokenAccountTxSignature = await sendAndConfirmTransaction(
 );
 
 console.log("Token Account Address:", tokenAccount.publicKey.toBase58());
-console.log("Transaction Signature:", tokenAccountTxSignature);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy Helper"
 import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
-import {
-  createMint,
-  createAccount,
-  TOKEN_2022_PROGRAM_ID
-} from "@solana/spl-token";
+import { createMint, createAccount, TOKEN_PROGRAM_ID } from "@solana/spl-token";
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -442,8 +440,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -458,9 +456,9 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create token account using helper function
 const tokenAccount = await createAccount(
@@ -472,9 +470,9 @@ const tokenAccount = await createAccount(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
+console.log("Token Account Address:", tokenAccount.toBase58());
 ```
 
 </CodeTabs>
@@ -482,128 +480,6 @@ console.log(`Token Account Address: ${tokenAccount.toBase58()}`);
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_token_2022::{
-    id as token_2022_program_id,
-    instruction::{initialize_account, initialize_mint},
-    state::{Account, Mint},
-};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Generate keypair to use as address of token account
-    let token_account = Keypair::new();
-
-    // Get token account size (in bytes)
-    let token_account_space = Account::LEN;
-    let token_account_rent = client.get_minimum_balance_for_rent_exemption(token_account_space)?;
-
-    // Instruction to create new account for token account (token 2022 program)
-    let create_token_account_instruction = create_account(
-        &fee_payer.pubkey(),        // payer
-        &token_account.pubkey(),    // new account (token account)
-        token_account_rent,         // lamports
-        token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
-    );
-
-    // Instruction to initialize token account data
-    let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
-        &token_account.pubkey(), // account
-        &mint.pubkey(),          // mint
-        &fee_payer.pubkey(),     // owner
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[
-            create_token_account_instruction,
-            initialize_token_account_instruction,
-        ],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &token_account],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Token Account Address: {}", token_account.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -615,8 +491,8 @@ use solana_sdk::{
     system_instruction::create_account,
     transaction::Transaction,
 };
-use spl_token_2022::{
-    id as token_2022_program_id,
+use spl_token::{
+    id as token_program_id,
     instruction::{initialize_account, initialize_mint},
     state::{Account, Mint},
 };
@@ -628,7 +504,7 @@ async fn main() -> Result<()> {
         String::from("http://localhost:8899"),
         CommitmentConfig::confirmed(),
     );
-    let recent_blockhash = client.get_latest_blockhash().await?;
+    let latestBlockhash = client.get_latest_blockhash().await?;
 
     // Generate a new keypair for the fee payer
     let fee_payer = Keypair::new();
@@ -655,18 +531,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(mint_space)
         .await?;
 
-    // Instruction to create new account for mint (token 2022 program)
+    // Instruction to create new account for mint (token program)
     let create_account_instruction = create_account(
         &fee_payer.pubkey(),      // payer
         &mint.pubkey(),           // new account (mint)
         mint_rent,                // lamports
         mint_space as u64,        // space
-        &token_2022_program_id(), // program id
+        &token_program_id(), // program id
     );
 
     // Instruction to initialize mint account data
     let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),            // mint
         &fee_payer.pubkey(),       // mint authority
         Some(&fee_payer.pubkey()), // freeze authority
@@ -678,7 +554,7 @@ async fn main() -> Result<()> {
         &[create_account_instruction, initialize_mint_instruction],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &mint],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -696,18 +572,18 @@ async fn main() -> Result<()> {
         .get_minimum_balance_for_rent_exemption(token_account_space)
         .await?;
 
-    // Instruction to create new account for token account (token 2022 program)
+    // Instruction to create new account for token account (token program)
     let create_token_account_instruction = create_account(
         &fee_payer.pubkey(),        // payer
         &token_account.pubkey(),    // new account (token account)
         token_account_rent,         // lamports
         token_account_space as u64, // space
-        &token_2022_program_id(),   // program id
+        &token_program_id(),   // program id
     );
 
     // Instruction to initialize token account data
     let initialize_token_account_instruction = initialize_account(
-        &token_2022_program_id(),
+        &token_program_id(),
         &token_account.pubkey(), // account
         &mint.pubkey(),          // mint
         &fee_payer.pubkey(),     // owner
@@ -721,7 +597,7 @@ async fn main() -> Result<()> {
         ],
         Some(&fee_payer.pubkey()),
         &[&fee_payer, &token_account],
-        recent_blockhash,
+        latestBlockhash,
     );
 
     // Send and confirm transaction
@@ -741,7 +617,7 @@ use solana_sdk::{
     commitment_config::CommitmentConfig,
     signature::{Keypair, Signer},
 };
-use spl_token_2022::id as token_2022_program_id;
+use spl_token::id as token_program_id;
 use spl_token_client::{
     client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
     token::{ExtensionInitializationParams, Token},
@@ -787,10 +663,10 @@ async fn main() -> Result<()> {
     // Number of decimals for the mint
     let decimals = 2;
 
-    // Create a token client for Token-2022
+    // Create a token client for Token program
     let token = Token::new(
         Arc::new(program_client),
-        &token_2022_program_id(),
+        &token_program_id(),
         &mint.pubkey(),
         Some(decimals),
         Arc::new(payer.insecure_clone()),
@@ -823,22 +699,21 @@ async fn main() -> Result<()> {
         .await?;
 
     println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
     Ok(())
 }
 ```
 
 </CodeTabs>
 
-## 如何创建 Associated Token Account
+## 如何创建一个关联 Token Account
 
-要创建 Associated Token Account，请调用
+创建一个 Associated Token Account (ATA) 需要使用
 [`Create`](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/instruction.rs#L18)
-指令。您可以在[这里](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66)找到该指令的实现。
+指令。请参阅
+[此处的实现](https://github.com/solana-program/associated-token-account/blob/c78722ee39ebf6741cdfa81dffd52135370a5015/program/src/processor.rs#L66)。
 
-创建一个 associated token account 的指令会自动调用 System Program 来创建 token
-account，并调用 Token Program 初始化 token account 数据。这是通过 Cross Program
-Invocations (CPI) 实现的。
+此单一指令通过 Cross Program Invocations (CPI) 自动处理创建 token
+account 并对其进行初始化。
 
 ### Typescript
 
@@ -865,9 +740,9 @@ import {
   getCreateAssociatedTokenInstructionAsync,
   getInitializeMintInstruction,
   getMintSize,
-  TOKEN_2022_PROGRAM_ADDRESS,
+  TOKEN_PROGRAM_ADDRESS,
   findAssociatedTokenPda
-} from "@solana-program/token-2022";
+} from "@solana-program/token";
 
 // Create Connection, local validator in this example
 const rpc = createSolanaRpc("http://localhost:8899");
@@ -895,18 +770,18 @@ const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
 // Get latest blockhash to include in transaction
 const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
-// Instruction to create new account for mint (token 2022 program)
+// Instruction to create new account for mint (token program)
 // Invokes the system program
 const createAccountInstruction = getCreateAccountInstruction({
   payer: feePayer,
   newAccount: mint,
   lamports: rent,
   space,
-  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+  programAddress: TOKEN_PROGRAM_ADDRESS
 });
 
 // Instruction to initialize mint account data
-// Invokes the token 2022 program
+// Invokes the token program
 const initializeMintInstruction = getInitializeMintInstruction({
   mint: mint.address,
   decimals: 2,
@@ -936,18 +811,18 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 // Get transaction signature
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 
-console.log("Mint Address: ", mint.address.toString());
-console.log("Transaction Signature: ", transactionSignature);
+console.log("Mint Address:", mint.address.toString());
+console.log("Transaction Signature:", transactionSignature);
 
 // Use findAssociatedTokenPda to derive the ATA address
 const [associatedTokenAddress] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: feePayer.address,
-  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
 });
 
 console.log(
-  "Associated Token Account Address: ",
+  "Associated Token Account Address:",
   associatedTokenAddress.toString()
 );
 
@@ -981,7 +856,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
 
 // Get transaction signature
 const transactionSignature2 = getSignatureFromTransaction(signedTransaction2);
-console.log("Transaction Signature: ", transactionSignature2);
+console.log("Transaction Signature:", transactionSignature2);
 ```
 
 ```ts !! title="Legacy"
@@ -997,7 +872,7 @@ import {
   createInitializeMintInstruction,
   MINT_SIZE,
   getMinimumBalanceForRentExemptMint,
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   getAssociatedTokenAddressSync,
   createAssociatedTokenAccountInstruction,
   ASSOCIATED_TOKEN_PROGRAM_ID
@@ -1005,7 +880,7 @@ import {
 
 // Create connection to local validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1016,8 +891,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1033,7 +908,7 @@ const createAccountInstruction = SystemProgram.createAccount({
   newAccountPubkey: mint.publicKey,
   space: MINT_SIZE,
   lamports: mintRent,
-  programId: TOKEN_2022_PROGRAM_ID
+  programId: TOKEN_PROGRAM_ID
 });
 
 // Initialize mint instruction
@@ -1042,14 +917,14 @@ const initializeMintInstruction = createInitializeMintInstruction(
   2, // decimals
   feePayer.publicKey, // mint authority
   feePayer.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction
 let transaction = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAccountInstruction, initializeMintInstruction);
 
 // Sign transaction
@@ -1067,7 +942,7 @@ const associatedTokenAccount = getAssociatedTokenAddressSync(
   mint.publicKey,
   feePayer.publicKey,
   false, // allowOwnerOffCurve
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
@@ -1077,15 +952,15 @@ const createAssociatedTokenAccountIx = createAssociatedTokenAccountInstruction(
   associatedTokenAccount, // associated token account address
   feePayer.publicKey, // owner
   mint.publicKey, // mint
-  TOKEN_2022_PROGRAM_ID,
+  TOKEN_PROGRAM_ID,
   ASSOCIATED_TOKEN_PROGRAM_ID
 );
 
 // Create and sign transaction for associated token account
 let transaction2 = new Transaction({
   feePayer: feePayer.publicKey,
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
 }).add(createAssociatedTokenAccountIx);
 
 // Sign and send transaction
@@ -1107,12 +982,12 @@ import { Connection, Keypair, LAMPORTS_PER_SOL } from "@solana/web3.js";
 import {
   createMint,
   createAssociatedTokenAccount,
-  TOKEN_2022_PROGRAM_ID
+  TOKEN_PROGRAM_ID
 } from "@solana/spl-token";
 
 // Create connection to validator
 const connection = new Connection("http://localhost:8899", "confirmed");
-const recentBlockhash = await connection.getLatestBlockhash();
+const latestBlockhash = await connection.getLatestBlockhash();
 
 // Generate a new keypair for the fee payer
 const feePayer = Keypair.generate();
@@ -1123,8 +998,8 @@ const airdropSignature = await connection.requestAirdrop(
   LAMPORTS_PER_SOL
 );
 await connection.confirmTransaction({
-  blockhash: recentBlockhash.blockhash,
-  lastValidBlockHeight: recentBlockhash.lastValidBlockHeight,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
   signature: airdropSignature
 });
 
@@ -1139,23 +1014,24 @@ const mintPubkey = await createMint(
   {
     commitment: "confirmed" // confirmation options
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID // program id
 );
-console.log(`Mint Address: ${mintPubkey.toBase58()}`);
+console.log("Mint Address:", mintPubkey.toBase58());
 
 // Create associated token account using helper function
 const associatedTokenAccount = await createAssociatedTokenAccount(
-  connection, // connection
-  feePayer, // fee payer
-  mintPubkey, // mint
-  feePayer.publicKey, // owner
+  connection,
+  feePayer,
+  mintPubkey,
+  feePayer.publicKey,
   {
-    commitment: "confirmed" // confirmation options
+    commitment: "confirmed"
   },
-  TOKEN_2022_PROGRAM_ID // program id
+  TOKEN_PROGRAM_ID
 );
 console.log(
-  `Associated Token Account Address: ${associatedTokenAccount.toBase58()}`
+  "Associated Token Account Address:",
+  associatedTokenAccount.toBase58()
 );
 ```
 
@@ -1164,340 +1040,6 @@ console.log(
 ### Rust
 
 <CodeTabs storage="token-rs" flags="r">
-
-```rust !! title="Rust"
-use anyhow::Result;
-use solana_client::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client.request_airdrop(&fee_payer.pubkey(), 1_000_000_000)?;
-    client.confirm_transaction(&airdrop_signature)?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature)?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client.get_minimum_balance_for_rent_exemption(mint_space)?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash()?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction and add instruction
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction)?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Rust Async"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    program_pack::Pack,
-    signature::{Keypair, Signer},
-    system_instruction::create_account,
-    transaction::Transaction,
-};
-use spl_associated_token_account::{
-    get_associated_token_address_with_program_id, instruction::create_associated_token_account,
-};
-use spl_token_2022::{id as token_2022_program_id, instruction::initialize_mint, state::Mint};
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Generate a new keypair for the fee payer
-    let fee_payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = client
-        .request_airdrop(&fee_payer.pubkey(), 1_000_000_000)
-        .await?;
-    client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Get default mint account size (in bytes), no extensions enabled
-    let mint_space = Mint::LEN;
-    let mint_rent = client
-        .get_minimum_balance_for_rent_exemption(mint_space)
-        .await?;
-
-    // Instruction to create new account for mint (token 2022 program)
-    let create_account_instruction = create_account(
-        &fee_payer.pubkey(),      // payer
-        &mint.pubkey(),           // new account (mint)
-        mint_rent,                // lamports
-        mint_space as u64,        // space
-        &token_2022_program_id(), // program id
-    );
-
-    // Instruction to initialize mint account data
-    let initialize_mint_instruction = initialize_mint(
-        &token_2022_program_id(),
-        &mint.pubkey(),            // mint
-        &fee_payer.pubkey(),       // mint authority
-        Some(&fee_payer.pubkey()), // freeze authority
-        2,                         // decimals
-    )?;
-
-    // Create transaction and add instructions
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_account_instruction, initialize_mint_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer, &mint],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("Transaction Signature: {}", transaction_signature);
-
-    // Get the latest blockhash for the next transaction
-    let recent_blockhash = client.get_latest_blockhash().await?;
-
-    // Derive the associated token account address for fee_payer
-    let associated_token_account = get_associated_token_address_with_program_id(
-        &fee_payer.pubkey(),      // owner
-        &mint.pubkey(),           // mint
-        &token_2022_program_id(), // program_id
-    );
-
-    // Instruction to create associated token account
-    let create_ata_instruction = create_associated_token_account(
-        &fee_payer.pubkey(),      // funding address
-        &fee_payer.pubkey(),      // wallet address (owner)
-        &mint.pubkey(),           // mint address
-        &token_2022_program_id(), // program id
-    );
-
-    // Create transaction for associated token account creation
-    let transaction = Transaction::new_signed_with_payer(
-        &[create_ata_instruction],
-        Some(&fee_payer.pubkey()),
-        &[&fee_payer],
-        recent_blockhash,
-    );
-
-    // Send and confirm transaction
-    let transaction_signature = client.send_and_confirm_transaction(&transaction).await?;
-
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_account.to_string()
-    );
-    println!("Transaction Signature: {}", transaction_signature);
-
-    Ok(())
-}
-```
-
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://localhost:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Derive the associated token account address
-    let associated_token_address = token.get_associated_token_address(&payer.pubkey());
-    println!(
-        "Associated Token Account Address: {}",
-        associated_token_address
-    );
-
-    // Create associated token account for the payer
-    let result = token
-        .create_associated_token_account(
-            &payer.pubkey(), // owner
-        )
-        .await?;
-
-    println!(" {}", result);
-
-    Ok(())
-}
-```
-
-</CodeTabs>
 
 ```rust !! title="Rust Async"
 use anyhow::Result;
@@ -1716,96 +1258,4 @@ async fn main() -> Result<()> {
 }
 ```
 
-```rust !! title="Token Client"
-use anyhow::Result;
-use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::{
-    commitment_config::CommitmentConfig,
-    signature::{Keypair, Signer},
-};
-use spl_token_2022::id as token_2022_program_id;
-use spl_token_client::{
-    client::{ProgramRpcClient, ProgramRpcClientSendTransaction},
-    token::{ExtensionInitializationParams, Token},
-};
-use std::sync::Arc;
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    // Create connection to local validator
-    let rpc_client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
-        CommitmentConfig::confirmed(),
-    );
-
-    // Generate a new keypair for the fee payer
-    let payer = Keypair::new();
-
-    // Airdrop 1 SOL to fee payer
-    let airdrop_signature = rpc_client
-        .request_airdrop(&payer.pubkey(), 1_000_000_000)
-        .await?;
-    rpc_client.confirm_transaction(&airdrop_signature).await?;
-
-    loop {
-        let confirmed = rpc_client.confirm_transaction(&airdrop_signature).await?;
-        if confirmed {
-            break;
-        }
-    }
-
-    // Generate keypair to use as address of mint
-    let mint = Keypair::new();
-
-    // Create a new program client
-    let program_client = ProgramRpcClient::new(
-        Arc::new(RpcClient::new_with_commitment(
-            String::from("http://localhost:8899"),
-            CommitmentConfig::confirmed(),
-        )),
-        ProgramRpcClientSendTransaction,
-    );
-
-    // Number of decimals for the mint
-    let decimals = 2;
-
-    // Create a token client for Token-2022
-    let token = Token::new(
-        Arc::new(program_client),
-        &token_2022_program_id(),
-        &mint.pubkey(),
-        Some(decimals),
-        Arc::new(payer.insecure_clone()),
-    );
-
-    // Create and initialize the mint
-    let extension_initialization_params: Vec<ExtensionInitializationParams> = Vec::new();
-
-    let mint_result = token
-        .create_mint(
-            &payer.pubkey(),                 // mint authority
-            Some(&payer.pubkey()),           // freeze authority
-            extension_initialization_params, // no extensions
-            &[&mint],                        // mint keypair needed as signer
-        )
-        .await?;
-
-    println!("Mint Address: {}", mint.pubkey());
-    println!("{}", mint_result);
-
-    // Generate keypair for token account
-    let token_account_keypair = Keypair::new();
-
-    // Create token account using the keypair
-    let token_account_result = token
-        .create_auxiliary_token_account(
-            &token_account_keypair, // account keypair
-            &payer.pubkey(),        // owner
-        )
-        .await?;
-
-    println!("Token Account Address: {}", token_account_result);
-    println!("{}", token_account_result);
-    Ok(())
-}
-```
+</CodeTabs>


### PR DESCRIPTION
### Problem

Lingo output for following pages and locales return (status 500)

Locales: es, fi, nl, pl, pt, ru, tr, uk, vi, zh
Route: /docs/tokens/basics/create-mint

Locales: ko, nl, pt, tr, uk, vi
Route: /docs/tokens/basics/create-token-account

### Summary of Changes

force rerun lingo for affect pages for all locales