### PR TITLE
chore(accelerate): update Miami Nomadz link

### DIFF
--- a/apps/accelerate/public/locales/en/common.json
+++ b/apps/accelerate/public/locales/en/common.json
@@ -197,7 +197,7 @@
         "nearestAirportValue": "Miami International Airport (MIA)",
         "accommodationsLabel": "Accommodations",
         "accommodationsValue": "Hotels near Miami Beach Convention Center",
-        "accommodationsSubValue": "Multiple hotel options available within walking distance."
+        "accommodationsSubValue": "Save up to 60% and pay on Solana for hotels near Miami Beach Convention Center."
       },
       "footerCta": {
         "dontMiss": "Don't miss",

--- a/apps/accelerate/src/app/[locale]/miami/page.tsx
+++ b/apps/accelerate/src/app/[locale]/miami/page.tsx
@@ -80,7 +80,7 @@ export default async function MiamiPage({ params }: PageProps) {
         translationPrefix="accelerate.miami.gettingThere"
         hotelDealsLink={{
           text: "View hotel deals on Nomadz (sign up required).",
-          href: "https://nomadz.xyz/stays?locationInputValue=Miami,%20FL,%20USA&destination.location=Miami&destination.latitude=25.7949095&destination.longitude=-80.1358448&filters.stars[0]=2&filters.stars[1]=3&filters.stars[2]=4&filters.stars[3]=5&filters.hideSoldOut=true&filters.distanceToPointMax=5000&checkIn=2026-05-04T00:00:00.000Z&checkOut=2026-05-07T00:00:00.000Z&guests.rooms[0].adults=1&guests.rooms[0].children[]&sort.property=Discount&sort.direction=desc",
+          href: "https://nomadz.xyz/stays?locationInputValue=Miami%20Beach%2C%20United%20States&destination.latitude=25.7947559&destination.longitude=-80.13378639999999&destination.radius=5000&guests.rooms%5B0%5D.adults=1&guests.rooms[0].children[]&checkIn=2026-05-03T23%3A00%3A00.000Z&checkOut=2026-05-06T21%3A00%3A00.000Z&filters.stars%5B0%5D=2&filters.stars%5B1%5D=3&filters.stars%5B2%5D=4&filters.stars%5B3%5D=5&filters.hideSoldOut=true&filters.distanceToPointMax=5000&sort.property=Discount&sort.direction=desc&event=10128847-d607-439e-8619-a70118d80090",
         }}
       />
       <FooterCTA

--- a/apps/accelerate/src/components/GettingThere.tsx
+++ b/apps/accelerate/src/components/GettingThere.tsx
@@ -51,7 +51,7 @@ const NOMADZ_PARAMS =
   "?checkin=2026-05-04&checkout=2026-05-07&guests.rooms%5B0%5D.adults=1&guests.rooms[0].children[]";
 
 const NOMADZ_MORE_STAYS =
-  "https://nomadz.xyz/stays?locationInputValue=Miami%2C%20FL%2C%20USA&destination.location=Miami&destination.latitude=25.7949095&destination.longitude=-80.1358448&filters.stars%5B0%5D=2&filters.stars%5B1%5D=3&filters.stars%5B2%5D=4&filters.stars%5B3%5D=5&filters.hideSoldOut=true&filters.distanceToPointMax=5000&checkIn=2026-05-04T00%3A00%3A00.000Z&checkOut=2026-05-07T00%3A00%3A00.000Z&guests.rooms%5B0%5D.adults=1&guests.rooms[0].children[]&sort.property=Discount&sort.direction=desc";
+  "https://nomadz.xyz/stays?locationInputValue=Miami%20Beach%2C%20United%20States&destination.latitude=25.7947559&destination.longitude=-80.13378639999999&destination.radius=5000&guests.rooms%5B0%5D.adults=1&guests.rooms[0].children[]&checkIn=2026-05-03T23%3A00%3A00.000Z&checkOut=2026-05-06T21%3A00%3A00.000Z&filters.stars%5B0%5D=2&filters.stars%5B1%5D=3&filters.stars%5B2%5D=4&filters.stars%5B3%5D=5&filters.hideSoldOut=true&filters.distanceToPointMax=5000&sort.property=Discount&sort.direction=desc&event=10128847-d607-439e-8619-a70118d80090";
 
 /* ─── Hotel deal data from Nomadz partnership ─── */
 const HOTEL_DEALS = [


### PR DESCRIPTION
## Summary
- update the Miami Accelerate Nomadz hotel deals URL to the new Miami Beach event link
- update the shared "More stays" link in the Accelerate getting-there component to match
- revise the Miami accommodations copy to mention saving up to 60% and paying on Solana near the venue

## Testing
- git diff --check