### PR TITLE
fix: Update x420 references to x402 in documentation

### DIFF
--- a/apps/web/content/guides/getstarted/intro-to-x402.mdx
+++ b/apps/web/content/guides/getstarted/intro-to-x402.mdx
@@ -325,7 +325,7 @@ endpoints across different networks. Site: https://x402scan.com/
 
 ### Nexus (Thirdweb)
 
-Thirdweb Nexus develops a x40 wrapper around API keys (currently in
+Thirdweb Nexus develops a x402 wrapper around API keys (currently in
 development). Site: https://nexus.thirdweb.com/
 
 ## Native example


### PR DESCRIPTION
### Problem

Currently, on the ["How to get started with x402 on Solana"](https://solana.com/es/developers/guides/getstarted/intro-to-x402) page, there are reference errors where the x402 protocol is mistakenly referred to as x420.

The most serious issue is that the link to x402scan is written as [x420scan.com](https://x420scan.com/), which leads to a dead website instead of the correct and functional one, [x402scan.com](https://www.x402scan.com/).

Additionally, in the [Nexus documentation](https://nexus.thirdweb.com/docs/proxy), the protocol is consistently referred to as x402, not x420.

**x420Scan**
<img width="1855" height="1128" alt="image" src="https://github.com/user-attachments/assets/aca48a59-90b3-40e3-a4d3-fa923dcaa999" />

**x402Scan**
<img width="1855" height="1128" alt="image" src="https://github.com/user-attachments/assets/3eea9cea-a700-4669-96a7-4f384d1a48c7" /> 


### Summary of Changes

This PR fixes those incorrect references in the file: `apps/web/content/guides/getstarted/intro-to-x402.mdx`


Fixes #