### PR TITLE
Add guides to add Metadata

### DIFF
--- a/apps/docs/content/cookbook/tokens/create-token-with-metadata.mdx
+++ b/apps/docs/content/cookbook/tokens/create-token-with-metadata.mdx
@@ -6,17 +6,19 @@ description:
 ---
 
 To add metadata (name, symbol, image) to a standard SPL Token, you need to use
-the [Metaplex Token Metadata Program](https://developers.metaplex.com/token-metadata).
+the
+[Metaplex Token Metadata Program](https://developers.metaplex.com/token-metadata).
 This creates a metadata account that is linked to your token mint via a Program
 Derived Address (PDA).
 
 <Callout type="info">
-  This guide covers metadata for standard SPL Tokens (Token Program) and is also applicable for Token-2022. 
-  If you want to use the Metadata Extension for Token-2022, see the
-  [Metadata Extension guide](/docs/tokens/extensions/metadata).
+  This guide covers metadata for standard SPL Tokens (Token Program) and is also
+  applicable for Token-2022. If you want to use the Metadata Extension for
+  Token-2022, see the [Metadata Extension
+  guide](/docs/tokens/extensions/metadata).
 </Callout>
 
-<CodeTabs storage="cookbook-token-metadata" flags="r">
+<CodeTabs storage="cookbook">
 
 ```ts !! title="Kit"
 import {
@@ -73,9 +75,9 @@ const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
 const transactionMessage = pipe(
   createTransactionMessage({ version: 0 }),
-  tx => setTransactionMessageFeePayerSigner(payer, tx),
-  tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  tx => appendTransactionMessageInstructions([createInstruction], tx)
+  (tx) => setTransactionMessageFeePayerSigner(payer, tx),
+  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+  (tx) => appendTransactionMessageInstructions([createInstruction], tx)
 );
 
 const signedTransaction =
@@ -86,7 +88,7 @@ await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
   { commitment: "confirmed" }
 );
 
-// !mark(1:6)
+// !mark(1:7)
 // Verify metadata was created
 const metadata = await fetchMetadataFromSeeds(rpc, { mint: mint.address });
 

--- a/apps/docs/content/cookbook/tokens/fetch-token-metadata.mdx
+++ b/apps/docs/content/cookbook/tokens/fetch-token-metadata.mdx
@@ -5,13 +5,14 @@ description:
   for any SPL Token."
 ---
 
-Tokens created with the [Metaplex Token Metadata Program](https://developers.metaplex.com/token-metadata)
+Tokens created with the
+[Metaplex Token Metadata Program](https://developers.metaplex.com/token-metadata)
 have a metadata account that stores the token's name, symbol, URI, and other
 information. The metadata account is a PDA derived from the mint address.
 
 ## Fetch Metadata for a Single Token
 
-<CodeTabs storage="cookbook" flags="r">
+<CodeTabs storage="cookbook">
 
 ```ts !! title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
@@ -42,7 +43,7 @@ if (metadata.data.creators.__option === "Some") {
   console.log("Creators:", metadata.data.creators.value);
 }
 
-// !mark(1:8)
+// !mark(1:9)
 // Option 2: Safe fetch (returns exists: false if not found)
 const [metadataPda] = await findMetadataPda({ mint: mintAddress });
 const maybeMetadata = await fetchMaybeMetadata(rpc, metadataPda);
@@ -61,7 +62,7 @@ if (maybeMetadata.exists) {
 The `uri` field in the on-chain metadata points to a JSON file containing
 extended metadata like the image URL, description, and attributes.
 
-<CodeTabs storage="cookbook" flags="r">
+<CodeTabs storage="cookbook">
 
 ```ts !! title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
@@ -73,7 +74,7 @@ const mintAddress = address("YourMintAddressHere");
 // Fetch on-chain metadata
 const metadata = await fetchMetadataFromSeeds(rpc, { mint: mintAddress });
 
-// !mark(1:7)
+// !mark(1:9)
 // Fetch off-chain JSON metadata
 if (metadata.data.uri) {
   const response = await fetch(metadata.data.uri);
@@ -82,7 +83,6 @@ if (metadata.data.uri) {
   console.log("Name:", jsonMetadata.name);
   console.log("Description:", jsonMetadata.description);
   console.log("Image:", jsonMetadata.image);
-
 }
 ```
 

--- a/apps/docs/content/cookbook/tokens/get-token-mint.mdx
+++ b/apps/docs/content/cookbook/tokens/get-token-mint.mdx
@@ -191,16 +191,15 @@ if __name__ == "__main__":
 
 ## Fetch Metaplex Token Metadata
 
-For tokens using the [Metaplex Token Metadata Program](https://developers.metaplex.com/token-metadata),
+For tokens using the
+[Metaplex Token Metadata Program](https://developers.metaplex.com/token-metadata),
 you can fetch the metadata account to get the token's name, symbol, and URI.
 
-<CodeTabs storage="cookbook" flags="r">
+<CodeTabs storage="cookbook">
 
 ```ts !! title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
-import {
-  fetchMetadataFromSeeds
-} from "@metaplex-foundation/mpl-token-metadata-kit";
+import { fetchMetadataFromSeeds } from "@metaplex-foundation/mpl-token-metadata-kit";
 
 const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 
@@ -221,7 +220,6 @@ console.log("Update Authority:", metadata.data.updateAuthority);
 
 <Callout type="info">
   Not all tokens have Metaplex metadata. Tokens created with Token Extensions
-  (Token-2022) may use the different functionality instead. See
-  [Token Extensions Metadata](/docs/tokens/extensions/metadata) for more
-  information.
+  (Token-2022) may use the different functionality instead. See [Token
+  Extensions Metadata](/docs/tokens/extensions/metadata) for more information.
 </Callout>

--- a/apps/docs/content/docs/en/tokens/basics/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/create-mint.mdx
@@ -452,11 +452,13 @@ authorities). To add human-readable metadata like a name, symbol, and image to
 your token, you have two options:
 
 <Cards>
-  <Card title="Metaplex Token Metadata" href="/docs/tokens/basics/add-metadata">
+  <Card title="Metaplex Token Metadata" href="/docs/tokens/metaplex">
    Add metadata using the Metaplex Token Metadata Program. Works with both, the original Token Program and Token-2022.
   </Card>
 
   <Card title="Token Extensions Metadata" href="/docs/tokens/extensions/metadata">
-   Use the built-in metadata extension with Token-2022.
+   Use the built-in metadata extension with Token-2022. 
+   The metadata extension is only available for mint accounts created with Token-2022.
+   To add metadata to mint accounts created with the original Token Program, use the Metaplex Token Metadata Program.
   </Card>
 </Cards>

--- a/apps/docs/content/docs/en/tokens/basics/meta.json
+++ b/apps/docs/content/docs/en/tokens/basics/meta.json
@@ -2,7 +2,6 @@
   "title": "Basics",
   "pages": [
     "create-mint",
-    "add-metadata",
     "create-token-account",
     "mint-tokens",
     "transfer-tokens",

--- a/apps/docs/content/docs/en/tokens/index.mdx
+++ b/apps/docs/content/docs/en/tokens/index.mdx
@@ -397,13 +397,15 @@ same transaction.
 
 There are two ways to add metadata (name, symbol, image) to tokens on Solana:
 
-1. **[Metaplex Token Metadata](/docs/tokens/basics/add-metadata)** - Creates a
-   separate metadata account linked to your mint. Works with the original Token
-   Program and Token-2022 and is widely supported by wallets and marketplaces.
+1. **[Metaplex Token Metadata](/docs/tokens/metaplex)** - Creates a separate
+   metadata account linked to your mint. Works with the original Token Program
+   and Token-2022 and is widely supported by wallets and marketplaces.
 
 2. **[Token Extensions Metadata](/docs/tokens/extensions/metadata)** - Stores
    metadata directly on the mint account using Token-2022. A newer approach with
-   built-in support.
+   built-in support. The metadata extension is only available for mint accounts
+   created with Token-2022. To add metadata to mint accounts created with the
+   original Token Program, use the Metaplex Token Metadata Program.
 
 #### SPL Token CLI Example
 
@@ -444,9 +446,7 @@ spl-token initialize-metadata BdhzpzhTD1MFqBiwNdrRy4jFo2FHFufw3n9e8sVjJczP "Toke
 View the metadata on
 [Solana Explorer](https://explorer.solana.com/address/BdhzpzhTD1MFqBiwNdrRy4jFo2FHFufw3n9e8sVjJczP?cluster=devnet).
 
-Learn more in the
-[Metadata Extension Guide](/developers/guides/token-extensions/metadata-pointer).
+Learn more in the [Token Extensions section](/docs/tokens/extensions/metadata).
 For details about Token Extensions, see the Token Extensions
-[Getting Started Guide](/developers/guides/token-extensions/getting-started) and
-the
+[Token Extensions section](/docs/tokens/extensions) and the
 [SPL documentation](https://www.solana-program.com/docs/token-2022/extensions).

--- a/apps/docs/content/docs/en/tokens/meta.json
+++ b/apps/docs/content/docs/en/tokens/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Tokens on Solana",
-  "pages": ["basics", "extensions"],
+  "pages": ["basics", "extensions", "metaplex"],
   "defaultOpen": false
 }

--- a/apps/docs/content/docs/en/tokens/metaplex.mdx
+++ b/apps/docs/content/docs/en/tokens/metaplex.mdx
@@ -1,5 +1,5 @@
 ---
-title: Add Metadata to Tokens
+title: Metaplex Metadata
 description:
   Learn how to add metadata to SPL Tokens using the Metaplex Token Metadata
   Program.
@@ -10,10 +10,10 @@ Standard SPL Tokens don't include metadata like a name, symbol, or image. The
 solves this by creating a metadata account linked to each token mint.
 
 <Callout type="info">
-  This guide covers the Metaplex Token Metadata Program which can be used for standard SPL Tokens and Token-2022. 
-  To use the Token-2022 Metadata Extension, see the
-  [Metadata Extension guide](/docs/tokens/extensions/metadata) which stores
-  metadata directly on the mint account.
+  This guide covers the Metaplex Token Metadata Program which can be used for
+  standard SPL Tokens and Token-2022. To use the Token-2022 Metadata Extension,
+  see the [Metadata Extension guide](/docs/tokens/extensions/metadata) which
+  stores metadata directly on the mint account.
 </Callout>
 
 ## How Token Metadata Works
@@ -44,7 +44,7 @@ single transaction.
 
 ### Typescript
 
-<CodeTabs storage="token-metadata-ts" flags="r">
+<CodeTabs storage="token-ts">
 
 ```ts !! title="Kit"
 import {
@@ -98,9 +98,9 @@ const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
 const transactionMessage = pipe(
   createTransactionMessage({ version: 0 }),
-  tx => setTransactionMessageFeePayerSigner(payer, tx),
-  tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  tx => appendTransactionMessageInstructions([createInstruction], tx)
+  (tx) => setTransactionMessageFeePayerSigner(payer, tx),
+  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+  (tx) => appendTransactionMessageInstructions([createInstruction], tx)
 );
 
 const signedTransaction =
@@ -162,9 +162,9 @@ const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
 const transactionMessage = pipe(
   createTransactionMessage({ version: 0 }),
-  tx => setTransactionMessageFeePayerSigner(payer, tx),
-  tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  tx => appendTransactionMessageInstructions([createInstruction], tx)
+  (tx) => setTransactionMessageFeePayerSigner(payer, tx),
+  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+  (tx) => appendTransactionMessageInstructions([createInstruction], tx)
 );
 
 const signedTransaction =
@@ -183,14 +183,14 @@ console.log("Mint Address:", mint.address);
 ## Fetch Token Metadata
 
 To learn how to fetch metadata for existing tokens, see the
-[Fetch Token Metadata](/developers/cookbook/tokens/fetch-token-metadata) cookbook
-recipe.
+[Fetch Token Metadata](/developers/cookbook/tokens/fetch-token-metadata)
+cookbook recipe.
 
 ## Update Token Metadata
 
 The update authority can modify the metadata if the account is mutable.
 
-<CodeTabs storage="token-metadata-ts" flags="r">
+<CodeTabs storage="token-ts">
 
 ```ts !! title="Kit"
 import {
@@ -242,9 +242,9 @@ const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
 
 const transactionMessage = pipe(
   createTransactionMessage({ version: 0 }),
-  tx => setTransactionMessageFeePayerSigner(authority, tx),
-  tx => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  tx => appendTransactionMessageInstructions([updateInstruction], tx)
+  (tx) => setTransactionMessageFeePayerSigner(authority, tx),
+  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
+  (tx) => appendTransactionMessageInstructions([updateInstruction], tx)
 );
 
 const signedTransaction =
@@ -264,14 +264,14 @@ console.log("Metadata updated successfully");
 
 The Token Metadata Program supports different token standards:
 
-| Standard                       | Description                                       | Use Case               |
-| ------------------------------ | ------------------------------------------------- | ---------------------- |
-| `Fungible`                     | Standard fungible token with metadata             | Currencies, points     |
-| `FungibleAsset`                | Fungible token representing a unique asset        | Semi-fungible items    |
-| `NonFungible`                  | NFT with Master Edition                           | 1/1 artwork            |
-| `ProgrammableNonFungible`      | NFT with enforced royalties                       | Creator royalties      |
-| `NonFungibleEdition`           | Printed copy of an NFT                            | Limited editions       |
-| `ProgrammableNonFungibleEdition` | Printed copy with enforced royalties            | Limited editions       |
+| Standard                         | Description                                | Use Case            |
+| -------------------------------- | ------------------------------------------ | ------------------- |
+| `Fungible`                       | Standard fungible token with metadata      | Currencies, points  |
+| `FungibleAsset`                  | Fungible token representing a unique asset | Semi-fungible items |
+| `NonFungible`                    | NFT with Master Edition                    | 1/1 artwork         |
+| `ProgrammableNonFungible`        | NFT with enforced royalties                | Creator royalties   |
+| `NonFungibleEdition`             | Printed copy of an NFT                     | Limited editions    |
+| `ProgrammableNonFungibleEdition` | Printed copy with enforced royalties       | Limited editions    |
 
 ```ts
 import { TokenStandard } from "@metaplex-foundation/mpl-token-metadata-kit";


### PR DESCRIPTION
### Problem
The Solana developer docs don't cover how to add metadata (name, symbol, image) to tokenkeg tokens. Developers looking for this info on solana.com have to go elsewhere currently.

### Summary of Changes
  - Added a new "Add Metadata to Tokens" guide under the tokens basics section, covering how to create tokens with metadata, update metadata, and the different token standards available
  - Added two new cookbook recipes: "Create a Token with Metadata" and "Fetch Token Metadata" with working code examples using @solana/kit
  - Updated the existing "Get Token Mint" cookbook page to include a section on fetching metadata from a mint
  - Updated the tokens overview page to mention both metadata approaches (Token Metadata Program and Token-2022 metadata extension)
  - Added "Next Steps" cards to the create-mint docs page pointing users to the metadata guides
 
Fixes #
- none