### PR TITLE
Fix metadata update logic with type safety and validation

### DIFF
--- a/apps/web/content/courses/token-extensions/token-extensions-metadata.mdx
+++ b/apps/web/content/courses/token-extensions/token-extensions-metadata.mdx
@@ -823,6 +823,7 @@ import {
   SystemProgram,
   Transaction,
 } from "@solana/web3.js";
+import { TransactionInstruction } from "@solana/web3.js";
 import { CreateNFTInputs } from "./helpers";
 import {
   createInitializeInstruction,
@@ -997,17 +998,25 @@ make an instruction to set each new additional field. We do this by calling
 
 ```typescript
 // 6. Set the additional metadata in the mint
-const setExtraMetadataInstructions = [];
-for (const attributes of Object.entries(tokenAdditionalMetadata || [])) {
-  setExtraMetadataInstructions.push(
-    createUpdateFieldInstruction({
-      updateAuthority: payer.publicKey,
-      metadata: mint.publicKey,
-      field: attributes[0],
-      value: attributes[1],
-      programId: TOKEN_2022_PROGRAM_ID,
-    }),
-  );
+const setExtraMetadataInstructions: TransactionInstruction[] = [];
+if (
+  tokenAdditionalMetadata &&
+  typeof tokenAdditionalMetadata === "object" &&
+  !Array.isArray(tokenAdditionalMetadata)
+) {
+  for (const [field, value] of Object.entries(tokenAdditionalMetadata)) {
+    if (field && value !== undefined && value !== null) {
+      setExtraMetadataInstructions.push(
+        createUpdateFieldInstruction({
+          updateAuthority: payer.publicKey,
+          metadata: mint.publicKey,
+          field,
+          value: String(value), // ensure consistent type
+          programId: TOKEN_2022_PROGRAM_ID,
+        }),
+      );
+    }
+  }
 }
 ```
 
@@ -1128,6 +1137,7 @@ import {
   SystemProgram,
   Transaction,
 } from "@solana/web3.js";
+import { TransactionInstruction } from "@solana/web3.js";
 import { CreateNFTInputs } from "./helpers";
 import {
   createInitializeInstruction,
@@ -1228,18 +1238,26 @@ export default async function createNFTWithEmbeddedMetadata(
   });
 
   // 6. Set the additional metadata in the mint
-  const setExtraMetadataInstructions = [];
-  for (const attributes of Object.entries(tokenAdditionalMetadata || [])) {
-    setExtraMetadataInstructions.push(
-      createUpdateFieldInstruction({
-        updateAuthority: payer.publicKey,
-        metadata: mint.publicKey,
-        field: attributes[0],
-        value: attributes[1],
-        programId: TOKEN_2022_PROGRAM_ID,
-      }),
-    );
+const setExtraMetadataInstructions: TransactionInstruction[] = [];
+if (
+  tokenAdditionalMetadata &&
+  typeof tokenAdditionalMetadata === "object" &&
+  !Array.isArray(tokenAdditionalMetadata)
+) {
+  for (const [field, value] of Object.entries(tokenAdditionalMetadata)) {
+    if (field && value !== undefined && value !== null) {
+      setExtraMetadataInstructions.push(
+        createUpdateFieldInstruction({
+          updateAuthority: payer.publicKey,
+          metadata: mint.publicKey,
+          field,
+          value: String(value), // ensure consistent type
+          programId: TOKEN_2022_PROGRAM_ID,
+        }),
+      );
+    }
   }
+}
 
   // 7. Create the associated token account and mint the NFT to it and remove the mint authority
   const ata = await getAssociatedTokenAddress(


### PR DESCRIPTION
### Problem
The metadata update logic caused a TypeScript error:
`Argument of type 'TransactionInstruction' is not assignable to parameter of type 'never'`.

This occurred because `setExtraMetadataInstructions` was initialized as an untyped empty array, which TypeScript inferred as `never[]`. Additionally, the iteration logic did not validate whether `tokenAdditionalMetadata` was a valid object, which could lead to runtime issues or invalid metadata updates.

### Summary of Changes
- Explicitly typed `setExtraMetadataInstructions` as `TransactionInstruction[]` to ensure proper type inference.
- Added validation to check that `tokenAdditionalMetadata` is a non-array object before iterating.
- Converted metadata field values to strings to ensure compatibility with Solana’s expected field types.
- Improved readability by using `[field, value]` destructuring and consistent variable naming.

Fixes #
