### PR TITLE
fix: filter synthetic wallet extension JSON-RPC errors in Sentry

### DIFF
--- a/apps/docs/src/instrumentation-client.ts
+++ b/apps/docs/src/instrumentation-client.ts
@@ -9,8 +9,10 @@ Sentry.init({
   tracesSampleRate: 0.1,
   debug: false,
   beforeSend(event, _) {
+    const exception = event.exception?.values?.[0];
+
     // Filter out browser extension errors by checking stack traces
-    const stackTrace = event.exception?.values?.[0]?.stacktrace?.frames;
+    const stackTrace = exception?.stacktrace?.frames;
 
     const isExtensionError = stackTrace?.some(
       (frame) =>
@@ -23,7 +25,20 @@ Sentry.init({
     );
 
     if (isExtensionError) {
-      return null; // Don't send to Sentry
+      return null;
+    }
+
+    // Filter out wallet extension JSON-RPC errors (e.g. TronLink, MetaMask).
+    // These surface as synthetic UnhandledRejections with no stack trace.
+    if (
+      exception?.mechanism?.synthetic &&
+      exception?.type === "UnhandledRejection" &&
+      typeof event.extra?.__serialized__ === "object" &&
+      event.extra.__serialized__ !== null &&
+      "code" in event.extra.__serialized__ &&
+      "message" in event.extra.__serialized__
+    ) {
+      return null;
     }
 
     return event;

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -9,8 +9,10 @@ Sentry.init({
   tracesSampleRate: 0.1,
   debug: false,
   beforeSend(event, _) {
+    const exception = event.exception?.values?.[0];
+
     // Filter out browser extension errors by checking stack traces
-    const stackTrace = event.exception?.values?.[0]?.stacktrace?.frames;
+    const stackTrace = exception?.stacktrace?.frames;
 
     const isExtensionError = stackTrace?.some(
       (frame) =>
@@ -23,7 +25,20 @@ Sentry.init({
     );
 
     if (isExtensionError) {
-      return null; // Don't send to Sentry
+      return null;
+    }
+
+    // Filter out wallet extension JSON-RPC errors (e.g. TronLink, MetaMask).
+    // These surface as synthetic UnhandledRejections with no stack trace.
+    if (
+      exception?.mechanism?.synthetic &&
+      exception?.type === "UnhandledRejection" &&
+      typeof event.extra?.__serialized__ === "object" &&
+      event.extra.__serialized__ !== null &&
+      "code" in event.extra.__serialized__ &&
+      "message" in event.extra.__serialized__
+    ) {
+      return null;
     }
 
     return event;


### PR DESCRIPTION
## Summary
- Wallet browser extensions (TronLink, MetaMask, Binance Wallet) throw unhandled JSON-RPC promise rejections (`{code: -32603, message: "Internal JSON-RPC error."}`) that Sentry captures as synthetic `UnhandledRejection` events with **no stack trace**
- The existing `beforeSend` filter only checks stack frames for extension URLs, so these stacktrace-less errors bypass it
- Adds a second filter to drop synthetic `UnhandledRejection` events where `event.extra.__serialized__` has a JSON-RPC error shape (`code` + `message` keys)
- Applied to both `apps/web` and `apps/docs` instrumentation clients

## Test plan
- [ ] Verify Sentry stops receiving `UnhandledRejection: Object captured as promise rejection with keys: code, message` errors after deploy
- [ ] Verify legitimate application errors (with real stack traces) still appear in Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)