### PR TITLE
fix: add claude.md files for monorepo structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,135 @@
+# Solana.com Monorepo
+
+This is the official Solana Foundation website monorepo, containing multiple
+Next.js applications and shared packages deployed on Vercel.
+
+## Monorepo Structure
+
+```
+solana-com/
+├── apps/
+│   ├── web/          # Main website (solana.com) - port 3000
+│   ├── docs/         # Developer documentation - port 3003
+│   ├── media/        # Blog & news (TinaCMS) - port 3002
+│   └── templates/    # Code templates showcase - port 3001
+├── packages/
+│   ├── config-eslint/       # Shared ESLint configurations
+│   ├── config-typescript/   # Shared TypeScript configurations
+│   ├── i18n/                # Shared i18n utilities (next-intl)
+│   ├── ui/                  # Shared UI components (Radix-based)
+│   └── ui-chrome/           # Shared Header, Footer, Theme components
+└── turbo/
+    └── generators/          # Turborepo generators for scaffolding
+```
+
+## Tech Stack
+
+- **Runtime**: Node.js with pnpm 10.15.1 (workspace protocol)
+- **Framework**: Next.js 15.5.9 with App Router
+- **Language**: TypeScript 5.8.3
+- **UI Library**: React 19.1.2
+- **Styling**: Tailwind CSS 3.4+ / SCSS / styled-components
+- **i18n**: next-intl (20 supported languages)
+- **Build System**: Turborepo for monorepo orchestration
+- **Deployment**: Vercel (multi-project setup with rewrites)
+- **Error Tracking**: Sentry
+- **Analytics**: PostHog
+
+## Development Commands
+
+```bash
+# Install dependencies
+pnpm install
+
+# Development (all apps)
+pnpm dev
+
+# Development (specific app)
+pnpm dev --filter solana-com        # Main website
+pnpm dev --filter solana-docs       # Documentation
+pnpm dev --filter solana-com-media  # Blog/Media
+pnpm dev --filter solana-templates  # Templates
+
+# Build all apps
+pnpm build
+
+# Run tests
+pnpm test
+
+# Linting
+pnpm lint
+
+# Format code
+pnpm format:all
+pnpm format:check
+
+# Clean build artifacts
+pnpm clean
+```
+
+## Workspace Dependencies
+
+Apps import shared packages using workspace protocol:
+
+- `@workspace/i18n` - i18n configuration and utilities
+- `@workspace/ui` - Shared UI components (Button, Dialog, Accordion, etc.)
+- `@solana-com/ui-chrome` - Header, Footer, ThemeProvider, InkeepChatButton
+- `@workspace/config-eslint` - ESLint configurations
+- `@workspace/config-typescript` - TypeScript configurations
+
+## Internationalization
+
+Supported locales (configured in `packages/i18n/src/config.ts`):
+
+- English (en) - default
+- Arabic (ar), Chinese (zh), Dutch (nl), Finnish (fi), French (fr)
+- German (de), Greek (el), Hindi (hi), Indonesian (id), Italian (it)
+- Japanese (ja), Korean (ko), Polish (pl), Portuguese (pt), Russian (ru)
+- Spanish (es), Turkish (tr), Ukrainian (uk), Vietnamese (vi)
+
+All apps use `[locale]` dynamic routing pattern.
+
+## Environment Variables
+
+Key environment variables (defined in `turbo.json`):
+
+- `NEXT_PUBLIC_BUILDER_API_KEY` - Builder.io CMS
+- `NEXT_PUBLIC_TINA_CLIENT_ID` / `TINA_TOKEN` - TinaCMS for media app
+- `SENTRY_AUTH_TOKEN` - Error tracking
+- `SIMPLECAST_API_KEY` / `SIMPLECAST_PODCAST_ID` - Podcast integration
+- `YOUTUBE_API_KEY` / `YOUTUBE_CHANNEL_ID` - YouTube integration
+- `INKEEP_API_KEY` - AI chat assistant
+
+## Git Hooks (Husky)
+
+Pre-commit hook runs:
+
+1. `pnpm format:check` - Prettier formatting check
+2. `pnpm lint` - ESLint across all workspaces
+
+## Code Conventions
+
+- Use TypeScript strict mode
+- Prefer functional React components with hooks
+- Use Radix UI primitives for accessible components
+- CSS: Prefer Tailwind utilities, use SCSS for complex styles
+- Import shared components from workspace packages, not relative paths
+- SVG handling: Use `.inline.svg` suffix for React components, regular `.svg`
+  for assets
+
+## PR Guidelines
+
+PRs should include:
+
+1. Problem description
+2. Summary of changes
+3. Reference to related issues (`Fixes #...`)
+
+## Sub-app Documentation
+
+Each app has its own CLAUDE.md with app-specific details:
+
+- `apps/web/CLAUDE.md` - Main website
+- `apps/docs/CLAUDE.md` - Documentation site
+- `apps/media/CLAUDE.md` - Blog/Media site
+- `apps/templates/CLAUDE.md` - Templates showcase

