### PR TITLE
Fix x402 template link

### DIFF
--- a/apps/web/src/app/[locale]/x402/hackathon/page.tsx
+++ b/apps/web/src/app/[locale]/x402/hackathon/page.tsx
@@ -124,7 +124,7 @@ export default async function Page(_props: Props) {
           "x402.hackathon.resources.items.x402Template.description",
         ),
         category: t("x402.hackathon.resources.items.x402Template.category"),
-        url: "https://templates.solana.com/x402-solana-protocol",
+        url: "https://templates.solana.com/x402-template",
       },
       {
         title: t("x402.hackathon.resources.items.coinbaseDocs.title"),


### PR DESCRIPTION
### Problem

Clicking on `Ship with a x402 template` at the bottom of the [docs page](https://solana.com/x402/hackathon) under `Getting Started` points to a [missing page](https://templates.solana.com/x402-solana-protocol) and returns `Not Found`.

<img width="2523" height="1036" alt="image" src="https://github.com/user-attachments/assets/7bbdd0b2-b17f-4ce9-acc1-8bfecec2a7c8" />

<img width="1983" height="860" alt="image" src="https://github.com/user-attachments/assets/2a731070-af6f-4259-af2a-3c8b25adffd8" />

### Summary of Changes

- Update the `x402Template` resource entry in `apps/web/src/app/[locale]/x402/hackathon/page.tsx` to use the live template link.  
  You can see the change here: `page.tsx` → `resources` array → `url` for `x402Template`.

**Summary**
- route the x402 hackathon resources card to the [current X402 template](https://templates.solana.com/x402-template) instead of the missing [`x402-solana-protocol` template page](https://templates.solana.com/x402-solana-protocol)

**Testing**
- Run `pnpm dev` from the repo root and visit `/x402/hackathon`
- Click `Ship with a x402 template` and confirm it opens the [updated template page](https://templates.solana.com/x402-template)

<img width="1968" height="1036" alt="image" src="https://github.com/user-attachments/assets/dea18525-5225-425a-b256-92be9507e26d" />

Fixes #

- The verified page now renders the [correct template link](https://templates.solana.com/x402-template).