### PR TITLE
Tune Sentry sampling and filter noisy events

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -244,6 +244,9 @@ export default withSentryConfig(moduleExports, {
   project: "javascript-nextjs",
   silent: !process.env.CI,
   widenClientFileUpload: true,
+  _experimental: {
+    thirdPartyOriginStackFrames: true,
+  },
   disableLogger: true,
   automaticVercelMonitors: true,
   sourcemaps: {

--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -1,6 +1,17 @@
 import * as Sentry from "@sentry/nextjs";
+import {
+  sentryBeforeSend,
+  sentryBeforeSendTransaction,
+  sentryDenyUrls,
+  sentryIgnoreErrors,
+  sentryTracesSampler,
+} from "./src/lib/sentry";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 0.1,
+  tracesSampler: sentryTracesSampler,
+  beforeSendTransaction: sentryBeforeSendTransaction,
+  beforeSend: sentryBeforeSend,
+  ignoreErrors: sentryIgnoreErrors,
+  denyUrls: sentryDenyUrls,
 });

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -1,6 +1,17 @@
 import * as Sentry from "@sentry/nextjs";
+import {
+  sentryBeforeSend,
+  sentryBeforeSendTransaction,
+  sentryDenyUrls,
+  sentryIgnoreErrors,
+  sentryTracesSampler,
+} from "./src/lib/sentry";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 0.1,
+  tracesSampler: sentryTracesSampler,
+  beforeSendTransaction: sentryBeforeSendTransaction,
+  beforeSend: sentryBeforeSend,
+  ignoreErrors: sentryIgnoreErrors,
+  denyUrls: sentryDenyUrls,
 });

--- a/apps/web/src/instrumentation-client.ts
+++ b/apps/web/src/instrumentation-client.ts
@@ -3,46 +3,22 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import {
+  sentryBeforeSend,
+  sentryBeforeSendTransaction,
+  sentryDenyUrls,
+  sentryIgnoreErrors,
+  sentryTracesSampler,
+} from "./lib/sentry";
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  tracesSampleRate: 0.1,
+  tracesSampler: sentryTracesSampler,
   debug: false,
