### PR TITLE
Fix: improve rating validation message for better clarity and debugging

### DIFF
--- a/apps/web/content/courses/native-onchain-development/program-security.mdx
+++ b/apps/web/content/courses/native-onchain-development/program-security.mdx
@@ -504,7 +504,7 @@ provided by the user outside of this range, we'll return our custom
 
 ```rust title="processor.rs"
 if rating > 5 || rating < 1 {
-    msg!("Rating cannot be higher than 5");
+    msg!("Invalid rating: {}. Rating must be between 1 and 5.", rating");
     return Err(ReviewError::InvalidRating.into())
 }
 ```


### PR DESCRIPTION
### Problem
Improved the rating validation message to provide clearer feedback and include the invalid rating value for easier debugging.



### Summary of Changes
- Updated `msg!()` text in rating validation to accurately reflect both upper and lower bounds.
- Added the invalid rating value in the log message for better visibility.
- Ensured consistent punctuation and tone with other validation messages.



Fixes #
**Before:**
Rating cannot be higher than 5

**After:**
Invalid rating: 7. Rating must be between 1 and 5.