### PR TITLE
Update revocation permissions in revoke-delegate.mdx

### DIFF
--- a/apps/web/content/docs/en/tokens/basics/revoke-delegate.mdx
+++ b/apps/web/content/docs/en/tokens/basics/revoke-delegate.mdx
@@ -9,7 +9,8 @@ The
 [`Revoke`](https://github.com/solana-program/token/blob/a7c488ca39ed4cd71a87950ed854929816e9099f/interface/src/instruction.rs#L133C5-L133C11)
 instruction removes all transfer permissions from the currently approved
 delegate. After revocation, the delegate can no longer transfer any tokens from
-your account. Only the token account owner can revoke a delegate.
+your account. For the Token Program, only the token account owner can revoke a delegate.
+For the Token Extension Program, the token account owner and current delegate can revoke the delegation.
 
 <Callout type="info">
   The [Token


### PR DESCRIPTION
Clarify revocation permissions for Token and Token Extension Programs. TE allows for the current delegate to revoke its delegation authority from the token account. [code](https://github.com/solana-program/token-2022/blob/main/program/src/processor.rs#L644)