### PR TITLE
docs: move gill cookbook snippets

### DIFF
--- a/apps/web/content/cookbook/accounts/calculate-rent.mdx
+++ b/apps/web/content/cookbook/accounts/calculate-rent.mdx
@@ -12,19 +12,6 @@ if the account is closed.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import { createSolanaClient } from "gill";
-
-const { rpc } = createSolanaClient({
-  urlOrMoniker: "localnet"
-});
-
-const space = 1500n; // bytes
-// !mark
-const lamports = await rpc.getMinimumBalanceForRentExemption(space).send();
-console.log("Minimum balance for rent exemption:", lamports);
-```
-
 ```ts !! title="Kit"
 import { createSolanaRpc } from "@solana/kit";
 
@@ -91,3 +78,16 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import { createSolanaClient } from "gill";
+
+const { rpc } = createSolanaClient({
+  urlOrMoniker: "localnet"
+});
+
+const space = 1500n; // bytes
+// !mark
+const lamports = await rpc.getMinimumBalanceForRentExemption(space).send();
+console.log("Minimum balance for rent exemption:", lamports);
+```

--- a/apps/web/content/cookbook/accounts/create-account.mdx
+++ b/apps/web/content/cookbook/accounts/create-account.mdx
@@ -24,66 +24,6 @@ can then initialize the account data through its own instructions.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  createSolanaClient,
-  createTransaction,
-  generateKeyPairSigner,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners
-} from "gill";
-import {
-  getCreateAccountInstruction,
-  SYSTEM_PROGRAM_ADDRESS
-} from "@solana-program/system";
-
-const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
-  urlOrMoniker: "localnet"
-});
-
-const sender = await generateKeyPairSigner();
-const LAMPORTS_PER_SOL = 1_000_000_000n;
-await airdropFactory({ rpc, rpcSubscriptions })({
-  recipientAddress: sender.address,
-  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
-  commitment: "confirmed"
-});
-
-const newAccount = await generateKeyPairSigner();
-
-const space = 0n;
-const rentLamports = await rpc.getMinimumBalanceForRentExemption(space).send();
-
-// !mark(1:7)
-const createAccountInstruction = getCreateAccountInstruction({
-  payer: sender,
-  newAccount: newAccount,
-  lamports: rentLamports,
-  programAddress: SYSTEM_PROGRAM_ADDRESS,
-  space
-});
-
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-const transactionMessage = createTransaction({
-  feePayer: sender,
-  version: "legacy",
-  instructions: [createAccountInstruction],
-  latestBlockhash
-});
-
-const signedTransaction =
-  await signTransactionMessageWithSigners(transactionMessage);
-await sendAndConfirmTransaction(signedTransaction);
-const transactionSignature = getSignatureFromTransaction(signedTransaction);
-console.log("Transaction Signature for create account:", transactionSignature);
-```
-
 ```ts !! title="Kit"
 import {
   airdropFactory,
@@ -324,3 +264,65 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import {
+  airdropFactory,
+  appendTransactionMessageInstructions,
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getSignatureFromTransaction,
+  lamports,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners
+} from "gill";
+import {
+  getCreateAccountInstruction,
+  SYSTEM_PROGRAM_ADDRESS
+} from "@solana-program/system";
+
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "localnet"
+  }
+);
+
+const sender = await generateKeyPairSigner();
+const LAMPORTS_PER_SOL = 1_000_000_000n;
+await airdropFactory({ rpc, rpcSubscriptions })({
+  recipientAddress: sender.address,
+  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
+  commitment: "confirmed"
+});
+
+const newAccount = await generateKeyPairSigner();
+
+const space = 0n;
+const rentLamports = await rpc.getMinimumBalanceForRentExemption(space).send();
+
+// !mark(1:7)
+const createAccountInstruction = getCreateAccountInstruction({
+  payer: sender,
+  newAccount: newAccount,
+  lamports: rentLamports,
+  programAddress: SYSTEM_PROGRAM_ADDRESS,
+  space
+});
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const transactionMessage = createTransaction({
+  feePayer: sender,
+  version: "legacy",
+  instructions: [createAccountInstruction],
+  latestBlockhash
+});
+
+const signedTransaction =
+  await signTransactionMessageWithSigners(transactionMessage);
+await sendAndConfirmTransaction(signedTransaction);
+const transactionSignature = getSignatureFromTransaction(signedTransaction);
+console.log("Transaction Signature for create account:", transactionSignature);
+```

--- a/apps/web/content/cookbook/accounts/get-account-balance.mdx
+++ b/apps/web/content/cookbook/accounts/get-account-balance.mdx
@@ -10,20 +10,6 @@ Every Solana account is required to maintain a minimum balance of native SOL
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import { createSolanaClient, Address } from "gill";
-
-const { rpc } = createSolanaClient({
-  urlOrMoniker: "mainnet"
-});
-
-const addresss = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" as Address;
-// !mark
-const { value } = await rpc.getBalance(addresss).send();
-
-console.log(`Balance: ${Number(value) / 1_000_000_000} SOL`);
-```
-
 ```ts !! title="Kit"
 import { createSolanaRpc, Address } from "@solana/kit";
 
@@ -97,3 +83,17 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import { createSolanaClient, Address } from "gill";
+
+const { rpc } = createSolanaClient({
+  urlOrMoniker: "mainnet"
+});
+
+const addresss = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" as Address;
+// !mark
+const { value } = await rpc.getBalance(addresss).send();
+
+console.log(`Balance: ${Number(value) / 1_000_000_000} SOL`);
+```

--- a/apps/web/content/cookbook/development/connect-environment.mdx
+++ b/apps/web/content/cookbook/development/connect-environment.mdx
@@ -18,14 +18,6 @@ Connect to a specific RPC endpoint:
 
 <CodeTabs storage="cookbook">
 
-```ts !! title="Gill"
-import { createSolanaClient } from "gill";
-
-const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient({
-  urlOrMoniker: "devnet"
-});
-```
-
 ```ts !! title="Kit"
 import { createSolanaRpc, createSolanaRpcSubscriptions } from "@solana/kit";
 
@@ -78,4 +70,14 @@ You can also connect to a public RPC endpoint by specifying its network name
 import { clusterApiUrl, Connection } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("mainnet-beta"), "confirmed");
