### PR TITLE
Fix broken internal PDA documentation link

### DIFF
--- a/apps/web/content/docs/en/core/cpi.mdx
+++ b/apps/web/content/docs/en/core/cpi.mdx
@@ -45,7 +45,7 @@ to 4.
 When a CPI requires a PDA signer, the
 [`invoke_signed`](https://github.com/anza-xyz/agave/blob/v2.1.13/sdk/program/src/program.rs#L51-L73)
 function is used. It takes the [signer seeds](mention:signer-seeds) used for
-deriving signer [PDAs](<(/docs/core/pda)>) The Solana runtime internally calls
+deriving signer [PDAs](/docs/core/pda) The Solana runtime internally calls
 [`create_program_address`](https://github.com/anza-xyz/agave/blob/v2.1.13/programs/bpf_loader/src/syscalls/cpi.rs#L552)
 using the `signers_seeds` and the `program_id` of the caller program. When a PDA
 is verified, it is


### PR DESCRIPTION
### **Description**

This PR fixes an incorrect internal MDX link that caused the PDAs reference
in the CPI documentation to resolve to a non-existent docs path.

The link has been corrected to use the proper Solana Docs internal routing.

---
### **Problem**

The PDAs link in the CPI documentation used invalid MDX syntax, which caused the docs site to generate a broken internal URL and return a documentation error instead of navigating to the PDA reference page.

This resulted in a poor user experience and made it difficult for readers to find the correct PDA documentation.

---
### **Summary of Changes**

* Corrected the internal MDX link syntax for the PDAs reference
* Updated the link to use the standard docs-relative path
* Ensured the link resolves correctly in the rendered Solana Docs site

---
### **Fixes**

Fixes broken internal documentation navigation for the PDAs reference in the CPI docs.
