### PR TITLE
feat: add GLAM skill to community skills (pinned to v1.0.0)

### DIFF
--- a/apps/web/src/data/skills/communitySkills.ts
+++ b/apps/web/src/data/skills/communitySkills.ts
@@ -68,6 +68,14 @@ export const COMMUNITY_SKILLS: CommunitySkill[] = [
     category: DEFI,
   },
   {
+    slug: "glam-skill",
+    title: "GLAM Skill",
+    description:
+      "AI coding skill for GLAM Protocol covering Solana vault management, tokenized vaults, and DeFi integrations.",
+    url: "https://github.com/glamsystems/glam-skill",
+    category: DEFI,
+  },
+  {
     slug: "jupiter-skill",
     title: "Jupiter Skill",
     description:

--- a/apps/web/src/data/skills/communitySkills.ts
+++ b/apps/web/src/data/skills/communitySkills.ts
@@ -72,7 +72,7 @@ export const COMMUNITY_SKILLS: CommunitySkill[] = [
     title: "GLAM Skill",
     description:
       "AI coding skill for GLAM Protocol covering Solana vault management, tokenized vaults, and DeFi integrations.",
-    url: "https://github.com/glamsystems/glam-skill",
+    url: "https://github.com/glamsystems/glam-skill/tree/v1.0.0",
     category: DEFI,
   },
   {


### PR DESCRIPTION
Adds the GLAM Protocol skill to the community skills listing under DeFi. URL is pinned to the v1.0.0 tagged release per the new CONTRIBUTING.md for community skills.

Supersedes #1335, which was closed so the tag could be cut before a fresh PR was opened.

```text
Repo:              https://github.com/glamsystems/glam-skill
Tag:               v1.0.0
Commit:            747211bef454c79e7a6ae4ec2ab9f71b44ae739a
Path:              / (repository root — SKILL.md lives at root)
Release:           https://github.com/glamsystems/glam-skill/releases/tag/v1.0.0
Maintainer:        @glamsystems
Security contact:  security@glam.systems
Secrets required:  none
Install behavior:  no remote bootstrap scripts, no postinstall hooks
Seed phrase / private key: never requested
```