### PR TITLE
fix(sitemap): include runtime sitemap inputs in Vercel trace

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -190,6 +190,18 @@ const nextConfig: NextConfig = {
     styledComponents: true,
   },
 
+  // Include files read at runtime by the sitemap route
+  outputFileTracingIncludes: {
+    "/sitemap.xml": [
+      "./rewrites-redirects.mjs",
+      "./src/app/[[]locale[]]/**/page.{tsx,jsx,js,mdx}",
+      "../../apps/accelerate/src/app/sitemap-routes.json",
+      "../../apps/docs/content/**/*.mdx",
+      "../../apps/media/content/**/*.mdx",
+      "../../apps/media/content/**/*.yaml",
+    ],
+  },
+
   async headers() {
     return [
       {

--- a/packages/sitemap/src/redirects.ts
+++ b/packages/sitemap/src/redirects.ts
@@ -24,38 +24,50 @@ function getRedirectBlockSource() {
 }
 
 export function getRedirectSourceUrls() {
-  const redirectBlock = getRedirectBlockSource();
-  const matches = [...redirectBlock.matchAll(/source:\s*"([^"]+)"/g)];
-  const localizedSources = new Set<string>();
+  try {
+    const redirectBlock = getRedirectBlockSource();
+    const matches = [...redirectBlock.matchAll(/source:\s*"([^"]+)"/g)];
+    const localizedSources = new Set<string>();
 
-  for (const match of matches) {
-    const source = match[1];
+    for (const match of matches) {
+      const source = match[1];
 
-    if (!source) {
-      continue;
-    }
-
-    if (source.includes(":") || source.includes("(") || source.includes("*")) {
-      continue;
-    }
-
-    const normalizedSource = normalizePath(source);
-    localizedSources.add(toAbsoluteUrl(normalizedSource));
-
-    if (normalizedSource === "/") {
-      continue;
-    }
-
-    for (const locale of LOCALES) {
-      if (locale === DEFAULT_LOCALE) {
+      if (!source) {
         continue;
       }
 
-      localizedSources.add(toAbsoluteUrl(`/${locale}${normalizedSource}`));
-    }
-  }
+      if (
+        source.includes(":") ||
+        source.includes("(") ||
+        source.includes("*")
+      ) {
+        continue;
+      }
 
-  return localizedSources;
+      const normalizedSource = normalizePath(source);
+      localizedSources.add(toAbsoluteUrl(normalizedSource));
+
+      if (normalizedSource === "/") {
+        continue;
+      }
+
+      for (const locale of LOCALES) {
+        if (locale === DEFAULT_LOCALE) {
+          continue;
+        }
+
+        localizedSources.add(toAbsoluteUrl(`/${locale}${normalizedSource}`));
+      }
+    }
+
+    return localizedSources;
+  } catch (error) {
+    console.error(
+      "Failed to read redirect sources for sitemap filtering",
+      error,
+    );
+    return new Set<string>();
+  }
 }
 
 export function excludeRedirectSources(entries: SitemapEntry[]) {


### PR DESCRIPTION
## Summary
- add sitemap-specific `outputFileTracingIncludes` for runtime files used by `/sitemap.xml`
- use a glob-safe `[[]locale[]]` pattern so Next traces locale page files correctly
- fall back gracefully if redirect source parsing cannot read `rewrites-redirects.mjs`

## Verification
- `pnpm --filter solana-com build`
- confirmed `apps/web/.next/server/app/sitemap.xml/route.js.nft.json` includes `rewrites-redirects.mjs`
- confirmed `apps/web/.next/server/app/sitemap.xml/route.js.nft.json` includes `accelerate/src/app/sitemap-routes.json`
- confirmed sitemap trace includes `src/app/[locale]` page files needed by marketing sitemap generation

## Context
This addresses the Vercel runtime failure at `/sitemap.xml` where the sitemap route could not open `apps/web/rewrites-redirects.mjs` and `apps/accelerate/src/app/sitemap-routes.json` from the deployed bundle.