### PR TITLE
Fix template links to use correct URL structure

### DIFF
--- a/apps/templates/src/components/search/search-card.tsx
+++ b/apps/templates/src/components/search/search-card.tsx
@@ -60,7 +60,7 @@ export const SearchCard = React.memo<SearchCardProps>(
       return <PlaceholderLogo />;
     };
 
-    const templateUrl = `/${template.source.id}/${template.name}`;
+    const templateUrl = `/${template.name}`;
 
     return (
       <Link

--- a/apps/templates/src/components/templates/templates-ui-grid-item.tsx
+++ b/apps/templates/src/components/templates/templates-ui-grid-item.tsx
@@ -14,7 +14,7 @@ export function TemplatesUiGridItem({ template }: { template: Template }) {
 
   return (
     <MotionLink
-      href={`/templates/${template.name}`}
+      href={`/${template.name}`}
       className="group relative overflow-hidden rounded-2xl bg-gradient-to-br from-zinc-900 to-zinc-950 p-6 block h-full flex flex-col"
       variants={fadeIn}
       initial="hidden"

--- a/apps/web/src/app/[locale]/x402/hackathon/page.tsx
+++ b/apps/web/src/app/[locale]/x402/hackathon/page.tsx
@@ -100,7 +100,7 @@ export default async function Page(_props: Props) {
           "x402.hackathon.resources.items.x402Template.description",
         ),
         category: t("x402.hackathon.resources.items.x402Template.category"),
-        url: "https://templates.solana.com/solana/x402-solana-protocol",
+        url: "https://templates.solana.com/x402-solana-protocol",
       },
       {
         title: t("x402.hackathon.resources.items.coinbaseDocs.title"),

--- a/apps/web/src/data/solutions/x402.ts
+++ b/apps/web/src/data/solutions/x402.ts
@@ -28,6 +28,6 @@ export const TOOLS = [
   },
   {
     key: "2",
-    href: "https://templates.solana.com/solana/x402-solana-protocol",
+    href: "https://templates.solana.com/x402-solana-protocol",
   },
 ];


### PR DESCRIPTION
## Summary
Fixes broken template detail page links by correcting the URL structure.

## Changes
- Updated template URLs from `/templates/[id]` and `/solana/[id]` to `/[id]`
- Updated external links from `templates.solana.com/solana/[id]` to `templates.solana.com/[id]`

## Context
The templates site uses a `[locale]/[id]` route structure where URLs like `templates.solana.com/gill-next-tailwind-basic` automatically redirect to `templates.solana.com/en/gill-next-tailwind-basic`. Internal links and external references were using incorrect path prefixes.

## Testing
- template-site preview should work with proper linking between page
- x402 hackathon page links should work in solana-com preview
