### PR TITLE
Replace Cookbook with Templates in navigation menu

### DIFF
--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -585,6 +585,7 @@
       "terminology": "Terminology",
       "courses": "Courses",
       "cookbook": "Cookbook",
+      "templates": "Templates",
       "toolkit": "Toolkit"
     },
     "carousel": {
@@ -825,6 +826,10 @@
         "cookbook": {
           "title": "Cookbook",
           "description": "Snippets and copyable example codes"
+        },
+        "templates": {
+          "title": "Templates",
+          "description": "Ready-to-use project templates for Solana"
         },
         "resources": {
           "title": "Resources",

--- a/packages/ui-chrome/src/assets/developers/templates.inline.svg
+++ b/packages/ui-chrome/src/assets/developers/templates.inline.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M3 3H10V10H3V3ZM14 3H21V10H14V3ZM3 14H10V21H3V14ZM14 14H21V21H14V14Z" fill="white" style="fill:white;fill-opacity:1;"/>
+</svg>

--- a/packages/ui-chrome/src/assets/nav/build/templates.inline.svg
+++ b/packages/ui-chrome/src/assets/nav/build/templates.inline.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M3 3H10V10H3V3ZM14 3H21V10H14V3ZM3 14H10V21H3V14ZM14 14H21V21H14V14Z" fill="white" style="fill:white;fill-opacity:1;"/>
+</svg>

--- a/packages/ui-chrome/src/developers-nav.jsx
+++ b/packages/ui-chrome/src/developers-nav.jsx
@@ -1,7 +1,7 @@
 import { Link } from "./link";
 import DocsIcon from "./assets/developers/docs.inline.svg";
 import RpcApiIcon from "./assets/developers/api.inline.svg";
-import CookbookIcon from "./assets/developers/cookbook.inline.svg";
+import TemplatesIcon from "./assets/developers/templates.inline.svg";
 import StackExchangeIcon from "./assets/developers/stackexchange.inline.svg";
 import { useTranslations } from "next-intl";
 
@@ -47,16 +47,16 @@ export function DevelopersNav({ containerClassName }) {
             </NavLink>
             <NavLink
               partiallyActive
-              to="/developers/cookbook"
+              to="/developers/templates"
               activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
             >
-              <CookbookIcon
+              <TemplatesIcon
                 height="16"
                 width="16"
                 className="inline-block mr-2"
               />
               <span className="align-middle">
-                {t("developers.nav.cookbook")}
+                {t("developers.nav.templates")}
               </span>
             </NavLink>
             <NavLink href="https://solana.stackexchange.com/" target="_blank">

--- a/packages/ui-chrome/src/header-list.build.jsx
+++ b/packages/ui-chrome/src/header-list.build.jsx
@@ -3,7 +3,7 @@ import { Link } from "./link";
 import { HeaderItem } from "./header-item";
 import NewspaperIcon from "./assets/nav/build/newspaper.inline.svg";
 import ApiConnectionIcon from "./assets/nav/build/api-connection.inline.svg";
-import CodeIcon from "./assets/nav/build/code.inline.svg";
+import TemplatesIcon from "./assets/nav/build/templates.inline.svg";
 import EthereumIcon from "./assets/nav/build/ethereum.inline.svg";
 import SchoolIcon from "./assets/nav/build/school.inline.svg";
 import HandIcon from "./assets/nav/build/hand.inline.svg";
@@ -44,14 +44,14 @@ const HeaderListBuild = () => {
             />
           </Link>
           <Link
-            to="/developers/cookbook"
+            to="/developers/templates"
             className="block no-underline text-inherit group/link"
             activeClassName="active"
           >
             <HeaderItem
-              title={t("nav.developers.items.cookbook.title")}
-              description={t("nav.developers.items.cookbook.description")}
-              Icon={CodeIcon}
+              title={t("nav.developers.items.templates.title")}
+              description={t("nav.developers.items.templates.description")}
+              Icon={TemplatesIcon}
               variant="large"
             />
           </Link>


### PR DESCRIPTION
### Problem

The navigation menu currently links to Cookbook, but we want to feature Templates instead.

### Summary of Changes

- Update header dropdown menu to link to `/developers/templates` instead of `/developers/cookbook`
- Update developers nav bar to link to Templates
- Add templates icon (2x2 grid SVG)
- Add English translations for Templates nav items