### PR TITLE
Update description of InitializePermanentDelegate extension

### DIFF
--- a/apps/web/content/docs/en/tokens/extensions/permanent-delegate.mdx
+++ b/apps/web/content/docs/en/tokens/extensions/permanent-delegate.mdx
@@ -7,10 +7,11 @@ description: Learn how to implement the InitializePermanentDelegate extension.
 
 The
 [`InitializePermanentDelegate`](https://github.com/solana-program/token-2022/blob/6f2473344d70271f632c3e9b7e945be00186c536/interface/src/instruction.rs#L678)
-assigns an irrevocable delegate with authority over all token accounts for a
+assigns a delegate with authority over all token accounts for a
 mint. Unlike regular delegates that token account owners can revoke, a permanent
-delegate cannot be changed or removed. The permanent delegate can transfer,
-burn, and freeze tokens in any token account of that mint.
+delegate cannot be changed or removed by token account owners.
+The permanent delegate can transfer or burn tokens in any token account of that mint.
+The permanent delegate role can be changed to a new account by the current permanent delegate.
 
 ### Typescript
 


### PR DESCRIPTION
Clarify the role of the permanent delegate and its authority. The current explanation is a bit misleading as it can be read to mean that the permanent delegate cannot be re-assigned to a new account.