+```
+
+```ts title="Gill"
+import { createSolanaClient } from "gill";
+
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "devnet"
+  }
+);
 ```

--- a/apps/web/content/cookbook/development/load-keypair-from-file.mdx
+++ b/apps/web/content/cookbook/development/load-keypair-from-file.mdx
@@ -13,51 +13,6 @@ can then load this keypair using the helper function below.
 
 <CodeTabs storage="cookbook">
 
-```ts !! title="Gill"
-// !collapse(1:8) collapsed
-
-import {
-  airdropFactory,
-  createSolanaClient,
-  lamports
-} from "gill";
-import { loadKeypairSignerFromFile } from "gill/node";
-
-const keypairSigner = await loadKeypairSignerFromFile();
-console.log(keypairSigner.address);
-
-export async function loadDefaultKeypairWithAirdrop(
-  cluster: string
-  // !collapse(1:24) collapsed
-): Promise<KeyPairSigner<string>> {
-  const keypair = await loadKeypairSignerFromFile();
-  const { rpc, rpcSubscriptions } = createSolanaClient({
-    urlOrMoniker: cluster
-  });
-
-  try {
-    const result = await rpc.getBalance(keypair.address).send();
-
-    console.log(`Balance: ${result.value} lamports`);
-    if (result.value < lamports(500_000n)) {
-      console.log(`Balance low requesting airdrop`);
-      const airdrop = airdropFactory({ rpc, rpcSubscriptions });
-      await airdrop({
-        commitment: "confirmed",
-        lamports: lamports(1_000_000_000n),
-        recipientAddress: keypair.address
-      });
-    }
-  } catch (err) {
-    console.error("Error fetching balance:", err);
-  }
-  return keypair;
-}
-
-const keypairSigner2 = await loadDefaultKeypairWithAirdrop("devnet");
-console.log(keypairSigner2.address);
-```
-
 ```ts !! title="Kit"
 // !collapse(1:29) collapsed
 
