### PR TITLE
feat(templates): add Pinocchio framework filter and default template

### DIFF
--- a/apps/templates/public/locales/en/common.json
+++ b/apps/templates/public/locales/en/common.json
@@ -27,6 +27,7 @@
       "react": "React",
       "react_native": "React Native",
       "node": "Node",
+      "pinocchio": "Pinocchio",
       "solana_kit": "@solana/kit",
       "solana_web3js": "@solana/web3.js",
       "wallet_ui": "Wallet UI",

--- a/apps/templates/src/lib/templates/filter-templates.ts
+++ b/apps/templates/src/lib/templates/filter-templates.ts
@@ -13,6 +13,7 @@ const DEFAULT_TEMPLATE_NAMES = [
   "phantom-embedded-react", // Phantom Embedded Wallet (Next.js)
   "phantom-embedded-react-native-starter", // Phantom Embedded (React Native)
   "phantom-embedded-js", // Phantom Embedded (Vite + JS)
+  "pinocchio-counter", // Pinocchio Counter
 ];
 
 export function filterTemplates({

--- a/apps/templates/src/lib/types/templates/filters.ts
+++ b/apps/templates/src/lib/types/templates/filters.ts
@@ -62,6 +62,10 @@ export const createFilters = (t: (key: string) => string): TemplateFilter[] => [
         id: "node",
         name: t("keywords.node"),
       },
+      {
+        id: "pinocchio",
+        name: t("keywords.pinocchio"),
+      },
     ],
     name: t("categories.frameworks"),
   },
@@ -122,6 +126,7 @@ export const filters: TemplateFilter[] = [
       { id: "react", name: "React" },
       { id: "react-native", name: "React Native" },
       { id: "node", name: "Node" },
+      { id: "pinocchio", name: "Pinocchio" },
     ],
     name: "Frameworks",
   },


### PR DESCRIPTION
## Summary

- Add Pinocchio to the Frameworks filter category on the templates page
- Add `pinocchio-counter` to the default templates list so it displays without filters

## Problem

The recently added `pinocchio-counter` template was not appearing on https://solana.com/developers/templates because:
1. There was no Pinocchio filter option under Frameworks
2. The template wasn't in the default templates list

## Changes

| File | Change |
|------|--------|
| `apps/templates/src/lib/types/templates/filters.ts` | Added `pinocchio` keyword to Frameworks filter |
| `apps/templates/public/locales/en/common.json` | Added translation for Pinocchio keyword |
| `apps/templates/src/lib/templates/filter-templates.ts` | Added `pinocchio-counter` to default templates |