### PR TITLE
docs: add filter criteria link to getprogramaccounts rpc page

### DIFF
--- a/apps/web/content/docs/en/rpc/http/getprogramaccounts.mdx
+++ b/apps/web/content/docs/en/rpc/http/getprogramaccounts.mdx
@@ -232,7 +232,8 @@ Request a slice of the account's data.
 
 !type array
 
-Filter results using up to 4 filter objects.
+Filter results using up to 4 filter objects. See
+[Filtering](/docs/rpc#filter-criteria).
 
 <Callout type="info">
   The resultant account(s) must meet **ALL** filter criteria to be included in


### PR DESCRIPTION
- add link to [filter criteria](https://solana.com/docs/rpc#filter-criteria) on getprogramaccounts rpc page