### PR TITLE
Fix typo: 'other that' to 'other than' in actions.mdx

### DIFF
--- a/apps/web/content/guides/advanced/actions.mdx
+++ b/apps/web/content/guides/advanced/actions.mdx
@@ -626,7 +626,7 @@ default to `text` and render a simple text input.
 The Action API is still responsible to validate and sanitize all data from the
 user input parameters, enforcing any “required” user input as necessary.
 
-For platforms other that HTML/web based ones (like native mobile), the
+For platforms other than HTML/web based ones (like native mobile), the
 equivalent native user input component should be used to achieve the equivalent
 experience and client side validation as the HTML/web input types described
 above.


### PR DESCRIPTION
The documentation contains a grammatical error where "other that" is used instead of the correct phrase "other than" in the Actions and Blinks guide. 

Fixed grammatical typo in actions.mdx
Changed "For platforms other that HTML/web based ones..." to "For platforms other than HTML/web based ones..."
This ensures the documentation uses correct English grammar and improves readability