### PR TITLE
refactor: rename ecosystem profile field and localize grid slug

### DIFF
--- a/apps/accelerate/src/components/Sponsors.tsx
+++ b/apps/accelerate/src/components/Sponsors.tsx
@@ -253,7 +253,7 @@ export function Sponsors({ sponsors }: { sponsors: Sponsor[] }) {
   const t = useTranslations("accelerate.sponsors");
 
   const activeSponsorData = activeSponsor?.sponsor;
-  const activeManualProfile = activeSponsorData?.gridProfile ?? null;
+  const activeManualProfile = activeSponsorData?.profile ?? null;
   const activeSlug = activeSponsorData?.gridProfileSlug ?? null;
   const activeProfile = activeSlug ? profilesBySlug[activeSlug] : undefined;
   const resolvedProfile = activeProfile ?? activeManualProfile ?? undefined;
@@ -293,7 +293,7 @@ export function Sponsors({ sponsors }: { sponsors: Sponsor[] }) {
     if (!isModalOpen || !activeSponsor) return;
 
     const slug = activeSponsor.sponsor.gridProfileSlug;
-    const manualProfile = activeSponsor.sponsor.gridProfile;
+    const manualProfile = activeSponsor.sponsor.profile;
     if (!slug || manualProfile || profilesBySlug[slug] || unmatchedSlugs[slug])
       return;
 

--- a/apps/accelerate/src/data/hong-kong/sponsors.json
+++ b/apps/accelerate/src/data/hong-kong/sponsors.json
@@ -3,7 +3,8 @@
   "sponsors": [
     {
       "companyId": "sunrise",
-      "sponsorshipLevel": "Headline"
+      "sponsorshipLevel": "Headline",
+      "gridProfileSlug": "sunrise"
     },
     {
       "companyId": "doublezero",
@@ -15,7 +16,8 @@
     },
     {
       "companyId": "play-solana",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "playsolana"
     },
     {
       "companyId": "libeara",
@@ -24,52 +26,64 @@
     },
     {
       "companyId": "dabba",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "dabba"
     },
     {
       "companyId": "arcium",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "Arcium"
     },
     {
       "companyId": "frodobots",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "FrodoBots"
     },
     {
       "companyId": "byreal",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "byreal"
     },
     {
       "companyId": "bydfi",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "bydfi"
     },
     {
       "companyId": "allnodes",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "allnodes"
     },
     {
       "companyId": "osl",
       "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "osl",
       "url": "https://www.osl.com/"
     },
     {
       "companyId": "fireblocks",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "Fireblocks"
     },
     {
       "companyId": "safepal-wallet",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "safepal"
     },
     {
       "companyId": "mantle-byreal",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "mantle_xyz"
     },
     {
       "companyId": "bonk",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "Bonk"
     },
     {
       "companyId": "solflare",
-      "sponsorshipLevel": "Signature"
+      "sponsorshipLevel": "Signature",
+      "gridProfileSlug": "Solflare"
     }
   ]
 }

--- a/apps/accelerate/src/data/miami/sponsors.json
+++ b/apps/accelerate/src/data/miami/sponsors.json
@@ -8,15 +8,18 @@
     },
     {
       "companyId": "jito",
-      "sponsorshipLevel": "Signature"
+      "sponsorshipLevel": "Signature",
+      "gridProfileSlug": "jito"
     },
     {
       "companyId": "solflare",
-      "sponsorshipLevel": "Signature"
+      "sponsorshipLevel": "Signature",
+      "gridProfileSlug": "Solflare"
     },
     {
       "companyId": "spi",
-      "sponsorshipLevel": "Signature"
+      "sponsorshipLevel": "Signature",
+      "gridProfileSlug": "solanapolicyinstitute"
     },
     {
       "companyId": "superteam-usa",
@@ -24,15 +27,18 @@
     },
     {
       "companyId": "quicknode",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "quicknode"
     },
     {
       "companyId": "galaxy",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "Galaxy_Digital"
     },
     {
       "companyId": "solayer",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "Solayer"
     },
     {
       "companyId": "kast",
@@ -48,7 +54,8 @@
     },
     {
       "companyId": "squads",
-      "sponsorshipLevel": "Signature"
+      "sponsorshipLevel": "Signature",
+      "gridProfileSlug": "Squads"
     },
     {
       "companyId": "bridge",
@@ -56,7 +63,8 @@
     },
     {
       "companyId": "solana-spaces",
-      "sponsorshipLevel": "Premium"
+      "sponsorshipLevel": "Premium",
+      "gridProfileSlug": "solanaspaces"
     }
   ]
 }

--- a/apps/accelerate/src/lib/sponsor-data.ts
+++ b/apps/accelerate/src/lib/sponsor-data.ts
@@ -11,6 +11,7 @@ export type SponsorAugmentation = {
   sponsorshipLevel: string;
   url?: string;
   featuredLogoId?: string;
+  gridProfileSlug?: string | null;
 };
 
 function getPublicLogoPath(
@@ -53,8 +54,8 @@ export function composeSponsors(
       availableLogos: company.logos.map((asset) =>
         resolveImportedAssetSrc(asset.source),
       ),
-      gridProfileSlug: company.gridProfileSlug ?? null,
-      gridProfile: company.gridProfile ?? null,
+      gridProfileSlug: entry.gridProfileSlug ?? null,
+      profile: company.profile ?? null,
     };
   });
 }

