### PR TITLE
fix: TypeScript error in docs by asserting blockhash lifetime

### DIFF
--- a/apps/web/content/docs/es/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/es/tokens/extensions/default-state.mdx
@@ -33,6 +33,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -151,6 +152,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/fi/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/fi/tokens/extensions/default-state.mdx
@@ -32,6 +32,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -150,6 +151,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/fr/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/fr/tokens/extensions/default-state.mdx
@@ -33,6 +33,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -151,6 +152,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/id/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/id/tokens/extensions/default-state.mdx
@@ -32,6 +32,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -150,6 +151,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/it/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/it/tokens/extensions/default-state.mdx
@@ -33,6 +33,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -151,6 +152,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/ja/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/ja/tokens/extensions/default-state.mdx
@@ -28,6 +28,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -146,6 +147,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/ko/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/ko/tokens/extensions/default-state.mdx
@@ -30,6 +30,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -148,6 +149,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/nl/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/nl/tokens/extensions/default-state.mdx
@@ -33,6 +33,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -151,6 +152,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/pl/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/pl/tokens/extensions/default-state.mdx
@@ -31,6 +31,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -149,6 +150,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/pt/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/pt/tokens/extensions/default-state.mdx
@@ -33,6 +33,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -151,6 +152,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/ru/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/ru/tokens/extensions/default-state.mdx
@@ -32,6 +32,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -150,6 +151,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/tr/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/tr/tokens/extensions/default-state.mdx
@@ -31,6 +31,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -149,6 +150,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/uk/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/uk/tokens/extensions/default-state.mdx
@@ -31,6 +31,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -149,6 +150,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/vi/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/vi/tokens/extensions/default-state.mdx
@@ -32,6 +32,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -150,6 +151,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(

--- a/apps/web/content/docs/zh/tokens/extensions/default-state.mdx
+++ b/apps/web/content/docs/zh/tokens/extensions/default-state.mdx
@@ -29,6 +29,7 @@ import {
 import {
   airdropFactory,
   appendTransactionMessageInstructions,
+  assertIsTransactionWithBlockhashLifetime,
   createSolanaRpc,
   createSolanaRpcSubscriptions,
   createTransactionMessage,
@@ -147,6 +148,9 @@ const transactionMessage = pipe(
 // Sign transaction message with all required signers
 const signedTransaction =
   await signTransactionMessageWithSigners(transactionMessage);
+
+// Assert blockhash-based transaction lifetime for TypeScript
+assertIsTransactionWithBlockhashLifetime(signedTransaction);
 
 // Send and confirm transaction
 await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(


### PR DESCRIPTION
Fixes a TypeScript error in the `default-state` docs by asserting a blockhash-based transaction lifetime. Updates all locales to keep examples consistent.

## Error (TypeScript)

```text
Type 'TransactionBlockhashLifetime | TransactionDurableNonceLifetime' is not assignable to type 'Omit<TransactionBlockhashLifetime, "blockhash">'.
Property 'lastValidBlockHeight' is missing in type 'TransactionDurableNonceLifetime'. ts(2345)
```

## Fix (TypeScript)
Adds `assertIsTransactionWithBlockhashLifetime(signedTransaction)` before calling `sendAndConfirmTransactionFactory(...)` to narrow the lifetime type.
