### PR TITLE
docs: Fix broken relative links

### DIFF
--- a/apps/docs/content/docs/en/core/accounts.mdx
+++ b/apps/docs/content/docs/en/core/accounts.mdx
@@ -774,7 +774,7 @@ async fn main() -> Result<()> {
 Not all accounts are assigned a new owner after being created by the System
 Program. Accounts owned by the System Program are called system accounts. All
 wallet accounts are system accounts, which allows them to pay
-[transaction fees](docs/core/fees).
+[transaction fees](/docs/core/fees).
 
 ![A wallet owned by the System Program containing 1,000,000 lamports](/assets/docs/core/accounts/system-account.svg)
 

--- a/apps/docs/content/docs/en/core/transactions.mdx
+++ b/apps/docs/content/docs/en/core/transactions.mdx
@@ -78,7 +78,7 @@ account's private key. A signature must be provided for each
 instructions.
 
 The first signature belongs to the account that will pay the transaction's
-[base fee](docs/core/fees#base-fee) and is the transaction signature. The
+[base fee](/docs/core/fees#base-fee) and is the transaction signature. The
 transaction signature can be used to look up the transaction's details on the
 network.
 


### PR DESCRIPTION
### Problem

Broken internal link in documentation

### Summary of Changes

Updated link to use absolute path for correct routing

