### PR TITLE
Added version to litesvm

### DIFF
--- a/apps/web/content/docs/en/programs/rust/index.mdx
+++ b/apps/web/content/docs/en/programs/rust/index.mdx
@@ -216,7 +216,7 @@ Next, test the program using the `litesvm` crate. Add the following dependencies
 to `Cargo.toml`.
 
 ```terminal
-$ cargo add litesvm --dev
+$ cargo add litesvm@0.6.1 --dev
 $ cargo add solana-sdk@2.2.0 --dev
 ```
 


### PR DESCRIPTION
Added @0.6.1 to litesvm, otherwise, the examples wouldn't compile.

### Problem
Currently, the version for litesvm is not specified, so the examples don't compile.


### Summary of Changes

Added @0.6.1 to litesvm so that the examples compile.

Fixes #