### PR TITLE
feat: add GLAM skill to community skills

### DIFF
--- a/apps/web/src/data/skills/communitySkills.ts
+++ b/apps/web/src/data/skills/communitySkills.ts
@@ -68,6 +68,14 @@ export const COMMUNITY_SKILLS: CommunitySkill[] = [
     category: DEFI,
   },
   {
+    slug: "glam-skill",
+    title: "GLAM Skill",
+    description:
+      "AI coding skill for GLAM Protocol covering Solana vault management, tokenized vaults, and DeFi integrations.",
+    url: "https://github.com/glamsystems/glam-skill",
+    category: DEFI,
+  },
+  {
     slug: "jupiter-skill",
     title: "Jupiter Skill",
     description:


### PR DESCRIPTION
## Summary
- Adds GLAM Protocol skill to the community skills listing under the DeFi category
- GLAM provides Solana vault management covering tokenized vaults and DeFi integrations (Jupiter, Kamino, etc.)
- Skill URL: https://github.com/glamsystems/glam-skill