### PR TITLE
docs: fix links to Transfer Hook Interface

### DIFF
--- a/apps/docs/content/guides/token-extensions/transfer-hook.mdx
+++ b/apps/docs/content/guides/token-extensions/transfer-hook.mdx
@@ -30,7 +30,7 @@ This unlocks many new use cases for token transfers, such as:
 - And many more
 
 To achieve this, developers must build a program that implements the
-[Transfer Hook Interface](https://github.com/solana-labs/solana-program-library/tree/master/token/transfer-hook/interface)
+[Transfer Hook Interface](https://github.com/solana-program/transfer-hook/tree/main/interface)
 and initialize a Mint Account with the Transfer Hook extension enabled.
 
 For every token transfer involving tokens from the Mint Account, the Token
@@ -59,7 +59,7 @@ instruction logic that is executed on every token transfer for a specific Mint
 Account.
 
 The Transfer Hook Interface specifies the following
-[instructions](https://github.com/solana-labs/solana-program-library/blob/master/token/transfer-hook/interface/src/instruction.rs):
+[instructions](https://github.com/solana-program/transfer-hook/blob/main/interface/src/instruction.rs):
 
 - `Execute`: An instruction that the Token Extension program invokes on every
   token transfer.
@@ -1558,7 +1558,7 @@ account's owner as a seed for a PDA.
 
 When creating the ExtraAccountMeta you can use the data of any account as an
 extra seed. In this case we want to derive a counter account from the token
-account owner and the string 'counter'. This means we will be always able to see
+account owner and the string "counter". This means we will be always able to see
 how often that token account owner has transferred tokens.
 
 This is how you set it up in the `extra_account_metas()` function.
@@ -1588,7 +1588,7 @@ impl<'info> InitializeExtraAccountMetaList<'info> {
 Let's look at the token account struct to understand how the account data is
 stored. Below is an example of a token account structure. So we can take 32
 bytes at position 32 to 64 as the owner of the token account, which is at
-'account_index: 0'. 'account_index` refers to the index of the account in the
+`account_index: 0`. `account_index` refers to the index of the account in the
 accounts array. In the case of a transfer hook, the owner token account is the
 first entry in the accounts array. The second account is always the mint and the
 third account is the destination token account. This account order is the same
@@ -1616,11 +1616,8 @@ pub struct Account {
 In our case, we want to derive a counter account from the owner of the sender
 token account so when we create the ExtraAccountMeta accounts we `init` this PDA
 counter account that is derived from the sender token account owner and the
-string 'counter'. When the PDA counter account is initialized we will be able to
+string "counter". When the PDA counter account is initialized we will be able to
 use it within the transfer hook to increment the value in every transfer.
-
-````rust
-struct.
 
 ```rust
 #[derive(Accounts)]
@@ -1646,7 +1643,7 @@ pub struct InitializeExtraAccountMetaList<'info> {
     pub associated_token_program: Program<'info, AssociatedToken>,
     pub system_program: Program<'info, System>,
 }
-````
+```
 
 We also need to define this extra counter account in the TransferHook struct.
 These are the accounts that are passed to our TransferHook program every time a


### PR DESCRIPTION
### Problem
Transfer Hook Interface was moved to a separate repository, the links became incorrect.


### Summary of Changes
Fixed the links. Also fixed some formatting.
