### PR TITLE
feat: add Phantom embedded wallet templates to landing page

### DIFF
--- a/apps/templates/src/lib/templates/filter-templates.ts
+++ b/apps/templates/src/lib/templates/filter-templates.ts
@@ -10,6 +10,9 @@ const DEFAULT_TEMPLATE_NAMES = [
   "web3js-expo", // Mobile
   "x402-template", // X402 Next.js
   "supabase-auth", // Auth
+  "phantom-embedded-react", // Phantom Embedded Wallet (Next.js)
+  "phantom-embedded-react-native-starter", // Phantom Embedded (React Native)
+  "phantom-embedded-js", // Phantom Embedded (Vite + JS)
 ];
 
 export function filterTemplates({


### PR DESCRIPTION
## Summary
- Adds all 3 Phantom embedded wallet templates to the default promoted templates on the templates landing page:
  - `phantom-embedded-react` - Next.js with Phantom SDK
  - `phantom-embedded-react-native-starter` - React Native/Expo
  - `phantom-embedded-js` - Vite + vanilla JS

## Context
The Phantom embedded wallet templates were recently merged and should be prominently featured on the templates landing page for discoverability.