@@ -259,3 +214,41 @@ async fn main() -> anyhow::Result<()> {
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import { airdropFactory, createSolanaClient, lamports } from "gill";
+import { loadKeypairSignerFromFile } from "gill/node";
+
+const keypairSigner = await loadKeypairSignerFromFile();
+console.log(keypairSigner.address);
+
+export async function loadDefaultKeypairWithAirdrop(
+  cluster: string
+): Promise<KeyPairSigner<string>> {
+  const keypair = await loadKeypairSignerFromFile();
+  const { rpc, rpcSubscriptions } = createSolanaClient({
+    urlOrMoniker: cluster
+  });
+
+  try {
+    const result = await rpc.getBalance(keypair.address).send();
+
+    console.log(`Balance: ${result.value} lamports`);
+    if (result.value < lamports(500_000n)) {
+      console.log(`Balance low requesting airdrop`);
+      const airdrop = airdropFactory({ rpc, rpcSubscriptions });
+      await airdrop({
+        commitment: "confirmed",
+        lamports: lamports(1_000_000_000n),
+        recipientAddress: keypair.address
+      });
+    }
+  } catch (err) {
+    console.error("Error fetching balance:", err);
+  }
+  return keypair;
+}
+
+const keypairSigner2 = await loadDefaultKeypairWithAirdrop("devnet");
+console.log(keypairSigner2.address);
+```

--- a/apps/web/content/cookbook/development/subscribing-events.mdx
+++ b/apps/web/content/cookbook/development/subscribing-events.mdx
@@ -9,47 +9,6 @@ instead receive those updates only when they happen.
 
 <CodeTabs storage="cookbook">
 
-```ts !! title="Gill"
-import {
-  createSolanaClient,
-  generateKeyPairSigner,
-  lamports
-} from "gill";
-
-const LAMPORTS_PER_SOL = lamports(1_000_000_000n);
-
-const { rpc, rpcSubscriptions } = createSolanaClient({
-  urlOrMoniker: "localnet"
-});
-
-const wallet = await generateKeyPairSigner();
-
-const abortController = new AbortController();
-
-// !mark(1:3)
-const notifications = await rpcSubscriptions
-  .accountNotifications(wallet.address, { commitment: "confirmed" })
-  .subscribe({ abortSignal: abortController.signal });
-
-(async () => {
-  for await (const notification of notifications) {
-    console.log(notification);
-  }
-})();
-
-const airdropSignature = await rpc
-  .requestAirdrop(wallet.address, LAMPORTS_PER_SOL)
-  .send();
-
-while (true) {
-  const status = await rpc.getSignatureStatuses([airdropSignature]).send();
-  if (status.value?.[0]?.confirmationStatus === "confirmed") break;
-  await new Promise((r) => setTimeout(r, 1000));
-}
-
-abortController.abort();
-```
-
 ```ts !! title="Kit"
 import {
   createSolanaRpc,
@@ -201,3 +160,40 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import { createSolanaClient, generateKeyPairSigner, lamports } from "gill";
+
+const LAMPORTS_PER_SOL = lamports(1_000_000_000n);
+
+const { rpc, rpcSubscriptions } = createSolanaClient({
+  urlOrMoniker: "localnet"
+});
+
+const wallet = await generateKeyPairSigner();
+
+const abortController = new AbortController();
+
+// !mark(1:3)
+const notifications = await rpcSubscriptions
+  .accountNotifications(wallet.address, { commitment: "confirmed" })
+  .subscribe({ abortSignal: abortController.signal });
+
+(async () => {
+  for await (const notification of notifications) {
+    console.log(notification);
+  }
+})();
+
+const airdropSignature = await rpc
+  .requestAirdrop(wallet.address, LAMPORTS_PER_SOL)
+  .send();
+
+while (true) {
+  const status = await rpc.getSignatureStatuses([airdropSignature]).send();
+  if (status.value?.[0]?.confirmationStatus === "confirmed") break;
+  await new Promise((r) => setTimeout(r, 1000));
+}
+
+abortController.abort();
+```

--- a/apps/web/content/cookbook/development/test-sol.mdx
+++ b/apps/web/content/cookbook/development/test-sol.mdx
@@ -12,33 +12,6 @@ You can fund an address by requesting an airdrop. If on devnet, you can use the
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import {
-  airdropFactory,
-  createSolanaClient,
-  generateKeyPairSigner,
-  lamports,
-} from "gill";
-
-const { rpc, rpcSubscriptions } = createSolanaClient({
-  urlOrMoniker: "localnet"
-});
-
-
-const wallet = await generateKeyPairSigner();
-const LAMPORTS_PER_SOL = 1_000_000_000n;
-
-// !mark(1:5)
-await airdropFactory({ rpc, rpcSubscriptions })({
-  recipientAddress: wallet.address,
-  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
-  commitment: "confirmed"
-});
-
-const { value } = await rpc.getBalance(wallet.address).send();
-console.log(`Balance: ${value / LAMPORTS_PER_SOL} SOL`);
-```
-
 ```ts !! title="Kit"
 import {
   airdropFactory,
@@ -146,3 +119,29 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import {
+  airdropFactory,
+  createSolanaClient,
+  generateKeyPairSigner,
+  lamports
+} from "gill";
+
+const { rpc, rpcSubscriptions } = createSolanaClient({
+  urlOrMoniker: "localnet"
+});
+
+const wallet = await generateKeyPairSigner();
+const LAMPORTS_PER_SOL = 1_000_000_000n;
+
+// !mark(1:5)
+await airdropFactory({ rpc, rpcSubscriptions })({
+  recipientAddress: wallet.address,
+  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
+  commitment: "confirmed"
+});
+
+const { value } = await rpc.getBalance(wallet.address).send();
+console.log(`Balance: ${value / LAMPORTS_PER_SOL} SOL`);
+```

--- a/apps/web/content/cookbook/tokens/get-all-token-accounts.mdx
+++ b/apps/web/content/cookbook/tokens/get-all-token-accounts.mdx
@@ -11,38 +11,6 @@ You can fetch token accounts by owner. There are two ways to do it.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import { address, createSolanaClient } from "gill";
-import { TOKEN_PROGRAM_ADDRESS } from "gill/programs/token";
-
-const { rpc } = createSolanaClient({
-  urlOrMoniker: "devnet"
-});
-
-let owner = address("4kg8oh3jdNtn7j2wcS7TrUua31AgbLzDVkBZgTAe44aF");
-
-let response = await rpc
-  .getTokenAccountsByOwner(
-    owner,
-    { programId: TOKEN_PROGRAM_ADDRESS },
-    { encoding: "jsonParsed" }
-  )
-  .send();
-
-response.value.forEach((accountInfo) => {
-  console.log(`pubkey:${accountInfo.pubkey}`);
-  console.log(`Mint:${accountInfo.account.data["parsed"]["info"]["mint"]}`);
-  console.log(`Owner:${accountInfo.account.data["parsed"]["info"]["owner"]}`);
-  console.log(
-    `Decimals:${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["decimals"]}`
-  );
-  console.log(
-    `Amount:${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["amount"]}`
-  );
-  console.log("=====================");
-});
-```
-
 ```ts !! title="Kit"
 import { TOKEN_PROGRAM_ADDRESS } from "@solana-program/token";
 import { address, createSolanaRpc } from "@solana/kit";
@@ -135,37 +103,41 @@ async fn main() -> anyhow::Result<()> {
 
 </CodeTabs>
 
-2. Filter By Mint
-
-<CodeTabs storage="cookbook" flags="r">
-
-```ts !! title="Gill"
+```ts title="Gill"
 import { address, createSolanaClient } from "gill";
+import { TOKEN_PROGRAM_ADDRESS } from "gill/programs/token";
 
 const { rpc } = createSolanaClient({
   urlOrMoniker: "devnet"
 });
 
 let owner = address("4kg8oh3jdNtn7j2wcS7TrUua31AgbLzDVkBZgTAe44aF");
-let mint = address("6sgxNSdXgkEFVLA2YEQFnuFHU3WGafhu9WYzXAXY7yCq");
 
 let response = await rpc
-  .getTokenAccountsByOwner(owner, { mint }, { encoding: "jsonParsed" })
+  .getTokenAccountsByOwner(
+    owner,
+    { programId: TOKEN_PROGRAM_ADDRESS },
+    { encoding: "jsonParsed" }
+  )
   .send();
 
 response.value.forEach((accountInfo) => {
-  console.log(`pubkey: ${accountInfo.pubkey}`);
-  console.log(`mint: ${accountInfo.account.data["parsed"]["info"]["mint"]}`);
-  console.log(`owner: ${accountInfo.account.data["parsed"]["info"]["owner"]}`);
+  console.log(`pubkey:${accountInfo.pubkey}`);
+  console.log(`Mint:${accountInfo.account.data["parsed"]["info"]["mint"]}`);
+  console.log(`Owner:${accountInfo.account.data["parsed"]["info"]["owner"]}`);
   console.log(
-    `decimals: ${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["decimals"]}`
+    `Decimals:${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["decimals"]}`
   );
   console.log(
-    `amount: ${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["amount"]}`
+    `Amount:${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["amount"]}`
   );
-  console.log("====================");
+  console.log("=====================");
 });
 ```
+
+2. Filter By Mint
+
+<CodeTabs storage="cookbook" flags="r">
 
 ```ts !! title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
@@ -297,3 +269,31 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import { address, createSolanaClient } from "gill";
+
+const { rpc } = createSolanaClient({
+  urlOrMoniker: "devnet"
+});
+
+let owner = address("4kg8oh3jdNtn7j2wcS7TrUua31AgbLzDVkBZgTAe44aF");
+let mint = address("6sgxNSdXgkEFVLA2YEQFnuFHU3WGafhu9WYzXAXY7yCq");
+
+let response = await rpc
+  .getTokenAccountsByOwner(owner, { mint }, { encoding: "jsonParsed" })
+  .send();
+
+response.value.forEach((accountInfo) => {
+  console.log(`pubkey: ${accountInfo.pubkey}`);
+  console.log(`mint: ${accountInfo.account.data["parsed"]["info"]["mint"]}`);
+  console.log(`owner: ${accountInfo.account.data["parsed"]["info"]["owner"]}`);
+  console.log(
+    `decimals: ${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["decimals"]}`
+  );
+  console.log(
+    `amount: ${accountInfo.account.data["parsed"]["info"]["tokenAmount"]["amount"]}`
+  );
+  console.log("====================");
+});
+```

--- a/apps/web/content/cookbook/tokens/get-token-account.mdx
+++ b/apps/web/content/cookbook/tokens/get-token-account.mdx
@@ -10,34 +10,6 @@ amount(balance).
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import { createSolanaClient, address } from "gill";
-import {
-  TOKEN_2022_PROGRAM_ADDRESS,
-  fetchToken,
-  getAssociatedTokenAccountAddress
-} from "gill/programs";
-
-const { rpc } = createSolanaClient({
-  urlOrMoniker: "mainnet"
-});
-
-const mintAddress = address("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo");
-
-const authority = address("AC5RDfQFmDS1deWZos921JfqscXdByf8BKHs5ACWjtW2");
-
-const associatedTokenAddress = await getAssociatedTokenAccountAddress(
-  mintAddress,
-  authority,
-  TOKEN_2022_PROGRAM_ADDRESS
-);
-
-// !mark
-const ataDetails = await fetchToken(rpc, associatedTokenAddress);
-
-console.log(ataDetails);
-```
-
 ```ts !! title="Kit"
 import {
   fetchToken,
@@ -193,3 +165,31 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import { createSolanaClient, address } from "gill";
+import {
+  TOKEN_2022_PROGRAM_ADDRESS,
+  fetchToken,
+  getAssociatedTokenAccountAddress
+} from "gill/programs";
+
+const { rpc } = createSolanaClient({
+  urlOrMoniker: "mainnet"
+});
+
+const mintAddress = address("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo");
+
+const authority = address("AC5RDfQFmDS1deWZos921JfqscXdByf8BKHs5ACWjtW2");
+
+const associatedTokenAddress = await getAssociatedTokenAccountAddress(
+  mintAddress,
+  authority,
+  TOKEN_2022_PROGRAM_ADDRESS
+);
+
+// !mark
+const ataDetails = await fetchToken(rpc, associatedTokenAddress);
+
+console.log(ataDetails);
+```

--- a/apps/web/content/cookbook/tokens/get-token-balance.mdx
+++ b/apps/web/content/cookbook/tokens/get-token-balance.mdx
@@ -10,23 +10,6 @@ PRC call
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import { createSolanaClient, address } from "gill";
-
-const { rpc } = createSolanaClient({
-  urlOrMoniker: "mainnet"
-});
-
-const tokenAccountAddress = address(
-  "GfVPzUxMDvhFJ1Xs6C9i47XQRSapTd8LHw5grGuTquyQ"
-);
-
-// !mark
-const balance = await rpc.getTokenAccountBalance(tokenAccountAddress).send();
-
-console.log(balance);
-```
-
 ```typescript !! title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
 
@@ -115,3 +98,20 @@ if __name__ == "__main__":
   A token account can only hold one kind of mint. When you specify a token
   account, you also specific a mint too.
 </Callout>
+
+```ts title="Gill"
+import { createSolanaClient, address } from "gill";
+
+const { rpc } = createSolanaClient({
+  urlOrMoniker: "mainnet"
+});
+
+const tokenAccountAddress = address(
+  "GfVPzUxMDvhFJ1Xs6C9i47XQRSapTd8LHw5grGuTquyQ"
+);
+
+// !mark
+const balance = await rpc.getTokenAccountBalance(tokenAccountAddress).send();
+
+console.log(balance);
+```

--- a/apps/web/content/cookbook/tokens/get-token-mint.mdx
+++ b/apps/web/content/cookbook/tokens/get-token-mint.mdx
@@ -10,22 +10,6 @@ need to get the account info for the token mint.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import { address, createSolanaClient } from "gill";
-import { fetchMint } from "gill/programs";
-
-const { rpc } = createSolanaClient({
-  urlOrMoniker: "mainnet"
-});
-
-const mintAddress = address("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo");
-
-// !mark
-const mint = await fetchMint(rpc, mintAddress);
-
-console.log(mint);
-```
-
 ```ts !! title="Kit"
 import { Address, createSolanaRpc } from "@solana/kit";
 import { fetchMint } from "@solana-program/token-2022";
@@ -202,3 +186,19 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import { address, createSolanaClient } from "gill";
+import { fetchMint } from "gill/programs";
+
+const { rpc } = createSolanaClient({
+  urlOrMoniker: "mainnet"
+});
+
+const mintAddress = address("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo");
+
+// !mark
+const mint = await fetchMint(rpc, mintAddress);
+
+console.log(mint);
+```

--- a/apps/web/content/cookbook/transactions/add-memo.mdx
+++ b/apps/web/content/cookbook/transactions/add-memo.mdx
@@ -9,55 +9,6 @@ Any transaction can add a message making use of the SPL memo program.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  createSolanaClient,
-  createTransaction,
-  generateKeyPairSigner,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners
-} from "gill";
-import { getAddMemoInstruction } from "gill/programs";
-
-const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
-  {
-    urlOrMoniker: "localnet"
-  }
-);
-
-const sender = await generateKeyPairSigner();
-const LAMPORTS_PER_SOL = 1_000_000_000n;
-await airdropFactory({ rpc, rpcSubscriptions })({
-  recipientAddress: sender.address,
-  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
-  commitment: "confirmed"
-});
-
-// !mark(1:3)
-const memoInstruction = getAddMemoInstruction({
-  memo: "Hello, world!"
-});
-
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-const tx = createTransaction({
-  feePayer: sender,
-  version: "legacy",
-  instructions: [memoInstruction],
-  latestBlockhash
-});
-
-const signedTransaction = await signTransactionMessageWithSigners(tx);
-
-const transactionSignature = getSignatureFromTransaction(signedTransaction);
-console.log("Transaction Signature:", transactionSignature);
-```
-
 ```ts !! title="Kit"
 import {
   airdropFactory,
@@ -294,3 +245,52 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import {
+  airdropFactory,
+  appendTransactionMessageInstructions,
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getSignatureFromTransaction,
+  lamports,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners
+} from "gill";
+import { getAddMemoInstruction } from "gill/programs";
+
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "localnet"
+  }
+);
+
+const sender = await generateKeyPairSigner();
+const LAMPORTS_PER_SOL = 1_000_000_000n;
+await airdropFactory({ rpc, rpcSubscriptions })({
+  recipientAddress: sender.address,
+  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
+  commitment: "confirmed"
+});
+
+// !mark(1:3)
+const memoInstruction = getAddMemoInstruction({
+  memo: "Hello, world!"
+});
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const tx = createTransaction({
+  feePayer: sender,
+  version: "legacy",
+  instructions: [memoInstruction],
+  latestBlockhash
+});
+
+const signedTransaction = await signTransactionMessageWithSigners(tx);
+
+const transactionSignature = getSignatureFromTransaction(signedTransaction);
+console.log("Transaction Signature:", transactionSignature);
+```

--- a/apps/web/content/cookbook/transactions/add-priority-fees.mdx
+++ b/apps/web/content/cookbook/transactions/add-priority-fees.mdx
@@ -12,83 +12,6 @@ To add a priority fee to a transaction, invoke instructions from the
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  createSolanaClient,
-  createTransaction,
-  generateKeyPairSigner,
-  getComputeUnitEstimateForTransactionMessageFactory,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  prependTransactionMessageInstructions,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners
-} from "gill";
-import {
-  getAddMemoInstruction,
-  getSetComputeUnitLimitInstruction,
-  getSetComputeUnitPriceInstruction
-} from "gill/programs";
-
-// Create an RPC
-const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
-  {
-    urlOrMoniker: "localnet"
-  }
-);
-
-// Create utility functions
-const airdrop = airdropFactory({ rpc, rpcSubscriptions });
-const getComputeUnitEstimate =
-  getComputeUnitEstimateForTransactionMessageFactory({ rpc });
-
-// Create and fund an account
-const keypairSigner = await generateKeyPairSigner();
-
-await airdrop({
-  commitment: "confirmed",
-  lamports: lamports(1000_000n),
-  recipientAddress: keypairSigner.address
-});
-
-// Create a memo transaction
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-const transactionMessage = createTransaction({
-  feePayer: keypairSigner,
-  version: "legacy",
-  instructions: [
-    // !mark
-    getSetComputeUnitPriceInstruction({ microLamports: 5000n }),
-    getAddMemoInstruction({ memo: "Hello, world!" })
-  ],
-  latestBlockhash
-});
-
-const estimatedComputeUnits = await getComputeUnitEstimate(transactionMessage);
-console.log(
-  `Transaction is estimated to consume ${estimatedComputeUnits} compute units`
-);
-
-// Add compute unit limit instruction to the transaction
-const budgetedTransactionMessage = prependTransactionMessageInstructions(
-  // !mark
-  [getSetComputeUnitLimitInstruction({ units: estimatedComputeUnits })],
-  transactionMessage
-);
-
-// Sign and send the transaction
-const signedTx = await signTransactionMessageWithSigners(
-  budgetedTransactionMessage
-);
-const transactionSignature = getSignatureFromTransaction(signedTx);
-await sendAndConfirmTransaction(signedTx, { commitment: "confirmed" });
-console.log(`Transaction Signature: ${transactionSignature}`);
-```
-
 ```ts !! title="Kit"
 import {
   airdropFactory,
@@ -361,3 +284,80 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import {
+  airdropFactory,
+  appendTransactionMessageInstructions,
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getComputeUnitEstimateForTransactionMessageFactory,
+  getSignatureFromTransaction,
+  lamports,
+  pipe,
+  prependTransactionMessageInstructions,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners
+} from "gill";
+import {
+  getAddMemoInstruction,
+  getSetComputeUnitLimitInstruction,
+  getSetComputeUnitPriceInstruction
+} from "gill/programs";
+
+// Create an RPC
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "localnet"
+  }
+);
+
+// Create utility functions
+const airdrop = airdropFactory({ rpc, rpcSubscriptions });
+const getComputeUnitEstimate =
+  getComputeUnitEstimateForTransactionMessageFactory({ rpc });
+
+// Create and fund an account
+const keypairSigner = await generateKeyPairSigner();
+
+await airdrop({
+  commitment: "confirmed",
+  lamports: lamports(1000_000n),
+  recipientAddress: keypairSigner.address
+});
+
+// Create a memo transaction
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const transactionMessage = createTransaction({
+  feePayer: keypairSigner,
+  version: "legacy",
+  instructions: [
+    // !mark
+    getSetComputeUnitPriceInstruction({ microLamports: 5000n }),
+    getAddMemoInstruction({ memo: "Hello, world!" })
+  ],
+  latestBlockhash
+});
+
+const estimatedComputeUnits = await getComputeUnitEstimate(transactionMessage);
+console.log(
+  `Transaction is estimated to consume ${estimatedComputeUnits} compute units`
+);
+
+// Add compute unit limit instruction to the transaction
+const budgetedTransactionMessage = prependTransactionMessageInstructions(
+  // !mark
+  [getSetComputeUnitLimitInstruction({ units: estimatedComputeUnits })],
+  transactionMessage
+);
+
+// Sign and send the transaction
+const signedTx = await signTransactionMessageWithSigners(
+  budgetedTransactionMessage
+);
+const transactionSignature = getSignatureFromTransaction(signedTx);
+await sendAndConfirmTransaction(signedTx, { commitment: "confirmed" });
+console.log(`Transaction Signature: ${transactionSignature}`);
+```

--- a/apps/web/content/cookbook/transactions/calculate-cost.mdx
+++ b/apps/web/content/cookbook/transactions/calculate-cost.mdx
@@ -11,103 +11,6 @@ determines the base transaction fee (5000 lamports per signature).
 
 <CodeTabs storage="cookbook" flags="r">
 
-```typescript !! title="Gill"
-import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  compileTransactionMessage,
-  createSolanaClient,
-  createTransaction,
-  generateKeyPairSigner,
-  getBase64Decoder,
-  getCompiledTransactionMessageEncoder,
-  getComputeUnitEstimateForTransactionMessageFactory,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  prependTransactionMessageInstructions,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-  type TransactionMessageBytesBase64
-} from "gill";
-import {
-  getAddMemoInstruction,
-  getSetComputeUnitLimitInstruction,
-  getSetComputeUnitPriceInstruction
-} from "gill/programs";
-
-// 1. Setup RPC connections
-const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
-  {
-    urlOrMoniker: "localnet"
-  }
-);
-
-// 2. Create utility functions
-const getComputeUnitEstimate =
-  getComputeUnitEstimateForTransactionMessageFactory({ rpc });
-const airdrop = airdropFactory({ rpc, rpcSubscriptions });
-
-// 3. Create and fund an account
-const signer = await generateKeyPairSigner();
-await airdrop({
-  commitment: "confirmed",
-  lamports: lamports(1000_000n),
-  recipientAddress: signer.address
-});
-console.log("Create and fund account with address", signer.address);
-
-// 4. Create a memo transaction
-console.log("Creating a memo transaction");
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-const transactionMessage = createTransaction({
-  feePayer: signer,
-  version: "legacy",
-  instructions: [
-    getSetComputeUnitPriceInstruction({ microLamports: 5000n }),
-    getAddMemoInstruction({ memo: "Hello, world!" })
-  ],
-  latestBlockhash
-});
-
-// 5. Estimate compute units
-const estimatedComputeUnits = await getComputeUnitEstimate(transactionMessage);
-// Transaction is estimated to consume 6236 compute units
-console.log(
-  `Transaction is estimated to consume ${estimatedComputeUnits} compute units`
-);
-
-// 6. Add compute unit limit instruction to the transaction
-const budgetedTransactionMessage = prependTransactionMessageInstructions(
-  [getSetComputeUnitLimitInstruction({ units: estimatedComputeUnits })],
-  transactionMessage
-);
-
-// 7. Calculate transaction fee
-const base64EncodedMessage = pipe(
-  budgetedTransactionMessage,
-  compileTransactionMessage,
-  getCompiledTransactionMessageEncoder().encode,
-  getBase64Decoder().decode
-) as TransactionMessageBytesBase64;
-
-const transactionCost = await rpc.getFeeForMessage(base64EncodedMessage).send();
-// Transaction is estimated to cost 5032 lamports
-console.log(
-  "Transaction is estimated to cost " + transactionCost.value + " lamports"
-);
-
-// 8. Sign and send the transaction
-const signedTx = await signTransactionMessageWithSigners(
-  budgetedTransactionMessage
-);
-const transactionSignature = getSignatureFromTransaction(signedTx);
-console.log("Transaction Signature:", transactionSignature);
-
-await sendAndConfirmTransaction(signedTx, { commitment: "confirmed" });
-```
-
 ```typescript !! title="Kit"
 import {
   airdropFactory,
@@ -432,3 +335,100 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import {
+  airdropFactory,
+  appendTransactionMessageInstructions,
+  compileTransactionMessage,
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getBase64Decoder,
+  getCompiledTransactionMessageEncoder,
+  getComputeUnitEstimateForTransactionMessageFactory,
+  getSignatureFromTransaction,
+  lamports,
+  pipe,
+  prependTransactionMessageInstructions,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners,
+  type TransactionMessageBytesBase64
+} from "gill";
+import {
+  getAddMemoInstruction,
+  getSetComputeUnitLimitInstruction,
+  getSetComputeUnitPriceInstruction
+} from "gill/programs";
+
+// 1. Setup RPC connections
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "localnet"
+  }
+);
+
+// 2. Create utility functions
+const getComputeUnitEstimate =
+  getComputeUnitEstimateForTransactionMessageFactory({ rpc });
+const airdrop = airdropFactory({ rpc, rpcSubscriptions });
+
+// 3. Create and fund an account
+const signer = await generateKeyPairSigner();
+await airdrop({
+  commitment: "confirmed",
+  lamports: lamports(1000_000n),
+  recipientAddress: signer.address
+});
+console.log("Create and fund account with address", signer.address);
+
+// 4. Create a memo transaction
+console.log("Creating a memo transaction");
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const transactionMessage = createTransaction({
+  feePayer: signer,
+  version: "legacy",
+  instructions: [
+    getSetComputeUnitPriceInstruction({ microLamports: 5000n }),
+    getAddMemoInstruction({ memo: "Hello, world!" })
+  ],
+  latestBlockhash
+});
+
+// 5. Estimate compute units
+const estimatedComputeUnits = await getComputeUnitEstimate(transactionMessage);
+// Transaction is estimated to consume 6236 compute units
+console.log(
+  `Transaction is estimated to consume ${estimatedComputeUnits} compute units`
+);
+
+// 6. Add compute unit limit instruction to the transaction
+const budgetedTransactionMessage = prependTransactionMessageInstructions(
+  [getSetComputeUnitLimitInstruction({ units: estimatedComputeUnits })],
+  transactionMessage
+);
+
+// 7. Calculate transaction fee
+const base64EncodedMessage = pipe(
+  budgetedTransactionMessage,
+  compileTransactionMessage,
+  getCompiledTransactionMessageEncoder().encode,
+  getBase64Decoder().decode
+) as TransactionMessageBytesBase64;
+
+const transactionCost = await rpc.getFeeForMessage(base64EncodedMessage).send();
+// Transaction is estimated to cost 5032 lamports
+console.log(
+  "Transaction is estimated to cost " + transactionCost.value + " lamports"
+);
+
+// 8. Sign and send the transaction
+const signedTx = await signTransactionMessageWithSigners(
+  budgetedTransactionMessage
+);
+const transactionSignature = getSignatureFromTransaction(signedTx);
+console.log("Transaction Signature:", transactionSignature);
+
+await sendAndConfirmTransaction(signedTx, { commitment: "confirmed" });
+```

--- a/apps/web/content/cookbook/transactions/send-sol.mdx
+++ b/apps/web/content/cookbook/transactions/send-sol.mdx
@@ -11,63 +11,6 @@ instruction.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import {
-  appendTransactionMessageInstructions,
-  airdropFactory,
-  createSolanaClient,
-  createTransaction,
-  generateKeyPairSigner,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners
-} from "gill";
-import { getTransferSolInstruction } from "@solana-program/system";
-
-const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
-  {
-    urlOrMoniker: "localnet"
-  }
-);
-
-const sender = await generateKeyPairSigner();
-const recipient = await generateKeyPairSigner();
-
-const LAMPORTS_PER_SOL = 1_000_000_000n;
-const transferAmount = lamports(LAMPORTS_PER_SOL / 100n); // 0.01 SOL
-
-await airdropFactory({ rpc, rpcSubscriptions })({
-  recipientAddress: sender.address,
-  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
-  commitment: "confirmed"
-});
-
-// !mark(1:5)
-const transferInstruction = getTransferSolInstruction({
-  source: sender,
-  destination: recipient.address,
-  amount: transferAmount
-});
-
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-const tx = createTransaction({
-  feePayer: sender,
-  version: "legacy",
-  instructions: [transferInstruction],
-  latestBlockhash
-});
-
-const signedTransaction = await signTransactionMessageWithSigners(tx);
-
-await sendAndConfirmTransaction(signedTransaction, { commitment: "confirmed" });
-
-const transactionSignature = getSignatureFromTransaction(signedTransaction);
-console.log("Transaction Signature:", transactionSignature);
-```
-
 ```ts !! title="Kit"
 import {
   airdropFactory,
@@ -305,3 +248,60 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import {
+  appendTransactionMessageInstructions,
+  airdropFactory,
+  createSolanaClient,
+  createTransaction,
+  generateKeyPairSigner,
+  getSignatureFromTransaction,
+  lamports,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners
+} from "gill";
+import { getTransferSolInstruction } from "@solana-program/system";
+
+const { rpc, rpcSubscriptions, sendAndConfirmTransaction } = createSolanaClient(
+  {
+    urlOrMoniker: "localnet"
+  }
+);
+
+const sender = await generateKeyPairSigner();
+const recipient = await generateKeyPairSigner();
+
+const LAMPORTS_PER_SOL = 1_000_000_000n;
+const transferAmount = lamports(LAMPORTS_PER_SOL / 100n); // 0.01 SOL
+
+await airdropFactory({ rpc, rpcSubscriptions })({
+  recipientAddress: sender.address,
+  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
+  commitment: "confirmed"
+});
+
+// !mark(1:5)
+const transferInstruction = getTransferSolInstruction({
+  source: sender,
+  destination: recipient.address,
+  amount: transferAmount
+});
+
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const tx = createTransaction({
+  feePayer: sender,
+  version: "legacy",
+  instructions: [transferInstruction],
+  latestBlockhash
+});
+
+const signedTransaction = await signTransactionMessageWithSigners(tx);
+
+await sendAndConfirmTransaction(signedTransaction, { commitment: "confirmed" });
+
+const transactionSignature = getSignatureFromTransaction(signedTransaction);
+console.log("Transaction Signature:", transactionSignature);
+```