--- a/apps/docs/CLAUDE.md
+++ b/apps/docs/CLAUDE.md
@@ -1,0 +1,191 @@
+# Solana Docs - Developer Documentation
+
+> See root `/CLAUDE.md` for monorepo-wide configuration and shared tooling.
+
+## Overview
+
+The Solana developer documentation site, providing comprehensive guides, API
+references, cookbook recipes, and learning resources for building on Solana.
+
+**Package name**: `solana-docs` **Default port**: 3003 **Asset prefix**:
+`/docs-assets`
+
+## Tech Stack
+
+- **Framework**: Next.js 15 (App Router) with next-intl
+- **Documentation**: Fumadocs (MDX-based documentation framework)
+- **Code Highlighting**: CodeHike for advanced code blocks
+- **Diagrams**: Mermaid for flowcharts and diagrams
+- **Styling**: Tailwind CSS, SCSS, styled-components
+- **AI Integration**: Vercel AI SDK with OpenAI
+- **UI Components**: Radix UI primitives, Fumadocs UI
+
+## Project Structure
+
+```
+apps/docs/
+├── src/
+│   ├── app/
+│   │   └── [locale]/
+│   │       ├── developers/
+│   │       │   ├── cookbook/     # Code recipes
+│   │       │   └── guides/       # Step-by-step guides
+│   │       └── docs/
+│   │           ├── (main)/       # Core documentation
+│   │           └── rpc/          # RPC API reference
+│   ├── components/               # React components
+│   ├── constants/                # App constants
+│   ├── hooks/                    # Custom React hooks
+│   ├── i18n/                     # i18n configuration
+│   ├── lib/                      # Utility libraries
+│   ├── markdown/                 # MDX processing utilities
+│   ├── scss/                     # SCSS stylesheets
+│   ├── types/                    # TypeScript types
+│   └── utils/                    # Helper utilities
+├── content/
+│   ├── cookbook/                 # Cookbook MDX files
+│   │   ├── accounts/
+│   │   ├── development/
+│   │   ├── tokens/
+│   │   ├── transactions/
+│   │   └── wallets/
+│   ├── docs/                     # Main docs (localized)
+│   │   ├── en/                   # English docs
+│   │   ├── ar/, de/, es/...      # Translated docs
+│   └── guides/                   # Developer guides
+├── assets/                       # Static assets
+└── public/                       # Public files
+```
+
+## Local Development
+
+```bash
+# From monorepo root
+pnpm dev --filter solana-docs
+
+# Or from this directory
+pnpm dev
+
+# Regenerate MDX sources (after content changes)
+pnpm postinstall  # Runs fumadocs-mdx
+
+# Lint
+pnpm lint
+pnpm lint:fix
+
+# Analyze bundle
+ANALYZE=true pnpm build
+```
+
+## Content Structure
+
+### Fumadocs MDX
+
+Content is organized using Fumadocs conventions:
+
+- Files in `content/` are processed by `fumadocs-mdx`
+- Generated source maps stored in `.source/` (gitignored)
+- Supports frontmatter for metadata
+
+### Content Categories
+
+1. **Docs** (`/docs/*`) - Core Solana documentation
+   - Core concepts (accounts, transactions, programs)
+   - Client libraries (JavaScript, Rust, Python)
+   - RPC API reference
+   - Staking documentation
+
+2. **Cookbook** (`/developers/cookbook/*`) - Code recipes
+   - Accounts management
+   - Token operations
+   - Transaction handling
+   - Wallet integration
+
+3. **Guides** (`/developers/guides/*`) - Step-by-step tutorials
+
+### Localization
+
+Documentation is translated into multiple languages:
+
+- Content stored in `content/docs/{locale}/`
+- Uses next-intl for routing
+- English (en) is the source language
+
+## Key Features
+
+### CodeHike Integration
+
+Advanced code blocks with:
+
+- Syntax highlighting
+- Line highlighting
+- Code annotations
+- File tabs
+
+### Mermaid Diagrams
+
+Flowcharts and sequence diagrams rendered from markdown.
+
+### AI Chat (Vercel AI SDK)
+
+- OpenAI integration for documentation search
+- Configured via `@ai-sdk/openai`
+
+## Key Dependencies (App-Specific)
+
+- `fumadocs-core`, `fumadocs-mdx`, `fumadocs-ui` - Documentation framework
+- `codehike` - Advanced code blocks
+- `mermaid` - Diagram rendering
+- `ai`, `@ai-sdk/openai` - AI integration
+- `seti-icons` - File type icons
+- `svg-pan-zoom` - Zoomable diagrams
+- `zod` - Schema validation
+
+## API Routes
+
+Located in `src/app/api/`:
+
+- AI chat endpoints
+- Search functionality
+
+## Build Configuration
+
+- Asset prefix: `/docs-assets` for Vercel multi-project deployment
+- Memory allocation: 8192MB for builds
+- Sentry integration for error tracking
+- Fumadocs MDX processing runs on postinstall
+
+## Environment Variables
+
+- `DEVELOPER_CONTENT_API_KEY` - Content API access
+- `DEVELOPER_DATA_API_KEY` - Data API access
+- `DEVELOPER_DATA_API_URL` - Data API endpoint
+
+## Content Conventions
+
+### MDX Frontmatter
+
+```yaml
+---
+title: Page Title
+description: Page description
+sidebarLabel: Sidebar Label (optional)
+sidebarSortOrder: 1 (optional)
+---
+```
+
+### Code Blocks
+
+Use CodeHike syntax for enhanced code blocks:
+
+````mdx
+```ts title="example.ts" {1,3-5}
+// highlighted lines
+```
+````
+
+```
+
+### Cross-References
+Link to other docs using relative paths or Fumadocs link syntax.
+```

