### PR TITLE
Share cookie consent across apps in ui-chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ i18n.cache
 .claude
 .cursor
 .codex
+.vscode
 
 # Ralph config (may contain API key)
 .cursor/ralph-config.json

--- a/apps/accelerate/src/app/[locale]/layout.tsx
+++ b/apps/accelerate/src/app/[locale]/layout.tsx
@@ -1,7 +1,11 @@
 import { ReactNode } from "react";
 import Script from "next/script";
 import { NextIntlClientProvider, AbstractIntlMessages } from "next-intl";
-import { PersistentPodcastPlayer, ThemeProvider } from "@solana-com/ui-chrome";
+import {
+  CookieConsentBanner,
+  PersistentPodcastPlayer,
+  ThemeProvider,
+} from "@solana-com/ui-chrome";
 import { FabMenu } from "@@/src/components/FabMenu";
 import { staticLocales } from "@workspace/i18n/config";
 import { loadMergedMessages } from "@workspace/i18n/messages";
@@ -118,6 +122,12 @@ export default async function RootLayout({ children, params }: Props) {
             window.dataLayer = window.dataLayer || [];
             function gtag(){dataLayer.push(arguments);}
             gtag('js', new Date());
+            gtag('consent', 'default', {
+              ad_storage: 'denied',
+              ad_user_data: 'denied',
+              ad_personalization: 'denied',
+              analytics_storage: 'denied',
+            });
             gtag('config', 'G-1YDTXXYYQ4');
           `}
         </Script>
@@ -125,6 +135,7 @@ export default async function RootLayout({ children, params }: Props) {
           <ThemeProvider>
             <main className="min-h-screen">{children}</main>
             <FabMenu />
+            <CookieConsentBanner />
             <PersistentPodcastPlayer />
           </ThemeProvider>
         </NextIntlClientProvider>

--- a/apps/breakpoint/src/app/[locale]/layout.tsx
+++ b/apps/breakpoint/src/app/[locale]/layout.tsx
@@ -4,7 +4,10 @@ import { NextIntlClientProvider } from "next-intl";
 import { getMessages } from "next-intl/server";
 import { staticLocales } from "@workspace/i18n/config";
 import { getLangDir } from "rtl-detect";
-import { PersistentPodcastPlayer } from "@solana-com/ui-chrome";
+import {
+  CookieConsentBanner,
+  PersistentPodcastPlayer,
+} from "@solana-com/ui-chrome";
 import { getBaseMetadata } from "@/app/metadata";
 import { FabMenu } from "@/components/FabMenu";
 
@@ -74,6 +77,7 @@ export default async function LocaleLayout({
       <NextIntlClientProvider locale={locale} messages={messages}>
         {children}
         <FabMenu />
+        <CookieConsentBanner />
         <PersistentPodcastPlayer />
       </NextIntlClientProvider>
     </div>

--- a/apps/breakpoint/tailwind.config.ts
+++ b/apps/breakpoint/tailwind.config.ts
@@ -1,7 +1,11 @@
 import type { Config } from "tailwindcss";
 
 export default {
-  content: ["./src/**/*.{ts,tsx}"],
+  content: [
+    "./src/**/*.{ts,tsx}",
+    "../../packages/ui/src/**/*.{js,ts,jsx,tsx}",
+    "../../packages/ui-chrome/src/**/*.{js,ts,jsx,tsx}",
+  ],
   theme: {
     screens: {
       sm: "23.5rem" /* 376px */,

--- a/apps/docs/src/components/CookieConsent/CookieConsent.jsx
+++ b/apps/docs/src/components/CookieConsent/CookieConsent.jsx
@@ -1,53 +1,7 @@
 "use client";
 
-import { useTranslations } from "next-intl";
-import { useCookieConsent } from "@solana-com/ui-chrome";
-import Button from "../shared/Button";
-import classNames from "classnames";
-import styles from "./CookieConsent.module.scss";
+import { CookieConsentBanner } from "@solana-com/ui-chrome";
 
 export default function CookieConsent() {
-  const t = useTranslations();
-  const { setCookieConsent, shouldShowBanner } = useCookieConsent();
-
-  return (
-    <>
-      {shouldShowBanner ? (
-        <div
-          className={classNames(
-            "border bg-black text-white p-4 rounded",
-            styles["cookie-consent"],
-          )}
-        >
-          <div className="small">
-            <p>{t("cookie-consent.title")}</p>
-          </div>
-
-          <div className="flex items-center justify-between smaller">
-            <div>
-              <Button
-                variant="captioned"
-                className="!px-0"
-                onClick={() => setCookieConsent(false)}
-              >
-                {t("cookie-consent.button.optout")}
-              </Button>
-              <Button
-                to="/privacy-policy#collection-of-information"
-                variant="captioned"
-                className="!px-0 ml-4"
-              >
-                {t("cookie-consent.button.details")}
-              </Button>
-            </div>
-            <Button onClick={() => setCookieConsent(true)}>
-              {t("cookie-consent.button.accept")}
-            </Button>
-          </div>
-        </div>
-      ) : (
-        ""
-      )}
-    </>
-  );
+  return <CookieConsentBanner />;
 }

--- a/apps/docs/src/components/CookieConsent/CookieConsent.jsx
+++ b/apps/docs/src/components/CookieConsent/CookieConsent.jsx
@@ -1,77 +1,18 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
+import { useCookieConsent } from "@solana-com/ui-chrome";
 import Button from "../shared/Button";
 import classNames from "classnames";
 import styles from "./CookieConsent.module.scss";
 
-// Get localstorage with expiry date
-const getLocalStorage = function (key, defaultValue) {
-  const now = new Date().getTime();
-  let sticky = null;
-
-  try {
-    sticky = JSON.parse(localStorage.getItem(key));
-  } catch (error) {
-    console.error(error);
-  }
-
-  if (sticky !== null && sticky !== "undefined") {
-    // remove stored consent value based on the expiration date
-    if (now > sticky.timeToExpire) {
-      localStorage.removeItem(key);
-    }
-    return sticky.value;
-  }
-
-  return defaultValue;
-};
-
-// Set localstorage with expiry date
-const setLocalStorage = function (key, value) {
-  const now = new Date().getTime();
-  const timeToExpire = 15778476000; //6months
-
-  const obj = { value, timeToExpire: now + timeToExpire };
-  localStorage.setItem(key, JSON.stringify(obj));
-};
-
 export default function CookieConsent() {
   const t = useTranslations();
-
-  // cookieConsent is blank by default
-  const [cookieConsent, setCookieConsent] = useState("");
-
-  // check if it has previously set within localStorage, or null otherwise
-  useEffect(() => {
-    const consent = getLocalStorage("cookie_consent", null);
-    setCookieConsent(consent);
-
-    // set builderNoTrack based on the previously set consent
-    if (typeof window !== "undefined" && consent) {
-      window.builderNoTrack = !consent;
-    }
-  }, [setCookieConsent]);
-
-  // update when cookieConsent is changed via onClick
-  useEffect(() => {
-    if (typeof window.gtag !== "undefined" && cookieConsent !== "") {
-      setLocalStorage("cookie_consent", cookieConsent);
-      window.gtag("consent", "update", {
-        ad_storage: cookieConsent ? "granted" : "denied",
-        ad_user_data: cookieConsent ? "granted" : "denied",
-        ad_personalization: cookieConsent ? "granted" : "denied",
-        analytics_storage: cookieConsent ? "granted" : "denied",
-      });
-
-      window.builderNoTrack = !cookieConsent;
-    }
-  }, [cookieConsent]);
+  const { setCookieConsent, shouldShowBanner } = useCookieConsent();
 
   return (
     <>
-      {cookieConsent === null ? (
+      {shouldShowBanner ? (
         <div
           className={classNames(
             "border bg-black text-white p-4 rounded",

--- a/apps/media/components/CookieConsent/CookieConsent.tsx
+++ b/apps/media/components/CookieConsent/CookieConsent.tsx
@@ -1,49 +1,7 @@
 "use client";
 
-import { useTranslations } from "next-intl";
-import { useCookieConsent } from "@solana-com/ui-chrome";
-import { Button } from "@/components/ui/button";
-import { Link } from "@workspace/i18n/routing";
+import { CookieConsentBanner } from "@solana-com/ui-chrome";
 
 export const CookieConsent = () => {
-  const t = useTranslations();
-  const { shouldShowBanner, setCookieConsent } = useCookieConsent();
-
-  return (
-    <>
-      {shouldShowBanner && (
-        <div className="fixed bottom-5 left-5 w-full max-w-[400px] z-[9999] border bg-black p-4 rounded shadow-lg md:bottom-5 md:left-5 max-md:bottom-0 max-md:left-0 max-md:max-w-full max-md:rounded-none max-md:border-l-0 max-md:border-r-0 max-md:border-b-0">
-          <div className="text-sm mb-3">
-            <p>{t("cookie-consent.title")}</p>
-          </div>
-
-          <div className="flex flex-col sm:flex-row items-center justify-between gap-3 text-xs">
-            <div className="flex gap-4">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-auto"
-                onClick={() => setCookieConsent(false)}
-              >
-                {t("cookie-consent.button.optout")}
-              </Button>
-              <Button variant="ghost" size="sm" className="h-auto" asChild>
-                <Link href="/privacy-policy#collection-of-information">
-                  {t("cookie-consent.button.details")}
-                </Link>
-              </Button>
-            </div>
-            <Button
-              variant="outline"
-              size="sm"
-              className="rounded-full !bg-black text-white"
-              onClick={() => setCookieConsent(true)}
-            >
-              {t("cookie-consent.button.accept")}
-            </Button>
-          </div>
-        </div>
-      )}
-    </>
-  );
+  return <CookieConsentBanner />;
 };

--- a/apps/media/components/CookieConsent/CookieConsent.tsx
+++ b/apps/media/components/CookieConsent/CookieConsent.tsx
@@ -1,82 +1,17 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
+import { useCookieConsent } from "@solana-com/ui-chrome";
 import { Button } from "@/components/ui/button";
 import { Link } from "@workspace/i18n/routing";
 
-// Get localstorage with expiry date
-const getLocalStorage = function (key: string, defaultValue: any) {
-  const now = new Date().getTime();
-  let sticky = null;
-
-  try {
-    sticky = JSON.parse(localStorage.getItem(key) || "null");
-  } catch (error) {
-    console.error(error);
-  }
-
-  if (sticky !== null && sticky !== "undefined") {
-    // remove stored consent value based on the expiration date
-    if (now > sticky.timeToExpire) {
-      localStorage.removeItem(key);
-    }
-    return sticky.value;
-  }
-
-  return defaultValue;
-};
-
-// Set localstorage with expiry date
-const setLocalStorage = function (key: string, value: boolean) {
-  const now = new Date().getTime();
-  const timeToExpire = 15778476000; //6months
-
-  const obj = { value, timeToExpire: now + timeToExpire };
-  localStorage.setItem(key, JSON.stringify(obj));
-};
-
 export const CookieConsent = () => {
   const t = useTranslations();
-
-  // cookieConsent is null by default
-  const [cookieConsent, setCookieConsent] = useState<boolean | null>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  // check if it has previously set within localStorage, or null otherwise
-  useEffect(() => {
-    const consent = getLocalStorage("cookie_consent", null);
-    setCookieConsent(consent);
-    setIsLoaded(true);
-
-    // set builderNoTrack based on the previously set consent
-    if (typeof window !== "undefined" && consent !== null) {
-      (window as any).builderNoTrack = !consent;
-    }
-  }, []);
-
-  // update when cookieConsent is changed via onClick
-  useEffect(() => {
-    if (
-      typeof (window as any).gtag !== "undefined" &&
-      cookieConsent !== null &&
-      isLoaded
-    ) {
-      setLocalStorage("cookie_consent", cookieConsent);
-      (window as any).gtag("consent", "update", {
-        ad_storage: cookieConsent ? "granted" : "denied",
-        ad_user_data: cookieConsent ? "granted" : "denied",
-        ad_personalization: cookieConsent ? "granted" : "denied",
-        analytics_storage: cookieConsent ? "granted" : "denied",
-      });
-
-      (window as any).builderNoTrack = !cookieConsent;
-    }
-  }, [cookieConsent, isLoaded]);
+  const { shouldShowBanner, setCookieConsent } = useCookieConsent();
 
   return (
     <>
-      {isLoaded && cookieConsent === null && (
+      {shouldShowBanner && (
         <div className="fixed bottom-5 left-5 w-full max-w-[400px] z-[9999] border bg-black p-4 rounded shadow-lg md:bottom-5 md:left-5 max-md:bottom-0 max-md:left-0 max-md:max-w-full max-md:rounded-none max-md:border-l-0 max-md:border-r-0 max-md:border-b-0">
           <div className="text-sm mb-3">
             <p>{t("cookie-consent.title")}</p>

--- a/apps/templates/src/components/cookie-consent.tsx
+++ b/apps/templates/src/components/cookie-consent.tsx
@@ -1,49 +1,7 @@
 "use client";
 
-import { useTranslations } from "next-intl";
-import { useCookieConsent } from "@solana-com/ui-chrome";
-import Link from "next/link";
-import { Button } from "@workspace/ui";
+import { CookieConsentBanner } from "@solana-com/ui-chrome";
 
 export const CookieConsent = () => {
-  const t = useTranslations();
-  const { shouldShowBanner, setCookieConsent } = useCookieConsent();
-
-  if (!shouldShowBanner) {
-    return null;
-  }
-
-  return (
-    <div className="fixed bottom-5 left-5 w-full max-w-[400px] z-[9999] rounded border bg-black p-4 shadow-lg md:bottom-5 md:left-5 max-md:bottom-0 max-md:left-0 max-md:max-w-full max-md:rounded-none max-md:border-l-0 max-md:border-r-0 max-md:border-b-0">
-      <div className="mb-3 text-sm">
-        <p>{t("cookie-consent.title")}</p>
-      </div>
-
-      <div className="flex flex-col items-center justify-between gap-3 text-xs sm:flex-row">
-        <div className="flex gap-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto"
-            onClick={() => setCookieConsent(false)}
-          >
-            {t("cookie-consent.button.optout")}
-          </Button>
-          <Button variant="ghost" size="sm" className="h-auto" asChild>
-            <Link href="/privacy-policy#collection-of-information">
-              {t("cookie-consent.button.details")}
-            </Link>
-          </Button>
-        </div>
-        <Button
-          variant="outline"
-          size="sm"
-          className="rounded-full !bg-black text-white"
-          onClick={() => setCookieConsent(true)}
-        >
-          {t("cookie-consent.button.accept")}
-        </Button>
-      </div>
-    </div>
-  );
+  return <CookieConsentBanner />;
 };

--- a/apps/templates/src/components/cookie-consent.tsx
+++ b/apps/templates/src/components/cookie-consent.tsx
@@ -1,87 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
+import { useCookieConsent } from "@solana-com/ui-chrome";
 import Link from "next/link";
 import { Button } from "@workspace/ui";
 
-type CookieConsentStore = {
-  value: boolean;
-  timeToExpire: number;
-};
-
-type WindowWithGtag = Window & {
-  gtag?: (...args: unknown[]) => void;
-  builderNoTrack?: boolean;
-};
-
-const getLocalStorage = (key: string, defaultValue: boolean | null) => {
-  const now = new Date().getTime();
-  let sticky: CookieConsentStore | null = null;
-
-  try {
-    const stored = JSON.parse(
-      localStorage.getItem(key) || "null",
-    ) as CookieConsentStore | null;
-    sticky = stored;
-  } catch (error) {
-    console.error(error);
-  }
-
-  if (sticky !== null) {
-    if (now > sticky.timeToExpire) {
-      localStorage.removeItem(key);
-    }
-    return sticky.value;
-  }
-
-  return defaultValue;
-};
-
-const setLocalStorage = (key: string, value: boolean) => {
-  const now = new Date().getTime();
-  const timeToExpire = 15778476000; // 6 months
-
-  const obj = { value, timeToExpire: now + timeToExpire };
-  localStorage.setItem(key, JSON.stringify(obj));
-};
-
 export const CookieConsent = () => {
   const t = useTranslations();
-  const [cookieConsent, setCookieConsent] = useState<boolean | null>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
+  const { shouldShowBanner, setCookieConsent } = useCookieConsent();
 
-  useEffect(() => {
-    const consent = getLocalStorage("cookie_consent", null);
-    setCookieConsent(consent);
-    setIsLoaded(true);
-
-    if (typeof window !== "undefined" && consent !== null) {
-      (window as WindowWithGtag).builderNoTrack = !consent;
-    }
-  }, []);
-
-  useEffect(() => {
-    const windowWithGtag = window as WindowWithGtag;
-
-    if (typeof windowWithGtag.gtag !== "undefined" && isLoaded) {
-      if (cookieConsent === null) {
-        return;
-      }
-
-      setLocalStorage("cookie_consent", cookieConsent);
-      windowWithGtag.gtag("consent", "update", {
-        ad_storage: cookieConsent ? "granted" : "denied",
-        ad_user_data: cookieConsent ? "granted" : "denied",
-        ad_personalization: cookieConsent ? "granted" : "denied",
-        analytics_storage: cookieConsent ? "granted" : "denied",
-      });
-
-      windowWithGtag.builderNoTrack = !cookieConsent;
-    }
-  }, [cookieConsent, isLoaded]);
-
-  if (!isLoaded || cookieConsent !== null) {
+  if (!shouldShowBanner) {
     return null;
   }
 

--- a/apps/web/src/components/CookieConsent/CookieConsent.jsx
+++ b/apps/web/src/components/CookieConsent/CookieConsent.jsx
@@ -1,53 +1,7 @@
 "use client";
 
-import { useTranslations } from "next-intl";
-import { useCookieConsent } from "@solana-com/ui-chrome";
-import Button from "../shared/Button";
-import classNames from "classnames";
-import styles from "./CookieConsent.module.scss";
+import { CookieConsentBanner } from "@solana-com/ui-chrome";
 
 export default function CookieConsent() {
-  const t = useTranslations();
-  const { setCookieConsent, shouldShowBanner } = useCookieConsent();
-
-  return (
-    <>
-      {shouldShowBanner ? (
-        <div
-          className={classNames(
-            "border bg-black text-white p-4 rounded",
-            styles["cookie-consent"],
-          )}
-        >
-          <div className="small">
-            <p>{t("cookie-consent.title")}</p>
-          </div>
-
-          <div className="flex items-center justify-between smaller">
-            <div>
-              <Button
-                variant="captioned"
-                className="!px-0"
-                onClick={() => setCookieConsent(false)}
-              >
-                {t("cookie-consent.button.optout")}
-              </Button>
-              <Button
-                to="/privacy-policy#collection-of-information"
-                variant="captioned"
-                className="!px-0 ml-4"
-              >
-                {t("cookie-consent.button.details")}
-              </Button>
-            </div>
-            <Button onClick={() => setCookieConsent(true)}>
-              {t("cookie-consent.button.accept")}
-            </Button>
-          </div>
-        </div>
-      ) : (
-        ""
-      )}
-    </>
-  );
+  return <CookieConsentBanner />;
 }

--- a/apps/web/src/components/CookieConsent/CookieConsent.jsx
+++ b/apps/web/src/components/CookieConsent/CookieConsent.jsx
@@ -1,77 +1,18 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { useTranslations } from "next-intl";
+import { useCookieConsent } from "@solana-com/ui-chrome";
 import Button from "../shared/Button";
 import classNames from "classnames";
 import styles from "./CookieConsent.module.scss";
 
-// Get localstorage with expiry date
-const getLocalStorage = function (key, defaultValue) {
-  const now = new Date().getTime();
-  let sticky = null;
-
-  try {
-    sticky = JSON.parse(localStorage.getItem(key));
-  } catch (error) {
-    console.error(error);
-  }
-
-  if (sticky !== null && sticky !== "undefined") {
-    // remove stored consent value based on the expiration date
-    if (now > sticky.timeToExpire) {
-      localStorage.removeItem(key);
-    }
-    return sticky.value;
-  }
-
-  return defaultValue;
-};
-
-// Set localstorage with expiry date
-const setLocalStorage = function (key, value) {
-  const now = new Date().getTime();
-  const timeToExpire = 15778476000; //6months
-
-  const obj = { value, timeToExpire: now + timeToExpire };
-  localStorage.setItem(key, JSON.stringify(obj));
-};
-
 export default function CookieConsent() {
   const t = useTranslations();
-
-  // cookieConsent is blank by default
-  const [cookieConsent, setCookieConsent] = useState("");
-
-  // check if it has previously set within localStorage, or null otherwise
-  useEffect(() => {
-    const consent = getLocalStorage("cookie_consent", null);
-    setCookieConsent(consent);
-
-    // set builderNoTrack based on the previously set consent
-    if (typeof window !== "undefined" && consent) {
-      window.builderNoTrack = !consent;
-    }
-  }, [setCookieConsent]);
-
-  // update when cookieConsent is changed via onClick
-  useEffect(() => {
-    if (typeof window.gtag !== "undefined" && cookieConsent !== "") {
-      setLocalStorage("cookie_consent", cookieConsent);
-      window.gtag("consent", "update", {
-        ad_storage: cookieConsent ? "granted" : "denied",
-        ad_user_data: cookieConsent ? "granted" : "denied",
-        ad_personalization: cookieConsent ? "granted" : "denied",
-        analytics_storage: cookieConsent ? "granted" : "denied",
-      });
-
-      window.builderNoTrack = !cookieConsent;
-    }
-  }, [cookieConsent]);
+  const { setCookieConsent, shouldShowBanner } = useCookieConsent();
 
   return (
     <>
-      {cookieConsent === null ? (
+      {shouldShowBanner ? (
         <div
           className={classNames(
             "border bg-black text-white p-4 rounded",

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -1410,7 +1410,8 @@
     "button": {
       "accept": "Accept",
       "optout": "Opt-out",
-      "details": "Details"
+      "details": "Details",
+      "manage": "Manage privacy"
     }
   },
   "artistsAndCreatorsNewsletter": {

--- a/packages/i18n/src/messages.test.ts
+++ b/packages/i18n/src/messages.test.ts
@@ -48,6 +48,24 @@ describe("@workspace/i18n messages", () => {
     expect(mediaMessages.nav).toEqual(webMessages.nav);
   });
 
+  it("inherits shared web messages for accelerate", async () => {
+    const messages = await loadMergedMessages({
+      app: "accelerate",
+      locale: "en",
+    });
+
+    expect(messages).toHaveProperty("cookie-consent");
+  });
+
+  it("inherits shared web messages for breakpoint", async () => {
+    const messages = await loadMergedMessages({
+      app: "breakpoint",
+      locale: "en",
+    });
+
+    expect(messages).toHaveProperty("cookie-consent");
+  });
+
   it("does not let primitives overwrite structured English objects", () => {
     const merged = deepMergeMessages(
       { nested: { label: "English" } },

--- a/packages/i18n/src/messages.ts
+++ b/packages/i18n/src/messages.ts
@@ -25,9 +25,9 @@ const appMessageLoaders: Partial<Record<AppId, MessageLoader>> = {
 const appInheritance: Record<AppId, AppId[]> = {
   web: [],
   docs: ["web"],
-  accelerate: [],
+  accelerate: ["web"],
   media: ["web"],
-  breakpoint: [],
+  breakpoint: ["web"],
   templates: ["web"],
 };
 

--- a/packages/ui-chrome/package.json
+++ b/packages/ui-chrome/package.json
@@ -52,6 +52,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-navigation-menu": "^1.2.3",
     "@radix-ui/react-visually-hidden": "^1.1.0",
+    "@workspace/ui": "workspace:*",
     "classnames": "^2.5.1",
     "react-feather": "^2.0.10",
     "tailwind-merge": "^3.3.1"

--- a/packages/ui-chrome/src/__tests__/cookie-consent.test.ts
+++ b/packages/ui-chrome/src/__tests__/cookie-consent.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  applyCookieConsent,
+  COOKIE_CONSENT_KEY,
+  COOKIE_CONSENT_TTL_MS,
+  persistCookieConsent,
+  readCookieConsent,
+} from "../cookie-consent";
+
+describe("cookie consent helpers", () => {
+  it("returns null and removes expired consent instead of reviving it", () => {
+    const removeItem = vi.fn();
+    const storage = {
+      getItem: vi.fn(() =>
+        JSON.stringify({
+          value: true,
+          timeToExpire: 10,
+        }),
+      ),
+      removeItem,
+    };
+
+    const consent = readCookieConsent({
+      now: 11,
+      storage,
+    });
+
+    expect(consent).toBeNull();
+    expect(removeItem).toHaveBeenCalledWith(COOKIE_CONSENT_KEY);
+  });
+
+  it("persists consent with the shared ttl", () => {
+    const setItem = vi.fn();
+
+    persistCookieConsent({
+      now: 100,
+      storage: { setItem },
+      value: false,
+    });
+
+    expect(setItem).toHaveBeenCalledWith(
+      COOKIE_CONSENT_KEY,
+      JSON.stringify({
+        value: false,
+        timeToExpire: 100 + COOKIE_CONSENT_TTL_MS,
+      }),
+    );
+  });
+
+  it("updates builder tracking even when gtag is unavailable", () => {
+    const targetWindow = {};
+
+    applyCookieConsent({
+      value: false,
+      targetWindow,
+    });
+
+    expect(targetWindow).toMatchObject({
+      builderNoTrack: true,
+    });
+  });
+
+  it("updates gtag consent when available", () => {
+    const gtag = vi.fn();
+
+    applyCookieConsent({
+      value: true,
+      targetWindow: {
+        gtag,
+      },
+    });
+
+    expect(gtag).toHaveBeenCalledWith("consent", "update", {
+      ad_storage: "granted",
+      ad_user_data: "granted",
+      ad_personalization: "granted",
+      analytics_storage: "granted",
+    });
+  });
+});

--- a/packages/ui-chrome/src/cookie-consent-banner.tsx
+++ b/packages/ui-chrome/src/cookie-consent-banner.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { Shield } from "react-feather";
+import { Button } from "@workspace/ui";
+import { Link } from "./link";
+import { useCookieConsent } from "./cookie-consent";
+
+export function CookieConsentBanner() {
+  const t = useTranslations();
+  const { shouldShowBanner, setCookieConsent } = useCookieConsent();
+
+  if (!shouldShowBanner) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-5 left-5 z-[9999] w-[calc(100%-2.5rem)] max-w-[28rem] max-md:bottom-0 max-md:left-0 max-md:w-full max-md:max-w-full">
+      <div className="relative overflow-hidden rounded-[1.75rem] border border-white/12 bg-zinc-950/95 p-5 text-white shadow-[0_24px_80px_-32px_rgba(0,0,0,0.9)] backdrop-blur-xl max-md:rounded-none max-md:border-x-0 max-md:border-b-0">
+        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(52,211,153,0.22),transparent_34%),radial-gradient(circle_at_top_right,rgba(129,140,248,0.2),transparent_30%),radial-gradient(circle_at_bottom_left,rgba(34,211,238,0.18),transparent_30%)]" />
+        <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-emerald-400/0 via-emerald-300/80 to-cyan-300/0" />
+
+        <div className="relative space-y-4">
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 rounded-2xl border border-emerald-400/20 bg-emerald-400/10 p-2.5 text-emerald-300">
+              <Shield className="size-4" />
+            </div>
+            <div className="space-y-2">
+              <div className="flex items-center gap-2">
+                <span className="h-2 w-2 rounded-full bg-emerald-400" />
+                <span className="h-2 w-2 rounded-full bg-indigo-400" />
+                <span className="h-2 w-2 rounded-full bg-cyan-400" />
+              </div>
+              <p className="max-w-[24rem] text-sm leading-6 text-white/88">
+                {t("cookie-consent.title")}
+              </p>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-wrap items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-auto rounded-full px-0 text-xs font-medium text-white/72 hover:bg-transparent hover:text-white"
+                onClick={() => setCookieConsent(false)}
+              >
+                {t("cookie-consent.button.optout")}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                className="h-8 rounded-full border-white/14 bg-white/6 px-3 text-xs text-white hover:border-cyan-300/40 hover:bg-white/10 hover:text-white"
+                asChild
+              >
+                <Link href="/privacy-policy#collection-of-information">
+                  {t("cookie-consent.button.details")}
+                </Link>
+              </Button>
+            </div>
+
+            <Button
+              size="sm"
+              className="h-9 rounded-full border border-transparent bg-gradient-to-r from-emerald-400 via-cyan-400 to-indigo-400 px-4 text-sm font-semibold text-zinc-950 shadow-[0_12px_32px_-16px_rgba(34,211,238,0.9)] transition-transform hover:scale-[1.01] hover:from-emerald-300 hover:via-cyan-300 hover:to-indigo-300"
+              onClick={() => setCookieConsent(true)}
+            >
+              {t("cookie-consent.button.accept")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui-chrome/src/cookie-consent-banner.tsx
+++ b/packages/ui-chrome/src/cookie-consent-banner.tsx
@@ -22,9 +22,6 @@ export function CookieConsentBanner() {
     <>
       <div className="fixed bottom-5 left-5 z-[9999] w-[calc(100%-2.5rem)] max-w-[28rem] max-md:bottom-0 max-md:left-0 max-md:w-full max-md:max-w-full">
         <div className="relative overflow-hidden bg-zinc-950/95 p-5 text-white shadow-[0_24px_80px_-32px_rgba(0,0,0,0.9)] backdrop-blur-xl max-md:rounded-none">
-          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(52,211,153,0.22),transparent_34%),radial-gradient(circle_at_top_right,rgba(129,140,248,0.2),transparent_30%),radial-gradient(circle_at_bottom_left,rgba(34,211,238,0.18),transparent_30%)]" />
-          <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-emerald-400/0 via-emerald-300/80 to-cyan-300/0" />
-
           <div className="relative space-y-4">
             <div className="flex items-start gap-3">
               <div className="px-2.5 text-emerald-300">

--- a/packages/ui-chrome/src/cookie-consent-banner.tsx
+++ b/packages/ui-chrome/src/cookie-consent-banner.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Shield } from "react-feather";
 import { Button } from "@workspace/ui";
-import { useCookieConsent } from "./cookie-consent";
+import { useCookieConsent } from "./use-cookie-consent";
 import { Link } from "./link";
 
 export function CookieConsentBanner() {

--- a/packages/ui-chrome/src/cookie-consent-banner.tsx
+++ b/packages/ui-chrome/src/cookie-consent-banner.tsx
@@ -1,74 +1,113 @@
 "use client";
 
+import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Shield } from "react-feather";
 import { Button } from "@workspace/ui";
-import { Link } from "./link";
 import { useCookieConsent } from "./cookie-consent";
+import { Link } from "./link";
 
 export function CookieConsentBanner() {
   const t = useTranslations();
-  const { shouldShowBanner, setCookieConsent } = useCookieConsent();
+  const { cookieConsent, isLoaded, setCookieConsent, shouldShowBanner } =
+    useCookieConsent();
+  const [isOpen, setIsOpen] = useState(false);
 
-  if (!shouldShowBanner) {
+  useEffect(() => {
+    if (shouldShowBanner) {
+      setIsOpen(true);
+    }
+  }, [shouldShowBanner]);
+
+  if (!isLoaded) {
     return null;
   }
 
+  const showBanner = shouldShowBanner || isOpen;
+
   return (
-    <div className="fixed bottom-5 left-5 z-[9999] w-[calc(100%-2.5rem)] max-w-[28rem] max-md:bottom-0 max-md:left-0 max-md:w-full max-md:max-w-full">
-      <div className="relative overflow-hidden rounded-[1.75rem] border border-white/12 bg-zinc-950/95 p-5 text-white shadow-[0_24px_80px_-32px_rgba(0,0,0,0.9)] backdrop-blur-xl max-md:rounded-none max-md:border-x-0 max-md:border-b-0">
-        <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(52,211,153,0.22),transparent_34%),radial-gradient(circle_at_top_right,rgba(129,140,248,0.2),transparent_30%),radial-gradient(circle_at_bottom_left,rgba(34,211,238,0.18),transparent_30%)]" />
-        <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-emerald-400/0 via-emerald-300/80 to-cyan-300/0" />
+    <>
+      {showBanner ? (
+        <div className="fixed bottom-5 left-5 z-[9999] w-[calc(100%-2.5rem)] max-w-[28rem] max-md:bottom-0 max-md:left-0 max-md:w-full max-md:max-w-full">
+          <div className="relative overflow-hidden rounded-[1.75rem] border border-white/12 bg-zinc-950/95 p-5 text-white shadow-[0_24px_80px_-32px_rgba(0,0,0,0.9)] backdrop-blur-xl max-md:rounded-none max-md:border-x-0 max-md:border-b-0">
+            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(52,211,153,0.22),transparent_34%),radial-gradient(circle_at_top_right,rgba(129,140,248,0.2),transparent_30%),radial-gradient(circle_at_bottom_left,rgba(34,211,238,0.18),transparent_30%)]" />
+            <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-emerald-400/0 via-emerald-300/80 to-cyan-300/0" />
 
-        <div className="relative space-y-4">
-          <div className="flex items-start gap-3">
-            <div className="mt-0.5 rounded-2xl border border-emerald-400/20 bg-emerald-400/10 p-2.5 text-emerald-300">
-              <Shield className="size-4" />
-            </div>
-            <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <span className="h-2 w-2 rounded-full bg-emerald-400" />
-                <span className="h-2 w-2 rounded-full bg-indigo-400" />
-                <span className="h-2 w-2 rounded-full bg-cyan-400" />
+            <div className="relative space-y-4">
+              <div className="flex items-start gap-3">
+                <div className="mt-0.5 rounded-2xl border border-emerald-400/20 bg-emerald-400/10 p-2.5 text-emerald-300">
+                  <Shield className="size-4" />
+                </div>
+                <div className="space-y-2">
+                  <div className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-emerald-400" />
+                    <span className="h-2 w-2 rounded-full bg-indigo-400" />
+                    <span className="h-2 w-2 rounded-full bg-cyan-400" />
+                  </div>
+                  <p className="max-w-[24rem] text-sm leading-6 text-white/88">
+                    {t("cookie-consent.title")}
+                  </p>
+                </div>
               </div>
-              <p className="max-w-[24rem] text-sm leading-6 text-white/88">
-                {t("cookie-consent.title")}
-              </p>
-            </div>
-          </div>
 
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex flex-wrap items-center gap-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-auto rounded-full px-0 text-xs font-medium text-white/72 hover:bg-transparent hover:text-white"
-                onClick={() => setCookieConsent(false)}
-              >
-                {t("cookie-consent.button.optout")}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-8 rounded-full border-white/14 bg-white/6 px-3 text-xs text-white hover:border-cyan-300/40 hover:bg-white/10 hover:text-white"
-                asChild
-              >
-                <Link href="/privacy-policy#collection-of-information">
-                  {t("cookie-consent.button.details")}
-                </Link>
-              </Button>
-            </div>
+              <div className="space-y-3">
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-10 rounded-full border-white/14 bg-white/6 px-4 text-sm font-semibold text-white hover:border-rose-300/40 hover:bg-white/10 hover:text-white"
+                    onClick={() => {
+                      setCookieConsent(false);
+                      setIsOpen(false);
+                    }}
+                  >
+                    {t("cookie-consent.button.optout")}
+                  </Button>
 
-            <Button
-              size="sm"
-              className="h-9 rounded-full border border-transparent bg-gradient-to-r from-emerald-400 via-cyan-400 to-indigo-400 px-4 text-sm font-semibold text-zinc-950 shadow-[0_12px_32px_-16px_rgba(34,211,238,0.9)] transition-transform hover:scale-[1.01] hover:from-emerald-300 hover:via-cyan-300 hover:to-indigo-300"
-              onClick={() => setCookieConsent(true)}
-            >
-              {t("cookie-consent.button.accept")}
-            </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-10 rounded-full border-white/14 bg-white/6 px-4 text-sm font-semibold text-white hover:border-emerald-300/40 hover:bg-white/10 hover:text-white"
+                    onClick={() => {
+                      setCookieConsent(true);
+                      setIsOpen(false);
+                    }}
+                  >
+                    {t("cookie-consent.button.accept")}
+                  </Button>
+                </div>
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="h-8 rounded-full border-white/14 bg-white/6 px-3 text-xs text-white hover:border-cyan-300/40 hover:bg-white/10 hover:text-white"
+                    asChild
+                  >
+                    <Link href="/privacy-policy#collection-of-information">
+                      {t("cookie-consent.button.details")}
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
-    </div>
+      ) : null}
+
+      {cookieConsent !== null && !isOpen ? (
+        <div className="fixed bottom-5 left-5 z-[9998] max-md:bottom-4 max-md:left-4">
+          <Button
+            variant="outline"
+            size="sm"
+            className="h-9 rounded-full border-white/12 bg-zinc-950/90 px-3 text-xs font-medium text-white shadow-[0_18px_48px_-28px_rgba(0,0,0,0.85)] backdrop-blur-xl hover:border-cyan-300/40 hover:bg-zinc-900 hover:text-white"
+            onClick={() => setIsOpen(true)}
+          >
+            <Shield className="size-3.5" />
+            {t("cookie-consent.button.manage")}
+          </Button>
+        </div>
+      ) : null}
+    </>
   );
 }

--- a/packages/ui-chrome/src/cookie-consent-banner.tsx
+++ b/packages/ui-chrome/src/cookie-consent-banner.tsx
@@ -21,21 +21,16 @@ export function CookieConsentBanner() {
   return (
     <>
       <div className="fixed bottom-5 left-5 z-[9999] w-[calc(100%-2.5rem)] max-w-[28rem] max-md:bottom-0 max-md:left-0 max-md:w-full max-md:max-w-full">
-        <div className="relative overflow-hidden rounded-[1.75rem] border border-white/12 bg-zinc-950/95 p-5 text-white shadow-[0_24px_80px_-32px_rgba(0,0,0,0.9)] backdrop-blur-xl max-md:rounded-none max-md:border-x-0 max-md:border-b-0">
+        <div className="relative overflow-hidden bg-zinc-950/95 p-5 text-white shadow-[0_24px_80px_-32px_rgba(0,0,0,0.9)] backdrop-blur-xl max-md:rounded-none">
           <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(52,211,153,0.22),transparent_34%),radial-gradient(circle_at_top_right,rgba(129,140,248,0.2),transparent_30%),radial-gradient(circle_at_bottom_left,rgba(34,211,238,0.18),transparent_30%)]" />
           <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-emerald-400/0 via-emerald-300/80 to-cyan-300/0" />
 
           <div className="relative space-y-4">
             <div className="flex items-start gap-3">
-              <div className="mt-0.5 rounded-2xl border border-emerald-400/20 bg-emerald-400/10 p-2.5 text-emerald-300">
-                <Shield className="size-4" />
+              <div className="px-2.5 text-emerald-300">
+                <Shield className="size-5" />
               </div>
               <div className="space-y-2">
-                <div className="flex items-center gap-2">
-                  <span className="h-2 w-2 rounded-full bg-emerald-400" />
-                  <span className="h-2 w-2 rounded-full bg-indigo-400" />
-                  <span className="h-2 w-2 rounded-full bg-cyan-400" />
-                </div>
                 <p className="max-w-[24rem] text-sm leading-6 text-white/88">
                   {t("cookie-consent.title")}
                 </p>
@@ -69,7 +64,7 @@ export function CookieConsentBanner() {
 
               <div className="flex flex-wrap items-center gap-2">
                 <Button
-                  variant="outline"
+                  variant="link"
                   size="sm"
                   className="h-8 rounded-full border-white/14 bg-white/6 px-3 text-xs text-white hover:border-cyan-300/40 hover:bg-white/10 hover:text-white"
                   asChild

--- a/packages/ui-chrome/src/cookie-consent-banner.tsx
+++ b/packages/ui-chrome/src/cookie-consent-banner.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { useTranslations } from "next-intl";
 import { Shield } from "react-feather";
 import { Button } from "@workspace/ui";
@@ -9,105 +8,81 @@ import { Link } from "./link";
 
 export function CookieConsentBanner() {
   const t = useTranslations();
-  const { cookieConsent, isLoaded, setCookieConsent, shouldShowBanner } =
-    useCookieConsent();
-  const [isOpen, setIsOpen] = useState(false);
-
-  useEffect(() => {
-    if (shouldShowBanner) {
-      setIsOpen(true);
-    }
-  }, [shouldShowBanner]);
+  const { isLoaded, setCookieConsent, shouldShowBanner } = useCookieConsent();
 
   if (!isLoaded) {
     return null;
   }
 
-  const showBanner = shouldShowBanner || isOpen;
+  if (!shouldShowBanner) {
+    return null;
+  }
 
   return (
     <>
-      {showBanner ? (
-        <div className="fixed bottom-5 left-5 z-[9999] w-[calc(100%-2.5rem)] max-w-[28rem] max-md:bottom-0 max-md:left-0 max-md:w-full max-md:max-w-full">
-          <div className="relative overflow-hidden rounded-[1.75rem] border border-white/12 bg-zinc-950/95 p-5 text-white shadow-[0_24px_80px_-32px_rgba(0,0,0,0.9)] backdrop-blur-xl max-md:rounded-none max-md:border-x-0 max-md:border-b-0">
-            <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(52,211,153,0.22),transparent_34%),radial-gradient(circle_at_top_right,rgba(129,140,248,0.2),transparent_30%),radial-gradient(circle_at_bottom_left,rgba(34,211,238,0.18),transparent_30%)]" />
-            <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-emerald-400/0 via-emerald-300/80 to-cyan-300/0" />
+      <div className="fixed bottom-5 left-5 z-[9999] w-[calc(100%-2.5rem)] max-w-[28rem] max-md:bottom-0 max-md:left-0 max-md:w-full max-md:max-w-full">
+        <div className="relative overflow-hidden rounded-[1.75rem] border border-white/12 bg-zinc-950/95 p-5 text-white shadow-[0_24px_80px_-32px_rgba(0,0,0,0.9)] backdrop-blur-xl max-md:rounded-none max-md:border-x-0 max-md:border-b-0">
+          <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top_left,rgba(52,211,153,0.22),transparent_34%),radial-gradient(circle_at_top_right,rgba(129,140,248,0.2),transparent_30%),radial-gradient(circle_at_bottom_left,rgba(34,211,238,0.18),transparent_30%)]" />
+          <div className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-emerald-400/0 via-emerald-300/80 to-cyan-300/0" />
 
-            <div className="relative space-y-4">
-              <div className="flex items-start gap-3">
-                <div className="mt-0.5 rounded-2xl border border-emerald-400/20 bg-emerald-400/10 p-2.5 text-emerald-300">
-                  <Shield className="size-4" />
+          <div className="relative space-y-4">
+            <div className="flex items-start gap-3">
+              <div className="mt-0.5 rounded-2xl border border-emerald-400/20 bg-emerald-400/10 p-2.5 text-emerald-300">
+                <Shield className="size-4" />
+              </div>
+              <div className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <span className="h-2 w-2 rounded-full bg-emerald-400" />
+                  <span className="h-2 w-2 rounded-full bg-indigo-400" />
+                  <span className="h-2 w-2 rounded-full bg-cyan-400" />
                 </div>
-                <div className="space-y-2">
-                  <div className="flex items-center gap-2">
-                    <span className="h-2 w-2 rounded-full bg-emerald-400" />
-                    <span className="h-2 w-2 rounded-full bg-indigo-400" />
-                    <span className="h-2 w-2 rounded-full bg-cyan-400" />
-                  </div>
-                  <p className="max-w-[24rem] text-sm leading-6 text-white/88">
-                    {t("cookie-consent.title")}
-                  </p>
-                </div>
+                <p className="max-w-[24rem] text-sm leading-6 text-white/88">
+                  {t("cookie-consent.title")}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-10 rounded-full border-white/14 bg-white/6 px-4 text-sm font-semibold text-white hover:border-rose-300/40 hover:bg-white/10 hover:text-white"
+                  onClick={() => {
+                    setCookieConsent(false);
+                  }}
+                >
+                  {t("cookie-consent.button.optout")}
+                </Button>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-10 rounded-full border-white/14 bg-white/6 px-4 text-sm font-semibold text-white hover:border-emerald-300/40 hover:bg-white/10 hover:text-white"
+                  onClick={() => {
+                    setCookieConsent(true);
+                  }}
+                >
+                  {t("cookie-consent.button.accept")}
+                </Button>
               </div>
 
-              <div className="space-y-3">
-                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-10 rounded-full border-white/14 bg-white/6 px-4 text-sm font-semibold text-white hover:border-rose-300/40 hover:bg-white/10 hover:text-white"
-                    onClick={() => {
-                      setCookieConsent(false);
-                      setIsOpen(false);
-                    }}
-                  >
-                    {t("cookie-consent.button.optout")}
-                  </Button>
-
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-10 rounded-full border-white/14 bg-white/6 px-4 text-sm font-semibold text-white hover:border-emerald-300/40 hover:bg-white/10 hover:text-white"
-                    onClick={() => {
-                      setCookieConsent(true);
-                      setIsOpen(false);
-                    }}
-                  >
-                    {t("cookie-consent.button.accept")}
-                  </Button>
-                </div>
-
-                <div className="flex flex-wrap items-center gap-2">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="h-8 rounded-full border-white/14 bg-white/6 px-3 text-xs text-white hover:border-cyan-300/40 hover:bg-white/10 hover:text-white"
-                    asChild
-                  >
-                    <Link href="/privacy-policy#collection-of-information">
-                      {t("cookie-consent.button.details")}
-                    </Link>
-                  </Button>
-                </div>
+              <div className="flex flex-wrap items-center gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="h-8 rounded-full border-white/14 bg-white/6 px-3 text-xs text-white hover:border-cyan-300/40 hover:bg-white/10 hover:text-white"
+                  asChild
+                >
+                  <Link href="/privacy-policy#collection-of-information">
+                    {t("cookie-consent.button.details")}
+                  </Link>
+                </Button>
               </div>
             </div>
           </div>
         </div>
-      ) : null}
-
-      {cookieConsent !== null && !isOpen ? (
-        <div className="fixed bottom-5 left-5 z-[9998] max-md:bottom-4 max-md:left-4">
-          <Button
-            variant="outline"
-            size="sm"
-            className="h-9 rounded-full border-white/12 bg-zinc-950/90 px-3 text-xs font-medium text-white shadow-[0_18px_48px_-28px_rgba(0,0,0,0.85)] backdrop-blur-xl hover:border-cyan-300/40 hover:bg-zinc-900 hover:text-white"
-            onClick={() => setIsOpen(true)}
-          >
-            <Shield className="size-3.5" />
-            {t("cookie-consent.button.manage")}
-          </Button>
-        </div>
-      ) : null}
+      </div>
     </>
   );
 }

--- a/packages/ui-chrome/src/cookie-consent.ts
+++ b/packages/ui-chrome/src/cookie-consent.ts
@@ -1,4 +1,5 @@
 export const COOKIE_CONSENT_KEY = "cookie_consent";
+// ~182.6 days (~6 months); 15778476000 = 6 × 30.436875d in ms
 export const COOKIE_CONSENT_TTL_MS = 15778476000;
 
 type CookieConsentStore = {

--- a/packages/ui-chrome/src/cookie-consent.ts
+++ b/packages/ui-chrome/src/cookie-consent.ts
@@ -1,5 +1,3 @@
-import { useEffect, useState } from "react";
-
 export const COOKIE_CONSENT_KEY = "cookie_consent";
 export const COOKIE_CONSENT_TTL_MS = 15778476000;
 
@@ -94,47 +92,4 @@ export const applyCookieConsent = ({
     ad_personalization: value ? "granted" : "denied",
     analytics_storage: value ? "granted" : "denied",
   });
-};
-
-export const useCookieConsent = () => {
-  const [cookieConsent, setCookieConsent] = useState<CookieConsentValue>(null);
-  const [isLoaded, setIsLoaded] = useState(false);
-
-  useEffect(() => {
-    const consent = readCookieConsent({
-      storage: window.localStorage,
-    });
-
-    setCookieConsent(consent);
-    setIsLoaded(true);
-
-    if (consent !== null) {
-      applyCookieConsent({
-        value: consent,
-        targetWindow: window as CookieConsentWindow,
-      });
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!isLoaded || cookieConsent === null) {
-      return;
-    }
-
-    persistCookieConsent({
-      storage: window.localStorage,
-      value: cookieConsent,
-    });
-    applyCookieConsent({
-      value: cookieConsent,
-      targetWindow: window as CookieConsentWindow,
-    });
-  }, [cookieConsent, isLoaded]);
-
-  return {
-    cookieConsent,
-    isLoaded,
-    setCookieConsent,
-    shouldShowBanner: isLoaded && cookieConsent === null,
-  };
 };

--- a/packages/ui-chrome/src/cookie-consent.ts
+++ b/packages/ui-chrome/src/cookie-consent.ts
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+
+export const COOKIE_CONSENT_KEY = "cookie_consent";
+export const COOKIE_CONSENT_TTL_MS = 15778476000;
+
+type CookieConsentStore = {
+  value: boolean;
+  timeToExpire: number;
+};
+
+type ConsentMode = "granted" | "denied";
+
+export type CookieConsentValue = boolean | null;
+
+export type CookieConsentWindow = {
+  builderNoTrack?: boolean;
+  gtag?: (
+    command: "consent",
+    action: "update",
+    payload: {
+      ad_storage: ConsentMode;
+      ad_user_data: ConsentMode;
+      ad_personalization: ConsentMode;
+      analytics_storage: ConsentMode;
+    },
+  ) => void;
+};
+
+export const readCookieConsent = ({
+  key = COOKIE_CONSENT_KEY,
+  now = Date.now(),
+  storage,
+}: {
+  key?: string;
+  now?: number;
+  storage: Pick<Storage, "getItem" | "removeItem">;
+}): CookieConsentValue => {
+  let sticky: CookieConsentStore | null = null;
+
+  try {
+    sticky = JSON.parse(storage.getItem(key) || "null") as CookieConsentStore;
+  } catch (error) {
+    console.error(error);
+    return null;
+  }
+
+  if (sticky === null) {
+    return null;
+  }
+
+  if (now > sticky.timeToExpire) {
+    storage.removeItem(key);
+    return null;
+  }
+
+  return sticky.value;
+};
+
+export const persistCookieConsent = ({
+  key = COOKIE_CONSENT_KEY,
+  now = Date.now(),
+  storage,
+  value,
+}: {
+  key?: string;
+  now?: number;
+  storage: Pick<Storage, "setItem">;
+  value: boolean;
+}) => {
+  const sticky: CookieConsentStore = {
+    value,
+    timeToExpire: now + COOKIE_CONSENT_TTL_MS,
+  };
+
+  storage.setItem(key, JSON.stringify(sticky));
+};
+
+export const applyCookieConsent = ({
+  value,
+  targetWindow,
+}: {
+  value: boolean;
+  targetWindow: CookieConsentWindow;
+}) => {
+  targetWindow.builderNoTrack = !value;
+
+  if (typeof targetWindow.gtag === "undefined") {
+    return;
+  }
+
+  targetWindow.gtag("consent", "update", {
+    ad_storage: value ? "granted" : "denied",
+    ad_user_data: value ? "granted" : "denied",
+    ad_personalization: value ? "granted" : "denied",
+    analytics_storage: value ? "granted" : "denied",
+  });
+};
+
+export const useCookieConsent = () => {
+  const [cookieConsent, setCookieConsent] = useState<CookieConsentValue>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const consent = readCookieConsent({
+      storage: window.localStorage,
+    });
+
+    setCookieConsent(consent);
+    setIsLoaded(true);
+
+    if (consent !== null) {
+      applyCookieConsent({
+        value: consent,
+        targetWindow: window as CookieConsentWindow,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isLoaded || cookieConsent === null) {
+      return;
+    }
+
+    persistCookieConsent({
+      storage: window.localStorage,
+      value: cookieConsent,
+    });
+    applyCookieConsent({
+      value: cookieConsent,
+      targetWindow: window as CookieConsentWindow,
+    });
+  }, [cookieConsent, isLoaded]);
+
+  return {
+    cookieConsent,
+    isLoaded,
+    setCookieConsent,
+    shouldShowBanner: isLoaded && cookieConsent === null,
+  };
+};

--- a/packages/ui-chrome/src/index.ts
+++ b/packages/ui-chrome/src/index.ts
@@ -20,6 +20,7 @@ export { ThemeProvider } from "./theme-provider";
 export { InkeepChatButton } from "./inkeep-chat-button";
 export { InkeepSearchBar } from "./inkeep-searchbar";
 export { NewsletterModal } from "./newsletter-modal";
+export { CookieConsentBanner } from "./cookie-consent-banner";
 export {
   applyCookieConsent,
   COOKIE_CONSENT_KEY,

--- a/packages/ui-chrome/src/index.ts
+++ b/packages/ui-chrome/src/index.ts
@@ -20,6 +20,14 @@ export { ThemeProvider } from "./theme-provider";
 export { InkeepChatButton } from "./inkeep-chat-button";
 export { InkeepSearchBar } from "./inkeep-searchbar";
 export { NewsletterModal } from "./newsletter-modal";
+export {
+  applyCookieConsent,
+  COOKIE_CONSENT_KEY,
+  COOKIE_CONSENT_TTL_MS,
+  persistCookieConsent,
+  readCookieConsent,
+  useCookieConsent,
+} from "./cookie-consent";
 export { PersistentPodcastPlayer } from "./persistent-podcast-player";
 export {
   DEFAULT_PODCAST_PLAYER_STATE,

--- a/packages/ui-chrome/src/index.ts
+++ b/packages/ui-chrome/src/index.ts
@@ -27,8 +27,8 @@ export {
   COOKIE_CONSENT_TTL_MS,
   persistCookieConsent,
   readCookieConsent,
-  useCookieConsent,
 } from "./cookie-consent";
+export { useCookieConsent } from "./use-cookie-consent";
 export { PersistentPodcastPlayer } from "./persistent-podcast-player";
 export {
   DEFAULT_PODCAST_PLAYER_STATE,

--- a/packages/ui-chrome/src/use-cookie-consent.ts
+++ b/packages/ui-chrome/src/use-cookie-consent.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  applyCookieConsent,
+  type CookieConsentValue,
+  type CookieConsentWindow,
+  persistCookieConsent,
+  readCookieConsent,
+} from "./cookie-consent";
+
+export const useCookieConsent = () => {
+  const [cookieConsent, setCookieConsent] = useState<CookieConsentValue>(null);
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  useEffect(() => {
+    const consent = readCookieConsent({
+      storage: window.localStorage,
+    });
+
+    setCookieConsent(consent);
+    setIsLoaded(true);
+
+    if (consent !== null) {
+      applyCookieConsent({
+        value: consent,
+        targetWindow: window as CookieConsentWindow,
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isLoaded || cookieConsent === null) {
+      return;
+    }
+
+    persistCookieConsent({
+      storage: window.localStorage,
+      value: cookieConsent,
+    });
+    applyCookieConsent({
+      value: cookieConsent,
+      targetWindow: window as CookieConsentWindow,
+    });
+  }, [cookieConsent, isLoaded]);
+
+  return {
+    cookieConsent,
+    isLoaded,
+    setCookieConsent,
+    shouldShowBanner: isLoaded && cookieConsent === null,
+  };
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,10 +470,10 @@ importers:
         version: 2.2.9(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@keystatic/core":
         specifier: ^0.5.48
-        version: 0.5.48(next@15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 0.5.48(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@keystatic/next":
         specifier: ^5.0.4
-        version: 5.0.4(@keystatic/core@0.5.48(next@15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 5.0.4(@keystatic/core@0.5.48(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@radix-ui/react-avatar":
         specifier: ^1.1.10
         version: 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -578,7 +578,7 @@ importers:
         version: 3.13.0
       styled-jsx:
         specifier: ^5.1.7
-        version: 5.1.7(@babel/core@7.28.4)(react@19.2.1)
+        version: 5.1.7(react@19.2.1)
       tailwind-merge:
         specifier: ^2.6.0
         version: 2.6.0
@@ -1233,6 +1233,9 @@ importers:
       "@workspace/i18n":
         specifier: workspace:*
         version: link:../i18n
+      "@workspace/ui":
+        specifier: workspace:*
+        version: link:../ui
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -19897,7 +19900,7 @@ snapshots:
 
   "@juggle/resize-observer@3.4.0": {}
 
-  "@keystar/ui@0.7.19(next@15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+  "@keystar/ui@0.7.19(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@babel/runtime": 7.28.4
       "@emotion/css": 11.13.5
@@ -19994,14 +19997,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@keystatic/core@0.5.48(next@15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+  "@keystatic/core@0.5.48(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@babel/runtime": 7.28.4
       "@braintree/sanitize-url": 6.0.4
       "@emotion/weak-memoize": 0.3.1
       "@floating-ui/react": 0.24.8(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@internationalized/string": 3.2.7
-      "@keystar/ui": 0.7.19(next@15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@keystar/ui": 0.7.19(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@markdoc/markdoc": 0.4.0(@types/react@19.1.12)(react@19.2.1)
       "@react-aria/focus": 3.21.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@react-aria/i18n": 3.12.15(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -20072,10 +20075,10 @@ snapshots:
       - next
       - supports-color
 
-  "@keystatic/next@5.0.4(@keystatic/core@0.5.48(next@15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
+  "@keystatic/next@5.0.4(@keystatic/core@0.5.48(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)":
     dependencies:
       "@babel/runtime": 7.28.4
-      "@keystatic/core": 0.5.48(next@15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      "@keystatic/core": 0.5.48(next@15.5.9(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       "@types/react": 19.1.12
       chokidar: 3.6.0
       next: 15.5.9(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.92.1)
@@ -29273,12 +29276,10 @@ snapshots:
     optionalDependencies:
       "@babel/core": 7.28.4
 
-  styled-jsx@5.1.7(@babel/core@7.28.4)(react@19.2.1):
+  styled-jsx@5.1.7(react@19.2.1):
     dependencies:
       client-only: 0.0.1
       react: 19.2.1
-    optionalDependencies:
-      "@babel/core": 7.28.4
 
   stylis@4.2.0: {}
 


### PR DESCRIPTION
## Summary
- move shared cookie consent behavior and banner UI into `@solana-com/ui-chrome`
- roll the shared banner out to web, docs, media, templates, accelerate, and breakpoint
- keep the binary Accept/Opt-out flow, but rebalance the actions visually and add a persistent Manage privacy control
- inherit shared web cookie strings in accelerate and breakpoint, and default accelerate GA consent to denied before opt-in

## Validation
- `pnpm --filter @solana-com/ui-chrome check-types`
- `pnpm --filter @solana-com/ui-chrome test`
- `pnpm --filter @workspace/i18n test`
- `pnpm --filter @workspace/i18n lint`

## Notes
- `pnpm --filter solana-com-accelerate check-types` still fails on the pre-existing `@solana-foundation/fab-menu` type resolution issue
- `pnpm --filter solana-com-breakpoint check-types` still fails on the same pre-existing `@solana-foundation/fab-menu` type resolution issue