### PR TITLE
fix: update broken Corbits docs link

### DIFF
--- a/apps/web/src/app/[locale]/x402/hackathon/page.tsx
+++ b/apps/web/src/app/[locale]/x402/hackathon/page.tsx
@@ -108,7 +108,7 @@ export default async function Page(_props: Props) {
         title: t("x402.hackathon.resources.items.x402SDK.title"),
         description: t("x402.hackathon.resources.items.x402SDK.description"),
         category: t("x402.hackathon.resources.items.x402SDK.category"),
-        url: "https://docs.corbits.dev/quickstart",
+        url: "https://docs.corbits.dev/build-with-corbits/ride-or-die",
       },
       {
         title: t("x402.hackathon.resources.items.facilitatorDocs.title"),

--- a/apps/web/src/data/solutions/x402.ts
+++ b/apps/web/src/data/solutions/x402.ts
@@ -20,7 +20,7 @@ export const PRODUCTS = [
 export const TOOLS = [
   {
     key: "0",
-    href: "https://docs.corbits.dev/quickstart",
+    href: "https://docs.corbits.dev/build-with-corbits/ride-or-die",
   },
   {
     key: "1",


### PR DESCRIPTION
## Summary
- Updated broken Corbits documentation link that was returning 404
- New link provided by the Corbits team

## Test plan
- Verify the link https://docs.corbits.dev/build-with-corbits/ride-or-die loads correctly