### PR TITLE
Update transaction size limit explanation

### DIFF
--- a/apps/web/content/docs/en/core/transactions.mdx
+++ b/apps/web/content/docs/en/core/transactions.mdx
@@ -55,8 +55,12 @@ This limit includes both the [`signatures`](#signatures) array
 and the [`message`](#message) struct.
 
 <Callout>
-This limit comes from the IPv6 Maximum Transmission Unit (MTU) size of
-1280 bytes, minus 48 bytes for network headers (40 bytes IPv6 + 8 bytes header).
+This limit is designed to avoid packet fragmentation on typical internet infrastructure.
+While IPv6 supports MTUs larger than 9000 bytes, most internet routers use a default
+MTU of 1500 bytes (standard Ethernet). To ensure transactions fit within a single packet
+without fragmentation, Solana uses 1280 bytes (the minimum MTU required for IPv6) minus
+48 bytes for network headers (40 bytes IPv6 + 8 bytes fragment/UDP header), resulting
+in the 1232 byte transaction size limit.
 </Callout>
 
 ![Diagram showing the transaction format and size limits](/assets/docs/core/transactions/issues_with_legacy_txs.png)


### PR DESCRIPTION
# Clarified the transaction size limit explanation to include details about IPv6 MTU and network headers

## Problem
The current documentation incorrectly states that the transaction size limit "comes from the IPv6 Maximum Transmission Unit (MTU) size of 1280 bytes." This is technically inaccurate because:

1. IPv6 does not have a maximum MTU - it can support MTUs larger than 9000 bytes
2. 1280 bytes is the **minimum** MTU required by IPv6, not the maximum
3. The real constraint is avoiding packet fragmentation on typical internet infrastructure where most routers use a 1500-byte default MTU (standard Ethernet)

## Summary of Changes
- Corrected the explanation to clarify that IPv6 supports MTUs larger than 9000 bytes
- Explained that 1280 bytes is the **minimum** MTU required for IPv6 (per RFC 8200)
- Added context about the 1500-byte default MTU used by most internet routers (standard Ethernet)
- Clarified that Solana uses the conservative 1280-byte limit to ensure transactions fit in a single packet without fragmentation across typical internet infrastructure
- Maintained the existing explanation of the 48-byte header overhead calculation

## Sources
- **RFC 8200 (IPv6 Specification)**: "IPv6 requires that every link in the Internet have an MTU of 1280 octets or greater." - [RFC 9268](https://datatracker.ietf.org/doc/rfc9268/)
- **IEEE 802.3 Standard**: Standard Ethernet MTU is 1500 bytes - [Huawei Documentation](https://info.support.huawei.com/info-finder/encyclopedia/en/MTU.html)
- **MTU Overview**: [Wikipedia - Maximum Transmission Unit](https://en.wikipedia.org/wiki/Maximum_transmission_unit)
- **Fragmentation Avoidance**: [Cloudflare - IPv6 MTU Discussion](https://blog.cloudflare.com/increasing-ipv6-mtu/)

Fixes #