### PR TITLE
Article: Refreshed upgrades page.

### DIFF
--- a/apps/media/content/posts/solana-network-upgrades.mdx
+++ b/apps/media/content/posts/solana-network-upgrades.mdx
@@ -2,9 +2,9 @@
 title: Solana Network Upgrades
 description: >-
   A regularly-updated page giving the status of upgrades to the Solana network:
-  QUIC, QoS, fee markets, and more.
+  Alpenglow, 100M CUs, SIMD 123, and more.
 slug: solana-network-upgrades
-date: "2022-12-13"
+date: "2026-2-3"
 categories:
   - category: content/categories/finance.mdx
   - category: content/categories/upgrades.mdx
@@ -13,8 +13,8 @@ status: published
 seo:
   title: Solana Network Upgrades
   description: >-
-    A regularly-updated page giving the status of upgrades to the Solana
-    network: QUIC, QoS, fee markets, and more.
+    A regularly-updated page giving the status of upgrades to the Solana network:
+    Alpenglow, 100M CUs, SIMD 123, and more.
   image: /uploads/builder/solana-network-upgrades/ec9179222f514efd84eb1643f68f42b3.png
   noIndex: false
   noFollow: false
@@ -22,73 +22,104 @@ seo:
     ogTitle: Solana Network Upgrades
     ogUrl: ""
     ogDescription: >-
-      A regularly-updated page giving the status of upgrades to the Solana
-      network: QUIC, QoS, fee markets, and more.
+      A regularly-updated page giving the status of upgrades to the Solana network:
+      Alpenglow, 100M CUs, SIMD 123, and more.
     ogType:
       - article
   twitter:
     twitterTitle: Solana Network Upgrades
     twitterDescription: >-
-      A regularly-updated page giving the status of upgrades to the Solana
-      network: QUIC, QoS, fee markets, and more.
+      A regularly-updated page giving the status of upgrades to the Solana network:
+      Alpenglow, 100M CUs, SIMD 123, and more.
 author: content/authors/solana-foundation.md
 tags:
   - tag: content/tags/announcements.mdx
 ---
 
-In order to strengthen the Solana network in the face of massive user growth and adoption, engineers have been working on a number of upgrades. This page will allow the greater Solana community to see how these upgrades are progressing.
+The Solana network continues to ship major protocol upgrades as the network scales with growing demand. This page is a technical roadmap of key features planned for upcoming releases. Version numbers and timelines are subject to change as development progresses.
 
-Last updated 14 December 2022
+Last updated 3 February 2026
 
-## **QUIC**
+## **Vote Account V4**
 
-**STATUS:**  🟢 Live on Mainnet-beta.
+**STATUS:** 🟡 Under development. Expected by Agave 3.1
 
-Solana uses a custom raw UDP-based protocol to pass transactions between RPC nodes and the current leader. Since UDP is connectionless and lacks both flow control and receipt acknowledgments, there is no meaningful way to discourage or mitigate abusive behavior. In order to affect control over network traffic, Solana's transaction ingestion protocol is being reimplemented atop QUIC, a protocol built by Google, designed for fast asynchronous communication like UDP, but with sessions and flow control like TCP. Once adopted, there will be additional options available to adapt and optimize data ingestion.
+Vote accounts are how validators participate in Solana's consensus mechanism. Currently, vote accounts use space inefficiently—over 40% of the account stores a history of previous authorized voters that is rarely needed. Vote Account V4 modernizes this structure to be leaner and more flexible.
 
-QUIC is currently adopted by the majority of validators and RPC operators on Mainnet-beta. In the upcoming 1.13.4 release, QUIC will be the default transaction ingestion protocol over UDP. With 1.13.4, QUIC will be fully adopted.
+The upgrade removes unnecessary historical tracking and introduces separate commission settings for different types of validator revenue. This means validators can set one commission rate for inflation rewards and a different rate for block revenue from transaction fees. Vote Account V4 is a foundational requirement for other upcoming features, particularly block revenue distribution to delegators and Alpenglow.
 
-## **Stake-weighted QoS**
+## **Rent Reduction**
 
-**STATUS:** 🟢 Live on Mainnet-beta.
+**STATUS:** 🟡 Under development. Expected by Agave 4.0
 
