### PR TITLE
feat: add x402 next template

### DIFF
--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -3203,6 +3203,10 @@
         "description": "Sell services with x402"
       },
       "2": {
+        "title": "x402 Next Template",
+        "description": "Build your fullstack dApp with x402 and Next.js"
+      },
+      "3": {
         "title": "x402 Template",
         "description": "Build your API with x402"
       }
@@ -3255,6 +3259,11 @@
         "solana": {
           "title": "Build on Solana",
           "description": "Get started with Solana development, wallets, and deploying your first program",
+          "cta": "Build"
+        },
+        "x402NextTemplate": {
+          "title": "x402 Next Template",
+          "description": "Build and deploy your Next.js dApp with an X402 integration",
           "cta": "Build"
         }
       },

--- a/apps/web/src/app/[locale]/x402/hackathon/page.tsx
+++ b/apps/web/src/app/[locale]/x402/hackathon/page.tsx
@@ -46,6 +46,11 @@ export default async function Page(_props: Props) {
     solanaTitle: t("x402.hackathon.prerequisites.solana.title"),
     solanaDescription: t("x402.hackathon.prerequisites.solana.description"),
     solanaCta: t("x402.hackathon.prerequisites.solana.cta"),
+    x402NextTitle: t("x402.hackathon.prerequisites.x402NextTemplate.title"),
+    x402NextDescription: t(
+      "x402.hackathon.prerequisites.x402NextTemplate.description",
+    ),
+    x402NextCta: t("x402.hackathon.prerequisites.x402NextTemplate.cta"),
 
     problemTitle: t("x402.hackathon.problem.title"),
     problemDescription: t("x402.hackathon.problem.description"),

--- a/apps/web/src/app/[locale]/x402/hackathon/x402-hackathon.tsx
+++ b/apps/web/src/app/[locale]/x402/hackathon/x402-hackathon.tsx
@@ -33,6 +33,9 @@ interface X402HackathonPageProps {
     solanaTitle: string;
     solanaDescription: string;
     solanaCta: string;
+    x402NextTitle: string;
+    x402NextDescription: string;
+    x402NextCta: string;
     problemTitle: string;
     problemDescription: string;
     requirementsTitle: string;
@@ -131,6 +134,13 @@ export function X402HackathonPage({ translations }: X402HackathonPageProps) {
                 url="#resources"
                 newTab={false}
                 ctaLabel={translations.solanaCta}
+              />
+              <DevelopersDocumentItem
+                title={translations.x402NextTitle}
+                description={translations.x402NextDescription}
+                url="https://templates.solana.com/x402-template"
+                newTab={false}
+                ctaLabel={translations.x402NextCta}
               />
             </div>
           </div>

--- a/apps/web/src/data/solutions/x402.ts
+++ b/apps/web/src/data/solutions/x402.ts
@@ -28,6 +28,10 @@ export const TOOLS = [
   },
   {
     key: "2",
+    href: "https://templates.solana.com/x402-template",
+  },
+  {
+    key: "3",
     href: "https://templates.solana.com/x402-solana-protocol",
   },
 ];


### PR DESCRIPTION
### Summary of Changes

This PR introduces adds updates to the "x402 Tools" and "Getting started" pages of "/x402" and "/x402/hackathon" pages with the x402 Next template.

Direct summary of pages:
- Added the metadata and items to the `/en/common.json` pages
- Made updates to the x402 hackathon page with the translation integration

<img width="1458" height="552" alt="Screenshot 2025-11-01 at 23 00 30" src="https://github.com/user-attachments/assets/9d2b4027-83dd-4569-a858-5fad623f441f" />

<img width="1029" height="547" alt="Screenshot 2025-11-01 at 23 31 40" src="https://github.com/user-attachments/assets/a1eb8263-9264-4cda-b78c-24c6d8cb5bac" />