### PR TITLE
rpc methods: fix getBlocksWithLimit required parameter

### DIFF
--- a/apps/web/content/docs/en/rpc/http/getblockswithlimit.mdx
+++ b/apps/web/content/docs/en/rpc/http/getblockswithlimit.mdx
@@ -79,6 +79,7 @@ Start slot
 #### !! limit
 
 !type u64
+!required
 
 Limit (must be no more than 500,000 blocks higher than the `start_slot`)
 


### PR DESCRIPTION
### Problem
`getBlocksWithLimit`'s `limit` parameter is required, but the docs say it is optional.

### Summary of Changes
make `limit` required.