--- a/apps/media/CLAUDE.md
+++ b/apps/media/CLAUDE.md
@@ -1,0 +1,217 @@
+# Solana Media - Blog & News
+
+> See root `/CLAUDE.md` for monorepo-wide configuration and shared tooling.
+
+## Overview
+
+The Solana blog and media site, powered by TinaCMS for content management. Includes blog posts, podcasts, and marketing content with a visual CMS editing experience.
+
+**Package name**: `solana-com-media`
+**Default port**: 3002
+**Asset prefix**: `/media-assets`
+
+## Tech Stack
+
+- **Framework**: Next.js 15 (App Router) with next-intl
+- **CMS**: TinaCMS (Git-backed headless CMS)
+- **Styling**: Tailwind CSS 4.x (latest), tw-animate-css
+- **Animation**: Motion (formerly Framer Motion)
+- **Code Highlighting**: Shiki
+- **Diagrams**: Mermaid
+- **UI Components**: Radix UI, Headless UI
+
+## Project Structure
+
+```
+apps/media/
+├── app/
+│   ├── [locale]/              # Locale-based routing
+│   │   ├── news/              # Blog posts listing
+│   │   ├── podcast/           # Podcast episodes
+│   │   └── [...slug]/         # Dynamic content pages
+│   ├── admin/                 # TinaCMS admin interface
+│   └── api/                   # API routes (RSS, etc.)
+├── components/
+│   ├── blocks/                # Content block components
+│   ├── layout/                # Layout components
+│   ├── podcast/               # Podcast components
+│   ├── post/                  # Blog post components
+│   ├── ui/                    # UI primitives
+│   ├── magicui/               # Magic UI effects
+│   └── motion-primitives/     # Animation primitives
+├── content/                   # TinaCMS content (MDX/JSON)
+│   ├── authors/               # Author profiles
+│   ├── categories/            # Post categories
+│   ├── ctas/                  # Call-to-action blocks
+│   ├── global/                # Global settings
+│   ├── links/                 # Link collections
+│   ├── podcasts/              # Podcast episodes
+│   ├── posts/                 # Blog posts (MDX)
+│   ├── switchbacks/           # Switchback sections
+│   └── tags/                  # Content tags
+├── tina/
+│   ├── config.tsx             # TinaCMS configuration
+│   ├── collection/            # Content collection schemas
+│   ├── fields/                # Custom field definitions
+│   ├── queries/               # GraphQL queries
+│   └── __generated__/         # Generated types (gitignored)
+├── lib/                       # Utility libraries
+├── i18n/                      # i18n configuration
+├── scripts/                   # Build scripts
+├── public/                    # Static files
+│   └── uploads/               # Media uploads
+└── openspec/                  # OpenAPI specifications
+```
+
+## Local Development
+
+```bash
+# Development with TinaCMS (recommended)
+pnpm dev
+
+# Development without TinaCMS
+pnpm dev:build && next dev
+
+# Build for production
+pnpm build
+
+# Build with local TinaCMS (no auth)
+pnpm build-local
+
+# Build with public local mode
+pnpm build-public
+
+# Format content files
+pnpm format:content
+
+# Clean generated files
+pnpm clean
+```
+
+## TinaCMS Configuration
+
+### Collections
+
+Defined in `tina/collection/`:
+
+- **Post** - Blog posts with rich content blocks
+- **Podcast** - Podcast episodes with audio links
+- **Author** - Author profiles
+- **Category** - Post categories
+- **Tag** - Content tags
+- **CTA** - Call-to-action blocks
+- **Switchback** - Alternating content sections
+- **Global** - Site-wide settings
+- **Link** - Reusable link collections
+
+### Content Schema
+
+Each collection has:
+
+- TypeScript schema in `tina/collection/*.ts`
+- Custom fields in `tina/fields/`
+- Generated types in `tina/__generated__/`
+
+### Admin Interface
+
+Access the CMS at `/admin`:
+
+- Visual editing interface
+- Media management (uploads to `public/uploads/`)
+- Branch switcher for content staging
+
+### Environment Variables
+
+```bash
+NEXT_PUBLIC_TINA_CLIENT_ID  # TinaCMS client ID
+NEXT_PUBLIC_TINA_BRANCH     # Git branch for content
+TINA_TOKEN                  # TinaCMS API token
+TINA_SEARCH_INDEXER_TOKEN   # Search indexing token
+TINA_PUBLIC_IS_LOCAL        # Set "true" for local mode
+```
+
+## Content Authoring
+
+### Blog Posts
+
+Posts are MDX files in `content/posts/`:
+
+```mdx
+---
+title: Post Title
+date: 2024-01-15
+author: content/authors/name.json
+category: content/categories/tech.json
+tags:
+  - content/tags/solana.json
+heroImage: /uploads/hero.jpg
+---
+
+Content here with **markdown** support.
+```
+
+### Content Blocks
+
+Posts can include rich content blocks:
+
+- Code blocks with Shiki highlighting
+- Embedded tweets (react-tweet)
+- Video embeds (react-player)
+- Mermaid diagrams
+- Custom CTA blocks
+
+### Podcasts
+
+Podcast episodes link to Simplecast:
+
+- `SIMPLECAST_API_KEY` - API access
+- `SIMPLECAST_PODCAST_ID` - Podcast identifier
+
+## Key Dependencies (App-Specific)
+
+- `tinacms`, `@tinacms/cli` - CMS framework
+- `shiki` - Code syntax highlighting
+- `react-tweet` - Twitter/X embeds
+- `react-player` - Video playback
+- `mermaid` - Diagram rendering
+- `feed` - RSS feed generation
+- `rss-parser` - RSS parsing
+- `motion` - Animations
+- `usehooks-ts` - React hooks collection
+
+## API Routes
+
+- `/api/rss` - RSS feed generation
+- TinaCMS API routes (auto-generated)
+
+## Build Process
+
+The build script (`scripts/build.sh`) handles:
+
+1. TinaCMS build (generates GraphQL client)
+2. Next.js build
+3. Conditional local vs cloud mode
+
+## Lint-Staged Configuration
+
+Pre-commit formatting:
+
+- JS/TS files: ESLint + Prettier
+- MDX/MD files: Prettier
+- JSON/YAML files: Prettier
+
+## Image Handling
+
+- Local uploads: `public/uploads/`
+- Remote images allowed from:
+  - `assets.tina.io` (TinaCMS media)
+  - `res.cloudinary.com`
+  - `*.cloudfront.net`
+  - `assets.getriver.io`
+
+## Gotchas
+
+1. **Generated Files**: Run `pnpm clean` to clear `tina/__generated__/` if types are stale
+2. **Local Mode**: Set `TINA_PUBLIC_IS_LOCAL=true` to bypass authentication
+3. **Branch Content**: TinaCMS uses Git branches for content staging
+4. **Asset Prefix**: All assets served from `/media-assets/` path

