### PR TITLE
Fix incorrect variable reference for collection address in NFT creation script

### DIFF
--- a/apps/web/content/courses/tokens-and-nfts/nfts-with-metaplex.mdx
+++ b/apps/web/content/courses/tokens-and-nfts/nfts-with-metaplex.mdx
@@ -721,7 +721,7 @@ created in the creation of a collection stage, and we will use the
 const metadata = findMetadataPda(umi, { mint: nftAddress });
 await verifyCollectionV1(umi, {
   metadata,
-  collectionMint: collectionAddress,
+  collectionMint: collectionNftAddress,
   authority: umi.identity,
 }).sendAndConfirm(umi);
 


### PR DESCRIPTION
This PR fixes a variable name mismatch in the create-metaplex-nft.ts script.
Previously, the code referenced collectionAddress, which was undefined and caused a runtime error.