### PR TITLE
feat: add Tweet component for embedding X posts in MDX (#669)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -67,6 +67,7 @@
     "react-resizable-panels": "^2.1.8",
     "react-share": "^5.1.0",
     "react-slick": "^0.30.2",
+    "react-tweet": "^3.2.1",
     "rehype-raw": "^7.0.0",
     "remark-gfm": "^4.0.0",
     "rtl-detect": "^1.1.2",

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -1,5 +1,6 @@
 import "@/scss/index.scss";
 import "@/app/globals.css";
+import "react-tweet/theme.css";
 
 import CookieConsent from "@/components/CookieConsent/CookieConsent";
 import GTMTrackingSnippet from "@/components/GTMTrackingSnippet";

--- a/apps/web/src/app/components/tweet.tsx
+++ b/apps/web/src/app/components/tweet.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Tweet as ReactTweet } from "react-tweet";
+import { useTheme } from "@solana-com/ui-chrome";
+
+interface TweetProps {
+  id: string;
+  fallback?: React.ReactNode;
+}
+
+/**
+ * Tweet component for embedding X (Twitter) posts in MDX content.
+ * Renders tweets statically at build time with automatic dark/light theme support.
+ *
+ * @example
+ * ```mdx
+ * <Tweet id="1234567890123456789" />
+ * ```
+ */
+export function Tweet({ id, fallback }: TweetProps) {
+  const { theme } = useTheme();
+
+  return (
+    <div className="not-prose my-6">
+      <div data-theme={theme}>
+        <ReactTweet id={id} fallback={fallback} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -629,3 +629,81 @@ html {
     background-position: 120% 0;
   }
 }
+
+/* react-tweet theme integration */
+[data-theme="dark"] .react-tweet-theme {
+  --tweet-font-family: inherit;
+  --tweet-font-color: hsl(var(--foreground));
+  --tweet-font-color-secondary: hsl(var(--fd-muted-foreground));
+  --tweet-bg-color: hsl(var(--background));
+  --tweet-bg-color-hover: hsl(var(--fd-accent));
+  --tweet-quoted-bg-color: hsl(var(--fd-card));
+  --tweet-quoted-bg-color-hover: hsl(var(--fd-accent));
+  --tweet-color-blue-primary: hsl(164.47deg 100% 50%);
+  --tweet-color-blue-primary-hover: hsl(164.47deg 100% 45%);
+  --tweet-color-blue-secondary: hsl(164.47deg 100% 50% / 0.1);
+  --tweet-color-blue-secondary-hover: hsl(164.47deg 100% 50% / 0.15);
+  --tweet-twitter-icon-color: hsl(var(--fd-muted-foreground));
+  --tweet-verified-old-color: #1d9bf0;
+  --tweet-verified-blue-color: #1d9bf0;
+}
+
+[data-theme="light"] .react-tweet-theme {
+  --tweet-font-family: inherit;
+  --tweet-font-color: hsl(var(--foreground));
+  --tweet-font-color-secondary: hsl(var(--fd-muted-foreground));
+  --tweet-bg-color: hsl(var(--background));
+  --tweet-bg-color-hover: hsl(var(--fd-accent));
+  --tweet-quoted-bg-color: hsl(var(--fd-card));
+  --tweet-quoted-bg-color-hover: hsl(var(--fd-accent));
+  --tweet-color-blue-primary: hsl(267.1deg 100% 63.53%);
+  --tweet-color-blue-primary-hover: hsl(267.1deg 100% 58%);
+  --tweet-color-blue-secondary: hsl(267.1deg 100% 63.53% / 0.1);
+  --tweet-color-blue-secondary-hover: hsl(267.1deg 100% 63.53% / 0.15);
+  --tweet-twitter-icon-color: hsl(var(--fd-muted-foreground));
+  --tweet-verified-old-color: #1d9bf0;
+  --tweet-verified-blue-color: #1d9bf0;
+}
+
+/* Verification badge styling - position beside username */
+[data-theme] .react-tweet-theme svg[aria-label*="Verified"],
+[data-theme] .react-tweet-theme svg[data-testid*="verified"] {
+  width: 1.25rem !important;
+  height: 1.25rem !important;
+  fill: #1d9bf0 !important;
+  color: #1d9bf0 !important;
+  display: inline !important;
+  vertical-align: text-bottom !important;
+  margin-left: 0.25rem !important;
+  position: relative !important;
+  top: 2px !important;
+}
+
+/* Make the header info display inline */
+[data-theme] .react-tweet-theme .tweet-header,
+[data-theme] .react-tweet-theme [data-testid="tweet-header"] {
+  display: flex !important;
+  align-items: center !important;
+  flex-wrap: nowrap !important;
+}
+
+/* Ensure username and badge container stays inline */
+[data-theme] .react-tweet-theme .tweet-author,
+[data-theme] .react-tweet-theme [data-testid="tweet-author"] {
+  display: inline-flex !important;
+  align-items: center !important;
+  gap: 0.25rem !important;
+}
+
+/* Twitter/X icon at top right */
+[data-theme="dark"] .react-tweet-theme a[aria-label*="View on X"] svg,
+[data-theme="dark"] .react-tweet-theme a[aria-label*="View on Twitter"] svg {
+  fill: #fff !important;
+  color: #fff !important;
+}
+
+[data-theme="light"] .react-tweet-theme a[aria-label*="View on X"] svg,
+[data-theme="light"] .react-tweet-theme a[aria-label*="View on Twitter"] svg {
+  fill: #000 !important;
+  color: #000 !important;
+}

--- a/apps/web/src/app/mdx-components.tsx
+++ b/apps/web/src/app/mdx-components.tsx
@@ -19,6 +19,7 @@ import { Mermaid } from "./components/code/mermaid";
 import { Download, Rocket, Coins } from "lucide-react";
 import { ScrollyCoding } from "./components/code/scrollycoding";
 import { CodePlaceholder } from "./components/code/scrollycoding.client";
+import { Tweet } from "./components/tweet";
 
 export const mdxComponents = {
   ...defaultMdxComponents,
@@ -40,6 +41,7 @@ export const mdxComponents = {
   TerminalPicker,
   ScrollyCoding,
   CodePlaceholder,
+  Tweet,
   // Icons
   Download,
   Rocket,

--- a/packages/ui-chrome/src/index.ts
+++ b/packages/ui-chrome/src/index.ts
@@ -1,4 +1,4 @@
 export { Footer } from "./footer";
 export { Header } from "./header";
-export { ThemeProvider } from "./theme-provider";
+export { ThemeProvider, useTheme } from "./theme-provider";
 export { InkeepChatButton } from "./inkeep-chat-button";


### PR DESCRIPTION
Add a new Tweet component that allows embedding X (Twitter) posts in MDX documentation and blog content with the following features:

- Static rendering at build time using react-tweet library
- Automatic dark/light theme support with Solana brand colors
- Twitter-style blue verification badge (#1d9bf0)
- White Twitter icon in dark mode, black in light mode
- Simple syntax: <Tweet id="..." />
- Graceful fallback for deleted tweets
- No external JavaScript dependencies

Changes:
- Add Tweet component at apps/web/src/app/components/tweet.tsx
- Register component in MDX components registry
- Import react-tweet theme CSS in root layout
- Export useTheme hook from ui-chrome package
- Add custom CSS for badge and icon styling


Fixes #669