### PR TITLE
Fix malformed cookie consent state

### DIFF
--- a/packages/ui-chrome/src/__tests__/cookie-consent.test.ts
+++ b/packages/ui-chrome/src/__tests__/cookie-consent.test.ts
@@ -30,6 +30,26 @@ describe("cookie consent helpers", () => {
     expect(removeItem).toHaveBeenCalledWith(COOKIE_CONSENT_KEY);
   });
 
+  it("returns null and removes malformed consent without a value", () => {
+    const removeItem = vi.fn();
+    const storage = {
+      getItem: vi.fn(() =>
+        JSON.stringify({
+          timeToExpire: 100,
+        }),
+      ),
+      removeItem,
+    };
+
+    const consent = readCookieConsent({
+      now: 10,
+      storage,
+    });
+
+    expect(consent).toBeNull();
+    expect(removeItem).toHaveBeenCalledWith(COOKIE_CONSENT_KEY);
+  });
+
   it("persists consent with the shared ttl", () => {
     const setItem = vi.fn();
 

--- a/packages/ui-chrome/src/cookie-consent.ts
+++ b/packages/ui-chrome/src/cookie-consent.ts
@@ -47,6 +47,16 @@ export const readCookieConsent = ({
     return null;
   }
 
+  // Clear malformed consent objects instead of treating them as a valid choice.
+  if (
+    typeof sticky.value !== "boolean" ||
+    typeof sticky.timeToExpire !== "number" ||
+    Number.isNaN(sticky.timeToExpire)
+  ) {
+    storage.removeItem(key);
+    return null;
+  }
+
   if (now > sticky.timeToExpire) {
     storage.removeItem(key);
     return null;

--- a/packages/ui-chrome/src/use-cookie-consent.ts
+++ b/packages/ui-chrome/src/use-cookie-consent.ts
@@ -30,7 +30,7 @@ export const useCookieConsent = () => {
   }, []);
 
   useEffect(() => {
-    if (!isLoaded || cookieConsent === null) {
+    if (!isLoaded || typeof cookieConsent !== "boolean") {
       return;
     }
 


### PR DESCRIPTION
## Summary
- treat malformed `cookie_consent` localStorage entries as invalid and remove them
- avoid re-persisting non-boolean consent values in the cookie consent hook
- add regression coverage for the observed `{ "timeToExpire": ... }` storage shape

## Testing
- pnpm --filter @solana-com/ui-chrome check-types
- pnpm --filter @solana-com/ui-chrome test