### PR TITLE
Fix link to transactions in programs documentation

### DIFF
--- a/apps/web/content/docs/en/core/programs.mdx
+++ b/apps/web/content/docs/en/core/programs.mdx
@@ -10,7 +10,7 @@ h1: Programs
 On Solana, a smart contract is called a program. A program is a stateless
 [account](/docs/core/accounts#program-account) that contains executable code.
 This code is organized into functions called instructions. Users interact with a
-program by sending a [transaction](/docs/core/transaction) containing one or
+program by sending a [transaction](/docs/core/transactions) containing one or
 more [instructions](/docs/core/instructions). A transaction can include
 instructions from multiple programs.
 


### PR DESCRIPTION
### Problem

The Programs documentation links to `/docs/core/transaction`, which is invalid. The correct path is `/docs/core/transactions`, causing the current link to be broken.

### Summary of Changes

- Fixed the broken link in `programs.mdx` by updating `transaction` → `transactions`
- Ensures the Programs documentation correctly references the Transactions docs