### PR TITLE
Fix cookie consent persistence across site apps

### DIFF
--- a/apps/docs/src/components/CookieConsent/CookieConsent.jsx
+++ b/apps/docs/src/components/CookieConsent/CookieConsent.jsx
@@ -40,38 +40,44 @@ const setLocalStorage = function (key, value) {
 export default function CookieConsent() {
   const t = useTranslations();
 
-  // cookieConsent is blank by default
-  const [cookieConsent, setCookieConsent] = useState("");
+  // cookieConsent is null by default
+  const [cookieConsent, setCookieConsent] = useState(null);
+  const [isLoaded, setIsLoaded] = useState(false);
 
   // check if it has previously set within localStorage, or null otherwise
   useEffect(() => {
     const consent = getLocalStorage("cookie_consent", null);
     setCookieConsent(consent);
+    setIsLoaded(true);
 
     // set builderNoTrack based on the previously set consent
-    if (typeof window !== "undefined" && consent) {
+    if (typeof window !== "undefined" && consent !== null) {
       window.builderNoTrack = !consent;
     }
-  }, [setCookieConsent]);
+  }, []);
 
   // update when cookieConsent is changed via onClick
   useEffect(() => {
-    if (typeof window.gtag !== "undefined" && cookieConsent !== "") {
-      setLocalStorage("cookie_consent", cookieConsent);
+    if (!isLoaded || cookieConsent === null) {
+      return;
+    }
+
+    setLocalStorage("cookie_consent", cookieConsent);
+    window.builderNoTrack = !cookieConsent;
+
+    if (typeof window.gtag !== "undefined") {
       window.gtag("consent", "update", {
         ad_storage: cookieConsent ? "granted" : "denied",
         ad_user_data: cookieConsent ? "granted" : "denied",
         ad_personalization: cookieConsent ? "granted" : "denied",
         analytics_storage: cookieConsent ? "granted" : "denied",
       });
-
-      window.builderNoTrack = !cookieConsent;
     }
-  }, [cookieConsent]);
+  }, [cookieConsent, isLoaded]);
 
   return (
     <>
-      {cookieConsent === null ? (
+      {isLoaded && cookieConsent === null ? (
         <div
           className={classNames(
             "border bg-black p-4 rounded",

--- a/apps/media/components/CookieConsent/CookieConsent.tsx
+++ b/apps/media/components/CookieConsent/CookieConsent.tsx
@@ -57,20 +57,20 @@ export const CookieConsent = () => {
 
   // update when cookieConsent is changed via onClick
   useEffect(() => {
-    if (
-      typeof (window as any).gtag !== "undefined" &&
-      cookieConsent !== null &&
-      isLoaded
-    ) {
-      setLocalStorage("cookie_consent", cookieConsent);
+    if (!isLoaded || cookieConsent === null) {
+      return;
+    }
+
+    setLocalStorage("cookie_consent", cookieConsent);
+    (window as any).builderNoTrack = !cookieConsent;
+
+    if (typeof (window as any).gtag !== "undefined") {
       (window as any).gtag("consent", "update", {
         ad_storage: cookieConsent ? "granted" : "denied",
         ad_user_data: cookieConsent ? "granted" : "denied",
         ad_personalization: cookieConsent ? "granted" : "denied",
         analytics_storage: cookieConsent ? "granted" : "denied",
       });
-
-      (window as any).builderNoTrack = !cookieConsent;
     }
   }, [cookieConsent, isLoaded]);
 

--- a/apps/templates/src/components/cookie-consent.tsx
+++ b/apps/templates/src/components/cookie-consent.tsx
@@ -64,20 +64,20 @@ export const CookieConsent = () => {
   useEffect(() => {
     const windowWithGtag = window as WindowWithGtag;
 
-    if (typeof windowWithGtag.gtag !== "undefined" && isLoaded) {
-      if (cookieConsent === null) {
-        return;
-      }
+    if (!isLoaded || cookieConsent === null) {
+      return;
+    }
 
-      setLocalStorage("cookie_consent", cookieConsent);
+    setLocalStorage("cookie_consent", cookieConsent);
+    windowWithGtag.builderNoTrack = !cookieConsent;
+
+    if (typeof windowWithGtag.gtag !== "undefined") {
       windowWithGtag.gtag("consent", "update", {
         ad_storage: cookieConsent ? "granted" : "denied",
         ad_user_data: cookieConsent ? "granted" : "denied",
         ad_personalization: cookieConsent ? "granted" : "denied",
         analytics_storage: cookieConsent ? "granted" : "denied",
       });
-
-      windowWithGtag.builderNoTrack = !cookieConsent;
     }
   }, [cookieConsent, isLoaded]);
 

--- a/apps/web/src/components/CookieConsent/CookieConsent.jsx
+++ b/apps/web/src/components/CookieConsent/CookieConsent.jsx
@@ -40,38 +40,44 @@ const setLocalStorage = function (key, value) {
 export default function CookieConsent() {
   const t = useTranslations();
 
-  // cookieConsent is blank by default
-  const [cookieConsent, setCookieConsent] = useState("");
+  // cookieConsent is null by default
+  const [cookieConsent, setCookieConsent] = useState(null);
+  const [isLoaded, setIsLoaded] = useState(false);
 
   // check if it has previously set within localStorage, or null otherwise
   useEffect(() => {
     const consent = getLocalStorage("cookie_consent", null);
     setCookieConsent(consent);
+    setIsLoaded(true);
 
     // set builderNoTrack based on the previously set consent
-    if (typeof window !== "undefined" && consent) {
+    if (typeof window !== "undefined" && consent !== null) {
       window.builderNoTrack = !consent;
     }
-  }, [setCookieConsent]);
+  }, []);
 
   // update when cookieConsent is changed via onClick
   useEffect(() => {
-    if (typeof window.gtag !== "undefined" && cookieConsent !== "") {
-      setLocalStorage("cookie_consent", cookieConsent);
+    if (!isLoaded || cookieConsent === null) {
+      return;
+    }
+
+    setLocalStorage("cookie_consent", cookieConsent);
+    window.builderNoTrack = !cookieConsent;
+
+    if (typeof window.gtag !== "undefined") {
       window.gtag("consent", "update", {
         ad_storage: cookieConsent ? "granted" : "denied",
         ad_user_data: cookieConsent ? "granted" : "denied",
         ad_personalization: cookieConsent ? "granted" : "denied",
         analytics_storage: cookieConsent ? "granted" : "denied",
       });
-
-      window.builderNoTrack = !cookieConsent;
     }
-  }, [cookieConsent]);
+  }, [cookieConsent, isLoaded]);
 
   return (
     <>
-      {cookieConsent === null ? (
+      {isLoaded && cookieConsent === null ? (
         <div
           className={classNames(
             "border bg-black p-4 rounded",


### PR DESCRIPTION
### Problem

The cookie consent flow only persisted consent and updated `builderNoTrack` when `window.gtag` was already available.

That created a privacy bug where an explicit opt-out could fail to persist if GTM had not initialized yet, and Builder tracking could remain enabled until analytics loaded. The `web` and `docs` variants also only restored `builderNoTrack` on mount when the saved consent value was truthy, so a saved opt-out was not applied consistently after reload.

### Summary of Changes

- normalized the consent state to `null | boolean` with an `isLoaded` guard
- persist `cookie_consent` immediately when consent changes, even if `gtag` is not available yet
- update `builderNoTrack` immediately for both opt-in and opt-out paths
- keep the `gtag("consent", "update", ...)` call conditional on `window.gtag` existing
- applied the fix across the `web`, `docs`, `media`, and `templates` cookie consent components

