### PR TITLE
Remove `/public` directory from Serverless Functions

### DIFF
--- a/apps/web/source.config.ts
+++ b/apps/web/source.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig, defineDocs } from "fumadocs-mdx/config";
 import { recmaCodeHike, remarkCodeHike } from "codehike/mdx";
 import { rehypeToc } from "fumadocs-core/mdx-plugins";
-import path from "path";
 
 import { z } from "zod";
 
@@ -64,9 +63,7 @@ const chConfig = {
 };
 export default defineConfig({
   mdxOptions: {
-    remarkImageOptions: {
-      publicDir: path.join(process.cwd(), "public"),
-    },
+    remarkImageOptions: false,
     recmaPlugins: [[recmaCodeHike, chConfig]],
     remarkPlugins: (v) => [[remarkCodeHike, chConfig], ...v],
     rehypePlugins: [rehypeToc],

--- a/apps/web/src/app/mdx-components.tsx
+++ b/apps/web/src/app/mdx-components.tsx
@@ -1,6 +1,4 @@
 import defaultMdxComponents from "fumadocs-ui/mdx";
-import NextImage from "next/image";
-import type { ImageProps } from "next/image";
 import { ImgHTMLAttributes } from "react";
 import { Step, Steps } from "fumadocs-ui/components/steps";
 import { Accordion, Accordions } from "fumadocs-ui/components/accordion";
@@ -72,23 +70,9 @@ function Link(props: LinkProps) {
 }
 
 function Image(props: ImgHTMLAttributes<HTMLImageElement>) {
-  if (typeof props.src === "string" && props.src.endsWith(".svg")) {
-    return (
-      <span className="block">
-        <img {...props} className="w-full mb-4 rounded-lg" />
-        <span className="block text-sm text-center text-fd-muted-foreground">
-          {props.alt}
-        </span>
-      </span>
-    );
-  }
   return (
     <span className="block">
-      <NextImage
-        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 70vw, 900px"
-        {...(props as ImageProps)}
-        className="mb-4 rounded-lg"
-      />
+      <img {...props} className="w-full mb-4 rounded-lg" />
       <span className="block text-sm text-center text-fd-muted-foreground">
         {props.alt}
       </span>


### PR DESCRIPTION
### Problem

- Production deployments fails because of Serverless Function exceeding maximum size. 
- Largest dependency is `public/` directory, which is only being used to calculate image width and height at runtime.

### Summary of Changes

- Disable the `remark-image` plugin.
- Replace Next `Image` with plain `<img>` (for images coming from .mdx files) since width/height are not available.

### Impact

Possible UX hit: larger image payloads and some layout shift.