--- a/apps/templates/CLAUDE.md
+++ b/apps/templates/CLAUDE.md
@@ -1,0 +1,139 @@
+# Solana Templates - Code Templates Showcase
+
+> See root `/CLAUDE.md` for monorepo-wide configuration and shared tooling.
+
+## Overview
+
+A showcase site for Solana code templates and starter projects. Provides
+browsable templates with filtering, search, and direct links to GitHub
+repositories.
+
+**Package name**: `solana-templates` **Default port**: 3001 **Asset prefix**:
+`/templates-assets`
+
+## Tech Stack
+
+- **Framework**: Next.js 15 (App Router) with next-intl
+- **Styling**: Tailwind CSS 3.4, SCSS, styled-components
+- **Animation**: Framer Motion
+- **Code Highlighting**: Shiki
+- **URL State**: nuqs (type-safe URL search params)
+- **UI Components**: Radix UI, React Bootstrap, Lucide icons
+
+## Project Structure
+
+```
+apps/templates/
+├── src/
+│   ├── app/
+│   │   ├── layout.tsx         # Root layout (no [locale] wrapper)
+│   │   ├── page.tsx           # Homepage
+│   │   └── [slug]/            # Template detail pages
+│   ├── components/            # React components
+│   │   ├── TemplateCard/
+│   │   ├── TemplateGrid/
+│   │   ├── FilterSidebar/
+│   │   └── SearchBar/
+│   ├── fonts/                 # Custom fonts
+│   ├── i18n/                  # i18n configuration
+│   ├── lib/                   # Utility libraries
+│   ├── scss/                  # SCSS stylesheets
+│   └── types/                 # TypeScript types
+├── public/                    # Static files
+└── next.config.ts
+```
+
+## Local Development
+
+```bash
+# From monorepo root
+pnpm dev --filter solana-templates
+
+# Or from this directory
+pnpm dev
+
+# Type checking
+pnpm check-types
+
+# Lint
+pnpm lint
+pnpm lint:fix
+```
+
+## Key Features
+
+### Template Discovery
+
+- Browse Solana starter templates
+- Filter by category, framework, difficulty
+- Search functionality with URL state persistence
+
+### URL State Management
+
+Uses `nuqs` for type-safe URL search params:
+
+```typescript
+import { parseAsString, useQueryState } from "nuqs";
+
+const [search, setSearch] = useQueryState("q", parseAsString);
+const [category, setCategory] = useQueryState("category", parseAsString);
+```
+
+### Template Data
+
+Templates sourced from `solana-foundation/templates` GitHub repository:
+
+- Images from `raw.githubusercontent.com/solana-foundation/templates/**`
+- Metadata and descriptions
+
+## Key Dependencies (App-Specific)
+
+- `nuqs` - URL search params state management
+- `shiki` - Code syntax highlighting
+- `marked` - Markdown parsing
+- `framer-motion` - Animations
+- `@inkeep/cxkit-react` - AI chat assistant
+- `@workspace/ui` - Shared UI components
+
+## Routing
+
+Unlike other apps, templates uses simpler routing:
+
+- No `[locale]` dynamic segment in most routes
+- i18n handled via next-intl plugin
+- Template detail pages: `/[slug]`
+
+## Image Configuration
+
+Allowed remote image sources:
+
+- `raw.githubusercontent.com/solana-foundation/templates/**` - Template
+  screenshots
+- `placehold.co` - Placeholder images
+
+## Environment Variables
+
+- `TEMPLATES_APP_URL` - Base URL for the templates app
+- Standard shared env vars from root turbo.json
+
+## Build Configuration
+
+- Asset prefix: `/templates-assets` for Vercel multi-project setup
+- styled-components compiler enabled
+- External workspace packages transpiled via `experimental.externalDir`
+
+## Styling
+
+Combines multiple styling approaches:
+
+- Tailwind CSS for utility classes
+- SCSS for custom styles
+- styled-components for component styles
+- Bootstrap utilities via react-bootstrap
+
+## Conventions
+
+1. **Components**: Functional components with TypeScript
+2. **State**: URL state for filters/search (shareable links)
+3. **Data**: Templates metadata fetched from GitHub API
+4. **Images**: Optimized via Next.js Image from GitHub raw URLs

