### PR TITLE
docs: update supabase-auth guide for framework-kit migration

### DIFF
--- a/apps/web/content/guides/getstarted/supabase-auth-guide.mdx
+++ b/apps/web/content/guides/getstarted/supabase-auth-guide.mdx
@@ -302,7 +302,7 @@ This starts Next.js with Turbopack (faster than the default webpack). You should
 see output like:
 
 ```text
-▲ Next.js 16.0.3
+▲ Next.js 16
 - Local:        http://localhost:3000
 ```
 
@@ -360,11 +360,11 @@ truncated (like `J4AJ...MAAP`). That's how you know it's connected.
 
 ![Connected wallet showing truncated address](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763205189/Screenshot_2025-11-15_at_8.12.57_AM_afhpjb.png)
 
-**What happens behind the scenes:** The wallet dropdown handles the connection
-internally. When you click a wallet in the dropdown, it manages calling
-`window.solana.connect()` behind the scenes. You don't need to call it directly.
-The connection state is managed automatically. The `@solana/react-hooks` hooks
-expose it to your components.
+**What happens behind the scenes:** The wallet dropdown uses the
+`useWalletConnection()` hook from `@solana/react-hooks`. When you click a wallet
+in the dropdown, it calls `connect(connectorId)` to establish the connection.
+The hook manages the connection state automatically and exposes it to your
+components through `connected`, `status`, and other properties.
 
 ## 7. Signing In with Solana
 
@@ -460,17 +460,18 @@ A 422 error usually means one of these:
 - Wallet authentication isn't enabled (see above)
 - Your Supabase project doesn't support wallet authentication (check if you're
   on a supported plan)
-- The `window.solana` provider isn't properly connected
+- The wallet connection wasn't established properly
 
 If you see a 422 error, check the browser console. You might see more details
 about what went wrong. The error message from Supabase usually tells you what's
 missing.
 
-**"Solana wallet not detected"**
+**"No wallet connectors available"**
 
-This means `window.solana` is not available. Make sure you have a Solana wallet
-extension installed and enabled. Make sure you've connected your wallet before
-trying to authenticate. The wallet connection must happen first.
+This means no wallet extensions were detected. Make sure you have a Solana
+wallet extension installed and enabled. The template uses `@solana/react-hooks`
+to auto-discover available wallet connectors. Make sure you've connected your
+wallet before trying to authenticate.
 
 **"Please connect a wallet first"**
 


### PR DESCRIPTION
## Summary

Updates the supabase-auth-guide.mdx documentation to reflect the framework-kit migration done in [solana-foundation/templates#232](https://github.com/solana-foundation/templates/pull/232).

### Changes

- Update wallet connection explanation to use `useWalletConnection()` hook instead of `window.solana.connect()`
- Update error message from "Solana wallet not detected" to "No wallet connectors available" to match new implementation
- Update error handling text to reflect connector-based architecture
- Generalize Next.js version reference to "16" instead of specific patch version

### Context

The supabase-auth template was migrated from `@wallet-ui/*` + `gill` to `@solana/client` + `@solana/react-hooks` in templates#232. This PR updates the documentation to match the new implementation.