### PR TITLE
chore(privacyhack): Remove starpay (maybe temporarily)

### DIFF
--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -3738,6 +3738,13 @@
           "url": "https://x.com/solana_devs"
         },
         {
+          "title": "PNP Exchange Workshop",
+          "date": "Friday Jan 16 · 10:00am ET / 3:00pm UTC",
+          "speaker": "PNP Exchange Team",
+          "speakerTitle": "PNP Exchange",
+          "url": "https://x.com/solana_devs"
+        },
+        {
           "title": "Confidential Transfers",
           "date": "Friday Jan 16 · 12:00pm ET / 5:00pm UTC",
           "speaker": "Ilan Gitter",


### PR DESCRIPTION
### Problem

People are unable to get API access to Starpay. Apparently they have a bug and are fixing. We agreed to remove their bounty from the website until they are ready



