### PR TITLE
rpc methods: fix encoding documentation

### DIFF
--- a/apps/web/content/docs/en/rpc/http/getaccountinfo.mdx
+++ b/apps/web/content/docs/en/rpc/http/getaccountinfo.mdx
@@ -98,7 +98,8 @@ The commitment describes how finalized a block is at that point in time. See
 ##### !! encoding
 
 !type string
-!values base58 base64 base64+zstd jsonParsed
+!values base58 base64 base64+zstd binary jsonParsed
+!default binary
 
 Encoding format for Account data. See
 [Parsed Responses](/docs/rpc#parsed-responses).
@@ -107,6 +108,7 @@ Encoding format for Account data. See
 - `base64` will return base64 encoded data for Account data of any size.
 - `base64+zstd` compresses the Account data using
   [Zstandard](https://facebook.github.io/zstd/) and base64-encodes the result.
+- `binary` (⚠️ deprecated) is similar to `base58`, except data will be a base58-encoded string and not an array that includes the encoding.
 - `jsonParsed` encoding attempts to use program-specific state parsers to return
   more human-readable and explicit account state data.
 - If `jsonParsed` is requested but a parser cannot be found, the field falls
@@ -166,10 +168,12 @@ object containing:
 
 #### !! data
 
-!type \[string,encoding\] | object
+!type string | \[string,encoding\] | object
 
-Data associated with the account, either as encoded binary data or JSON format
-`{<program>: <state>}` - depending on encoding parameter
+Data associated with the account. Format depends on encoding parameter:
+- If the encoding parameter is left as the deprecated default of `binary`, this will be a string containing encoded binary data.
+- If `base58`, `base64`, or `base64+zstd` is specified, this will be an array, where the first element is the encoded data string and the second element is the encoding format.
+- If `jsonParsed` is specified, this will be JSON format `{<program>: <state>}`.
 
 #### !! executable
 

--- a/apps/web/content/docs/en/rpc/http/getprogramaccounts.mdx
+++ b/apps/web/content/docs/en/rpc/http/getprogramaccounts.mdx
@@ -199,8 +199,8 @@ Wrap the result in an RpcResponse JSON object
 ##### !! encoding
 
 !type string
-!values jsonParsed base58 base64 base64+zstd
-!default json
+!values jsonParsed base58 base64 base64+zstd binary 
+!default binary
 
 Encoding format for the returned Account data
 
@@ -208,6 +208,7 @@ Encoding format for the returned Account data
 - `base64` will return base64 encoded data for Account data of any size.
 - `base64+zstd` compresses the Account data using
   [Zstandard](https://facebook.github.io/zstd/) and base64-encodes the result.
+- `binary` (⚠️ deprecated) is similar to `base58`, except data will be a base58-encoded string and not an array that includes the encoding.
 - `jsonParsed` encoding attempts to use program-specific state parsers to return
   more human-readable and explicit account state data.
 - If `jsonParsed` is requested but a parser cannot be found, the field falls
@@ -293,9 +294,10 @@ A JSON object containing:
 - `lamports: <u64>` - number of lamports assigned to this account, as a u64
 - `owner: <string>` - base-58 encoded Pubkey of the program this account has
   been assigned to
-- `data: <[string,encoding]|object>` - data associated with the account, either
-  as encoded binary data or JSON format `{<program>: <state>}` - depending on
-  encoding parameter
+- `data: <string|[string,encoding]|object>` - data associated with the account. Format depends on encoding parameter:
+  - If the encoding parameter is left as the deprecated default of `binary`, this will be a string containing encoded binary data.
+  - If `base58`, `base64`, or `base64+zstd` is specified, this will be an array, where the first element is the encoded data string and the second element is the encoding format.
+  - If `jsonParsed` is specified, this will be JSON format `{<program>: <state>}`.
 - `executable: <bool>` - boolean indicating if the account contains a program
   (and is strictly read-only)
 - `rentEpoch: <u64>` - the epoch at which this account will next owe rent, as

--- a/apps/web/content/docs/en/rpc/http/gettokenaccountsbydelegate.mdx
+++ b/apps/web/content/docs/en/rpc/http/gettokenaccountsbydelegate.mdx
@@ -149,7 +149,8 @@ Request a slice of the account's data.
 ##### !! encoding
 
 !type string
-!values base58 base64 base64+zstd jsonParsed
+!values base58 base64 base64+zstd binary jsonParsed
+!default binary
 
 Encoding format for Account data
 
@@ -157,6 +158,7 @@ Encoding format for Account data
 - `base64` will return base64 encoded data for Account data of any size.
 - `base64+zstd` compresses the Account data using
   [Zstandard](https://facebook.github.io/zstd/) and base64-encodes the result.
+- `binary` (⚠️ deprecated) is similar to `base58`, except data will be a base58-encoded string and not an array that includes the encoding.
 - `jsonParsed` encoding attempts to use program-specific state parsers to return
   more human-readable and explicit account state data.
 - If `jsonParsed` is requested but a parser cannot be found, the field falls
@@ -233,8 +235,10 @@ A JSON object containing:
 - `lamports: <u64>` - number of lamports assigned to this account, as a u64
 - `owner: <string>` - base-58 encoded Pubkey of the program this account has
   been assigned to
-- `data: <object>` - Token state data associated with the account, either as
-  encoded binary data or in JSON format `{<program>: <state>}`
+- `data: <string|[string,encoding]|object>` - Token state data associated with the account. Format depends on encoding parameter:
+  - If the encoding parameter is left as the deprecated default of `binary`, this will be a string containing encoded binary data.
+  - If `base58`, `base64`, or `base64+zstd` is specified, this will be an array, where the first element is the encoded data string and the second element is the encoding format.
+  - If `jsonParsed` is specified, this will be JSON format `{<program>: <state>}`.
 - `executable: <bool>` - boolean indicating if the account contains a program
   (and is strictly read-only)
 - `rentEpoch: <u64>` - the epoch at which this account will next owe rent, as

--- a/apps/web/content/docs/en/rpc/http/gettokenaccountsbyowner.mdx
+++ b/apps/web/content/docs/en/rpc/http/gettokenaccountsbyowner.mdx
@@ -168,7 +168,8 @@ Request a slice of the account's data.
 ##### !! encoding
 
 !type string
-!values base58 base64 base64+zstd jsonParsed
+!values base58 base64 base64+zstd binary jsonParsed
+!default binary
 
 Encoding format for Account data
 
@@ -176,6 +177,7 @@ Encoding format for Account data
 - `base64` will return base64 encoded data for Account data of any size.
 - `base64+zstd` compresses the Account data using
   [Zstandard](https://facebook.github.io/zstd/) and base64-encodes the result.
+- `binary` (⚠️ deprecated) is similar to `base58`, except data will be a base58-encoded string and not an array that includes the encoding.
 - `jsonParsed` encoding attempts to use program-specific state parsers to return
   more human-readable and explicit account state data.
 - If `jsonParsed` is requested but a parser cannot be found, the field falls
@@ -245,8 +247,10 @@ A JSON object containing:
 - `lamports: <u64>` - number of lamports assigned to this account, as a u64
 - `owner: <string>` - base-58 encoded Pubkey of the program this account has
   been assigned to
-- `data: <object>` - Token state data associated with the account, either as
-  encoded binary data or in JSON format `{<program>: <state>}`
+- `data: <string|[string,encoding]|object>` - Token state data associated with the account. Format depends on encoding parameter:
+  - If the encoding parameter is left as the deprecated default of `binary`, this will be a string containing encoded binary data.
+  - If `base58`, `base64`, or `base64+zstd` is specified, this will be an array, where the first element is the encoded data string and the second element is the encoding format.
+  - If `jsonParsed` is specified, this will be JSON format `{<program>: <state>}`.
 - `executable: <bool>` - boolean indicating if the account contains a program
   (and is strictly read-only)
 - `rentEpoch: <u64>` - the epoch at which this account will next owe rent, as


### PR DESCRIPTION
### Problem
The RPC documentation has removed mention of `binary` encoding, since we discourage its use, but this encoding is not only still supported but is the default for some RPC APIs. This is causing confusion (see https://github.com/anza-xyz/agave/issues/6325)

This brings the API documentation in line with the various RPC implementations (including Agave) by documenting the default `binary` encoding.

### Summary of Changes

For `getProgramAccounts`:
- Change the default `encoding` param from `json` (not correct) to `binary`

For `getAccountInfo`, `getTokenAccountsByDelegate`, and `getTokenAccountsByOwner`:
- Document the default `encoding` param of `binary` (previously not specified)

For `getAccountInfo`, `getProgramAccounts`, `getTokenAccountsByDelegate`, and `getTokenAccountsByOwner`:
- Document the data result format and how it depends on the `encoding` param

For all other methods that take an `encoding` param:
- No change. I verified the rest of the documentation reflects the correct (albeit inconsistent) behavior for the `encoding` param

| API | Before | After |
|-|-|-|
| [getAccountInfo](https://solana.com/docs/rpc/http/getaccountinfo) | <img width="555" height="1300" alt="image" src="https://github.com/user-attachments/assets/117a6f38-341e-44b9-924c-48f7c389aae2" /> | <img width="555" height="1300" alt="image" src="https://github.com/user-attachments/assets/19e49a19-d72f-4a29-ac62-160efe536d84" /> |
| [getProgramAccounts](http://localhost:3000/docs/rpc/http/getprogramaccounts) | <img width="553" height="1690" alt="image" src="https://github.com/user-attachments/assets/b638ecfa-d5b7-40a6-b365-be556d43b082" /> | <img width="553" height="1690" alt="image" src="https://github.com/user-attachments/assets/c0318d6b-2f83-4115-967a-a755780a8b2b" /> |
| [getTokenAccountsByDelegate](http://localhost:3000/docs/rpc/http/gettokenaccountsbydelegate) | <img width="556" height="1703" alt="image" src="https://github.com/user-attachments/assets/d136d573-13b4-47c0-bc18-7ad2467e7a7b" /> | <img width="556" height="1703" alt="image" src="https://github.com/user-attachments/assets/e7b520a5-6ced-497b-b6a7-d55e366ab430" /> |
| [getTokenAccountsByOwner](http://localhost:3000/docs/rpc/http/gettokenaccountsbyowner) | <img width="558" height="1687" alt="image" src="https://github.com/user-attachments/assets/cf73ebde-1553-4a3d-a772-f2cdad8e59d2" /> | <img width="558" height="1687" alt="image" src="https://github.com/user-attachments/assets/59798860-eace-471e-b962-e535fa105a3c" /> |

Current state of `encoding` param across the API:
| getAccountInfo | Default encoding param (in Agave, Helius, QuickNode) |
|-|-|
| getAccountInfo | binary |
| getBlock | json |
| getMultipleAccounts | base64 |
| getProgramAccounts | binary |
| getTokenAccountsByDelegate | binary |
| getTokenAccountsByOwner | binary |
| getTransaction | json |
| simulateTransaction | base58 (input) |

Fixes https://github.com/anza-xyz/agave/issues/6325