--- a/apps/web/content/cookbook/wallets/create-keypair.mdx
+++ b/apps/web/content/cookbook/wallets/create-keypair.mdx
@@ -16,13 +16,6 @@ need to generate a keypair to sign your transactions.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import { generateKeyPairSigner } from "gill";
-
-const signer = await generateKeyPairSigner();
-console.log("address: ", signer.address);
-```
-
 ```ts !! title="Kit"
 import { generateKeyPairSigner } from "@solana/kit";
 
@@ -57,3 +50,10 @@ print(f"secret: {keypair.secret()}")
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import { generateKeyPairSigner } from "gill";
+
+const signer = await generateKeyPairSigner();
+console.log("address: ", signer.address);
+```

--- a/apps/web/content/cookbook/wallets/restore-from-mnemonic.mdx
+++ b/apps/web/content/cookbook/wallets/restore-from-mnemonic.mdx
@@ -10,24 +10,6 @@ convert the mnemonic to Keypairs for local testing.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import { createKeyPairSignerFromPrivateKeyBytes } from "gill";
-import * as bip39 from "bip39";
-
-const mnemonic =
-  "pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter";
-const seed = bip39.mnemonicToSeedSync(mnemonic, "");
-
-// Extract the first 32 bytes for the private key
-const privateKeyBytes = seed.subarray(0, 32);
-
-const signer = await createKeyPairSignerFromPrivateKeyBytes(
-  new Uint8Array(privateKeyBytes)
-);
-
-console.log(signer.address);
-```
-
 ```ts !! title="Kit"
 import { createKeyPairSignerFromPrivateKeyBytes } from "@solana/kit";
 import * as bip39 from "bip39";
@@ -80,31 +62,27 @@ fn main() -> Result<()> {
 
 </CodeTabs>
 
+```ts title="Gill"
+import { createKeyPairSignerFromPrivateKeyBytes } from "gill";
+import * as bip39 from "bip39";
+
+const mnemonic =
+  "pill tomorrow foster begin walnut borrow virtual kick shift mutual shoe scatter";
+const seed = bip39.mnemonicToSeedSync(mnemonic, "");
+
+// Extract the first 32 bytes for the private key
+const privateKeyBytes = seed.subarray(0, 32);
+
+const signer = await createKeyPairSignerFromPrivateKeyBytes(
+  new Uint8Array(privateKeyBytes)
+);
+
+console.log(signer.address);
+```
+
 ## Restoring BIP44 format mnemonics
 
 <CodeTabs storage="cookbook" flags="r">
-
-```ts !! title="Gill"
-import { HDKey } from "micro-ed25519-hdkey";
-import * as bip39 from "bip39";
-import { createKeyPairSignerFromPrivateKeyBytes } from "gill";
-
-const mnemonic =
-  "neither lonely flavor argue grass remind eye tag avocado spot unusual intact";
-const seed = bip39.mnemonicToSeedSync(mnemonic);
-const hd = HDKey.fromMasterSeed(seed.toString("hex"));
-
-for (let i = 0; i < 10; i++) {
-  const path = `m/44'/501'/${i}'/0'`;
-  const child = hd.derive(path);
-
-  const signer = await createKeyPairSignerFromPrivateKeyBytes(
-    new Uint8Array(child.privateKey)
-  );
-  // The signer object has the address directly
-  console.log(`${path} => ${signer.address}`);
-}
-```
 
 ```ts !! title="Kit"
 import { HDKey } from "micro-ed25519-hdkey";