--- a/apps/accelerate/src/types/sponsors.ts
+++ b/apps/accelerate/src/types/sponsors.ts
@@ -30,7 +30,7 @@ export interface Sponsor {
   logo: string;
   availableLogos: string[];
   gridProfileSlug?: string | null;
-  gridProfile?: GridProfile | null;
+  profile?: GridProfile | null;
 }
 
 export interface SponsorTier {

--- a/packages/ecosystem-data/PLAN.md
+++ b/packages/ecosystem-data/PLAN.md
@@ -114,8 +114,7 @@ export type CompanyRecord = {
   slug: string;
   name: string;
   legalName?: string;
-  gridProfileSlug?: string | null;
-  gridProfile?: GridProfile | null;
+  profile?: Profile | null;
   tagline?: string;
   shortDescription?: string;
   sectors?: string[];
@@ -237,8 +236,7 @@ This adapter can live in the app or in a thin app-specific helper layer and shou
 - `sponsorshipLevel`
 - `logo`
 - `availableLogos`
-- `gridProfileSlug`
-- `gridProfile`
+- `profile`
 
 That adapter is the migration hinge. It lets `apps/accelerate` keep its existing `Sponsors` component while the company source moves underneath it.
 
@@ -359,14 +357,14 @@ Deliver the smallest replacement that unblocks reuse:
 
 ## Open decisions
 
-1. Whether `gridProfile` should stay embedded as optional manual override data, or move into a separate enrichment layer.
+1. Whether `profile` should stay embedded as optional manual override data, or move into a separate enrichment layer.
 2. Whether the sync source remains Google Sheets or moves to a more explicit registry workflow.
 
 ## Recommended answer to those decisions
 
 For the first version:
 
-- keep `gridProfile` override support in the package
+- keep `profile` override support in the package
 - keep all event-specific sponsor declarations outside the package
 - keep the current `Sponsor` UI type as an app-derived compatibility layer
 - import package-owned company assets directly instead of copying them into app `public/`

--- a/packages/ecosystem-data/README.md
+++ b/packages/ecosystem-data/README.md
@@ -88,7 +88,7 @@ The company record should remain useful outside any single event.
 
 ## Populating registry companies with enrichment data
 
-Company records can include an optional `gridProfile` object with enriched ecosystem metadata such as:
+Company records can include an optional `profile` object with enriched ecosystem metadata such as:
 
 - tagline
 - short and long descriptions
@@ -102,7 +102,7 @@ Use the enrichment workflow in:
 packages/ecosystem-data/skills/enrich-ecosystem-data.md
 ```
 
-That workflow is the source of truth for how to research and populate missing `gridProfile` data in:
+That workflow is the source of truth for how to research and populate missing `profile` data in:
 
 ```text
 packages/ecosystem-data/src/companies/registry.ts
@@ -110,7 +110,7 @@ packages/ecosystem-data/src/companies/registry.ts
 
 Expected process:
 
-1. read the registry and identify companies where `gridProfile` is `null`
+1. read the registry and identify companies where `profile` is `null`
 2. run the audit script to see which companies are missing enrichment or have asset mismatches:
 
 ```bash
@@ -118,7 +118,7 @@ pnpm --filter @workspace/ecosystem-data audit:data
 ```
 
 3. research each company using publicly available sources, starting with the official website
-4. populate only the `gridProfile` field with neutral, factual copy and verified URLs
+4. populate only the `profile` field with neutral, factual copy and verified URLs
 5. omit socials that cannot be confidently verified
 6. validate the package with:
 
@@ -128,10 +128,10 @@ pnpm --filter @workspace/ecosystem-data exec tsc --noEmit
 
 Rules:
 
-- only modify `gridProfile`
-- do not change `id`, `slug`, `name`, `logos`, `defaultLogoId`, or `gridProfileSlug`
+- only modify `profile`
+- do not change `id`, `slug`, `name`, `logos`, `defaultLogoId`
 - match the tone of existing enriched records
-- leave `gridProfile: null` when reliable information is not available
+- leave `profile: null` when reliable information is not available
 
 ## What not to put here
 

--- a/packages/ecosystem-data/scripts/audit-ecosystem-data.mjs
+++ b/packages/ecosystem-data/scripts/audit-ecosystem-data.mjs
@@ -161,10 +161,10 @@ for (const fileName of recordFiles) {
   const id = getObjectPropertyString(recordNode, "id");
   const slug = getObjectPropertyString(recordNode, "slug");
   const defaultLogoId = getObjectPropertyString(recordNode, "defaultLogoId");
-  const gridProfileNode = getNestedProperty(recordNode, ["gridProfile"]);
-  const gridProfileObject = ts.isObjectLiteralExpression(gridProfileNode) ? gridProfileNode : null;
-  const urlEntries = getObjectPropertyArray(gridProfileObject, "urls");
-  const socialsNode = getNestedProperty(recordNode, ["gridProfile", "root", "socials"]);
+  const profileNode = getNestedProperty(recordNode, ["profile"]);
+  const profileObject = ts.isObjectLiteralExpression(profileNode) ? profileNode : null;
+  const urlEntries = getObjectPropertyArray(profileObject, "urls");
+  const socialsNode = getNestedProperty(recordNode, ["profile", "root", "socials"]);
   const logosArray = getObjectPropertyArray(recordNode, "logos");
   const logos = [];
 
@@ -217,7 +217,7 @@ for (const fileName of recordFiles) {
     slug,
     defaultLogoId,
     logos,
-    gridProfileNull: gridProfileNode?.kind === ts.SyntaxKind.NullKeyword,
+    profileNull: profileNode?.kind === ts.SyntaxKind.NullKeyword,
     hasWebsiteUrl,
     socialCount,
   });
@@ -243,14 +243,14 @@ const issues = {
   recordsWithoutAssetFolder: records
     .filter((record) => record.slug && !assetFolderSet.has(record.slug))
     .map((record) => `${record.id} -> ${record.slug}`),
-  recordsWithNullGridProfile: records
-    .filter((record) => record.gridProfileNull)
+  recordsWithNullProfile: records
+    .filter((record) => record.profileNull)
     .map((record) => record.id),
   recordsMissingWebsite: records
-    .filter((record) => !record.gridProfileNull && !record.hasWebsiteUrl)
+    .filter((record) => !record.profileNull && !record.hasWebsiteUrl)
     .map((record) => record.id),
   recordsMissingSocials: records
-    .filter((record) => !record.gridProfileNull && record.socialCount === 0)
+    .filter((record) => !record.profileNull && record.socialCount === 0)
     .map((record) => record.id),
   recordsWithoutLogos: records
     .filter((record) => record.logos.length === 0)
@@ -310,8 +310,8 @@ for (const record of records) {
 const summary = {
   companyRecords: records.length,
   assetFolders: assetFolders.length,
-  enrichedRecords: records.length - issues.recordsWithNullGridProfile.length,
-  nullGridProfiles: issues.recordsWithNullGridProfile.length,
+  enrichedRecords: records.length - issues.recordsWithNullProfile.length,
+  nullProfiles: issues.recordsWithNullProfile.length,
 };
 
 let hasIssues = false;

--- a/packages/ecosystem-data/skills/enrich-ecosystem-data.md
+++ b/packages/ecosystem-data/skills/enrich-ecosystem-data.md
@@ -7,14 +7,14 @@ Web search for all companies in the ecosystem-data registry and update their rec
 - Registry: `packages/ecosystem-data/src/companies/registry.ts`
 - Types: `packages/ecosystem-data/src/types.ts`
 - Package guide: `packages/ecosystem-data/README.md`
-- Each company has a `CompanyRecord` with an optional `gridProfile` field containing enriched data (tagline, descriptions, sector, socials, URLs).
+- Each company has a `CompanyRecord` with an optional `profile` field containing enriched data (tagline, descriptions, sector, socials, URLs).
 - The goal is to enrich canonical company data only. Event-specific sponsorship metadata stays in consuming apps.
 
 ## Workflow
 
 ### 1. Read current state
 
-Read the registry and types files. Build a list of all company IDs and note which ones have `gridProfile: null` (need enrichment) vs. a populated `gridProfile` object (may need refresh).
+Read the registry and types files. Build a list of all company IDs and note which ones have `profile: null` (need enrichment) vs. a populated `profile` object (may need refresh).
 
 Before research, run:
 
@@ -26,7 +26,7 @@ Use the audit output to spot companies that have asset folders and company recor
 
 ### 2. Research each company
 
-For every company with `gridProfile: null`, launch parallel Agent subprocesses (subagent_type: "general-purpose") to web search and gather:
+For every company with `profile: null`, launch parallel Agent subprocesses (subagent_type: "general-purpose") to web search and gather:
 
 | Field | Source hint |
 |---|---|
@@ -62,10 +62,10 @@ If sources conflict, prefer the official website. Do not fill fields from low-co
 
 ### 3. Update the registry
 
-For each researched company, replace `"gridProfile": null` with a populated object matching this shape:
+For each researched company, replace `"profile": null` with a populated object matching this shape:
 
 ```ts
-"gridProfile": {
+"profile": {
   "name": "<Display Name>",
   "tagLine": "<Tagline>",
   "descriptionShort": "<Short description.>",
@@ -102,7 +102,7 @@ Only include social entries where a URL was found. Omit socials with no discover
 When enriching:
 
 - preserve existing field ordering and object shape used by nearby records
-- use the company display name already present in the record for `gridProfile.name` unless the registry itself clearly uses a different canonical style
+- use the company display name already present in the record for `profile.name` unless the registry itself clearly uses a different canonical style
 - include the homepage in `urls` even when social links are sparse
 - prefer direct organization URLs over link-in-bio or profile aggregators
 
@@ -116,10 +116,10 @@ pnpm --filter @workspace/ecosystem-data exec tsc --noEmit
 
 ### Rules
 
-- **Only modify `gridProfile`** — never touch `id`, `slug`, `name`, `logos`, `defaultLogoId`, or `gridProfileSlug`.
+- **Only modify `profile`** — never touch `id`, `slug`, `name`, `logos`, `defaultLogoId`.
 - Use factual, neutral language — no marketing superlatives.
 - Match the tone of existing enriched records (Bridge, DoubleZero, KAST, Libeara, OSL, Superteam USA, velia.net).
-- If reliable information cannot be found for a company, leave `gridProfile: null` and note it in the summary.
+- If reliable information cannot be found for a company, leave `profile: null` and note it in the summary.
 - Process companies in parallel to save time.
 - Keep `packages/ecosystem-data/README.md` accurate if the enrichment workflow or expectations materially change.
 

--- a/packages/ecosystem-data/src/companies/records/aisa.ts
+++ b/packages/ecosystem-data/src/companies/records/aisa.ts
@@ -6,8 +6,7 @@ export const aisa = {
   "slug": "aisa",
   "name": "AIsa",
   "legalName": "AIsa Inc.",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "AIsa",
     "tagLine": "The Unified Resource & Payment Layer for AI Agents",
     "descriptionShort": "AIsa is an AI infrastructure platform that combines a unified resource gateway with usage-based payment infrastructure for AI agents and applications.",

--- a/packages/ecosystem-data/src/companies/records/alchemy.ts
+++ b/packages/ecosystem-data/src/companies/records/alchemy.ts
@@ -10,8 +10,7 @@ export const alchemy = {
   "id": "alchemy",
   "slug": "alchemy",
   "name": "Alchemy",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Alchemy",
     "tagLine": "Infrastructure that moves billions at scale.",
     "descriptionShort": "Web3 development platform providing blockchain infrastructure, APIs, and developer tools across multiple chains including Solana.",

--- a/packages/ecosystem-data/src/companies/records/allnodes.ts
+++ b/packages/ecosystem-data/src/companies/records/allnodes.ts
@@ -5,8 +5,7 @@ export const allnodes = {
   "id": "allnodes",
   "slug": "allnodes",
   "name": "Allnodes",
-  "gridProfileSlug": "allnodes",
-  "gridProfile": {
+  "profile": {
     "name": "Allnodes",
     "tagLine": "Non-custodial platform for node hosting and staking across 120+ protocols",
     "descriptionShort": "Allnodes is a non-custodial infrastructure platform that provides node hosting, validator services, and staking for Solana and 120+ other blockchain protocols.",

--- a/packages/ecosystem-data/src/companies/records/arcium.ts
+++ b/packages/ecosystem-data/src/companies/records/arcium.ts
@@ -5,8 +5,7 @@ export const arcium = {
   "id": "arcium",
   "slug": "arcium",
   "name": "Arcium",
-  "gridProfileSlug": "Arcium",
-  "gridProfile": {
+  "profile": {
     "name": "Arcium",
     "tagLine": "Encrypt Everything. Compute Anything.",
     "descriptionShort": "Arcium is a decentralized confidential computing network built on Solana that enables encrypted computations using multi-party computation, fully homomorphic encryption, and zero-knowledge proofs.",

--- a/packages/ecosystem-data/src/companies/records/atxp.ts
+++ b/packages/ecosystem-data/src/companies/records/atxp.ts
@@ -5,8 +5,7 @@ export const atxp = {
   "id": "atxp",
   "slug": "atxp",
   "name": "ATXP",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "ATXP",
     "tagLine": "A web-wide protocol for agentic payments",
     "descriptionShort": "ATXP is a protocol built by Circuit & Chisel that enables AI agents to autonomously handle commerce from discovery to payment, with support for Solana-based micropayments.",

--- a/packages/ecosystem-data/src/companies/records/bonk.ts
+++ b/packages/ecosystem-data/src/companies/records/bonk.ts
@@ -5,8 +5,7 @@ export const bonk = {
   "id": "bonk",
   "slug": "bonk",
   "name": "BONK",
-  "gridProfileSlug": "Bonk",
-  "gridProfile": {
+  "profile": {
     "name": "BONK",
     "tagLine": "The first Solana dog coin for the people, by the people",
     "descriptionShort": "BONK is a community-driven dog-themed memecoin on Solana, governed by BonkDAO, with over 350 on-chain integrations and a deflationary burn mechanism.",

--- a/packages/ecosystem-data/src/companies/records/bridge.ts
+++ b/packages/ecosystem-data/src/companies/records/bridge.ts
@@ -5,8 +5,7 @@ export const bridge = {
   "id": "bridge",
   "slug": "bridge",
   "name": "Bridge",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Bridge",
     "tagLine": "Make money move",
     "descriptionShort": "An entirely new payments platform built with stablecoins to simplify global money movement.",

--- a/packages/ecosystem-data/src/companies/records/bydfi.ts
+++ b/packages/ecosystem-data/src/companies/records/bydfi.ts
@@ -5,8 +5,7 @@ export const bydfi = {
   "id": "bydfi",
   "slug": "bydfi",
   "name": "BYDFi",
-  "gridProfileSlug": "bydfi",
-  "gridProfile": {
+  "profile": {
     "name": "BYDFi",
     "tagLine": "BUIDL Your Dream Finance",
     "descriptionShort": "BYDFi is a centralized cryptocurrency exchange supporting trading of 1000+ altcoins and 500+ perpetual contracts, including Solana ecosystem tokens.",

--- a/packages/ecosystem-data/src/companies/records/byreal.ts
+++ b/packages/ecosystem-data/src/companies/records/byreal.ts
@@ -5,8 +5,7 @@ export const byreal = {
   "id": "byreal",
   "slug": "byreal",
   "name": "Byreal",
-  "gridProfileSlug": "byreal",
-  "gridProfile": {
+  "profile": {
     "name": "Byreal",
     "tagLine": "The onchain liquidity network for the next wave of assets",
     "descriptionShort": "Byreal is an AI agent-native DEX on Solana incubated by Bybit, combining CEX-grade liquidity with DeFi-native transparency for trading real-world and digital assets.",

--- a/packages/ecosystem-data/src/companies/records/coinbase.ts
+++ b/packages/ecosystem-data/src/companies/records/coinbase.ts
@@ -5,8 +5,7 @@ export const coinbase = {
   "id": "coinbase",
   "slug": "coinbase",
   "name": "Coinbase",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Coinbase",
     "tagLine": "Increase economic freedom in the world",
     "descriptionShort": "Coinbase is a publicly traded cryptocurrency exchange that provides a platform for buying, selling, storing, and managing digital assets including Solana and SPL tokens.",

--- a/packages/ecosystem-data/src/companies/records/dabba.ts
+++ b/packages/ecosystem-data/src/companies/records/dabba.ts
@@ -5,8 +5,7 @@ export const dabba = {
   "id": "dabba",
   "slug": "dabba",
   "name": "Dabba",
-  "gridProfileSlug": "dabba",
-  "gridProfile": {
+  "profile": {
     "name": "Dabba",
     "tagLine": "Web3 powered WiFi networks, built for emerging markets",
     "descriptionShort": "Dabba Network is a DePIN project on Solana that deploys decentralized WiFi hotspots across India to provide affordable high-speed internet access to underserved communities.",

--- a/packages/ecosystem-data/src/companies/records/darkresearch.ts
+++ b/packages/ecosystem-data/src/companies/records/darkresearch.ts
@@ -5,8 +5,7 @@ export const darkresearch = {
   "id": "darkresearch",
   "slug": "darkresearch",
   "name": "Dark Research",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Dark Research",
     "tagLine": "An AI lab for the new internet",
     "descriptionShort": "Dark Research is an applied AI lab building production applications at the intersection of blockchain infrastructure and artificial intelligence, with tools for Solana.",

--- a/packages/ecosystem-data/src/companies/records/doublezero.ts
+++ b/packages/ecosystem-data/src/companies/records/doublezero.ts
@@ -5,8 +5,7 @@ export const doublezero = {
   "id": "doublezero",
   "slug": "doublezero",
   "name": "DoubleZero",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "DoubleZero",
     "tagLine": "The High-Performance Global Network",
     "descriptionShort": "DoubleZero is a decentralized fiber network providing low-latency connectivity for distributed systems like blockchain networks.",

--- a/packages/ecosystem-data/src/companies/records/fireblocks.ts
+++ b/packages/ecosystem-data/src/companies/records/fireblocks.ts
@@ -5,8 +5,7 @@ export const fireblocks = {
   "id": "fireblocks",
   "slug": "fireblocks",
   "name": "Fireblocks",
-  "gridProfileSlug": "Fireblocks",
-  "gridProfile": {
+  "profile": {
     "name": "Fireblocks",
     "tagLine": "Digital asset and stablecoin infrastructure",
     "descriptionShort": "Fireblocks provides enterprise-grade digital asset infrastructure for securely storing, transferring, and issuing assets on Solana and other blockchains.",

--- a/packages/ecosystem-data/src/companies/records/frodobots.ts
+++ b/packages/ecosystem-data/src/companies/records/frodobots.ts
@@ -5,8 +5,7 @@ export const frodobots = {
   "id": "frodobots",
   "slug": "frodobots",
   "name": "FrodoBots",
-  "gridProfileSlug": "FrodoBots",
-  "gridProfile": {
+  "profile": {
     "name": "FrodoBots",
     "tagLine": "Crowdsourcing real-world datasets with robotic gaming",
     "descriptionShort": "FrodoBots is a robotics and blockchain company on Solana that lets users remotely control physical robots in a gaming experience while collecting real-world datasets for embodied AI research.",

--- a/packages/ecosystem-data/src/companies/records/galaxy.ts
+++ b/packages/ecosystem-data/src/companies/records/galaxy.ts
@@ -5,8 +5,7 @@ export const galaxy = {
   "id": "galaxy",
   "slug": "galaxy",
   "name": "Galaxy",
-  "gridProfileSlug": "Galaxy_Digital",
-  "gridProfile": {
+  "profile": {
     "name": "Galaxy",
     "tagLine": "Global leader in digital assets and data center infrastructure",
     "descriptionShort": "Galaxy is a publicly traded digital asset and blockchain financial services firm that provides institutional-grade trading, asset management, and infrastructure solutions.",

--- a/packages/ecosystem-data/src/companies/records/gradient.ts
+++ b/packages/ecosystem-data/src/companies/records/gradient.ts
@@ -5,8 +5,7 @@ export const gradient = {
   "id": "gradient",
   "slug": "gradient",
   "name": "Gradient Network",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Gradient Network",
     "tagLine": "Building open intelligence collectively",
     "descriptionShort": "Gradient Network is a decentralized AI infrastructure platform on Solana that enables distributed training, serving, and agentic systems through its Open Intelligence Stack.",

--- a/packages/ecosystem-data/src/companies/records/jito.ts
+++ b/packages/ecosystem-data/src/companies/records/jito.ts
@@ -5,8 +5,7 @@ export const jito = {
   "id": "jito",
   "slug": "jito",
   "name": "Jito",
-  "gridProfileSlug": "jito",
-  "gridProfile": {
+  "profile": {
     "name": "Jito",
     "tagLine": "Non-custodial liquid staking on Solana",
     "descriptionShort": "Jito is the largest DeFi protocol on Solana, providing non-custodial liquid staking with MEV rewards and MEV-optimized validator infrastructure.",

--- a/packages/ecosystem-data/src/companies/records/kast.ts
+++ b/packages/ecosystem-data/src/companies/records/kast.ts
@@ -5,8 +5,7 @@ export const kast = {
   "id": "kast",
   "slug": "kast",
   "name": "KAST",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "KAST",
     "tagLine": "Borderless finance for the internet economy.",
     "descriptionShort": "KAST is building a global financial account that lets users hold, move, and spend stablecoins across cards, transfers, and everyday payments.",

--- a/packages/ecosystem-data/src/companies/records/libeara.ts
+++ b/packages/ecosystem-data/src/companies/records/libeara.ts
@@ -5,8 +5,7 @@ export const libeara = {
   "id": "libeara",
   "slug": "libeara",
   "name": "Libeara",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Libeara",
     "tagLine": "Investing is more accessible and equitable with tokenised assets.",
     "descriptionShort": "SC Ventures incubated tokenisation platform helping organizations create, issue, and manage real-world assets on-chain.",

--- a/packages/ecosystem-data/src/companies/records/mantle-byreal.ts
+++ b/packages/ecosystem-data/src/companies/records/mantle-byreal.ts
@@ -5,8 +5,7 @@ export const mantleByreal = {
   "id": "mantle-byreal",
   "slug": "mantle-byreal",
   "name": "Mantle / Byreal",
-  "gridProfileSlug": "mantle_xyz",
-  "gridProfile": {
+  "profile": {
     "name": "Mantle / Byreal",
     "tagLine": "Building the Liquidity Chain of the Future",
     "descriptionShort": "Mantle is an Ethereum Layer 2 network that has expanded to Solana via the Mantle Super Portal and Byreal, a Solana-native decentralized exchange incubated by Bybit.",

--- a/packages/ecosystem-data/src/companies/records/openmined.ts
+++ b/packages/ecosystem-data/src/companies/records/openmined.ts
@@ -5,8 +5,7 @@ export const openmined = {
   "id": "openmined",
   "slug": "openmined",
   "name": "OpenMined",
-  "gridProfileSlug": null,
-  "gridProfile": null,
+  "profile": null,
   "defaultLogoId": "logo",
   "logos": [
     {

--- a/packages/ecosystem-data/src/companies/records/osl.ts
+++ b/packages/ecosystem-data/src/companies/records/osl.ts
@@ -5,8 +5,7 @@ export const osl = {
   "id": "osl",
   "slug": "osl",
   "name": "OSL",
-  "gridProfileSlug": "osl",
-  "gridProfile": {
+  "profile": {
     "name": "OSL",
     "tagLine": "Built for simple crypto trading.",
     "descriptionShort": "Licensed digital asset exchange providing secure trading, fiat deposits, and custody services.",

--- a/packages/ecosystem-data/src/companies/records/phantom.ts
+++ b/packages/ecosystem-data/src/companies/records/phantom.ts
@@ -5,8 +5,7 @@ export const phantom = {
   "id": "phantom",
   "slug": "phantom",
   "name": "Phantom",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Phantom",
     "tagLine": "The crypto app for everyone",
     "descriptionShort": "Phantom is a self-custodial multi-chain crypto wallet originally built for Solana, supporting token management, swaps, NFTs, and dApp interactions.",

--- a/packages/ecosystem-data/src/companies/records/play-solana.ts
+++ b/packages/ecosystem-data/src/companies/records/play-solana.ts
@@ -5,8 +5,7 @@ export const playSolana = {
   "id": "play-solana",
   "slug": "play-solana",
   "name": "Play Solana",
-  "gridProfileSlug": "playsolana",
-  "gridProfile": {
+  "profile": {
     "name": "Play Solana",
     "tagLine": "Your gateway to the Web3 gaming revolution",
     "descriptionShort": "Play Solana is a Web3 gaming ecosystem on Solana that combines a handheld gaming console, a token economy, and a curated game library.",

--- a/packages/ecosystem-data/src/companies/records/quicknode.ts
+++ b/packages/ecosystem-data/src/companies/records/quicknode.ts
@@ -5,8 +5,7 @@ export const quicknode = {
   "id": "quicknode",
   "slug": "quicknode",
   "name": "Quicknode",
-  "gridProfileSlug": "quicknode",
-  "gridProfile": {
+  "profile": {
     "name": "QuickNode",
     "tagLine": "Build, scale, and ship without compromise",
     "descriptionShort": "QuickNode provides high-performance RPC endpoints and developer tooling for building and scaling applications on Solana and other blockchains.",

--- a/packages/ecosystem-data/src/companies/records/safepal-wallet.ts
+++ b/packages/ecosystem-data/src/companies/records/safepal-wallet.ts
@@ -5,8 +5,7 @@ export const safepalWallet = {
   "id": "safepal-wallet",
   "slug": "safepal-wallet",
   "name": "Safepal wallet",
-  "gridProfileSlug": "safepal",
-  "gridProfile": {
+  "profile": {
     "name": "SafePal",
     "tagLine": "The best wallet to protect your assets",
     "descriptionShort": "SafePal is a hardware and software crypto wallet suite supporting Solana and 100+ blockchains, offering air-gapped cold storage and integrated DeFi access.",

--- a/packages/ecosystem-data/src/companies/records/solana-spaces.ts
+++ b/packages/ecosystem-data/src/companies/records/solana-spaces.ts
@@ -5,8 +5,7 @@ export const solanaSpaces = {
   "id": "solana-spaces",
   "slug": "solana-spaces",
   "name": "Solana Spaces",
-  "gridProfileSlug": "solanaspaces",
-  "gridProfile": {
+  "profile": {
     "name": "Solana Spaces",
     "tagLine": "Activating e-commerce and global IRL stores for Solana and its ecosystem",
     "descriptionShort": "Solana Spaces provides end-to-end events, merchandise, and community activations for the Solana ecosystem, operating pop-up retail stores at crypto conferences.",

--- a/packages/ecosystem-data/src/companies/records/solayer.ts
+++ b/packages/ecosystem-data/src/companies/records/solayer.ts
@@ -5,8 +5,7 @@ export const solayer = {
   "id": "solayer",
   "slug": "solayer",
   "name": "Solayer",
-  "gridProfileSlug": "Solayer",
-  "gridProfile": {
+  "profile": {
     "name": "Solayer",
     "tagLine": "Hardware-accelerated SVM",
     "descriptionShort": "Solayer is Solana's native restaking protocol, enabling SOL holders to extend the utility of their staked assets to secure additional services and protocols within the ecosystem.",

--- a/packages/ecosystem-data/src/companies/records/solflare.ts
+++ b/packages/ecosystem-data/src/companies/records/solflare.ts
@@ -5,8 +5,7 @@ export const solflare = {
   "id": "solflare",
   "slug": "solflare",
   "name": "Solflare",
-  "gridProfileSlug": "Solflare",
-  "gridProfile": {
+  "profile": {
     "name": "Solflare",
     "tagLine": "The Solana Wallet",
     "descriptionShort": "Solflare is a self-custody wallet for the Solana ecosystem, enabling users to buy, store, stake, swap tokens, and manage NFTs across web, browser extension, and mobile platforms.",

--- a/packages/ecosystem-data/src/companies/records/spi.ts
+++ b/packages/ecosystem-data/src/companies/records/spi.ts
@@ -5,8 +5,7 @@ export const spi = {
   "id": "spi",
   "slug": "spi",
   "name": "Solana Policy Institute",
-  "gridProfileSlug": "solanapolicyinstitute",
-  "gridProfile": {
+  "profile": {
     "name": "Solana Policy Institute",
     "tagLine": "Educating policymakers on how decentralized networks are the future of the digital economy",
     "descriptionShort": "The Solana Policy Institute is a non-partisan, not-for-profit organization that educates policymakers on decentralized networks and advocates for legal clarity for the Solana ecosystem.",

--- a/packages/ecosystem-data/src/companies/records/squads.ts
+++ b/packages/ecosystem-data/src/companies/records/squads.ts
@@ -5,8 +5,7 @@ export const squads = {
   "id": "squads",
   "slug": "squads",
   "name": "Squads",
-  "gridProfileSlug": "Squads",
-  "gridProfile": {
+  "profile": {
     "name": "Squads",
     "tagLine": "Finance Without Legacy Constraints",
     "descriptionShort": "Squads is the multisig standard on Solana, providing smart account infrastructure for teams, DAOs, and businesses to securely manage on-chain assets with shared ownership and permissions.",

--- a/packages/ecosystem-data/src/companies/records/sunrise.ts
+++ b/packages/ecosystem-data/src/companies/records/sunrise.ts
@@ -5,8 +5,7 @@ export const sunrise = {
   "id": "sunrise",
   "slug": "sunrise",
   "name": "Sunrise",
-  "gridProfileSlug": "sunrise",
-  "gridProfile": {
+  "profile": {
     "name": "Sunrise",
     "tagLine": "Strengthen Solana and offset carbon emissions simultaneously",
     "descriptionShort": "Sunrise Stake is a regenerative finance protocol on Solana that lets users stake SOL and automatically donate staking yield to carbon offset programs.",

--- a/packages/ecosystem-data/src/companies/records/superteam-usa.ts
+++ b/packages/ecosystem-data/src/companies/records/superteam-usa.ts
@@ -5,8 +5,7 @@ export const superteamUsa = {
   "id": "superteam-usa",
   "slug": "superteam-usa",
   "name": "Solana Superteam USA",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Superteam USA",
     "tagLine": "The talent layer of Solana in the United States.",
     "descriptionShort": "US chapter of the Superteam community connecting founders, developers, creatives, and operators building on Solana.",

--- a/packages/ecosystem-data/src/companies/records/switchboard.ts
+++ b/packages/ecosystem-data/src/companies/records/switchboard.ts
@@ -5,8 +5,7 @@ export const switchboard = {
   "id": "switchboard",
   "slug": "switchboard",
   "name": "Switchboard",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Switchboard",
     "tagLine": "The Everything Oracle",
     "descriptionShort": "Switchboard is a permissionless, multi-chain oracle protocol on Solana that provides customizable data feeds, verifiable randomness, and off-chain compute for smart contracts.",

--- a/packages/ecosystem-data/src/companies/records/triton.ts
+++ b/packages/ecosystem-data/src/companies/records/triton.ts
@@ -5,8 +5,7 @@ export const triton = {
   "id": "triton",
   "slug": "triton",
   "name": "Triton",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Triton",
     "tagLine": "Ship fast. Scale ambitiously. Never settle for downtime.",
     "descriptionShort": "Triton One is a high-performance RPC infrastructure provider for Solana, offering enterprise-grade node services with full historical data access and advanced APIs.",

--- a/packages/ecosystem-data/src/companies/records/velia-net.ts
+++ b/packages/ecosystem-data/src/companies/records/velia-net.ts
@@ -5,8 +5,7 @@ export const veliaNet = {
   "id": "velia-net",
   "slug": "velia-net",
   "name": "velia.net",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "velia.net",
     "tagLine": "Bare Metal Server Power — Reliable Server Hosting",
     "descriptionShort": "Enterprise dedicated server and bare metal hosting provider with over 20 years of industry experience.",

--- a/packages/ecosystem-data/src/companies/records/visa.ts
+++ b/packages/ecosystem-data/src/companies/records/visa.ts
@@ -5,8 +5,7 @@ export const visa = {
   "id": "visa",
   "slug": "visa",
   "name": "Visa",
-  "gridProfileSlug": null,
-  "gridProfile": {
+  "profile": {
     "name": "Visa",
     "tagLine": "A world leader in digital payments",
     "descriptionShort": "Visa has expanded its stablecoin settlement capabilities to the Solana blockchain, using USDC for cross-border payments between participating banks.",

--- a/packages/ecosystem-data/src/types.ts
+++ b/packages/ecosystem-data/src/types.ts
@@ -1,14 +1,14 @@
-export type GridProfileUrl = {
+export type ProfileUrl = {
   url?: string | null;
   urlType?: { name?: string | null } | null;
 };
 
-export type GridProfileSocial = {
+export type ProfileSocial = {
   socialType?: { name?: string | null } | null;
-  urls?: GridProfileUrl[] | null;
+  urls?: ProfileUrl[] | null;
 };
 
-export type GridProfile = {
+export type Profile = {
   name?: string | null;
   logo?: string | null;
   tagLine?: string | null;
@@ -18,8 +18,8 @@ export type GridProfile = {
   profileSector?: { name?: string | null } | null;
   profileStatus?: { name?: string | null } | null;
   profileType?: { name?: string | null } | null;
-  urls?: GridProfileUrl[] | null;
-  root?: { slug?: string | null; socials?: GridProfileSocial[] | null } | null;
+  urls?: ProfileUrl[] | null;
+  root?: { slug?: string | null; socials?: ProfileSocial[] | null } | null;
 };
 
 export type CompanyLogoFormat = "svg" | "png" | "jpg" | "jpeg" | "webp";
@@ -47,8 +47,7 @@ export type CompanyRecord = {
   slug: string;
   name: string;
   legalName?: string;
-  gridProfileSlug?: string | null;
-  gridProfile?: GridProfile | null;
+  profile?: Profile | null;
   logos: CompanyLogoAsset[];
   defaultLogoId?: string;
 };


### PR DESCRIPTION
## Summary
- rename the shared ecosystem company enrichment field from `gridProfile` to `profile`
- remove `gridProfileSlug` from `@workspace/ecosystem-data` company records and keep it as Accelerate-local sponsor augmentation
- update the ecosystem data audit/docs and Accelerate sponsor composition to match the new field ownership

## Testing
- pnpm --filter @workspace/ecosystem-data check-types
- pnpm --filter @workspace/ecosystem-data lint
- pnpm --filter solana-com-accelerate check-types
- pnpm --filter @workspace/ecosystem-data audit:data
  - expected to report `openmined` as the one remaining null profile
