### PR TITLE
fix(ui-chrome): share and lazy-load Inkeep modal across apps

### DIFF
--- a/apps/docs/src/app/[locale]/layout.tsx
+++ b/apps/docs/src/app/[locale]/layout.tsx
@@ -13,6 +13,8 @@ import { getLangDir } from "rtl-detect";
 import {
   Header,
   Footer,
+  InkeepModal,
+  InkeepProvider,
   PersistentPodcastPlayer,
   ThemeProvider,
   SitewideTopAlert,
@@ -45,13 +47,16 @@ export default async function RootLayout({ children, params }: Props) {
         <NextIntlClientProvider messages={messages} locale={locale}>
           <PostHogProvider>
             <ThemeProvider>
-              <GTMTrackingSnippet />
-              <SitewideTopAlert />
-              <CookieConsent />
-              <Header />
-              {children}
-              <Footer />
-              <PersistentPodcastPlayer />
+              <InkeepProvider>
+                <GTMTrackingSnippet />
+                <SitewideTopAlert />
+                <CookieConsent />
+                <Header />
+                {children}
+                <Footer />
+                <PersistentPodcastPlayer />
+                <InkeepModal />
+              </InkeepProvider>
             </ThemeProvider>
           </PostHogProvider>
         </NextIntlClientProvider>

--- a/apps/media/app/[locale]/layout.tsx
+++ b/apps/media/app/[locale]/layout.tsx
@@ -7,6 +7,8 @@ import { getLangDir } from "rtl-detect";
 import {
   Header,
   Footer,
+  InkeepModal,
+  InkeepProvider,
   PersistentPodcastPlayer,
   ThemeProvider,
 } from "@solana-com/ui-chrome";
@@ -121,17 +123,20 @@ export default async function LocaleLayout({ children, params }: Props) {
       {/* End Google Tag Manager (noscript) */}
       <NextIntlClientProvider messages={messages} locale={locale}>
         <ThemeProvider>
-          <GTMTrackingSnippet />
-          <CookieConsent />
-          <LayoutProvider globalSettings={globalData.global} pageData={null}>
-            <VideoDialogProvider>
-              <Header />
-              <main>{children}</main>
-              <Footer />
-              <PersistentPodcastPlayer />
-              <VideoDialog />
-            </VideoDialogProvider>
-          </LayoutProvider>
+          <InkeepProvider>
+            <GTMTrackingSnippet />
+            <CookieConsent />
+            <LayoutProvider globalSettings={globalData.global} pageData={null}>
+              <VideoDialogProvider>
+                <Header />
+                <main>{children}</main>
+                <Footer />
+                <PersistentPodcastPlayer />
+                <InkeepModal />
+                <VideoDialog />
+              </VideoDialogProvider>
+            </LayoutProvider>
+          </InkeepProvider>
         </ThemeProvider>
       </NextIntlClientProvider>
       <TailwindIndicator />

--- a/apps/templates/src/app/layout.tsx
+++ b/apps/templates/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { NextIntlClientProvider } from "next-intl";
 import {
   Header,
   Footer,
+  InkeepModal,
+  InkeepProvider,
   PersistentPodcastPlayer,
   ThemeProvider,
 } from "@solana-com/ui-chrome";
@@ -49,12 +51,15 @@ export default async function RootLayout({ children }: Props) {
         </noscript>
         <NextIntlClientProvider messages={messages} locale={locale}>
           <ThemeProvider>
-            <GTMTrackingSnippet />
-            <CookieConsent />
-            <Header showLanguage={false} showDevelopersNav={false} />
-            <main className="min-h-screen">{children}</main>
-            <Footer />
-            <PersistentPodcastPlayer />
+            <InkeepProvider>
+              <GTMTrackingSnippet />
+              <CookieConsent />
+              <Header showLanguage={false} showDevelopersNav={false} />
+              <main className="min-h-screen">{children}</main>
+              <Footer />
+              <PersistentPodcastPlayer />
+              <InkeepModal />
+            </InkeepProvider>
           </ThemeProvider>
         </NextIntlClientProvider>
       </body>

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -16,6 +16,8 @@ import {
   ThemeProvider,
   SitewideTopAlert,
   InkeepChatButton,
+  InkeepModal,
+  InkeepProvider,
   PersistentPodcastPlayer,
 } from "@solana-com/ui-chrome";
 import { ChromeWrapper } from "@/components/ChromeWrapper";
@@ -53,18 +55,21 @@ export default async function RootLayout({ children, params }: Props) {
         <NextIntlClientProvider messages={messages} locale={locale}>
           <PostHogProvider>
             <ThemeProvider>
-              <GTMTrackingSnippet />
-              <SitewideTopAlert />
-              <CookieConsent />
-              <ChromeWrapper>
-                <Header />
-              </ChromeWrapper>
-              {children}
-              <ChromeWrapper>
-                <Footer />
-              </ChromeWrapper>
-              <PersistentPodcastPlayer />
-              <InkeepChatButton />
+              <InkeepProvider>
+                <GTMTrackingSnippet />
+                <SitewideTopAlert />
+                <CookieConsent />
+                <ChromeWrapper>
+                  <Header />
+                </ChromeWrapper>
+                {children}
+                <ChromeWrapper>
+                  <Footer />
+                </ChromeWrapper>
+                <PersistentPodcastPlayer />
+                <InkeepChatButton />
+                <InkeepModal />
+              </InkeepProvider>
               <Script
                 id="signals-script"
                 strategy="afterInteractive"

--- a/packages/ui-chrome/src/index.ts
+++ b/packages/ui-chrome/src/index.ts
@@ -18,6 +18,8 @@ export { Footer } from "./footer";
 export { Header } from "./header";
 export { ThemeProvider } from "./theme-provider";
 export { InkeepChatButton } from "./inkeep-chat-button";
+export { InkeepProvider } from "./inkeep-config";
+export { InkeepModal } from "./inkeep-modal";
 export { InkeepSearchBar } from "./inkeep-searchbar";
 export { NewsletterModal } from "./newsletter-modal";
 export { PersistentPodcastPlayer } from "./persistent-podcast-player";

--- a/packages/ui-chrome/src/inkeep-chat-button.tsx
+++ b/packages/ui-chrome/src/inkeep-chat-button.tsx
@@ -1,17 +1,8 @@
 "use client";
 
-import dynamic from "next/dynamic";
-import { useInkeepConfig } from "./inkeep-config";
+import { useInkeepConfig, useOpenInkeep } from "./inkeep-config";
 import { useTranslations } from "next-intl";
 import { useId } from "react";
-
-const InkeepModalSearchAndChat = dynamic(
-  () =>
-    import("@inkeep/cxkit-react").then((mod) => mod.InkeepModalSearchAndChat),
-  {
-    ssr: false,
-  },
-);
 
 const SolanaIcon = ({ className }: { className?: string }) => {
   const id = useId();
@@ -64,35 +55,23 @@ export function InkeepChatButton({
   variant = "fixed",
 }: InkeepChatButtonProps) {
   const inkeepConfig = useInkeepConfig();
+  const openInkeep = useOpenInkeep();
   const t = useTranslations();
 
   return (
-    <>
-      <button
-        className={
-          className +
-          BUTTON_CLASSNAME[variant] +
-          " h-[36px] md:h-[44px] px-[16px] md:px-[20px] justify-center items-center gap-[8px] rounded-full !bg-gradient-to-b from-black to-[#14001D] hover:from-black hover:to-[#2A013C] shadow-[0_-4px_12px_0_#361B40_inset,0_1px_0_0_#C37CE0_inset,0_-1px_0_0_#D06BF8_inset] hover:shadow-[0_-4px_12px_0_#482654_inset,0_1px_0_0_#E2B6F4_inset,0_-1px_0_0_#EEBAFF_inset] backdrop-blur-[3px] text-white font-brand text-[14px] md:text-[16px] leading-[1.42] md:leading-[1.5] tracking-[-0.14px] md:tracking-[-0.16px] flex hover:backdrop-blur-[3px]"
-        }
-        onClick={() => inkeepConfig.modalSettings.onOpenChange(true)}
-        type="button"
-      >
-        <SolanaIcon className="size-4" />
-        <span>{t("commands.askAI")}</span>
-      </button>
-
-      <InkeepModalSearchAndChat
-        defaultView={inkeepConfig.shouldForceSearchView ? "search" : "chat"}
-        forceDefaultView={inkeepConfig.shouldForceSearchView}
-        baseSettings={inkeepConfig.baseSettings}
-        searchSettings={inkeepConfig.searchSettings}
-        aiChatSettings={inkeepConfig.aiChatSettings}
-        modalSettings={{
-          isOpen: inkeepConfig.modalSettings.isOpen,
-          onOpenChange: inkeepConfig.modalSettings.onOpenChange,
-          shortcutKey: "k",
-        }}
-      />
-    </>
+    <button
+      className={
+        className +
+        BUTTON_CLASSNAME[variant] +
+        " h-[36px] md:h-[44px] px-[16px] md:px-[20px] justify-center items-center gap-[8px] rounded-full !bg-gradient-to-b from-black to-[#14001D] hover:from-black hover:to-[#2A013C] shadow-[0_-4px_12px_0_#361B40_inset,0_1px_0_0_#C37CE0_inset,0_-1px_0_0_#D06BF8_inset] hover:shadow-[0_-4px_12px_0_#482654_inset,0_1px_0_0_#E2B6F4_inset,0_-1px_0_0_#EEBAFF_inset] backdrop-blur-[3px] text-white font-brand text-[14px] md:text-[16px] leading-[1.42] md:leading-[1.5] tracking-[-0.14px] md:tracking-[-0.16px] flex hover:backdrop-blur-[3px]"
+      }
+      onClick={openInkeep}
+      onFocus={inkeepConfig.ensureModalLoaded}
+      onPointerEnter={inkeepConfig.ensureModalLoaded}
+      type="button"
+    >
+      <SolanaIcon className="size-4" />
+      <span>{t("commands.askAI")}</span>
+    </button>
   );
 }

--- a/packages/ui-chrome/src/inkeep-config.ts
+++ b/packages/ui-chrome/src/inkeep-config.ts
@@ -815,9 +815,41 @@ export function InkeepProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (!shouldForceSearchView || !isOpen) return;
 
-    searchFunctionsRef.current?.updateQuery(searchQuery);
-    searchFunctionsRef.current?.focusInput();
-  }, [isOpen, searchQuery, shouldForceSearchView]);
+    let frameId: number | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let attempts = 0;
+
+    const syncSearchQuery = () => {
+      const searchFunctions = searchFunctionsRef.current;
+
+      if (searchFunctions) {
+        searchFunctions.updateQuery(searchQuery);
+        searchFunctions.focusInput();
+        return;
+      }
+
+      if (attempts >= 10) {
+        return;
+      }
+
+      attempts += 1;
+      timeoutId = setTimeout(() => {
+        frameId = window.requestAnimationFrame(syncSearchQuery);
+      }, 50);
+    };
+
+    syncSearchQuery();
+
+    return () => {
+      if (frameId !== null) {
+        window.cancelAnimationFrame(frameId);
+      }
+
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+    };
+  }, [isOpen, searchQuery, shouldForceSearchView, shouldRenderModal]);
 
   const value = useMemo<InkeepConfigContextValue>(
     () => ({

--- a/packages/ui-chrome/src/inkeep-config.ts
+++ b/packages/ui-chrome/src/inkeep-config.ts
@@ -1,4 +1,14 @@
-import { useEffect, useRef, useState } from "react";
+"use client";
+
+import {
+  createContext,
+  createElement,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useSearchParams } from "next/navigation";
 import faviconPng from "./assets/favicon.png";
 import type {
@@ -761,19 +771,28 @@ const aiChatSettings: InkeepAIChatSettings = {
   ],
 };
 
-export function useInkeepConfig(): {
+type InkeepConfigContextValue = {
   baseSettings: InkeepBaseSettings;
   searchSettings: InkeepSearchSettings;
   aiChatSettings: InkeepAIChatSettings;
   shouldForceSearchView: boolean;
+  shouldRenderModal: boolean;
+  ensureModalLoaded: () => void;
   modalSettings: {
     isOpen: boolean;
     onOpenChange: (isOpen: boolean) => void;
   };
-} {
+};
+
+const InkeepConfigContext = createContext<InkeepConfigContextValue | null>(
+  null,
+);
+
+export function InkeepProvider({ children }: { children: React.ReactNode }) {
   const searchParams = useSearchParams();
   const [syncTarget, setSyncTarget] = useState<HTMLElement | null>(null);
   const [isOpen, setIsOpen] = useState(false);
+  const [shouldRenderModal, setShouldRenderModal] = useState(false);
   const searchFunctionsRef = useRef<{
     updateQuery: (query: string) => void;
     focusInput: () => void;
@@ -789,6 +808,7 @@ export function useInkeepConfig(): {
   useEffect(() => {
     if (!shouldForceSearchView) return;
 
+    setShouldRenderModal(true);
     setIsOpen(true);
   }, [shouldForceSearchView]);
 
@@ -799,27 +819,59 @@ export function useInkeepConfig(): {
     searchFunctionsRef.current?.focusInput();
   }, [isOpen, searchQuery, shouldForceSearchView]);
 
-  return {
-    baseSettings: {
-      ...baseSettings,
-      colorMode: {
-        sync: {
-          target: syncTarget,
-          attributes: ["class"],
-          isDarkMode: (attributes) => !!attributes.class?.includes("dark"),
+  const value = useMemo<InkeepConfigContextValue>(
+    () => ({
+      baseSettings: {
+        ...baseSettings,
+        colorMode: {
+          sync: {
+            target: syncTarget,
+            attributes: ["class"],
+            isDarkMode: (attributes) => !!attributes.class?.includes("dark"),
+          },
         },
       },
-    },
-    modalSettings: {
-      isOpen,
-      onOpenChange: setIsOpen,
-    },
-    shouldForceSearchView,
-    searchSettings: {
-      ...searchSettings,
-      defaultQuery: searchQuery,
-      searchFunctionsRef,
-    },
-    aiChatSettings,
+      modalSettings: {
+        isOpen,
+        onOpenChange: (nextIsOpen) => {
+          if (nextIsOpen) {
+            setShouldRenderModal(true);
+          }
+
+          setIsOpen(nextIsOpen);
+        },
+      },
+      shouldForceSearchView,
+      shouldRenderModal,
+      ensureModalLoaded: () => setShouldRenderModal(true),
+      searchSettings: {
+        ...searchSettings,
+        defaultQuery: searchQuery,
+        searchFunctionsRef,
+      },
+      aiChatSettings,
+    }),
+    [isOpen, searchQuery, shouldForceSearchView, shouldRenderModal, syncTarget],
+  );
+
+  return createElement(InkeepConfigContext.Provider, { value }, children);
+}
+
+export function useInkeepConfig(): InkeepConfigContextValue {
+  const context = useContext(InkeepConfigContext);
+
+  if (!context) {
+    throw new Error("useInkeepConfig must be used within an InkeepProvider");
+  }
+
+  return context;
+}
+
+export function useOpenInkeep() {
+  const { ensureModalLoaded, modalSettings } = useInkeepConfig();
+
+  return () => {
+    ensureModalLoaded();
+    modalSettings.onOpenChange(true);
   };
 }

--- a/packages/ui-chrome/src/inkeep-modal.tsx
+++ b/packages/ui-chrome/src/inkeep-modal.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useInkeepConfig } from "./inkeep-config";
+
+const InkeepModalSearchAndChat = dynamic(
+  () =>
+    import("@inkeep/cxkit-react").then((mod) => mod.InkeepModalSearchAndChat),
+  {
+    ssr: false,
+  },
+);
+
+export function InkeepModal() {
+  const inkeepConfig = useInkeepConfig();
+
+  if (!inkeepConfig.shouldRenderModal) {
+    return null;
+  }
+
+  return (
+    <InkeepModalSearchAndChat
+      defaultView={inkeepConfig.shouldForceSearchView ? "search" : "chat"}
+      forceDefaultView={inkeepConfig.shouldForceSearchView}
+      baseSettings={inkeepConfig.baseSettings}
+      searchSettings={inkeepConfig.searchSettings}
+      aiChatSettings={inkeepConfig.aiChatSettings}
+      modalSettings={{
+        isOpen: inkeepConfig.modalSettings.isOpen,
+        onOpenChange: inkeepConfig.modalSettings.onOpenChange,
+        shortcutKey: "k",
+      }}
+    />
+  );
+}

--- a/packages/ui-chrome/src/inkeep-searchbar.tsx
+++ b/packages/ui-chrome/src/inkeep-searchbar.tsx
@@ -1,16 +1,7 @@
 "use client";
 
-import { useInkeepConfig } from "./inkeep-config";
-import dynamic from "next/dynamic";
+import { useInkeepConfig, useOpenInkeep } from "./inkeep-config";
 import { useTranslations } from "next-intl";
-
-const InkeepModalSearchAndChat = dynamic(
-  () =>
-    import("@inkeep/cxkit-react").then((mod) => mod.InkeepModalSearchAndChat),
-  {
-    ssr: false,
-  },
-);
 
 const SearchIcon = ({ className }: { className?: string }) => {
   return (
@@ -35,43 +26,31 @@ interface InkeepSearchBarProps {
 
 export function InkeepSearchBar({ className, expanded }: InkeepSearchBarProps) {
   const inkeepConfig = useInkeepConfig();
+  const openInkeep = useOpenInkeep();
   const t = useTranslations();
 
   return (
-    <>
-      <div
-        data-expanded={expanded || undefined}
-        className={`${className} group relative xl:w-[21.75rem] data-[expanded]:w-[21.75rem]`}
+    <div
+      data-expanded={expanded || undefined}
+      className={`${className} group relative xl:w-[21.75rem] data-[expanded]:w-[21.75rem]`}
+    >
+      <button
+        type="button"
+        onClick={openInkeep}
+        onFocus={inkeepConfig.ensureModalLoaded}
+        onPointerEnter={inkeepConfig.ensureModalLoaded}
+        className="w-full flex items-center gap-2 m-0 py-2.5 max-xl:px-2 xl:pr-6 xl:pl-5 group-data-[expanded]:pr-6 group-data-[expanded]:pl-5 !rounded-full bg-gray-900/50 max-xl:text-white xl:text-gray-400 group-data-[expanded]:text-gray-400 hover:text-gray-300 hover:bg-gray-900/70 focus:ring-gray-700 xl:border-[1px] group-data-[expanded]:border-[1px] !border-gray-700 shadow-sm light:!bg-white light:!border-gray-300 light:text-[#7f8391] light:hover:!bg-white light:hover:text-gray-900 focus:outline-none focus:ring-2 text-sm md:text-base leading-6 tracking-normal cursor-text transition-all duration-200 ease-in-out"
       >
-        <button
-          type="button"
-          onClick={() => inkeepConfig.modalSettings.onOpenChange(true)}
-          className="w-full flex items-center gap-2 m-0 py-2.5 max-xl:px-2 xl:pr-6 xl:pl-5 group-data-[expanded]:pr-6 group-data-[expanded]:pl-5 !rounded-full bg-gray-900/50 max-xl:text-white xl:text-gray-400 group-data-[expanded]:text-gray-400 hover:text-gray-300 hover:bg-gray-900/70 focus:ring-gray-700 xl:border-[1px] group-data-[expanded]:border-[1px] !border-gray-700 shadow-sm light:!bg-white light:!border-gray-300 light:text-[#7f8391] light:hover:!bg-white light:hover:text-gray-900 focus:outline-none focus:ring-2 text-sm md:text-base leading-6 tracking-normal cursor-text transition-all duration-200 ease-in-out"
-        >
-          <SearchIcon className="flex-shrink-0" />
+        <SearchIcon className="flex-shrink-0" />
 
-          <span className="text-left flex-1 hidden xl:inline-flex group-data-[expanded]:inline-flex">
-            {t("commands.searchOrAskAI")}
-          </span>
+        <span className="text-left flex-1 hidden xl:inline-flex group-data-[expanded]:inline-flex">
+          {t("commands.searchOrAskAI")}
+        </span>
 
-          <kbd className="hidden xl:inline-flex group-data-[expanded]:inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-gray-500 bg-gray-900/50 rounded light:text-gray-700 light:bg-gray-200">
-            ⌘K
-          </kbd>
-        </button>
-      </div>
-
-      <InkeepModalSearchAndChat
-        defaultView="search"
-        forceDefaultView={inkeepConfig.shouldForceSearchView}
-        baseSettings={inkeepConfig.baseSettings}
-        searchSettings={inkeepConfig.searchSettings}
-        aiChatSettings={inkeepConfig.aiChatSettings}
-        modalSettings={{
-          isOpen: inkeepConfig.modalSettings.isOpen,
-          onOpenChange: inkeepConfig.modalSettings.onOpenChange,
-          shortcutKey: "k",
-        }}
-      />
-    </>
+        <kbd className="hidden xl:inline-flex group-data-[expanded]:inline-flex items-center gap-1 px-2 py-0.5 text-xs font-medium text-gray-500 bg-gray-900/50 rounded light:text-gray-700 light:bg-gray-200">
+          ⌘K
+        </kbd>
+      </button>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace duplicate eager Inkeep modal mounts with a shared lazily rendered modal in `@solana-com/ui-chrome`
- add `InkeepProvider` and `InkeepModal` to the shared app layouts for web, docs, media, and templates
- keep `?search=` deep links working while avoiding missing-provider crashes on routes like `/news`

## Testing
- pnpm --filter @solana-com/ui-chrome check-types
- pnpm --filter @solana-com/ui-chrome lint
- pnpm --filter solana-com test -- --runInBand
- pnpm --filter solana-com-media lint
- pnpm --filter solana-docs lint
- pnpm --filter solana-templates lint