### PR TITLE
Fix /ai redirect and update x402 hero metrics

### DIFF
--- a/apps/web/public/locales/en/common.json
+++ b/apps/web/public/locales/en/common.json
@@ -4996,20 +4996,16 @@
       "build": "Build with x402",
       "stats": {
         "0": {
-          "value": "35M+",
-          "label": "Transactions"
+          "value": "37M+",
+          "label": "Transactions on Solana"
         },
         "1": {
-          "value": "$10M+",
-          "label": "Volume"
+          "value": "20K+",
+          "label": "Buyers and Sellers"
         },
         "2": {
-          "value": "10000+",
-          "label": "Buyers"
-        },
-        "3": {
-          "value": "300%",
-          "label": "MoM Growth"
+          "value": "70%",
+          "label": "Monthly Volume on Solana"
         }
       }
     },

--- a/apps/web/src/app/[locale]/x402/page.tsx
+++ b/apps/web/src/app/[locale]/x402/page.tsx
@@ -21,10 +21,6 @@ export default async function Page(_props: Props) {
       value: t("x402.hero.stats.2.value"),
       label: t("x402.hero.stats.2.label"),
     },
-    {
-      value: t("x402.hero.stats.3.value"),
-      label: t("x402.hero.stats.3.label"),
-    },
   ];
 
   const translations = {

--- a/apps/web/src/app/[locale]/x402/x402.tsx
+++ b/apps/web/src/app/[locale]/x402/x402.tsx
@@ -36,7 +36,7 @@ export function X402Page({ translations }: X402PageProps) {
             subtitle={translations.heroSubtitle}
             extraCta={translations.extraCta}
             extraCtaHref={translations.extraCtaHref}
-            stats={undefined}
+            stats={translations.stats}
             bgJsonFilePath="/src/img/solutions/defi/hero-bg.json"
           />
         </div>


### PR DESCRIPTION
## Changes

- **Redirect /ai to /solutions/ai**: Updated redirect rules and navigation link to point to the correct solutions page
- **Update x402 hero metrics**: 
  - Changed from 4 stats to 3 stats
  - Updated values: 37M+ transactions, 20K+ buyers/sellers, 70% monthly volume
  - Enabled stats display on x402 page by passing translations.stats instead of undefined
- **Localization updates**: Modified en/common.json with new hero metric labels and values for x402 solution