### PR TITLE
docs: add solana keychain references to documentation

### DIFF
--- a/apps/docs/content/docs/en/clients/official/javascript.mdx
+++ b/apps/docs/content/docs/en/clients/official/javascript.mdx
@@ -49,7 +49,7 @@ For kit-compatible backend signing across multiple key management backends:
 
 | Package           | Description                                                          | GitHub                                                             |
 | ----------------- | -------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| @solana/keychain  | Unified signing: Memory, Vault, AWS KMS, Privy, Turnkey, Fireblocks  | [Source](https://github.com/solana-foundation/solana-keychain)     |
+| @solana/keychain  | Unified signing: Memory, Vault, AWS KMS, Privy, Turnkey, Fireblocks, CDP, Dfns, Para  | [Source](https://github.com/solana-foundation/solana-keychain)     |
 
 See the [Adding Signers guide](https://github.com/solana-foundation/solana-keychain/blob/main/docs/ADDING_SIGNERS.md) to integrate additional key management services.
 

--- a/apps/docs/content/docs/en/clients/official/rust.mdx
+++ b/apps/docs/content/docs/en/clients/official/rust.mdx
@@ -95,6 +95,6 @@ For production backend signing across multiple key management backends:
 
 | Crate            | Description                                                          | Docs                                              | GitHub                                                             |
 | ---------------- | -------------------------------------------------------------------- | ------------------------------------------------- | ------------------------------------------------------------------ |
-| solana-keychain  | Unified signing: Memory, Vault, AWS KMS, Privy, Turnkey, Fireblocks  | [Crate](https://crates.io/crates/solana-keychain) | [Source](https://github.com/solana-foundation/solana-keychain)     |
+| solana-keychain  | Unified signing: Memory, Vault, AWS KMS, Privy, Turnkey, Fireblocks, CDP, Dfns, Para  | [Crate](https://crates.io/crates/solana-keychain) | [Source](https://github.com/solana-foundation/solana-keychain)     |
 
 Use feature flags to include only the backends you need. See the [Adding Signers guide](https://github.com/solana-foundation/solana-keychain/blob/main/docs/ADDING_SIGNERS.md) to integrate additional key management services.

--- a/apps/docs/content/docs/en/payments/developer-tools.mdx
+++ b/apps/docs/content/docs/en/payments/developer-tools.mdx
@@ -19,7 +19,7 @@ description: Third-party platforms and services for building payments on Solana
 | Solana Kit (`@solana/kit`)                       | Solana JavaScript Primitives                        | [GitHub](https://github.com/anza-xyz/kit) • [Docs](https://www.solanakit.com/) • [npm](https://www.npmjs.com/package/@solana/kit)                                                 |
 | Solana Client (`@solana/client`)                 | JS Client for Solana built on Solana Kit            | [GitHub](https://github.com/solana-foundation/framework-kit) • [Docs](https://www.framework-kit.com/) • [npm](https://www.npmjs.com/package/@solana/client)                       |
 | Solana React (`@solana/react`)                   | React hooks for wallets/balances/tx (Framework Kit) | [GitHub](https://github.com/solana-foundation/framework-kit) • [Docs](https://solana.com/docs/frontend/react-hooks) • [npm](https://www.npmjs.com/package/@solana/react)          |
-| Solana Keychain (`@solana/keychain`)             | Unified signing across Vault, KMS, Privy, Turnkey, Fireblocks | [GitHub](https://github.com/solana-foundation/solana-keychain) • [npm](https://www.npmjs.com/package/@solana/keychain)                                                            |
+| Solana Keychain (`@solana/keychain`)             | Unified signing across Vault, KMS, Privy, Turnkey, Fireblocks, CDP, Dfns, Para | [GitHub](https://github.com/solana-foundation/solana-keychain) • [npm](https://www.npmjs.com/package/@solana/keychain)                                                            |
 | Token Program Client (`@solana-program/token`)   | JS Client for SPL Token program                     | [GitHub](https://github.com/solana-program/token) • [npm](https://www.npmjs.com/package/@solana-program/token) • [Docs](https://www.solana-program.com/docs/token)                |
 | Token-2022 Client (`@solana-program/token-2022`) | JS Client for Token-2022 + extensions               | [GitHub](https://github.com/solana-program/token-2022) • [npm](https://www.npmjs.com/package/@solana-program/token-2022) • [Docs](https://www.solana-program.com/docs/token-2022) |
 | Memo Program Client (`@solana-program/memo`)     | JS Client for Memo program                          | [GitHub](https://github.com/solana-program/memo) • [npm](https://www.npmjs.com/package/@solana-program/memo) • [Docs](https://www.solana-program.com/docs/memo)                   |
@@ -30,7 +30,7 @@ description: Third-party platforms and services for building payments on Solana
 | ---------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ |
 | Solana Rust SDK  | Rust SDK for writing client side applications in Rust             | [GitHub](https://github.com/anza-xyz/solana-sdk) • [Crate](https://crates.io/crates/solana-sdk)              |
 | Solana Program   | Rust SDK for writing Solana programs                              | [GitHub](https://github.com/anza-xyz/solana-sdk) • [Crate](https://crates.io/crates/solana-program)          |
-| Solana Keychain  | Unified signing across Vault, KMS, Privy, Turnkey, Fireblocks     | [GitHub](https://github.com/solana-foundation/solana-keychain) • [Crate](https://crates.io/crates/solana-keychain) |
+| Solana Keychain  | Unified signing across Vault, KMS, Privy, Turnkey, Fireblocks, CDP, Dfns, Para     | [GitHub](https://github.com/solana-foundation/solana-keychain) • [Crate](https://crates.io/crates/solana-keychain) |
 
 ### Python SDKs
 

--- a/apps/docs/content/docs/en/payments/production-readiness.mdx
+++ b/apps/docs/content/docs/en/payments/production-readiness.mdx
@@ -411,7 +411,7 @@ for complete implementation.
 For production backend signing, consider using
 [solana-keychain](https://github.com/solana-foundation/solana-keychain)—a
 unified signing library that abstracts multiple key management backends
-through a single interface: Memory, Vault, AWS KMS, Privy, Turnkey, Fireblocks.
+through a single interface: Memory, Vault, AWS KMS, Privy, Turnkey, Fireblocks, CDP, Dfns, Para.
 This allows you to develop locally with in-memory keys, then swap to
 production-grade backends without changing application code.
 


### PR DESCRIPTION
### Problem
Do not have documentation references for Solana Keychain 

### Summary of Changes

- Add @solana/keychain to JavaScript SDK signing section
- Add solana-keychain to Rust SDK signing section
- Add keychain to developer tools table
- Add signing infrastructure section to production readiness

Fixes # PRO-770