### PR TITLE
fix: update Agent Registry links to 8004.qnt.sh

### DIFF
--- a/apps/web/src/app/[locale]/agent-registry/page.tsx
+++ b/apps/web/src/app/[locale]/agent-registry/page.tsx
@@ -32,8 +32,7 @@ export default async function Page(_props: Props) {
     featuresTitle: t("agentRegistry.features.title"),
     featuresDescription: t("agentRegistry.features.description"),
     featuresCtaButton: t("agentRegistry.features.ctaButton"),
-    featuresCtaButtonHref:
-      "https://github.com/QuantuLabs/8004-solana-ts/blob/main/skill.md",
+    featuresCtaButtonHref: "https://8004.qnt.sh/skill.md",
     ecoProjectsTitle: t("agentRegistry.ecoProjects.title"),
     toolsTitle: t("agentRegistry.tools.title"),
     toolsDescription: t("agentRegistry.tools.description"),

--- a/apps/web/src/data/solutions/agent-registry.ts
+++ b/apps/web/src/data/solutions/agent-registry.ts
@@ -24,7 +24,7 @@ export const TOOLS = [
   },
   {
     key: "1",
-    href: "https://quantulabs.github.io/8004-solana/",
+    href: "https://8004.qnt.sh",
   },
   {
     key: "2",


### PR DESCRIPTION
## Summary
- Update "Try Agent Skill" button link to `https://8004.qnt.sh/skill.md`
- Update Agent Registry Spec toolkit link to `https://8004.qnt.sh`

## Test plan
- [ ] Verify "Try Agent Skill" button on `/agent-registry` links to correct URL
- [ ] Verify "Agent Registry Spec" in toolkit links to correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)