### PR TITLE
fix: Not Found page

### DIFF
--- a/apps/web/src/app/[locale]/[...rest]/page.tsx
+++ b/apps/web/src/app/[locale]/[...rest]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from "next/navigation";
+
+export default function CatchAll() {
+  notFound();
+}


### PR DESCRIPTION
### Problem

The custom i18n-aware 404 page at [locale]/not-found.tsx was never rendered for unmatched routes. Without a catch-all route, unmatched paths never entered the [locale] segment, so Next.js fell back to its default 404 instead of the localized one.

### Summary of Changes

Added [locale]/[...rest]/page.tsx — a catch-all route that calls notFound(). This ensures any unmatched path runs through the locale layout, then renders the existing [locale]/not-found.tsx with proper translations.
