### PR TITLE
fix(footer): ensure content renders above decorative SVG shapes

### DIFF
--- a/packages/ui-chrome/src/footer.jsx
+++ b/packages/ui-chrome/src/footer.jsx
@@ -73,7 +73,7 @@ export const Footer = ({ className = "" }) => {
       )}
     >
       <div
-        className="w-full max-w-[1440px] px-[20px] md:px-[32px] xl:px-[72px] pt-[56px] xl:pt-[88px] pb-[136px] md:pb-[164px] xl:pb-[320px] mx-auto bg-[length:100%_auto] bg-bottom md:bg-[position:center_120%] xl:bg-bottom bg-no-repeat"
+        className="relative z-[1] w-full max-w-[1440px] px-[20px] md:px-[32px] xl:px-[72px] pt-[56px] xl:pt-[88px] pb-[136px] md:pb-[164px] xl:pb-[320px] mx-auto bg-[length:100%_auto] bg-bottom md:bg-[position:center_120%] xl:bg-bottom bg-no-repeat"
         style={{ backgroundImage: `url(${SolanaBgSvg})` }}
       >
         <div className="relative grid grid-cols-2 xl:grid-cols-6 gap-[30px]">
@@ -193,7 +193,7 @@ export const Footer = ({ className = "" }) => {
           </div>
         </div>
       </div>
-      <FooterMouseEffect className="absolute bottom-0 left-0 w-full h-[300px] hidden xl:block" />
+      <FooterMouseEffect className="absolute bottom-0 left-0 w-full h-[300px] hidden xl:block pointer-events-none" />
     </div>
   );
 };


### PR DESCRIPTION
## Summary

Fixes #1264

On the `/developers/templates` page, the footer's decorative background SVG elements (the `FooterMouseEffect` overlay) render above the footer content (logo, copyright text, social links), making them partially obscured and unclickable.

## Fix

- Added `relative z-[1]` to the footer content wrapper to establish a stacking context above the absolutely-positioned `FooterMouseEffect` overlay
- Added `pointer-events-none` to the `FooterMouseEffect` layer so it cannot block interactions with footer links

## Test plan

- Navigate to `/developers/templates`
- Scroll to the footer
- Verify logo, copyright text, and social links are fully visible and unobstructed by decorative SVGs
- Verify footer links (social icons, navigation links) are clickable
- Check on xl breakpoint where the `FooterMouseEffect` is visible (`hidden xl:block`)
- Confirm the mouse-follow effect still renders visually but does not interfere with content

🤖 Generated with [Claude Code](https://claude.com/claude-code)