### PR TITLE
Corrected type error.

### DIFF
--- a/apps/web/content/docs/en/tokens/basics/create-mint.mdx
+++ b/apps/web/content/docs/en/tokens/basics/create-mint.mdx
@@ -66,6 +66,7 @@ You need invoke two instructions to create a mint account:
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithinSizeLimit,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -142,6 +143,9 @@ const transactionMessage = pipe(
 // Sign transaction message with required signers (fee payer and mint keypair)
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert TransationWithinSizeLimit type to the transaction
+assertIsTransactionWithinSizeLimit(signedTransaction);  
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(


### PR DESCRIPTION
Added assertion to check transaction size limit before sending.

### Problem
 Property '"__transactionSize:@solana/kit"' is missing in type 'FullySignedTransaction & TransactionWithBlockhashLifetime & Readonly<{ messageBytes: TransactionMessageBytes; signatures: SignaturesMap; }>' but required in type 'TransactionWithinSizeLimit'.

### Summary of Changes
Asserted the required type  just before sending the transaction.

Fixes #
Used assertIsTransactionWithinSizeLimit() function from @solana/kit