### PR TITLE
feat(x402): display hero metrics on x402 page

### DIFF
--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -4996,20 +4996,16 @@
       "build": "Build with x402",
       "stats": {
         "0": {
-          "value": "35M+",
-          "label": "Transactions"
+          "value": "37M+",
+          "label": "Transactions on Solana"
         },
         "1": {
-          "value": "$10M+",
-          "label": "Volume"
+          "value": "20K+",
+          "label": "Buyers and Sellers"
         },
         "2": {
-          "value": "10000+",
-          "label": "Buyers"
-        },
-        "3": {
-          "value": "300%",
-          "label": "MoM Growth"
+          "value": "70%",
+          "label": "Monthly Volume on Solana"
         }
       }
     },

--- a/apps/web/src/app/[locale]/x402/page.tsx
+++ b/apps/web/src/app/[locale]/x402/page.tsx
@@ -21,10 +21,6 @@ export default async function Page(_props: Props) {
       value: t("x402.hero.stats.2.value"),
       label: t("x402.hero.stats.2.label"),
     },
-    {
-      value: t("x402.hero.stats.3.value"),
-      label: t("x402.hero.stats.3.label"),
-    },
   ];
 
   const translations = {

--- a/apps/web/src/app/[locale]/x402/x402.tsx
+++ b/apps/web/src/app/[locale]/x402/x402.tsx
@@ -36,7 +36,7 @@ export function X402Page({ translations }: X402PageProps) {
             subtitle={translations.heroSubtitle}
             extraCta={translations.extraCta}
             extraCtaHref={translations.extraCtaHref}
-            stats={undefined}
+            stats={translations.stats}
             bgJsonFilePath="/src/img/solutions/defi/hero-bg.json"
           />
         </div>


### PR DESCRIPTION
## Summary
- Enable the stats section on the x402 hero (was previously set to `undefined`)
- Update metrics to reflect current x402 activity data:
  - **37M+** Transactions on Solana
  - **20K+** Buyers and Sellers
  - **70%** Monthly Volume on Solana
- Remove the previous placeholder 4th stat, now displaying 3 metrics (consistent with DePIN page pattern)

## Changes
- `x402.tsx`: Pass `translations.stats` to `SolutionHero` instead of `undefined`
- `page.tsx`: Reduce stats array from 4 to 3 entries
- `common.json`: Update stat values and labels

## Test plan
- [ ] Verify the 3 metrics render correctly in the hero section at `/x402`
- [ ] Confirm responsive layout (2-col mobile, 3-col desktop) matches DePIN page behavior
- [ ] Check staggered fade-in animation works for the stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)