### PR TITLE
fix(web): accept long TLD emails in validator and add regression test

### DIFF
--- a/apps/web/src/__tests__/utils/emailUtils.test.js
+++ b/apps/web/src/__tests__/utils/emailUtils.test.js
@@ -1,0 +1,16 @@
+import { isValidEmail } from "@/utils/emailUtils";
+
+describe("isValidEmail", () => {
+  it("accepts common valid email formats", () => {
+    expect(isValidEmail("user.name+tag@example.com")).toBe(true);
+  });
+
+  it("accepts valid emails with long top-level domains", () => {
+    expect(isValidEmail("builder@solana.technology")).toBe(true);
+  });
+
+  it("rejects malformed email addresses", () => {
+    expect(isValidEmail("not-an-email")).toBe(false);
+    expect(isValidEmail("user@example")).toBe(false);
+  });
+});

--- a/apps/web/src/utils/emailUtils.js
+++ b/apps/web/src/utils/emailUtils.js
@@ -1,3 +1,3 @@
 export function isValidEmail(value) {
-  return /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4}$/i.test(value);
+  return /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,63}$/i.test(value);
 }


### PR DESCRIPTION
### Problem

`isValidEmail` in `apps/web/src/utils/emailUtils.js` only allowed TLDs with 2-4 characters.
That rejects valid modern email addresses like `builder@solana.technology`.

### Summary of Changes

- Updated email validation regex to allow TLD lengths from 2 to 63 characters.
- Added `apps/web/src/__tests__/utils/emailUtils.test.js` with:
  - valid common email case
  - valid long-TLD email case (`.technology`)
  - malformed email rejection cases
- Verified utils tests pass after the fix.

