### PR TITLE
fix: update solutions nav AI link and redirects to /solutions/ai

### DIFF
--- a/apps/web/rewrites-redirects.mjs
+++ b/apps/web/rewrites-redirects.mjs
@@ -449,7 +449,8 @@ export default {
     { source: "/summercamp(.*)", destination: "/hackathon" },
     { source: "/grizzlython(.*)", destination: "/hackathon" },
     { source: "/hyperdrive(.*)", destination: "/hackathon" },
-    { source: "/developers/ai", destination: "/ai" },
+    { source: "/developers/ai", destination: "/solutions/ai" },
+    { source: "/ai", destination: "/solutions/ai" },
     { source: "/developer", destination: "/developers" },
     { source: "/token22", destination: "/solutions/token-extensions" },
     {

--- a/packages/ui-chrome/src/header-list.solutions.jsx
+++ b/packages/ui-chrome/src/header-list.solutions.jsx
@@ -327,7 +327,7 @@ const HeaderListSolutions = ({ isMobile = false }) => {
                 />
               </Link>
               <Link
-                to="/ai"
+                to="/solutions/ai"
                 className="block no-underline text-inherit group/link"
                 activeClassName="active"
               >


### PR DESCRIPTION
## Problem
The solutions dropdown nav was linking to `/ai` instead of `/solutions/ai`, which has the new design. The `/ai` page content is outdated and `/developers/ai` was also redirecting to the wrong place.

## Changes
- Update solutions dropdown nav link from `/ai` → `/solutions/ai`
- Add redirect `/ai` → `/solutions/ai`
- Update `/developers/ai` redirect to point to `/solutions/ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)