-Leader network bandwidth has a fixed capacity. To effectively use it, stake-weighting is needed to end the practice of indiscriminately accepting transactions on a first-come-first-served basis, without regard for source. Given that Solana is a proof of stake network, it is natural to extend the utility of stake-weighting to transaction quality of service. Under this model, for example, a node with 0.5% stake will have the right to transmit at least 0.5% of the packets to the leader, while the rest of the network – and no combination of the remaining stake – will be able to fully wash them out.
+The Solana protocol requires a rent deposit every time an account is opened. Rent is a misnomer: the deposit is actually a redeemable bond that is recovered whenever the account is closed. The cost of the rent is denoted in lamports per byte. Rent reduction will gradually reduce lamports per byte in a series of feature activations, allowing new Solana accounts to be created at a reduced rent amount. This makes it more affordable for developers to build applications and for users to interact with the network, potentially reducing costs by up to 90%.
 
-Stake-weighted QoS was built in parallel with QUIC and enabled before QUIC was adopted on Mainnet-beta.
+## **Alpenglow**
 
-## **Fee markets**
+**STATUS:** 🟡 Under development. Expected by Agave 4.1
 
-**STATUS:** 🟢 Live on Mainnet-beta, with RPC and wallet support coming soon.
+[Follow progress on Github.](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0326-alpenglow.md)
 
