### PR TITLE
docs: add Kit to searchbar tabs

### DIFF
--- a/packages/ui-chrome/src/inkeep-config.ts
+++ b/packages/ui-chrome/src/inkeep-config.ts
@@ -152,6 +152,7 @@ const searchSettings: InkeepSearchSettings = {
     "All",
     "Solana Docs",
     "Anchor Docs",
+    "Kit Docs",
     "Anza Docs",
     "Stack Exchange",
     "GitHub",


### PR DESCRIPTION
- forgot to add Kit tab name to searchbar tabs array
https://github.com/solana-foundation/solana-com/pull/910