### PR TITLE
Fix: replace incorrect '\\n' with proper newline '\n' in logs

### DIFF
--- a/apps/web/content/courses/token-extensions/token-extensions-in-the-client.mdx
+++ b/apps/web/content/courses/token-extensions/token-extensions-in-the-client.mdx
@@ -321,7 +321,7 @@ export async function createAndMintToken(
   decimals: number,
   mintAmount: number,
 ): Promise<PublicKey> {
-  console.log("\\nCreating a new mint...");
+  console.log("\nCreating a new mint...");
   const mint = await createMint(
     connection,
     payer,
@@ -335,13 +335,13 @@ export async function createAndMintToken(
     tokenProgramId,
   );
 
-  console.log("\\nFetching mint info...");
+  console.log("\nFetching mint info...");
 
   const mintInfo = await getMint(connection, mint, "finalized", tokenProgramId);
 
   printTableData(mintInfo);
 
-  console.log("\\nCreating associated token account...");
+  console.log("\nCreating associated token account...");
   const tokenAccount = await getOrCreateAssociatedTokenAccount(
     connection,
     payer,
@@ -355,7 +355,7 @@ export async function createAndMintToken(
 
   console.log(`Associated token account: ${tokenAccount.address.toBase58()}`);
 
-  console.log("\\nMinting to associated token account...");
+  console.log("\nMinting to associated token account...");
   await mintTo(
     connection,
     payer,


### PR DESCRIPTION
Replaced '\\n' with '\n' in all console.log statements to ensure proper line breaks in terminal output.

### Problem
The console.log statements in createAndMintToken.ts were using \\n, which prints a literal backslash and n instead of creating a newline. This makes logs harder to read during token creation and minting.


### Summary of Changes
Replaced all occurrences of \\n with \n in console.log statements.
Ensures proper line breaks in terminal output for better readability.
Fixes # (You can put the relevant issue number here if you have one)


Fixes #