### PR TITLE
Fix scrollycoding `rootMargin`

### DIFF
--- a/apps/web/src/app/components/code/scrollycoding.tsx
+++ b/apps/web/src/app/components/code/scrollycoding.tsx
@@ -65,7 +65,7 @@ function OneColumnStep(props: { step: Steps[number] }) {
 function TwoColumnLayout(props: { steps: Steps; className?: string }) {
   const { steps, className } = props;
   const stickers = getStickers(steps);
-  const rootMargin = "-40% 0px -60% 0px";
+  const rootMargin = "-39% 0px -60% 0px";
   return (
     <SelectionProvider className={className} rootMargin={rootMargin}>
       <ResizablePanelGroup


### PR DESCRIPTION
### Problem

The intersection observer from the ScrollyCoding component wasn't triggering when the browser height wasn't large enough.

### Summary of Changes

Give more space to the `rootMargin`