### PR TITLE
add gill examples to development section of cookbook

### DIFF
--- a/apps/web/content/cookbook/accounts/create-account.mdx
+++ b/apps/web/content/cookbook/accounts/create-account.mdx
@@ -28,14 +28,12 @@ can then initialize the account data through its own instructions.
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
+  createSolanaClient,
   createTransaction,
   generateKeyPairSigner,
   getSignatureFromTransaction,
   lamports,
   pipe,
-  sendAndConfirmTransactionFactory,
   setTransactionMessageFeePayerSigner,
   setTransactionMessageLifetimeUsingBlockhash,
   signTransactionMessageWithSigners
@@ -45,10 +43,9 @@ import {
   SYSTEM_PROGRAM_ADDRESS
 } from "@solana-program/system";
 
-const { rpc, sendAndConfirmTransaction } = createSolanaClient({
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
   urlOrMoniker: "localnet"
 });
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 const sender = await generateKeyPairSigner();
 const LAMPORTS_PER_SOL = 1_000_000_000n;
@@ -82,10 +79,7 @@ const transactionMessage = createTransaction({
 
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
-await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-  signedTransaction,
-  { commitment: "confirmed" }
-);
+await sendAndConfirmTransaction(signedTransaction);
 const transactionSignature = getSignatureFromTransaction(signedTransaction);
 console.log("Transaction Signature for create account:", transactionSignature);
 ```

--- a/apps/web/content/cookbook/development/connect-environment.mdx
+++ b/apps/web/content/cookbook/development/connect-environment.mdx
@@ -18,6 +18,14 @@ Connect to a specific RPC endpoint:
 
 <CodeTabs storage="cookbook">
 
+```ts !! title="Gill"
+import { createSolanaClient } from "gill";
+
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
+  urlOrMoniker: "devnet"
+});
+```
+
 ```ts !! title="Kit"
 import { createSolanaRpc, createSolanaRpcSubscriptions } from "@solana/kit";
 

--- a/apps/web/content/cookbook/development/load-keypair-from-file.mdx
+++ b/apps/web/content/cookbook/development/load-keypair-from-file.mdx
@@ -13,6 +13,51 @@ can then load this keypair using the helper function below.
 
 <CodeTabs storage="cookbook">
 
+```ts !! title="Gill"
+// !collapse(1:8) collapsed
+
+import {
+  airdropFactory,
+  createSolanaClient,
+  lamports
+} from "gill";
+import { loadKeypairSignerFromFile } from "gill/node";
+
+const keypairSigner = await loadKeypairSignerFromFile();
+console.log(keypairSigner.address);
+
+export async function loadDefaultKeypairWithAirdrop(
+  cluster: string
+  // !collapse(1:24) collapsed
+): Promise<KeyPairSigner<string>> {
+  const keypair = await loadKeypairSignerFromFile();
+  const { rpc, rpcSubscriptions } = createSolanaClient({
+    urlOrMoniker: cluster
+  });
+
+  try {
+    const result = await rpc.getBalance(keypair.address).send();
+
+    console.log(`Balance: ${result.value} lamports`);
+    if (result.value < lamports(500_000n)) {
+      console.log(`Balance low requesting airdrop`);
+      const airdrop = airdropFactory({ rpc, rpcSubscriptions });
+      await airdrop({
+        commitment: "confirmed",
+        lamports: lamports(1_000_000_000n),
+        recipientAddress: keypair.address
+      });
+    }
+  } catch (err) {
+    console.error("Error fetching balance:", err);
+  }
+  return keypair;
+}
+
+const keypairSigner2 = await loadDefaultKeypairWithAirdrop("devnet");
+console.log(keypairSigner2.address);
+```
+
 ```ts !! title="Kit"
 // !collapse(1:29) collapsed
 
@@ -97,6 +142,9 @@ export async function loadDefaultKeypairWithAirdrop(
   }
   return keypair;
 }
+
+const keypairSigner2 = await loadDefaultKeypairWithAirdrop("devnet");
+console.log(keypairSigner2.address);
 ```
 
 ```ts !! title="Legacy"

--- a/apps/web/content/cookbook/development/subscribing-events.mdx
+++ b/apps/web/content/cookbook/development/subscribing-events.mdx
@@ -9,6 +9,47 @@ instead receive those updates only when they happen.
 
 <CodeTabs storage="cookbook">
 
+```ts !! title="Gill"
+import {
+  createSolanaClient,
+  generateKeyPairSigner,
+  lamports
+} from "gill";
+
+const LAMPORTS_PER_SOL = lamports(1_000_000_000n);
+
+const { rpc, rpcSubscriptions } = createSolanaClient({
+  urlOrMoniker: "localnet"
+});
+
+const wallet = await generateKeyPairSigner();
+
+const abortController = new AbortController();
+
+// !mark(1:3)
+const notifications = await rpcSubscriptions
+  .accountNotifications(wallet.address, { commitment: "confirmed" })
+  .subscribe({ abortSignal: abortController.signal });
+
+(async () => {
+  for await (const notification of notifications) {
+    console.log(notification);
+  }
+})();
+
+const airdropSignature = await rpc
+  .requestAirdrop(wallet.address, LAMPORTS_PER_SOL)
+  .send();
+
+while (true) {
+  const status = await rpc.getSignatureStatuses([airdropSignature]).send();
+  if (status.value?.[0]?.confirmationStatus === "confirmed") break;
+  await new Promise((r) => setTimeout(r, 1000));
+}
+
+abortController.abort();
+```
+
 ```ts !! title="Kit"
 import {
   createSolanaRpc,

--- a/apps/web/content/cookbook/development/test-sol.mdx
+++ b/apps/web/content/cookbook/development/test-sol.mdx
@@ -12,6 +12,33 @@ You can fund an address by requesting an airdrop. If on devnet, you can use the
 
 <CodeTabs storage="cookbook" flags="r">
 
+```ts !! title="Gill"
+import {
+  airdropFactory,
+  createSolanaClient,
+  generateKeyPairSigner,
+  lamports,
+} from "gill";
+
+const { rpc, rpcSubscriptions } = createSolanaClient({
+  urlOrMoniker: "localnet"
+});
+
+
+const wallet = await generateKeyPairSigner();
+const LAMPORTS_PER_SOL = 1_000_000_000n;
+
+// !mark(1:5)
+await airdropFactory({ rpc, rpcSubscriptions })({
+  recipientAddress: wallet.address,
+  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
+  commitment: "confirmed"
+});
+
+const { value } = await rpc.getBalance(wallet.address).send();
+console.log(`Balance: ${value / LAMPORTS_PER_SOL} SOL`);
+```
+
 ```ts !! title="Kit"
 import {
   airdropFactory,


### PR DESCRIPTION
### Problem
Follow up to Gill examples in #792 . Gill examples for "Development" section of Cookbook are missing and the create account example has a mistake.


### Summary of Changes
- add Gill examples to Development section
- add missing `createSolanaClient` import and use it in create account example
- 


Fixes #