-[Follow progress on Github.](https://github.com/solana-labs/solana/pull/25406)
+Alpenglow is a state-of-the-art consensus protocol that will bring 150ms confirmation times to Solana. Existing protocol features such as Proof of History (PoH) and on-chain vote transactions will be removed to make way for a simpler mechanism in Alpenglow. This represents a fundamental simplification of how the network agrees on blocks, materially improving reliability while sharply reducing confirmation times.
 
-Once ingested, transactions still compete for modifying shared account data. This contention has been dealt with by a simple first-come-first-served similar to network data ingestions, leaving users no means to express the urgency of their transaction execution. Fee markets provide a way for a user to add an additional fee to their transactions to express urgency in comparison to other transactions modifying the same account. The first step of creating fee markets is implementing priority fees, which offer users the ability to specify an additional fee at their discretion to be collected upon the execution of a transaction and its inclusion in a block. Priority fees are calculated based on the amount of computing resources that a transaction is expected to require. For example, a simple token transfer would require a lower total priority fee than an NFT mint that expresses the same level of urgency.
+Alpenglow introduces the concept of VAT (Validator Admission Ticket). VAT is a 1.6 SOL fee that validators must pay to be included in the consensus set each epoch. With the introduction of VAT, Alpenglow paves the way for faster block times and increased CU capacity with the removal of vote transactions from blocks.
 
-Fee markets are currently being developed to include more functionality on the RPC, higher fees for highly contested accounts, and improvements to block scheduling.
+## **SIMD-123: Block Revenue Distribution**
 
-## **Transaction size increase**
+**STATUS:** 🟡 Under development. Expected by Agave 4.1
 
-**STATUS:** 🟡 Under development.
+[Follow progress on Github.](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0123-block-revenue-distribution.md)
 
-Transactions on the Solana network are currently limited to a maximum of 1,232 bytes. This limitation restricts that ability for programs to compose with each other as the transaction has a specific amount of data to fit. With the implementation of QUIC, the possibility of increasing transaction size is within reach.
+When you delegate SOL to a validator, you currently only receive rewards from inflation in the protocol. But validators also earn revenue from transaction fees, priority fees and MEV (maximal extractable value) when they produce blocks. SIMD-123 enables validators to share this block revenue with their delegators automatically through the protocol.
 
-Core engineers are currently testing larger transaction sizes.
+Validators will be able to set a commission rate for block revenue—similar to how they set commission for inflation rewards. The protocol will automatically calculate and distribute the remaining revenue to delegators at the end of each epoch based on their stake. This creates more transparency and allows delegators to choose validators offering better revenue-sharing terms.
 
-## **Compact vote state**
+## **XDP (eXpress Data Path)**
 
-**STATUS:** 🟡 Live on Testnet.
+**STATUS:** 🟢 Available in Agave 3.0+
 
-[Follow the feature on Github.](https://github.com/solana-labs/solana/issues/26617)
+[Learn more about XDP setup.](https://www.anza.xyz/blog/agave-xdp-setup-guide)
 
-Vote transactions on the network are the most common transactions transmitted across all nodes. A large voting schema both increases the amount of bandwidth used by the network as well as the block size. Lowering the vote state even by a few bytes can lead to substantial improvements on the network, as less data is being transmitted and stored on the nodes.
+XDP is a high-performance networking technology from the Linux kernel that allows Solana validators to process network packets faster. Think of it as a shortcut that bypasses normal network processing, letting data flow more directly between the network card and validator software. This reduces latency by up to 200x.
 
-The compact vote state is being tested in a feature, which is currently live on testnet.
+Agave version 3.0.9 and later supports XDP for block propagation, but validators must enable the feature. Early testing shows that 100M compute unit blocks are achievable when validator operators adopt XDP. While XDP is not a protocol change, it is a critical performance improvement that will increase network capacity.
+
+## **100M CUs (Compute Units)**
+
+**STATUS:** 🟡 Under development. Expected by Agave 4.1
+
+[Follow progress on Github.](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0286-raise-block-limits-to-100M.md)
+
+Solana's blocks have a capacity limit measured in compute units (CUs). Each transaction consumes some number of CUs depending on how complex it is. The current limit is 60 million CUs per block.
+
+[SIMD-286](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0286-raise-block-limits-to-100M.md) proposes increasing this limit to 100 million CUs, a 66% boost in capacity. This means more transactions per block, higher throughput, and reduced congestion during peak demand.
+
+## **SIMD-296: Larger Transaction Size**
+
+**STATUS:** 🟡 Under development. Expected by Agave 4.1
+
+[Follow progress on Github.](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0296-larger-transactions.md)
+
+Transactions on the Solana network are currently limited to a maximum of 1,232 bytes. This limitation restricts the ability for programs to compose with each other, as transactions have a specific amount of data to fit. Larger transactions enable more complex operations in a single transaction, reducing the need for awkward multi-step execution patterns.
+
+Core engineers have accepted SIMD-296 to enable more expressive transactions that can interact with more programs and accounts in a single atomic operation.
+
+## **SIMD-268: Raise CPI Nesting Limit**
+
+**STATUS:** 🟡 Under development. Expected by Agave 4.1
+
+[Follow progress on Github.](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0268-raise-cpi-nesting-limit.md)
+
+Cross-Program Invocation (CPI) is how Solana programs call into other programs during execution. The current maximum nesting depth is 4 levels, meaning a program can call another program, which calls another, up to 4 deep. This limits the sophistication of multi-program interactions.
+
+SIMD-268 increases the nesting limit from 4 to 8, doubling the depth of program-to-program calls. This enables developers to build more complex decentralized applications that compose multiple protocols together.
 
 ## **Resources**
 
-- [“QUIC Tech Talk” Twitter Space with Anatoly Yakovenko](https://drive.google.com/file/d/1eWGRkk8OtfNK_ek-wweOxYzfdtOb7w8m/view?usp=sharing&ref=solana.ghost.io)
-- [Thread from Solana Labs co-founder Anatoly Yakovenko on fee markets](https://twitter.com/aeyakovenko/status/1537270721570824192)
-- [“3 Major Upcoming Upgrades on Solana That Will Improve Network Performance” by Thalita Franklin at Chorus One](https://medium.com/chorus-one/how-will-solana-improve-its-stability-6d4b0ba41866)
-- [Report from 04-30-22 Solana Mainnet Beta Outage](https://solana.com/news/04-30-22-solana-mainnet-beta-outage-report-mitigation)
-- [Report from 06-01-22 Solana Mainnet Beta Outage](https://solana.com/news/06-01-22-solana-mainnet-beta-outage-report-2)
-- [“ELI5: QUIC” on r/solana](https://www.reddit.com/r/solana/comments/tbhyqi/eli5_quic/)
+- [Alpenglow: Introduction by Roger Wattenhofer (YouTube)](https://www.youtube.com/watch?v=x1sxtm-dvyE)
+- [Anza's 2026 Roadmap](https://www.anza.xyz/blog/anza26)
+- [SIMD-0326: Alpenglow Consensus Protocol Proposal (Solana Forum)](https://forum.solana.com/t/simd-0326-proposal-for-the-new-alpenglow-consensus-protocol/4236)
+- [SIMD-123: Block Revenue Distribution Discussion (Solana Forum)](https://forum.solana.com/t/proposal-for-an-in-protocol-distribution-of-block-rewards-to-stakers/3295)
+- [Agave XDP Setup Guide (Anza)](https://www.anza.xyz/blog/agave-xdp-setup-guide)
+- [Firedancer Documentation](https://docs.firedancer.io/)
+- [Solana Improvement Documents (SIMDs) Repository](https://github.com/solana-foundation/solana-improvement-documents)


### PR DESCRIPTION
Adding more details to the upgrades page

### Problem
The /upgrades page, aka /news/solana-network-upgrades, is very out of date.  It contains inaccurate information and old links from 2022.


### Summary of Changes

I refreshed the page to include more recent network upgrades coming in 2026.

Fixes #

All content changes in /news/solana-network-upgrades