### PR TITLE
Remove 'Break Solana' link from footer

### DIFF
--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -723,7 +723,6 @@
     "solana": {
       "heading": "Solana",
       "grants": "Grants",
-      "break": "Break Solana",
       "media": "Media Kit",
       "careers": "Careers",
       "disclaimer": "Disclaimer",

--- a/packages/ui-chrome/src/footer.jsx
+++ b/packages/ui-chrome/src/footer.jsx
@@ -119,14 +119,6 @@ export const Footer = ({ className = "" }) => {
                 </InlineLink>
               </li>
               <li>
-                <InlineLink
-                  to="https://break.solana.com/"
-                  className="!no-underline !text-[#ababbc] hover:!text-white transition-colors"
-                >
-                  {t("footer.solana.break")}
-                </InlineLink>
-              </li>
-              <li>
                 <Link
                   to="/branding"
                   className="!no-underline !text-[#ababbc] hover:!text-white transition-colors"


### PR DESCRIPTION
### Problem
Break Solana is listed in the footer. We're at the point that this doesn't belong anymore.


### Summary of Changes
Deleted the 'Break Solana' entry from the Solana section in the footer and removed its corresponding translation key from the English locale file.


Fixes #897