--- a/apps/web/CLAUDE.md
+++ b/apps/web/CLAUDE.md
@@ -1,0 +1,130 @@
+# Solana.com - Main Website
+
+> See root `/CLAUDE.md` for monorepo-wide configuration and shared tooling.
+
+## Overview
+
+The main Solana website (`solana.com`) serving landing pages, ecosystem
+information, events, news aggregation, and marketing content.
+
+**Package name**: `solana-com` **Default port**: 3000
+
+## Tech Stack
+
+- **Framework**: Next.js 15 (App Router) with next-intl
+- **Styling**: Tailwind CSS, SCSS, styled-components, Bootstrap 5
+- **Animation**: Framer Motion, GSAP
+- **CMS**: Builder.io for dynamic content and redirects
+- **UI Components**: Radix UI primitives, React Bootstrap
+- **Testing**: Jest + React Testing Library
+- **Icons**: Lucide React, React Feather
+
+## Project Structure
+
+```
+apps/web/
+├── src/
+│   ├── app/
+│   │   └── [locale]/          # Locale-based routing
+│   │       ├── (home)/        # Homepage routes
+│   │       ├── ai/            # AI-related pages
+│   │       ├── breakpoint/    # Breakpoint conference
+│   │       ├── branding/      # Brand assets
+│   │       ├── developers/    # Developer resources
+│   │       ├── ecosystem/     # Ecosystem directory
+│   │       ├── events/        # Events calendar
+│   │       ├── news/          # News aggregation
+│   │       ├── solutions/     # Solutions pages
+│   │       └── x402/          # X402 special section
+│   ├── components/            # React components
+│   ├── component-library/     # Design system components
+│   ├── constants/             # App constants
+│   ├── data/                  # Static data files
+│   ├── hooks/                 # Custom React hooks
+│   ├── i18n/                  # i18n configuration
+│   ├── lib/                   # Utility libraries
+│   ├── pages/                 # Legacy pages (being migrated)
+│   ├── scss/                  # SCSS stylesheets
+│   ├── types/                 # TypeScript types
+│   └── utils/                 # Helper utilities
+├── assets/                    # Static assets by section
+├── content/guides/            # MDX guide content
+├── public/                    # Public static files
+└── __tests__/                 # Jest tests
+```
+
+## Local Development
+
+```bash
+# From monorepo root
+pnpm dev --filter solana-com
+
+# Or from this directory
+pnpm dev
+
+# Run tests
+pnpm test
+
+# Lint
+pnpm lint
+pnpm lint:fix
+
+# Analyze bundle
+ANALYZE=true pnpm build
+```
+
+## Key Integrations
+
+### Builder.io CMS
+
+- Dynamic page content
+- URL redirects management (fetched at build time)
+- API Key: `NEXT_PUBLIC_BUILDER_API_KEY`
+
+### External APIs
+
+- **Luma** - Events calendar (`LUMA_PRIVATE_API_KEY`)
+- **YouTube** - Video content (`YOUTUBE_API_KEY`, `YOUTUBE_CHANNEL_ID`)
+- **River** - Newsletter integration (`RIVER_KEY`)
+- **Inkeep** - AI chat assistant (`INKEEP_API_KEY`)
+
+### PostHog Analytics
+
+- Client-side analytics via `posthog-js`
+
+## SVG Handling
+
+- `*.inline.svg` - Imported as React components via @svgr/webpack
+- `*.svg` - Imported as static assets
+
+## Routing Patterns
+
+- All routes are under `[locale]` for i18n support
+- Uses Next.js App Router with layouts and route groups
+- Rewrites and redirects managed in `rewrites-redirects.mjs` + Builder.io
+
+## Key Dependencies (App-Specific)
+
+- `@builder.io/react` - Builder.io CMS integration
+- `@typeform/embed` - Typeform embeds
+- `gsap` - GreenSock animations (transpiled via next.config)
+- `react-slick` / `slick-carousel` - Carousels
+- `react-player` - Video playback
+- `react-countup` - Animated counters
+- `swr` - Data fetching with caching
+- `unicornstudio-react` - Interactive backgrounds
+
+## Build Configuration
+
+- Memory allocation: 8192MB for builds
+- Sentry source maps uploaded in production only
+- Sitemap generated via `next-sitemap` postbuild
+
+## Testing
+
+```bash
+pnpm test          # Run all tests
+pnpm test:watch    # Watch mode
+```
+
+Tests located in `src/__tests__/` using Jest and React Testing Library.


### PR DESCRIPTION
## Summary
Add CLAUDE.md documentation files to provide context for AI assistants (Claude Code) working with this monorepo. These files document the project structure, tech stack, development commands, and conventions.

## Changes
- Add root `CLAUDE.md` with monorepo overview, tech stack, commands, and code conventions
- Add `apps/web/CLAUDE.md` with main website-specific details
- Add `apps/docs/CLAUDE.md` with documentation site specifics
- Add `apps/media/CLAUDE.md` with blog/media site and TinaCMS details
- Add `apps/templates/CLAUDE.md` with templates showcase specifics

## Testing
Documentation-only changes - no code changes to test.

## Related Issues
N/A