### PR TITLE
docs: fix lingo parsing edge case

### DIFF
--- a/apps/web/content/docs/en/tokens/extensions/interest-bearing-tokens.mdx
+++ b/apps/web/content/docs/en/tokens/extensions/interest-bearing-tokens.mdx
@@ -10,8 +10,8 @@ The
 allows you to set an interest rate directly on a mint account. Interest
 continuously compounds based on the network timestamp, but the actual token
 balance stored in each token account remains unchanged. The total value (token
-balance + accrued interest) is only a calculation. No new tokens are minted with
-this extension.
+balance plus accrued interest) is only a calculation. No new tokens are minted
+with this extension.
 
 ### Typescript
 


### PR DESCRIPTION
change "+" to "plus" to fix lingo parsing edge case