@@ -148,3 +126,25 @@ for (let i = 0; i < 10; i++) {
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import { HDKey } from "micro-ed25519-hdkey";
+import * as bip39 from "bip39";
+import { createKeyPairSignerFromPrivateKeyBytes } from "gill";
+
+const mnemonic =
+  "neither lonely flavor argue grass remind eye tag avocado spot unusual intact";
+const seed = bip39.mnemonicToSeedSync(mnemonic);
+const hd = HDKey.fromMasterSeed(seed.toString("hex"));
+
+for (let i = 0; i < 10; i++) {
+  const path = `m/44'/501'/${i}'/0'`;
+  const child = hd.derive(path);
+
+  const signer = await createKeyPairSignerFromPrivateKeyBytes(
+    new Uint8Array(child.privateKey)
+  );
+  // The signer object has the address directly
+  console.log(`${path} => ${signer.address}`);
+}
+```

--- a/apps/web/content/cookbook/wallets/restore-keypair.mdx
+++ b/apps/web/content/cookbook/wallets/restore-keypair.mdx
@@ -10,20 +10,6 @@ allows you to access your wallet and sign transactions in your dApp.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import { createKeyPairSignerFromBytes } from "gill";
-
-const keypairBytes = new Uint8Array([
-  174, 47, 154, 16, 202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56,
-  222, 53, 138, 189, 224, 216, 117, 173, 10, 149, 53, 45, 73, 251, 237, 246, 15,
-  185, 186, 82, 177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240, 121, 121,
-  35, 172, 247, 68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135
-]);
-
-const signer = await createKeyPairSignerFromBytes(keypairBytes);
-console.log(signer.address);
-```
-
 ```ts !! title="Kit"
 import { createKeyPairSignerFromBytes } from "@solana/kit";
 
@@ -73,27 +59,23 @@ fn main() -> Result<()> {
 
 </CodeTabs>
 
+```ts title="Gill"
+import { createKeyPairSignerFromBytes } from "gill";
+
+const keypairBytes = new Uint8Array([
+  174, 47, 154, 16, 202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56,
+  222, 53, 138, 189, 224, 216, 117, 173, 10, 149, 53, 45, 73, 251, 237, 246, 15,
+  185, 186, 82, 177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240, 121, 121,
+  35, 172, 247, 68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135
+]);
+
+const signer = await createKeyPairSignerFromBytes(keypairBytes);
+console.log(signer.address);
+```
+
 ## From Base58 String
 
 <CodeTabs storage="cookbook" flags="r">
-
-```ts !! title="Gill"
-import {
-  createKeyPairFromBytes,
-  createSignerFromKeyPair,
-  getBase58Encoder
-} from "gill";
-
-const keypairBase58 =
-  "5MaiiCavjCmn9Hs1o3eznqDEhRwxo7pXiAYez7keQUviUkauRiTMD8DrESdrNjN8zd9mTmVhRvBJeg5vhyvgrAhG";
-
-const keypair = await createKeyPairFromBytes(
-  getBase58Encoder().encode(keypairBase58)
-);
-const signer = await createSignerFromKeyPair(keypair);
-
-console.log(signer.address);
-```
 
 ```ts !! title="Kit"
 import {
@@ -158,3 +140,21 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import {
+  createKeyPairFromBytes,
+  createSignerFromKeyPair,
+  getBase58Encoder
+} from "gill";
+
+const keypairBase58 =
+  "5MaiiCavjCmn9Hs1o3eznqDEhRwxo7pXiAYez7keQUviUkauRiTMD8DrESdrNjN8zd9mTmVhRvBJeg5vhyvgrAhG";
+
+const keypair = await createKeyPairFromBytes(
+  getBase58Encoder().encode(keypairBase58)
+);
+const signer = await createSignerFromKeyPair(keypair);
+
+console.log(signer.address);
+```

--- a/apps/web/content/cookbook/wallets/sign-message.mdx
+++ b/apps/web/content/cookbook/wallets/sign-message.mdx
@@ -9,26 +9,6 @@ to be sure that the data was signed by the owner of a specific private key.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```typescript !! title="Gill"
-import {
-  generateKeyPair,
-  signBytes,
-  verifySignature,
-  getUtf8Encoder,
-  getBase58Decoder
-} from "gill";
-
-const keys = await generateKeyPair();
-const message = getUtf8Encoder().encode("Hello, World!");
-const signedBytes = await signBytes(keys.privateKey, message);
-
-const decoded = getBase58Decoder().decode(signedBytes);
-console.log("Signature:", decoded);
-
-const verified = await verifySignature(keys.publicKey, signedBytes, message);
-console.log("Verified:", verified);
-```
-
 ```typescript !! title="Kit"
 import {
   generateKeyPair,
@@ -132,3 +112,23 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import {
+  generateKeyPair,
+  signBytes,
+  verifySignature,
+  getUtf8Encoder,
+  getBase58Decoder
+} from "gill";
+
+const keys = await generateKeyPair();
+const message = getUtf8Encoder().encode("Hello, World!");
+const signedBytes = await signBytes(keys.privateKey, message);
+
+const decoded = getBase58Decoder().decode(signedBytes);
+console.log("Signature:", decoded);
+
+const verified = await verifySignature(keys.publicKey, signedBytes, message);
+console.log("Verified:", verified);
+```

--- a/apps/web/content/cookbook/wallets/verify-keypair.mdx
+++ b/apps/web/content/cookbook/wallets/verify-keypair.mdx
@@ -9,23 +9,6 @@ public key:
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Gill"
-import { createKeyPairSignerFromBytes, address } from "gill";
-
-const publicKey = address("24PNhTaNtomHhoy3fTRaMhAFCRj4uHqhZEEoWrKDbR5p");
-
-const keypairBytes = new Uint8Array([
-  174, 47, 154, 16, 202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56,
-  222, 53, 138, 189, 224, 216, 117, 173, 10, 149, 53, 45, 73, 251, 237, 246, 15,
-  185, 186, 82, 177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240, 121, 121,
-  35, 172, 247, 68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135
-]);
-
-const signer = await createKeyPairSignerFromBytes(keypairBytes);
-
-console.log(signer.address === publicKey);
-```
-
 ```ts !! title="Kit"
 import { createKeyPairSignerFromBytes, address } from "@solana/kit";
 
@@ -102,3 +85,20 @@ if __name__ == "__main__":
 ```
 
 </CodeTabs>
+
+```ts title="Gill"
+import { createKeyPairSignerFromBytes, address } from "gill";
+
+const publicKey = address("24PNhTaNtomHhoy3fTRaMhAFCRj4uHqhZEEoWrKDbR5p");
+
+const keypairBytes = new Uint8Array([
+  174, 47, 154, 16, 202, 193, 206, 113, 199, 190, 53, 133, 169, 175, 31, 56,
+  222, 53, 138, 189, 224, 216, 117, 173, 10, 149, 53, 45, 73, 251, 237, 246, 15,
+  185, 186, 82, 177, 240, 148, 69, 241, 227, 167, 80, 141, 89, 240, 121, 121,
+  35, 172, 247, 68, 251, 226, 218, 48, 63, 176, 109, 168, 89, 238, 135
+]);
+
+const signer = await createKeyPairSignerFromBytes(keypairBytes);
+
+console.log(signer.address === publicKey);
+```


### PR DESCRIPTION
### Problem

gill's `createSolanaClient` throws error when using surfnet rpc.

```
SolanaError: WebSocket failed to connect

  context: {
    __code: 8190004,
    errorEvent: ErrorEvent {
      Symbol(type): 'error',
      Symbol(kTarget): WebSocket {
        Symbol(kEvents): SafeMap(0) {},
        Symbol(events.maxEventTargetListeners): 10,
        Symbol(events.maxEventTargetListenersWarned): false,
        Symbol(kHandlers): SafeMap(0) {}
      },
      Symbol(kIsBeingDispatched): false
    }
  }
```

### Summary of Changes

move gill cookbook snippets out of runnable code tabs