### PR TITLE
docs: add verified builds FAQ and verify.osec.io link

### DIFF
--- a/apps/docs/content/docs/en/programs/verified-builds.mdx
+++ b/apps/docs/content/docs/en/programs/verified-builds.mdx
@@ -667,6 +667,219 @@ On-chain Program Hash: 890d68f48f96991016222b1fcbc2cc81b8ef2dcbf280c44fe378c523c
 Program hash matches ✅
 ```
 
+# Frequently asked questions
+
+## My verification is failing. What should I do?
+
+Check these common issues:
+
+- **Wrong signer**: Confirm your signer is the program's upgrade authority by
+  running `solana program show YourProgramId`
+- **No on-chain PDA**: Run `solana-verify verify-from-repo -um` and **select YES
+  when prompted**. Without uploading the PDA, the API can't retrieve your
+  verification metadata.
+- **PDA data mismatch**: Update your PDA if you've redeployed your program. Your
+  PDA data must match your deployed program.
+- **Incorrect commit hash**: Create your PDA using the exact commit hash you
+  deployed
+- **Build environment differences**: Use Docker with solana-verify when creating
+  your PDA
+
+## My local build hash doesn't match the on-chain hash. Why?
+
+This usually means:
+
+- You're using different Rust/Solana toolchain versions
+- Your dependencies were updated between builds
+- You didn't build in a Docker container
+- You checked out the wrong commit
+
+Fix this by building with `solana-verify build` in Docker using the exact commit
+you deployed.
+
+## How long will my verification take?
+
+Expect these timeframes based on your program size:
+
+- Simple programs: 1-5 minutes
+- Complex programs: 5-15 minutes
+- Very large programs: Up to 30 minutes
+
+Track your progress using the job status endpoint.
+
+## My program is immutable (no upgrade authority). How can I verify it?
+
+If your program has no upgrade authority or was made immutable before you could
+create a PDA, we have a whitelisted address for this situation. Contact us at
+contact@osec.io, and we'll help you get your program verified.
+
+## What is the PDA and why does it matter?
+
+Your PDA (Program Derived Account) enables trustless verification:
+
+- **On-Chain Storage**: Store your verification metadata (repo URL, commit hash,
+  build params) on-chain in a PDA owned by the Otter Verify program
+  (`verifycLy8mB96wd9wqq3WDXQwM4oU6r42Th37Db9fC`)
+- **Cryptographic Link**: Your PDA is derived from your program address,
+  creating an immutable link to your verification data
+- **Decentralized Trust**: Anyone can read your PDA and independently verify
+  your program
+
+## Why must I create the PDA before using the API?
+
+The API only works with on-chain PDAs because:
+
+- **Trustless**: The API rejects arbitrary data - it only uses what your upgrade
+  authority stored on-chain
+- **Simpler**: Just provide signer + program_id; the API gets everything else
+  from your PDA
+- **Tamper-Proof**: Your PDA creates an immutable record anyone can verify
+  independently
+- **Ownership Proof**: Your signer must be the upgrade authority,
+  cryptographically proving you control the program
+
+## How often should I verify my program?
+
+Verify your program:
+
+- After every deployment or upgrade
+- When you update your source repository
+- Don't worry about re-verifying otherwise - the API automatically re-verifies
+  all programs every 24 hours
+
+## What happens when I upgrade my program?
+
+Follow these steps after upgrading:
+
+1. The API detects your upgrade and unverifies your program.
+2. Update your PDA with new verification metadata:
+
+```bash
+solana-verify verify-from-repo -um \
+  --program-id YourProgramId... \
+  https://github.com/your-org/your-program
+```
+
+3. Submit a new verification request using your upgrade authority
+4. The API will verify your new version against the updated PDA
+
+**Important**: Always update your PDA using your upgrade authority with the new
+commit hash for the upgraded program.
+
+## Can I trust the verification results?
+
+Yes - the system is designed to be trustless and independently verifiable:
+
+**What Makes It Trustworthy:**
+
+- **On-Chain PDA**: Your verification metadata lives on-chain, not controlled by
+  any central authority
+- **Upgrade Authority Proof**: Only your program's upgrade authority can
+  create/update the PDA
+- **Independent Verification**: Anyone can verify by reading your PDA and
+  running `solana-verify` locally
+- **Continuous Re-verification**: The API automatically re-verifies all programs
+  every 24 hours
+
+**Understand These Limitations:**
+
+- Verification confirms source matches deployment - **NOT** that your code is
+  secure
+- Always review code before interacting with programs
+- Verified ≠ audited, or safe
+- Check the repository and commit in the PDA to confirm it's from a trusted
+  source
+
+## How can I independently verify a program?
+
+Verify any program yourself by reading its on-chain PDA and running verification
+locally:
+
+**Step 1: Read the On-Chain PDA**
+
+```bash
+# Install solana-verify if you haven't
+cargo install solana-verify
+
+# Get the PDA data
+solana-verify list-program-pdas --program-id YourProgramId...
+```
+
+**Step 2: Verify Locally**
+
+```bash
+# Verify using the repository and commit & other arguments from the PDA
+solana-verify verify-from-repo \
+  --program-id YourProgramId... \
+  https://github.com/your-org/your-program
+  --commit-hash <commit-hash>
+  ... (other arguments from the PDA)
+# Confirm the hash output matches the on-chain program hash
+```
+
+**This proves:**
+
+1. The PDA metadata is authentic (stored on-chain)
+2. The source code in the PDA's repository matches the deployed program
+3. You don't need to trust the API - verify everything yourself on-chain
+
+## Can someone else verify my program without permission?
+
+Yes, that's the reason why we require the signer to be the upgrade authority. We
+only consider the verification to be valid if the signer is the upgrade
+authority.
+
+## What do I need to create verifiable builds?
+
+Install these tools:
+
+- Docker (for deterministic builds)
+- Cargo (Rust package manager)
+- Solana Verify CLI: `cargo install solana-verify`
+- A public Git repository with your source code
+
+## Can I verify private repositories?
+
+No - verification requires public source code:
+
+- Your PDA stores a public repository URL that anyone can access
+- Trustless verification depends on public code access
+- Users need to read your source code to understand what your program does
+- The entire purpose is to let users independently verify source matches
+  deployment
+
+Private repositories break the verification system's core trust model.
+
+## How do I verify a program controlled by Squads Multisig?
+
+Follow these steps for multisig-controlled programs:
+
+```bash
+# 1. Build and deploy normally
+solana-verify build
+solana program deploy <your-program.so> --program-id YourProgramId...
+
+# 2. Verify locally first - confirm the hash matches
+solana-verify verify-from-repo -um \
+  --program-id YourProgramId... \
+  https://github.com/your-org/your-program
+
+# 3. Export the PDA creation transaction
+solana-verify export-pda-tx \
+  --program-id YourProgramId... \
+  https://github.com/your-org/your-program
+
+# 4. Execute the PDA transaction through your Squads Multisig interface
+
+# 5. After multisig execution, trigger remote verification
+solana-verify remote submit-job \
+  --program-id YourProgramId... \
+  --uploader YourMultisigAddress...
+```
+
+**Critical**: Always verify locally (step 2) to confirm the build hash matches
+before exporting the PDA transaction.
+
 # Conclusion
 
 Using [verified builds on Solana](/developers/guides/advanced/verified-builds)
@@ -806,3 +1019,6 @@ This is
 
 The `security.txt` project is maintained by
 [Neodyme Labs](https://github.com/neodyme-labs)
+
+You can check verification status and browse verified programs at
+[verify.osec.io](https://verify.osec.io).


### PR DESCRIPTION
### Summary of Changes
Add verified-builds FAQ (14 Q&As) and a bottom callout linking to verify.osec.io.
