### PR TITLE
fix: vercel build size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .env.test
 .env.production
 i18n.cache
+.vercel

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -237,7 +237,7 @@ const nextConfig: NextConfig = {
   // Ignore public and content directories from the build output
   // https://github.com/vercel/next.js/discussions/68160
   outputFileTracingExcludes: {
-    "*": ["public/**", "content/**"],
+    "*": ["public/**"],
   },
 };
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -36,7 +36,7 @@ if (process.env.NEXT_PUBLIC_VERCEL_ENV === "preview") {
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
-  productionBrowserSourceMaps: true,
+  productionBrowserSourceMaps: false,
   trailingSlash: false,
 
   async rewrites() {
@@ -232,6 +232,12 @@ const nextConfig: NextConfig = {
         console.warn(message);
       },
     },
+  },
+
+  // Ignore public and content directories from the build output
+  // https://github.com/vercel/next.js/discussions/68160
+  outputFileTracingExcludes: {
+    "*": ["public/**", "content/**"],
   },
 };
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -233,12 +233,6 @@ const nextConfig: NextConfig = {
       },
     },
   },
-
-  // Ignore public and content directories from the build output
-  // https://github.com/vercel/next.js/discussions/68160
-  outputFileTracingExcludes: {
-    "*": ["public/**"],
-  },
 };
 
 const moduleExports = (): NextConfig => {


### PR DESCRIPTION
### Problem

Vercel is failing because the serverless functions are exceeding 250mb

### Summary of Changes

We don't need the content and public files in the serverless functions build

Fixes #

Documented in code 