### PR TITLE
Replace gill with kit templates as defaults

### DIFF
--- a/apps/templates/public/locales/en/common.json
+++ b/apps/templates/public/locales/en/common.json
@@ -29,7 +29,6 @@
       "node": "Node",
       "solana_kit": "@solana/kit",
       "solana_web3js": "@solana/web3.js",
-      "gill": "Gill",
       "wallet_ui": "Wallet UI",
       "mobile_wallet_adapter": "Mobile Wallet Adapter",
       "wallet_adapter": "Wallet Adapter"

--- a/apps/templates/src/app/[id]/opengraph-image.tsx
+++ b/apps/templates/src/app/[id]/opengraph-image.tsx
@@ -41,7 +41,8 @@ export default async function Image({
       node: "Node",
       express: "Express",
       web3js: "Web3.js",
-      gill: "Gill",
+      kit: "Kit",
+      anchor: "Anchor",
       mobile: "Mobile",
       dapp: "dApp",
       spl: "SPL",
@@ -67,7 +68,8 @@ export default async function Image({
     if (parts.includes("node") || parts.includes("nodejs"))
       tech.push("Node.js");
     if (parts.includes("web3js")) tech.push("Web3.js");
-    if (parts.includes("gill")) tech.push("Gill (based on @solana/kit)");
+    if (parts.includes("kit")) tech.push("@solana/kit");
+    if (parts.includes("anchor")) tech.push("Anchor");
     if (parts.includes("mobile")) type = "mobile template";
     if (parts.includes("basic")) type = "starter template";
     if (parts.includes("counter")) type = "counter app template";
@@ -96,7 +98,8 @@ export default async function Image({
       node: ["nodejs"],
       nodejs: ["nodejs"],
       web3js: ["web3js", "blockchain"],
-      gill: ["gill", "solana-kit"],
+      kit: ["solana-kit"],
+      anchor: ["anchor", "program"],
       wallet: ["wallet", "wallet-ui"],
       basic: ["starter", "template"],
       counter: ["dapp", "example"],

--- a/apps/templates/src/app/[id]/twitter-image.tsx
+++ b/apps/templates/src/app/[id]/twitter-image.tsx
@@ -41,7 +41,8 @@ export default async function Image({
       node: "Node",
       express: "Express",
       web3js: "Web3.js",
-      gill: "Gill",
+      kit: "Kit",
+      anchor: "Anchor",
       mobile: "Mobile",
       dapp: "dApp",
       spl: "SPL",
@@ -67,7 +68,8 @@ export default async function Image({
     if (parts.includes("node") || parts.includes("nodejs"))
       tech.push("Node.js");
     if (parts.includes("web3js")) tech.push("Web3.js");
-    if (parts.includes("gill")) tech.push("Gill (based on @solana/kit)");
+    if (parts.includes("kit")) tech.push("@solana/kit");
+    if (parts.includes("anchor")) tech.push("Anchor");
     if (parts.includes("mobile")) type = "mobile template";
     if (parts.includes("basic")) type = "starter template";
     if (parts.includes("counter")) type = "counter app template";
@@ -96,7 +98,8 @@ export default async function Image({
       node: ["nodejs"],
       nodejs: ["nodejs"],
       web3js: ["web3js", "blockchain"],
-      gill: ["gill", "solana-kit"],
+      kit: ["solana-kit"],
+      anchor: ["anchor", "program"],
       wallet: ["wallet", "wallet-ui"],
       basic: ["starter", "template"],
       counter: ["dapp", "example"],

--- a/apps/templates/src/lib/templates/filter-templates.ts
+++ b/apps/templates/src/lib/templates/filter-templates.ts
@@ -3,13 +3,12 @@ import { TemplateUrlState } from "./use-template-url-state";
 
 // Default templates to show when no filters are applied
 const DEFAULT_TEMPLATE_NAMES = [
-  "gill-next-tailwind-basic", // Fullstack boilerplate (Next.js)
-  "gill-react-vite-tailwind-basic", // Fullstack boilerplate (Vite)
+  "nextjs", // Kit - Next.js
+  "nextjs-anchor", // Kit - Next.js with Anchor
+  "react-vite", // Kit - React + Vite
+  "react-vite-anchor", // Kit - React + Vite with Anchor
   "web3js-expo", // Mobile
-  "gill-jito-airdrop", // Airdrop
   "x402-template", // X402 Next.js
-  "gill-node-solanax402", // X402 Express Server
-  "gill-node-express", // Backend
   "supabase-auth", // Auth
 ];
 

--- a/apps/templates/src/lib/types/templates/filters.ts
+++ b/apps/templates/src/lib/types/templates/filters.ts
@@ -76,10 +76,6 @@ export const createFilters = (t: (key: string) => string): TemplateFilter[] => [
         id: "solana-web3js",
         name: t("keywords.solana_web3js"),
       },
-      {
-        id: "gill",
-        name: t("keywords.gill"),
-      },
     ],
     name: t("categories.solana_sdks"),
   },
@@ -134,7 +130,6 @@ export const filters: TemplateFilter[] = [
     keywords: [
       { id: "solana-kit", name: "@solana/kit" },
       { id: "solana-web3js", name: "@solana/web3.js" },
-      { id: "gill", name: "Gill" },
     ],
     name: "Solana SDKs",
   },

--- a/apps/templates/src/types/index.ts
+++ b/apps/templates/src/types/index.ts
@@ -1,7 +1,6 @@
 export type Tech = "next" | "vite" | "react" | "node" | "expo" | "other";
 
 export type TemplateTag =
-  | "gill"
   | "nextjs"
   | "react"
   | "solana-kit"


### PR DESCRIPTION
### Problem

The templates page promotes gill templates as defaults, but we've introduced new kit templates that should be featured instead.

### Summary of Changes

- Replace default/promoted templates with the 4 kit templates (nextjs, nextjs-anchor, react-vite, react-vite-anchor)
- Remove gill from SDK filter options
- Update OG and Twitter image generation to support kit and anchor templates
- Remove gill from TemplateTag type
- Keep web3js-expo, x402-template, and supabase-auth as additional defaults