### PR TITLE
Add rewrite rules for /developers/templates path

### DIFF
--- a/apps/templates/next.config.ts
+++ b/apps/templates/next.config.ts
@@ -7,7 +7,7 @@ const nextConfig: NextConfig = {
   // Use basePath only when env var is set (for proxy integration)
   // Without env var, templates serves at root for standalone subdomain
   ...(process.env.NEXT_PUBLIC_USE_BASE_PATH === "true" && {
-    basePath: "/templates",
+    basePath: "/developers/templates",
   }),
 
   webpack(config) {

--- a/apps/web/rewrites-redirects.mjs
+++ b/apps/web/rewrites-redirects.mjs
@@ -14,14 +14,16 @@ export default {
         locale: false,
       },
       {
-        source: "/templates",
-        destination: "https://solana-com-templates.vercel.app/templates",
+        source: "/developers/templates",
+        destination:
+          "https://solana-com-templates.vercel.app/developers/templates",
         locale: false,
       },
       // everything underneath
       {
-        source: "/templates/:path*",
-        destination: "https://solana-com-templates.vercel.app/templates/:path*",
+        source: "/developers/templates/:path*",
+        destination:
+          "https://solana-com-templates.vercel.app/developers/templates/:path*",
         locale: false,
       },
     ],

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -6,10 +6,10 @@ import { locales } from "@workspace/i18n/config";
 const handleI18nRouting = createMiddleware(routing);
 
 export default async function middleware(req: NextRequest) {
-  // Skip i18n for /breakpoint/* and /templates/* paths
+  // Skip i18n for /breakpoint/* and /developers/templates/* paths
   if (
     req.nextUrl.pathname.startsWith("/breakpoint") ||
-    req.nextUrl.pathname.startsWith("/templates")
+    req.nextUrl.pathname.startsWith("/developers/templates")
   ) {
     return NextResponse.next();
   }
@@ -55,8 +55,6 @@ export default async function middleware(req: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    "/((?!api|opengraph|_next|_vercel|breakpoint|templates|.*\\..*).*)",
-  ],
+  matcher: ["/((?!api|opengraph|_next|_vercel|breakpoint|.*\\..*).*)"],
   runtime: "nodejs",
 };


### PR DESCRIPTION
Add rewrite rules to proxy /developers/template to the templates Vercel deployment.

**NB let me merge, i want to be online for the migration**

## Implementation

This PR configures the templates app to be accessible at solana.com/developers/template via proxy rewrite, following the same pattern as /breakpoint.

Changes:
- Add /templates rewrite rules in rewrites-redirects.mjs
- Add conditional basePath to templates app (activated via env var)

## Deployment Flow

1. Merge this PR - templates.solana.com continues to work normally
2. Add NEXT_PUBLIC_USE_BASE_PATH=true env var to templates production deployment
3. Redeploy templates app - solana.com/developers/template becomes active
4. Set up Cloudflare 301 redirect: templates.solana.com -> solana.com/developers/template5. All traffic flows to new path with no downtime