### PR TITLE
docs: move verifiable builds page from guides to docs

### DIFF
--- a/apps/web/content/docs/en/programs/meta.json
+++ b/apps/web/content/docs/en/programs/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Developing Programs",
-  "pages": ["rust", "testing", "deploying", "examples", "limitations"],
+  "pages": ["rust", "testing", "deploying", "verified-builds", "examples", "limitations"],
   "defaultOpen": false
 }

--- a/apps/web/content/docs/en/programs/verified-builds.mdx
+++ b/apps/web/content/docs/en/programs/verified-builds.mdx
@@ -1,21 +1,9 @@
 ---
-date: 2024-09-26T00:00:00Z
-difficulty: intermediate
-title: "How to Verify a Program"
+title: "Verifying Programs"
 description:
   "Verified builds is a way to link your program to its source code and let
   everyone independently verify that the program was indeed built from that
   provided source code."
-tags:
-  - web3js
-keywords:
-  - tutorial
-  - verified builds
-  - security.txt
-  - verified source code
-  - find a programs source code
-  - security
-  - blockchain tutorial
 ---
 
 This guide is meant to be a reference for developers who want to implement

--- a/apps/web/rewrites-redirects.mjs
+++ b/apps/web/rewrites-redirects.mjs
@@ -930,5 +930,9 @@ export default {
       source: "/developers/cookbook/tokens/manage-wrapped-sol",
       destination: "/docs/tokens/basics/sync-native",
     },
+    {
+      source: "/developers/guides/advanced/verified-builds",
+      destination: "/docs/programs/verified-builds",
+    },
   ],
 };


### PR DESCRIPTION
- move verifiable builds page from guides to docs
- add redirect