### PR TITLE
docs: Add Orb Solana block explorer to references and UI

### DIFF
--- a/apps/web/content/docs/en/references/clusters.mdx
+++ b/apps/web/content/docs/en/references/clusters.mdx
@@ -33,6 +33,7 @@ well.
 An example of some of these Solana blockchain explorers include:
 
 - [http://explorer.solana.com/](https://explorer.solana.com/).
+- [http://orb.helius.dev/](https://orb.helius.dev/).
 - [http://solana.fm/](https://solana.fm/).
 - [http://solscan.io/](https://solscan.io/).
 - [http://solanabeach.io/](http://solanabeach.io/).

--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -961,6 +961,10 @@
           {
             "title": "Solana Explorer",
             "description": "Blocks, accounts, transactions, programs and tokens."
+          },
+          {
+            "title": "Orb",
+            "description": "A fast, human-readable Solana block explorer"
           }
         ]
       },

--- a/packages/ui-chrome/src/header-list.network.jsx
+++ b/packages/ui-chrome/src/header-list.network.jsx
@@ -93,6 +93,15 @@ const HeaderListNetwork = () => {
             </strong>
             {networkInspectItems[2].description}
           </InlineLink>
+          <InlineLink
+            to="https://orb.helius.dev/"
+            className="block !border !border-transparent rounded-lg px-2 py-1.5 my-1 -mx-2 hover:!border-white/10 hover:bg-[#151118] !text-[#ababbc] hover:!text-white transition-colors !no-underline text-sm"
+          >
+            <strong className="block !text-white text-sm">
+              {networkInspectItems[3].title}
+            </strong>
+            {networkInspectItems[3].description}
+          </InlineLink>
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Included Orb as a new Solana blockchain explorer in the documentation.
- Updated the common.json file to add Orb with a description.
- Added a link to Orb in the network header list for better accessibility.

### Problem



### Summary of Changes



Fixes #