### PR TITLE
docs: update supabase tutorial for framework-kit migration

### DIFF
--- a/apps/web/content/guides/getstarted/supabase-auth-guide.mdx
+++ b/apps/web/content/guides/getstarted/supabase-auth-guide.mdx
@@ -83,16 +83,16 @@ verification, just one click.
 Before you start, make sure you have these installed. If you're missing
 something, the app won't run. Don't worry, we'll check each one.
 
-**Node.js v24.11.1(LTS)**
+**Node.js v24 (LTS)**
 
-The template uses Next.js. It requires Node.js v24.11.1(LTS). Check your
+The template uses Next.js. It requires Node.js v24 (LTS) or later. Check your
 version:
 
 ```bash
 node --version
 ```
 
-If you see Node.js v24.11.1(LTS), you're good. If not, install
+If you see Node.js v24 or later, you're good. If not, install
 [Node.js](https://nodejs.org) from [nodejs.org](https://nodejs.org). Use the LTS
 version. It's the most stable.
 
@@ -133,7 +133,7 @@ Use VS Code, Cursor, or any editor you prefer. The template uses TypeScript, so
 an editor with [TypeScript](https://www.typescriptlang.org/) support helps. But
 it's not required. You can use any text editor.
 
-That's it. If you have Node.js v24.11.1(LTS), a Supabase account, and a Solana
+That's it. If you have Node.js v24 (LTS) or later, a Supabase account, and a Solana
 wallet, you're ready. If you're missing something, install it now. We'll wait.
 
 ## 5. Setting Up the Project
@@ -363,8 +363,8 @@ truncated (like `J4AJ...MAAP`). That's how you know it's connected.
 **What happens behind the scenes:** The wallet dropdown handles the connection
 internally. When you click a wallet in the dropdown, it manages calling
 `window.solana.connect()` behind the scenes. You don't need to call it directly.
-The connection state is managed automatically. The `useSolana` hook exposes it
-to your components.
+The connection state is managed automatically. The `@solana/react-hooks` hooks
+expose it to your components.
 
 ## 7. Signing In with Solana
 
@@ -565,14 +565,13 @@ Once authenticated and on `/account/[address]`, you'll see:
 
 ![Account page showing balance, tokens, and transactions](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763205913/Screenshot_2025-11-15_at_8.24.57_AM_cfgmwf.png)
 
-The page uses TanStack Query to fetch data. It caches responses for better
-performance. If you refresh, it might show cached data while fetching fresh
-data.
+The page uses React hooks with `@solana/react-hooks` to fetch data from the
+Solana network.
 
 The account detail component is in
 `src/features/account/account-feature-detail.tsx`. It extracts the address from
-the URL params. It validates the address using Gill's `assertIsAddress`. If the
-address is invalid, it shows an error.
+the URL params. It validates the address using `toAddress` from `@solana/client`.
+If the address is invalid, it shows an error.
 
 ### Testing protected routes
 


### PR DESCRIPTION
## Summary

Updates the Supabase authentication tutorial to reflect the framework-kit migration changes from the templates repo (commit 3752a0d).

### Changes
- Updated Node.js version format from `v24.11.1(LTS)` to `v24 (LTS) or later`
- Replaced `useSolana` hook reference with `@solana/react-hooks` hooks
- Replaced TanStack Query reference with React hooks using `@solana/react-hooks`
- Replaced Gill's `assertIsAddress` reference with `toAddress` from `@solana/client`

### Related
- Templates repo migration PR: solana-foundation/templates#232