-  beforeSend(event, _) {
-    const exception = event.exception?.values?.[0];
-
-    // Filter out browser extension errors by checking stack traces
-    const stackTrace = exception?.stacktrace?.frames;
-
-    const isExtensionError = stackTrace?.some(
-      (frame) =>
-        frame.filename?.includes("extensionServiceWorker.js") ||
-        frame.filename?.includes("chrome-extension://") ||
-        frame.filename?.includes("moz-extension://") ||
-        frame.filename?.includes("safari-extension://") ||
-        frame.filename?.includes("extension://") ||
-        frame.filename?.startsWith("app:///"),
-    );
-
-    if (isExtensionError) {
-      return null;
-    }
-
-    // Filter out wallet extension JSON-RPC errors (e.g. TronLink, MetaMask).
-    // These surface as synthetic UnhandledRejections with no stack trace.
-    if (
-      exception?.mechanism?.synthetic &&
-      exception?.type === "UnhandledRejection" &&
-      typeof event.extra?.__serialized__ === "object" &&
-      event.extra.__serialized__ !== null &&
-      "code" in event.extra.__serialized__ &&
-      "message" in event.extra.__serialized__
-    ) {
-      return null;
-    }
-
-    return event;
-  },
+  beforeSend: sentryBeforeSend,
+  beforeSendTransaction: sentryBeforeSendTransaction,
+  ignoreErrors: sentryIgnoreErrors,
+  denyUrls: sentryDenyUrls,
 });
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/apps/web/src/lib/sentry.ts
+++ b/apps/web/src/lib/sentry.ts
@@ -1,0 +1,265 @@
+const BOT_USER_AGENT_PATTERN =
+  /\b(bot|crawler|spider|crawling|headless|lighthouse|pagespeed|slurp|bingpreview)\b/i;
+const DEBUG_TRANSACTION_MARKERS = ["sentry-debug", "__sentry_debug__"];
+const HEALTH_ROUTE_MARKERS = [
+  "/api/health",
+  "/api/ping",
+  "/health",
+  "/healthz",
+  "/readyz",
+];
+const STATIC_ROUTE_MARKERS = [
+  "/_next/",
+  "/favicon.ico",
+  "/robots.txt",
+  "/sitemap",
+  "/manifest",
+  "/images/",
+  "/fonts/",
+];
+const STATIC_ASSET_EXTENSIONS = [
+  ".js",
+  ".css",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".svg",
+  ".webp",
+  ".ico",
+  ".map",
+  ".txt",
+  ".xml",
+  ".woff",
+  ".woff2",
+  ".ttf",
+];
+
+type SentryEventLike = {
+  exception?: {
+    values?: Array<{
+      type?: string;
+      value?: string;
+      mechanism?: {
+        synthetic?: boolean;
+      };
+      stacktrace?: {
+        frames?: Array<{
+          filename?: string;
+        }>;
+      };
+    }>;
+  };
+  extra?: Record<string, unknown>;
+  tags?: Record<string, unknown>;
+  request?: {
+    method?: string;
+    url?: string;
+    headers?: Record<string, string | string[] | undefined>;
+  };
+  transaction?: string;
+  spans?: unknown[];
+};
+
+type SentrySamplingContextLike = {
+  transactionContext?: {
+    name?: string;
+  };
+  name?: string;
+  normalizedRequest?: {
+    method?: string;
+    headers?: Record<string, string | string[] | undefined>;
+    url?: string;
+  };
+  request?: {
+    method?: string;
+    headers?: Record<string, string | string[] | undefined>;
+    url?: string;
+  };
+};
+
+export const sentryIgnoreErrors = [
+  /^ResizeObserver loop/,
+  /^Non-Error promise rejection captured/,
+  /^TypeError: Failed to fetch/,
+  /^TypeError: NetworkError/,
+  /^TypeError: Load failed/,
+  /^AbortError/,
+  /Hydration failed/,
+  /There was an error while hydrating/,
+  /Text content does not match/,
+];
+
+export const sentryDenyUrls = [
+  /extensions\//i,
+  /^chrome:\/\//i,
+  /^chrome-extension:\/\//i,
+  /^moz-extension:\/\//i,
+  /^safari-extension:\/\//i,
+  /googletagmanager\.com/i,
+  /google-analytics\.com/i,
+  /connect\.facebook\.net/i,
+];
+
+function getHeaderValue(
+  headers: Record<string, string | string[] | undefined> | undefined,
+  key: string,
+): string {
+  const value = headers?.[key] ?? headers?.[key.toLowerCase()];
+
+  if (Array.isArray(value)) {
+    return value.join(" ");
+  }
+
+  return typeof value === "string" ? value : "";
+}
+
+function getSamplingContextName(context: SentrySamplingContextLike): string {
+  return (
+    context.transactionContext?.name ??
+    context.normalizedRequest?.url ??
+    context.request?.url ??
+    context.name ??
+    ""
+  );
+}
+
+function hasMarker(value: string, markers: string[]): boolean {
+  const normalizedValue = value.toLowerCase();
+  return markers.some((marker) => normalizedValue.includes(marker));
+}
+
+function isStaticAssetRequest(name: string): boolean {
+  return (
+    hasMarker(name, STATIC_ROUTE_MARKERS) ||
+    STATIC_ASSET_EXTENSIONS.some((extension) => name.includes(extension))
+  );
+}
+
+function isBotUserAgent(userAgent: string): boolean {
+  return BOT_USER_AGENT_PATTERN.test(userAgent);
+}
+
+function isExtensionStackFrame(filename: string): boolean {
+  return (
+    filename.includes("extensionServiceWorker.js") ||
+    filename.includes("chrome-extension://") ||
+    filename.includes("moz-extension://") ||
+    filename.includes("safari-extension://") ||
+    filename.includes("extension://")
+  );
+}
+
+function isAppFrame(filename: string): boolean {
+  return filename.startsWith("app://") || filename.startsWith("/_next/");
+}
+
+function isThirdPartyFrame(filename: string): boolean {
+  return (
+    filename.startsWith("http://") ||
+    filename.startsWith("https://") ||
+    filename.startsWith("webpack-internal://")
+  );
+}
+
+function isWalletExtensionError(event: SentryEventLike): boolean {
+  const exception = event.exception?.values?.[0];
+  const serialized = event.extra?.__serialized__;
+
+  return Boolean(
+    exception?.mechanism?.synthetic &&
+      exception.type === "UnhandledRejection" &&
+      serialized &&
+      typeof serialized === "object" &&
+      "code" in serialized &&
+      "message" in serialized,
+  );
+}
+
+export function sentryTracesSampler(
+  context: SentrySamplingContextLike,
+): number {
+  const name = getSamplingContextName(context).toLowerCase();
+  const userAgent = getHeaderValue(
+    context.normalizedRequest?.headers ?? context.request?.headers,
+    "user-agent",
+  );
+
+  if (hasMarker(name, DEBUG_TRANSACTION_MARKERS)) {
+    return 1;
+  }
+
+  if (isBotUserAgent(userAgent)) {
+    return 0;
+  }
+
+  if (hasMarker(name, HEALTH_ROUTE_MARKERS) || isStaticAssetRequest(name)) {
+    return 0;
+  }
+
+  if (name.startsWith("/api/")) {
+    return 0.01;
+  }
+
+  return 0.1;
+}
+
+export function sentryBeforeSendTransaction<T extends SentryEventLike>(
+  event: T,
+): T | null {
+  const method = event.request?.method?.toUpperCase();
+  const transactionName = (
+    event.transaction ??
+    event.request?.url ??
+    ""
+  ).toLowerCase();
+
+  if (event.spans && event.spans.length > 100) {
+    return null;
+  }
+
+  if (method === "OPTIONS" || method === "HEAD") {
+    return null;
+  }
+
+  if (
+    hasMarker(transactionName, HEALTH_ROUTE_MARKERS) ||
+    isStaticAssetRequest(transactionName)
+  ) {
+    return null;
+  }
+
+  return event;
+}
+
+export function sentryBeforeSend<T extends SentryEventLike>(
+  event: T,
+): T | null {
+  const exception = event.exception?.values?.[0];
+  const stackTrace = exception?.stacktrace?.frames ?? [];
+  const filenames = stackTrace
+    .map((frame) => frame.filename ?? "")
+    .filter(Boolean);
+
+  if (filenames.some((filename) => isExtensionStackFrame(filename))) {
+    return null;
+  }
+
+  if (isWalletExtensionError(event)) {
+    return null;
+  }
+
+  const hasAppFrame = filenames.some((filename) => isAppFrame(filename));
+  const hasThirdPartyFrame = filenames.some((filename) =>
+    isThirdPartyFrame(filename),
+  );
+
+  if (hasThirdPartyFrame && !hasAppFrame) {
+    event.tags = {
+      ...event.tags,
+      third_party_code: "true",
+    };
+  }
+
+  return event;
+}


### PR DESCRIPTION
## Summary
- replace flat tracing with route-aware Sentry sampling in `apps/web`
- drop noisy transactions and common browser/extension error noise
- enable experimental third-party stack frame handling and tag likely third-party-only errors

## Verification
- pnpm build --filter ./apps/web
  - verified via `pnpm build` in `apps/web`

## Notes
- existing Tailwind ambiguous utility warnings and Browserslist warning remain
- replay sampling was left unchanged