### PR TITLE
docs: fix link to configuring-state-commitment

### DIFF
--- a/apps/web/content/docs/ar/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/ar/rpc/http/sendtransaction.mdx
@@ -167,7 +167,7 @@ async fn main() -> Result<()> {
 !type string
 
 مستوى الالتزام المستخدم للفحص المسبق. انظر
-[تكوين التزام الحالة](/docs/rpc/index.mdx#configuring-state-commitment). الإعداد
+[تكوين التزام الحالة](/docs/rpc#configuring-state-commitment). الإعداد
 الافتراضي `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/ar/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/ar/rpc/http/simulatetransaction.mdx
@@ -174,7 +174,7 @@ async fn main() -> Result<()> {
 !type string
 
 مستوى الالتزام لمحاكاة المعاملة عنده. انظر
-[تكوين التزام الحالة](/docs/rpc/index.mdx#configuring-state-commitment).
+[تكوين التزام الحالة](/docs/rpc#configuring-state-commitment).
 الافتراضي `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/de/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/de/rpc/http/sendtransaction.mdx
@@ -172,7 +172,7 @@ Wenn `true`, überspringen Sie die Preflight-Transaktionsprüfungen. Standard:
 !type string
 
 Commitment-Level für Preflight. Siehe
-[Konfiguration des State Commitment](/docs/rpc/index.mdx#configuring-state-commitment).
+[Konfiguration des State Commitment](/docs/rpc#configuring-state-commitment).
 Standard `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/de/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/de/rpc/http/simulatetransaction.mdx
@@ -175,7 +175,7 @@ Konfigurationsobjekt mit den folgenden Feldern:
 !type string
 
 Commitment-Level, auf dem die Transaktion simuliert werden soll. Siehe
-[Konfiguration des State Commitment](/docs/rpc/index.mdx#configuring-state-commitment).
+[Konfiguration des State Commitment](/docs/rpc#configuring-state-commitment).
 Standard `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/el/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/el/rpc/http/sendtransaction.mdx
@@ -173,7 +173,7 @@ async fn main() -> Result<()> {
 !type string
 
 Επίπεδο δέσμευσης που χρησιμοποιείται για την προπτήση. Δείτε
-[Διαμόρφωση Δέσμευσης Κατάστασης](/docs/rpc/index.mdx#configuring-state-commitment).
+[Διαμόρφωση Δέσμευσης Κατάστασης](/docs/rpc#configuring-state-commitment).
 Προεπιλογή `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/el/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/el/rpc/http/simulatetransaction.mdx
@@ -175,7 +175,7 @@ async fn main() -> Result<()> {
 !type string
 
 Επίπεδο δέσμευσης για την προσομοίωση της συναλλαγής. Δείτε
-[Διαμόρφωση Δέσμευσης Κατάστασης](/docs/rpc/index.mdx#configuring-state-commitment).
+[Διαμόρφωση Δέσμευσης Κατάστασης](/docs/rpc#configuring-state-commitment).
 Προεπιλογή `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/en/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/en/rpc/http/sendtransaction.mdx
@@ -169,7 +169,7 @@ When `true`, skip the preflight transaction checks. Default: `false`.
 !type string
 
 Commitment level to use for preflight. See
-[Configuring State Commitment](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configuring State Commitment](/docs/rpc#configuring-state-commitment).
 Default `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/en/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/en/rpc/http/simulatetransaction.mdx
@@ -174,7 +174,7 @@ Configuration object containing the following fields:
 !type string
 
 Commitment level to simulate the transaction at. See
-[Configuring State Commitment](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configuring State Commitment](/docs/rpc#configuring-state-commitment).
 Default `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/es/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/es/rpc/http/sendtransaction.mdx
@@ -173,7 +173,7 @@ predeterminado: `false`.
 !type string
 
 Nivel de compromiso a utilizar para preflight. Consulta
-[Configuración del compromiso de estado](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configuración del compromiso de estado](/docs/rpc#configuring-state-commitment).
 Valor predeterminado `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/es/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/es/rpc/http/simulatetransaction.mdx
@@ -175,7 +175,7 @@ Objeto de configuración que contiene los siguientes campos:
 !type string
 
 Nivel de compromiso para simular la transacción. Consulta
-[Configuración del compromiso de estado](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configuración del compromiso de estado](/docs/rpc#configuring-state-commitment).
 Predeterminado `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/fi/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/fi/rpc/http/sendtransaction.mdx
@@ -170,7 +170,7 @@ Kun `true`, ohita transaktion ennakkotarkistukset. Oletus: `false`.
 !type string
 
 Sitoutumistaso, jota käytetään ennakkotarkistuksessa. Katso
-[Tilan sitoutumisen määrittäminen](/docs/rpc/index.mdx#configuring-state-commitment).
+[Tilan sitoutumisen määrittäminen](/docs/rpc#configuring-state-commitment).
 Oletus `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/fi/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/fi/rpc/http/simulatetransaction.mdx
@@ -175,7 +175,7 @@ Määrittelyobjekti, joka sisältää seuraavat kentät:
 !type string
 
 Sitoutumistaso, jolla transaktio simuloidaan. Katso
-[Tilan sitoutumisen määrittäminen](/docs/rpc/index.mdx#configuring-state-commitment).
+[Tilan sitoutumisen määrittäminen](/docs/rpc#configuring-state-commitment).
 Oletus `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/fr/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/fr/rpc/http/sendtransaction.mdx
@@ -173,7 +173,7 @@ défaut : `false`.
 !type string
 
 Niveau d'engagement à utiliser pour le préliminaire. Voir
-[Configuration de l'engagement d'état](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configuration de l'engagement d'état](/docs/rpc#configuring-state-commitment).
 Par défaut `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/fr/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/fr/rpc/http/simulatetransaction.mdx
@@ -175,7 +175,7 @@ Objet de configuration contenant les champs suivants :
 !type string
 
 Niveau d'engagement pour simuler la transaction. Voir
-[Configuration de l'engagement d'état](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configuration de l'engagement d'état](/docs/rpc#configuring-state-commitment).
 Par défaut `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/id/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/id/rpc/http/sendtransaction.mdx
@@ -169,7 +169,7 @@ Ketika `true`, lewati pemeriksaan transaksi preflight. Default: `false`.
 !type string
 
 Level komitmen yang digunakan untuk preflight. Lihat
-[Mengonfigurasi State Commitment](/docs/rpc/index.mdx#configuring-state-commitment).
+[Mengonfigurasi State Commitment](/docs/rpc#configuring-state-commitment).
 Default `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/id/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/id/rpc/http/simulatetransaction.mdx
@@ -175,7 +175,7 @@ Objek konfigurasi yang berisi bidang-bidang berikut:
 !type string
 
 Level commitment untuk mensimulasikan transaksi. Lihat
-[Mengonfigurasi State Commitment](/docs/rpc/index.mdx#configuring-state-commitment).
+[Mengonfigurasi State Commitment](/docs/rpc#configuring-state-commitment).
 Default `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/it/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/it/rpc/http/sendtransaction.mdx
@@ -173,7 +173,7 @@ Quando `true`, salta i controlli di preflight della transazione. Predefinito:
 !type string
 
 Livello di commitment da utilizzare per il preflight. Vedi
-[Configurazione del commitment di stato](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configurazione del commitment di stato](/docs/rpc#configuring-state-commitment).
 Predefinito `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/it/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/it/rpc/http/simulatetransaction.mdx
@@ -175,7 +175,7 @@ Oggetto di configurazione contenente i seguenti campi:
 !type string
 
 Livello di commitment per simulare la transazione. Vedi
-[Configurazione del commitment di stato](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configurazione del commitment di stato](/docs/rpc#configuring-state-commitment).
 Predefinito `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/ja/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/ja/rpc/http/sendtransaction.mdx
@@ -157,7 +157,7 @@ async fn main() -> Result<()> {
 !type string
 
 プリフライトに使用するコミットメントレベル。
-[ステートコミットメントの設定](/docs/rpc/index.mdx#configuring-state-commitment)を参照してください。デフォルト
+[ステートコミットメントの設定](/docs/rpc#configuring-state-commitment)を参照してください。デフォルト
 `finalized`。
 
 ##### !! maxRetries

--- a/apps/web/content/docs/ja/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/ja/rpc/http/simulatetransaction.mdx
@@ -174,7 +174,7 @@ async fn main() -> Result<()> {
 !type string
 
 トランザクションをシミュレートするコミットメントレベル。
-[ステートコミットメントの設定](/docs/rpc/index.mdx#configuring-state-commitment)を参照してください。デフォルトは
+[ステートコミットメントの設定](/docs/rpc#configuring-state-commitment)を参照してください。デフォルトは
 `finalized` です。
 
 ##### !! encoding

--- a/apps/web/content/docs/ko/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/ko/rpc/http/sendtransaction.mdx
@@ -167,7 +167,7 @@ async fn main() -> Result<()> {
 !type string
 
 사전 점검에 사용할 커밋먼트 레벨입니다.
-[상태 커밋먼트 구성](/docs/rpc/index.mdx#configuring-state-commitment)을
+[상태 커밋먼트 구성](/docs/rpc#configuring-state-commitment)을
 참조하세요. 기본값 `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/ko/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/ko/rpc/http/simulatetransaction.mdx
@@ -174,7 +174,7 @@ async fn main() -> Result<()> {
 !type string
 
 트랜잭션을 시뮬레이션할 커밋먼트 레벨.
-[상태 커밋먼트 구성](/docs/rpc/index.mdx#configuring-state-commitment) 참조.
+[상태 커밋먼트 구성](/docs/rpc#configuring-state-commitment) 참조.
 기본값 `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/nl/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/nl/rpc/http/sendtransaction.mdx
@@ -173,7 +173,7 @@ Wanneer `true`, sla de preflight transactiecontroles over. Standaard: `false`.
 !type string
 
 Commitment-niveau om te gebruiken voor preflight. Zie
-[Configureren van state commitment](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configureren van state commitment](/docs/rpc#configuring-state-commitment).
 Standaard `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/nl/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/nl/rpc/http/simulatetransaction.mdx
@@ -175,7 +175,7 @@ Configuratieobject met de volgende velden:
 !type string
 
 Commitment-niveau waarop de transactie gesimuleerd wordt. Zie
-[Configureren van State Commitment](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configureren van State Commitment](/docs/rpc#configuring-state-commitment).
 Standaard `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/pl/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/pl/rpc/http/sendtransaction.mdx
@@ -171,7 +171,7 @@ Gdy `true`, pomiń wstępne sprawdzanie transakcji. Domyślnie: `false`.
 !type string
 
 Poziom zaangażowania do użycia podczas wstępnego sprawdzania. Zobacz
-[Konfigurowanie zaangażowania stanu](/docs/rpc/index.mdx#configuring-state-commitment).
+[Konfigurowanie zaangażowania stanu](/docs/rpc#configuring-state-commitment).
 Domyślnie `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/pl/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/pl/rpc/http/simulatetransaction.mdx
@@ -174,7 +174,7 @@ Obiekt konfiguracyjny zawierający następujące pola:
 !type string
 
 Poziom zaangażowania do symulacji transakcji. Zobacz
-[Konfigurowanie zaangażowania stanu](/docs/rpc/index.mdx#configuring-state-commitment).
+[Konfigurowanie zaangażowania stanu](/docs/rpc#configuring-state-commitment).
 Domyślnie `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/pt/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/pt/rpc/http/sendtransaction.mdx
@@ -170,7 +170,7 @@ Quando `true`, ignora as verificações de transação de pré-voo. Padrão: `fa
 !type string
 
 Nível de compromisso a ser usado para o pré-voo. Veja
-[Configurando o Compromisso de Estado](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configurando o Compromisso de Estado](/docs/rpc#configuring-state-commitment).
 Padrão `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/pt/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/pt/rpc/http/simulatetransaction.mdx
@@ -174,7 +174,7 @@ Objeto de configuração contendo os seguintes campos:
 !type string
 
 Nível de commitment para simular a transação. Veja
-[Configurando State Commitment](/docs/rpc/index.mdx#configuring-state-commitment).
+[Configurando State Commitment](/docs/rpc#configuring-state-commitment).
 Padrão `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/ru/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/ru/rpc/http/sendtransaction.mdx
@@ -171,7 +171,7 @@ async fn main() -> Result<()> {
 !type string
 
 Уровень обязательств для предварительной проверки. См. раздел
-[Настройка обязательств состояния](/docs/rpc/index.mdx#configuring-state-commitment).
+[Настройка обязательств состояния](/docs/rpc#configuring-state-commitment).
 По умолчанию `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/ru/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/ru/rpc/http/simulatetransaction.mdx
@@ -175,7 +175,7 @@ async fn main() -> Result<()> {
 !type string
 
 Уровень подтверждения, на котором будет симулироваться транзакция. См. раздел
-[Настройка подтверждения состояния](/docs/rpc/index.mdx#configuring-state-commitment).
+[Настройка подтверждения состояния](/docs/rpc#configuring-state-commitment).
 По умолчанию `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/tr/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/tr/rpc/http/sendtransaction.mdx
@@ -168,7 +168,7 @@ BIRAKILMIŞ**), veya `base64`.
 !type string
 
 Ön kontrol için kullanılacak taahhüt seviyesi. Bkz.
-[Durum Taahhüdünü Yapılandırma](/docs/rpc/index.mdx#configuring-state-commitment).
+[Durum Taahhüdünü Yapılandırma](/docs/rpc#configuring-state-commitment).
 Varsayılan `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/tr/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/tr/rpc/http/simulatetransaction.mdx
@@ -174,7 +174,7 @@ Aşağıdaki alanları içeren yapılandırma nesnesi:
 !type string
 
 İşlemin simüle edileceği taahhüt seviyesi. Bkz.
-[Durum Taahhüdünü Yapılandırma](/docs/rpc/index.mdx#configuring-state-commitment).
+[Durum Taahhüdünü Yapılandırma](/docs/rpc#configuring-state-commitment).
 Varsayılan `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/uk/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/uk/rpc/http/sendtransaction.mdx
@@ -170,7 +170,7 @@ async fn main() -> Result<()> {
 !type string
 
 Рівень підтвердження для використання перед виконанням. Дивіться
-[Налаштування підтвердження стану](/docs/rpc/index.mdx#configuring-state-commitment).
+[Налаштування підтвердження стану](/docs/rpc#configuring-state-commitment).
 За замовчуванням `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/uk/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/uk/rpc/http/simulatetransaction.mdx
@@ -175,7 +175,7 @@ async fn main() -> Result<()> {
 !type string
 
 Рівень підтвердження для симуляції транзакції. Дивіться
-[Налаштування підтвердження стану](/docs/rpc/index.mdx#configuring-state-commitment).
+[Налаштування підтвердження стану](/docs/rpc#configuring-state-commitment).
 За замовчуванням `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/vi/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/vi/rpc/http/sendtransaction.mdx
@@ -167,7 +167,7 @@ Khi `true`, bỏ qua các kiểm tra giao dịch preflight. Mặc định: `fals
 !type string
 
 Mức độ cam kết sử dụng cho preflight. Xem
-[Cấu hình cam kết trạng thái](/docs/rpc/index.mdx#configuring-state-commitment).
+[Cấu hình cam kết trạng thái](/docs/rpc#configuring-state-commitment).
 Mặc định `finalized`.
 
 ##### !! maxRetries

--- a/apps/web/content/docs/vi/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/vi/rpc/http/simulatetransaction.mdx
@@ -174,7 +174,7 @@ Giao dịch, dưới dạng chuỗi đã được mã hóa.
 !type string
 
 Mức cam kết để mô phỏng giao dịch. Xem
-[Cấu hình State Commitment](/docs/rpc/index.mdx#configuring-state-commitment).
+[Cấu hình State Commitment](/docs/rpc#configuring-state-commitment).
 Mặc định `finalized`.
 
 ##### !! encoding

--- a/apps/web/content/docs/zh/rpc/http/sendtransaction.mdx
+++ b/apps/web/content/docs/zh/rpc/http/sendtransaction.mdx
@@ -158,7 +158,7 @@ async fn main() -> Result<()> {
 !type string
 
 用于预检的承诺级别。请参阅
-[配置状态承诺](/docs/rpc/index.mdx#configuring-state-commitment)。默认值：`finalized`。
+[配置状态承诺](/docs/rpc#configuring-state-commitment)。默认值：`finalized`。
 
 ##### !! maxRetries
 

--- a/apps/web/content/docs/zh/rpc/http/simulatetransaction.mdx
+++ b/apps/web/content/docs/zh/rpc/http/simulatetransaction.mdx
@@ -172,7 +172,7 @@ async fn main() -> Result<()> {
 !type string
 
 模拟交易时的承诺级别。请参阅
-[配置状态承诺](/docs/rpc/index.mdx#configuring-state-commitment)。默认值
+[配置状态承诺](/docs/rpc#configuring-state-commitment)。默认值
 `finalized`。
 
 ##### !! encoding


### PR DESCRIPTION
### Problem

Links to "Configuring State Commitment" in the docs for `sendTransaction` and `simulateTransaction` are currently incorrect

### Summary of Changes
Fixed the links
