### PR TITLE
fix: normalize legacy cookie consent values for GTM

### DIFF
--- a/apps/accelerate/src/app/[locale]/layout.tsx
+++ b/apps/accelerate/src/app/[locale]/layout.tsx
@@ -3,6 +3,7 @@ import Script from "next/script";
 import { NextIntlClientProvider, AbstractIntlMessages } from "next-intl";
 import {
   CookieConsentBanner,
+  getCookieConsentBootstrapScript,
   PersistentPodcastPlayer,
   ThemeProvider,
 } from "@solana-com/ui-chrome";
@@ -118,39 +119,9 @@ export default async function RootLayout({ children, params }: Props) {
           strategy="afterInteractive"
         />
         <Script id="google-analytics" strategy="afterInteractive">
-          {`
-            window.dataLayer = window.dataLayer || [];
-            window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
-            var rawConsent = localStorage.getItem('cookie_consent');
-            var parsedConsent = null;
-            try {
-              parsedConsent = JSON.parse(rawConsent || 'null');
-            } catch (_) {
-              parsedConsent = rawConsent;
-            }
-            var consentValue =
-              typeof parsedConsent === 'boolean' ? parsedConsent :
-              parsedConsent === 1 || parsedConsent === '1' || parsedConsent === 'true' ? true :
-              parsedConsent === 0 || parsedConsent === '0' || parsedConsent === 'false' ? false :
-              parsedConsent && typeof parsedConsent === 'object' && typeof parsedConsent.value === 'boolean' ? parsedConsent.value :
-              null;
-            window.gtag('js', new Date());
-            window.gtag('consent', 'default', {
-              ad_storage: 'denied',
-              ad_user_data: 'denied',
-              ad_personalization: 'denied',
-              analytics_storage: 'denied',
-            });
-            if (consentValue !== null) {
-              window.gtag('consent', 'update', {
-                ad_storage: consentValue ? 'granted' : 'denied',
-                ad_user_data: consentValue ? 'granted' : 'denied',
-                ad_personalization: consentValue ? 'granted' : 'denied',
-                analytics_storage: consentValue ? 'granted' : 'denied',
-              });
-            }
-            window.gtag('config', 'G-1YDTXXYYQ4');
-          `}
+          {getCookieConsentBootstrapScript({
+            gaMeasurementId: "G-1YDTXXYYQ4",
+          })}
         </Script>
         <NextIntlClientProvider messages={messages} locale={locale}>
           <ThemeProvider>

--- a/apps/accelerate/src/app/[locale]/layout.tsx
+++ b/apps/accelerate/src/app/[locale]/layout.tsx
@@ -120,15 +120,36 @@ export default async function RootLayout({ children, params }: Props) {
         <Script id="google-analytics" strategy="afterInteractive">
           {`
             window.dataLayer = window.dataLayer || [];
-            function gtag(){dataLayer.push(arguments);}
-            gtag('js', new Date());
-            gtag('consent', 'default', {
+            window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
+            var rawConsent = localStorage.getItem('cookie_consent');
+            var parsedConsent = null;
+            try {
+              parsedConsent = JSON.parse(rawConsent || 'null');
+            } catch (_) {
+              parsedConsent = rawConsent;
+            }
+            var consentValue =
+              typeof parsedConsent === 'boolean' ? parsedConsent :
+              parsedConsent === 1 || parsedConsent === '1' || parsedConsent === 'true' ? true :
+              parsedConsent === 0 || parsedConsent === '0' || parsedConsent === 'false' ? false :
+              parsedConsent && typeof parsedConsent === 'object' && typeof parsedConsent.value === 'boolean' ? parsedConsent.value :
+              null;
+            window.gtag('js', new Date());
+            window.gtag('consent', 'default', {
               ad_storage: 'denied',
               ad_user_data: 'denied',
               ad_personalization: 'denied',
               analytics_storage: 'denied',
             });
-            gtag('config', 'G-1YDTXXYYQ4');
+            if (consentValue !== null) {
+              window.gtag('consent', 'update', {
+                ad_storage: consentValue ? 'granted' : 'denied',
+                ad_user_data: consentValue ? 'granted' : 'denied',
+                ad_personalization: consentValue ? 'granted' : 'denied',
+                analytics_storage: consentValue ? 'granted' : 'denied',
+              });
+            }
+            window.gtag('config', 'G-1YDTXXYYQ4');
           `}
         </Script>
         <NextIntlClientProvider messages={messages} locale={locale}>

--- a/apps/docs/src/app/components/posthog/PostHogProvider.tsx
+++ b/apps/docs/src/app/components/posthog/PostHogProvider.tsx
@@ -1,13 +1,20 @@
 "use client";
 
 import { PostHogProvider as PHProvider, usePostHog } from "posthog-js/react";
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
+import {
+  COOKIE_CONSENT_EVENT,
+  readCookieConsent,
+  type CookieConsentValue,
+} from "@solana-com/ui-chrome";
 
 import posthog from "posthog-js";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const hasInitialized = useRef(false);
+  const [isEnabled, setIsEnabled] = useState(false);
 
   useEffect(() => {
     if (!apiKey) {
@@ -15,14 +22,68 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    posthog.init(apiKey, {
-      api_host: "https://us.i.posthog.com",
-      capture_pageview: false,
-      capture_pageleave: true,
-    });
+    const syncPostHogConsent = (consent: CookieConsentValue) => {
+      if (consent === true) {
+        if (!hasInitialized.current) {
+          posthog.init(apiKey, {
+            api_host: "https://us.i.posthog.com",
+            capture_pageview: false,
+            capture_pageleave: true,
+          });
+          hasInitialized.current = true;
+        }
+
+        if (typeof posthog.opt_in_capturing === "function") {
+          posthog.opt_in_capturing();
+        }
+
+        setIsEnabled(true);
+        return;
+      }
+
+      if (
+        hasInitialized.current &&
+        typeof posthog.opt_out_capturing === "function"
+      ) {
+        posthog.opt_out_capturing();
+      }
+
+      setIsEnabled(false);
+    };
+
+    syncPostHogConsent(
+      readCookieConsent({
+        storage: window.localStorage,
+      }),
+    );
+
+    const handleConsentChange = (
+      event: Event | CustomEvent<{ value?: boolean }>,
+    ) => {
+      const consent = "detail" in event ? event.detail?.value : undefined;
+      syncPostHogConsent(
+        typeof consent === "boolean"
+          ? consent
+          : readCookieConsent({
+              storage: window.localStorage,
+            }),
+      );
+    };
+
+    window.addEventListener(
+      COOKIE_CONSENT_EVENT,
+      handleConsentChange as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener(
+        COOKIE_CONSENT_EVENT,
+        handleConsentChange as EventListener,
+      );
+    };
   }, [apiKey]);
 
-  if (!apiKey) {
+  if (!apiKey || !isEnabled) {
     return children;
   }
 

--- a/apps/docs/src/components/GTMTrackingSnippet.js
+++ b/apps/docs/src/components/GTMTrackingSnippet.js
@@ -1,6 +1,7 @@
 "use client";
 
 import Script from "next/script";
+import { getCookieConsentBootstrapScript } from "@solana-com/ui-chrome";
 import { config } from "src/config";
 
 const GTMTrackingSnippet = () => {
@@ -20,38 +21,7 @@ const GTMTrackingSnippet = () => {
 
       {/* The consent */}
       <Script strategy="afterInteractive" id="gtag-invocation">
-        {`
-        window.dataLayer = window.dataLayer || [];
-        window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
-        var rawConsent = localStorage.getItem('cookie_consent');
-        var parsedConsent = null;
-        try {
-          parsedConsent = JSON.parse(rawConsent || 'null');
-        } catch (_) {
-          parsedConsent = rawConsent;
-        }
-        var consentValue =
-          typeof parsedConsent === 'boolean' ? parsedConsent :
-          parsedConsent === 1 || parsedConsent === '1' || parsedConsent === 'true' ? true :
-          parsedConsent === 0 || parsedConsent === '0' || parsedConsent === 'false' ? false :
-          parsedConsent && typeof parsedConsent === 'object' && typeof parsedConsent.value === 'boolean' ? parsedConsent.value :
-          null;
-        window.gtag('js', new Date());
-        window.gtag('consent', 'default', {
-          'ad_storage': 'denied',
-          'ad_user_data': 'denied',
-          'ad_personalization': 'denied',
-          'analytics_storage': 'denied'
-        });
-        if (consentValue !== null) {
-          window.gtag('consent', 'update', {
-            'ad_storage': consentValue ? 'granted' : 'denied',
-            'ad_user_data': consentValue ? 'granted' : 'denied',
-            'ad_personalization': consentValue ? 'granted' : 'denied',
-            'analytics_storage': consentValue ? 'granted' : 'denied'
-          });
-        }
-        `}
+        {getCookieConsentBootstrapScript()}
       </Script>
     </>
   );

--- a/apps/docs/src/components/GTMTrackingSnippet.js
+++ b/apps/docs/src/components/GTMTrackingSnippet.js
@@ -22,14 +22,35 @@ const GTMTrackingSnippet = () => {
       <Script strategy="afterInteractive" id="gtag-invocation">
         {`
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('consent', 'default', {
+        window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
+        var rawConsent = localStorage.getItem('cookie_consent');
+        var parsedConsent = null;
+        try {
+          parsedConsent = JSON.parse(rawConsent || 'null');
+        } catch (_) {
+          parsedConsent = rawConsent;
+        }
+        var consentValue =
+          typeof parsedConsent === 'boolean' ? parsedConsent :
+          parsedConsent === 1 || parsedConsent === '1' || parsedConsent === 'true' ? true :
+          parsedConsent === 0 || parsedConsent === '0' || parsedConsent === 'false' ? false :
+          parsedConsent && typeof parsedConsent === 'object' && typeof parsedConsent.value === 'boolean' ? parsedConsent.value :
+          null;
+        window.gtag('js', new Date());
+        window.gtag('consent', 'default', {
           'ad_storage': 'denied',
           'ad_user_data': 'denied',
           'ad_personalization': 'denied',
           'analytics_storage': 'denied'
         });
+        if (consentValue !== null) {
+          window.gtag('consent', 'update', {
+            'ad_storage': consentValue ? 'granted' : 'denied',
+            'ad_user_data': consentValue ? 'granted' : 'denied',
+            'ad_personalization': consentValue ? 'granted' : 'denied',
+            'analytics_storage': consentValue ? 'granted' : 'denied'
+          });
+        }
         `}
       </Script>
     </>

--- a/apps/media/components/GTMTrackingSnippet.tsx
+++ b/apps/media/components/GTMTrackingSnippet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Script from "next/script";
+import { getCookieConsentBootstrapScript } from "@solana-com/ui-chrome";
 import { config } from "@/lib/config";
 
 export const GTMTrackingSnippet = () => {
@@ -20,38 +21,7 @@ export const GTMTrackingSnippet = () => {
 
       {/* Default consent configuration */}
       <Script strategy="afterInteractive" id="gtag-invocation">
-        {`
-        window.dataLayer = window.dataLayer || [];
-        window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
-        var rawConsent = localStorage.getItem('cookie_consent');
-        var parsedConsent = null;
-        try {
-          parsedConsent = JSON.parse(rawConsent || 'null');
-        } catch (_) {
-          parsedConsent = rawConsent;
-        }
-        var consentValue =
-          typeof parsedConsent === 'boolean' ? parsedConsent :
-          parsedConsent === 1 || parsedConsent === '1' || parsedConsent === 'true' ? true :
-          parsedConsent === 0 || parsedConsent === '0' || parsedConsent === 'false' ? false :
-          parsedConsent && typeof parsedConsent === 'object' && typeof parsedConsent.value === 'boolean' ? parsedConsent.value :
-          null;
-        window.gtag('js', new Date());
-        window.gtag('consent', 'default', {
-          'ad_storage': 'denied',
-          'ad_user_data': 'denied',
-          'ad_personalization': 'denied',
-          'analytics_storage': 'denied'
-        });
-        if (consentValue !== null) {
-          window.gtag('consent', 'update', {
-            'ad_storage': consentValue ? 'granted' : 'denied',
-            'ad_user_data': consentValue ? 'granted' : 'denied',
-            'ad_personalization': consentValue ? 'granted' : 'denied',
-            'analytics_storage': consentValue ? 'granted' : 'denied'
-          });
-        }
-        `}
+        {getCookieConsentBootstrapScript()}
       </Script>
     </>
   );

--- a/apps/media/components/GTMTrackingSnippet.tsx
+++ b/apps/media/components/GTMTrackingSnippet.tsx
@@ -22,14 +22,35 @@ export const GTMTrackingSnippet = () => {
       <Script strategy="afterInteractive" id="gtag-invocation">
         {`
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('consent', 'default', {
+        window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
+        var rawConsent = localStorage.getItem('cookie_consent');
+        var parsedConsent = null;
+        try {
+          parsedConsent = JSON.parse(rawConsent || 'null');
+        } catch (_) {
+          parsedConsent = rawConsent;
+        }
+        var consentValue =
+          typeof parsedConsent === 'boolean' ? parsedConsent :
+          parsedConsent === 1 || parsedConsent === '1' || parsedConsent === 'true' ? true :
+          parsedConsent === 0 || parsedConsent === '0' || parsedConsent === 'false' ? false :
+          parsedConsent && typeof parsedConsent === 'object' && typeof parsedConsent.value === 'boolean' ? parsedConsent.value :
+          null;
+        window.gtag('js', new Date());
+        window.gtag('consent', 'default', {
           'ad_storage': 'denied',
           'ad_user_data': 'denied',
           'ad_personalization': 'denied',
           'analytics_storage': 'denied'
         });
+        if (consentValue !== null) {
+          window.gtag('consent', 'update', {
+            'ad_storage': consentValue ? 'granted' : 'denied',
+            'ad_user_data': consentValue ? 'granted' : 'denied',
+            'ad_personalization': consentValue ? 'granted' : 'denied',
+            'analytics_storage': consentValue ? 'granted' : 'denied'
+          });
+        }
         `}
       </Script>
     </>

--- a/apps/templates/src/components/gtm-tracking-snippet.tsx
+++ b/apps/templates/src/components/gtm-tracking-snippet.tsx
@@ -21,14 +21,35 @@ export const GTMTrackingSnippet = () => {
       <Script strategy="afterInteractive" id="gtag-invocation">
         {`
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('consent', 'default', {
+        window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
+        var rawConsent = localStorage.getItem('cookie_consent');
+        var parsedConsent = null;
+        try {
+          parsedConsent = JSON.parse(rawConsent || 'null');
+        } catch (_) {
+          parsedConsent = rawConsent;
+        }
+        var consentValue =
+          typeof parsedConsent === 'boolean' ? parsedConsent :
+          parsedConsent === 1 || parsedConsent === '1' || parsedConsent === 'true' ? true :
+          parsedConsent === 0 || parsedConsent === '0' || parsedConsent === 'false' ? false :
+          parsedConsent && typeof parsedConsent === 'object' && typeof parsedConsent.value === 'boolean' ? parsedConsent.value :
+          null;
+        window.gtag('js', new Date());
+        window.gtag('consent', 'default', {
           'ad_storage': 'denied',
           'ad_user_data': 'denied',
           'ad_personalization': 'denied',
           'analytics_storage': 'denied'
         });
+        if (consentValue !== null) {
+          window.gtag('consent', 'update', {
+            'ad_storage': consentValue ? 'granted' : 'denied',
+            'ad_user_data': consentValue ? 'granted' : 'denied',
+            'ad_personalization': consentValue ? 'granted' : 'denied',
+            'analytics_storage': consentValue ? 'granted' : 'denied'
+          });
+        }
         `}
       </Script>
     </>

--- a/apps/templates/src/components/gtm-tracking-snippet.tsx
+++ b/apps/templates/src/components/gtm-tracking-snippet.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Script from "next/script";
+import { getCookieConsentBootstrapScript } from "@solana-com/ui-chrome";
 import { config } from "@/config";
 
 export const GTMTrackingSnippet = () => {
@@ -19,38 +20,7 @@ export const GTMTrackingSnippet = () => {
       </Script>
 
       <Script strategy="afterInteractive" id="gtag-invocation">
-        {`
-        window.dataLayer = window.dataLayer || [];
-        window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
-        var rawConsent = localStorage.getItem('cookie_consent');
-        var parsedConsent = null;
-        try {
-          parsedConsent = JSON.parse(rawConsent || 'null');
-        } catch (_) {
-          parsedConsent = rawConsent;
-        }
-        var consentValue =
-          typeof parsedConsent === 'boolean' ? parsedConsent :
-          parsedConsent === 1 || parsedConsent === '1' || parsedConsent === 'true' ? true :
-          parsedConsent === 0 || parsedConsent === '0' || parsedConsent === 'false' ? false :
-          parsedConsent && typeof parsedConsent === 'object' && typeof parsedConsent.value === 'boolean' ? parsedConsent.value :
-          null;
-        window.gtag('js', new Date());
-        window.gtag('consent', 'default', {
-          'ad_storage': 'denied',
-          'ad_user_data': 'denied',
-          'ad_personalization': 'denied',
-          'analytics_storage': 'denied'
-        });
-        if (consentValue !== null) {
-          window.gtag('consent', 'update', {
-            'ad_storage': consentValue ? 'granted' : 'denied',
-            'ad_user_data': consentValue ? 'granted' : 'denied',
-            'ad_personalization': consentValue ? 'granted' : 'denied',
-            'analytics_storage': consentValue ? 'granted' : 'denied'
-          });
-        }
-        `}
+        {getCookieConsentBootstrapScript()}
       </Script>
     </>
   );

--- a/apps/web/src/app/components/posthog/PostHogProvider.tsx
+++ b/apps/web/src/app/components/posthog/PostHogProvider.tsx
@@ -1,13 +1,20 @@
 "use client";
 
 import { PostHogProvider as PHProvider, usePostHog } from "posthog-js/react";
-import { Suspense, useEffect } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
+import {
+  COOKIE_CONSENT_EVENT,
+  readCookieConsent,
+  type CookieConsentValue,
+} from "@solana-com/ui-chrome";
 
 import posthog from "posthog-js";
 
 export function PostHogProvider({ children }: { children: React.ReactNode }) {
   const apiKey = process.env.NEXT_PUBLIC_POSTHOG_KEY;
+  const hasInitialized = useRef(false);
+  const [isEnabled, setIsEnabled] = useState(false);
 
   useEffect(() => {
     if (!apiKey) {
@@ -15,14 +22,68 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
       return;
     }
 
-    posthog.init(apiKey, {
-      api_host: "https://us.i.posthog.com",
-      capture_pageview: false,
-      capture_pageleave: true,
-    });
+    const syncPostHogConsent = (consent: CookieConsentValue) => {
+      if (consent === true) {
+        if (!hasInitialized.current) {
+          posthog.init(apiKey, {
+            api_host: "https://us.i.posthog.com",
+            capture_pageview: false,
+            capture_pageleave: true,
+          });
+          hasInitialized.current = true;
+        }
+
+        if (typeof posthog.opt_in_capturing === "function") {
+          posthog.opt_in_capturing();
+        }
+
+        setIsEnabled(true);
+        return;
+      }
+
+      if (
+        hasInitialized.current &&
+        typeof posthog.opt_out_capturing === "function"
+      ) {
+        posthog.opt_out_capturing();
+      }
+
+      setIsEnabled(false);
+    };
+
+    syncPostHogConsent(
+      readCookieConsent({
+        storage: window.localStorage,
+      }),
+    );
+
+    const handleConsentChange = (
+      event: Event | CustomEvent<{ value?: boolean }>,
+    ) => {
+      const consent = "detail" in event ? event.detail?.value : undefined;
+      syncPostHogConsent(
+        typeof consent === "boolean"
+          ? consent
+          : readCookieConsent({
+              storage: window.localStorage,
+            }),
+      );
+    };
+
+    window.addEventListener(
+      COOKIE_CONSENT_EVENT,
+      handleConsentChange as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener(
+        COOKIE_CONSENT_EVENT,
+        handleConsentChange as EventListener,
+      );
+    };
   }, [apiKey]);
 
-  if (!apiKey) {
+  if (!apiKey || !isEnabled) {
     return children;
   }
 

--- a/apps/web/src/components/GTMTrackingSnippet.js
+++ b/apps/web/src/components/GTMTrackingSnippet.js
@@ -1,6 +1,7 @@
 "use client";
 
 import Script from "next/script";
+import { getCookieConsentBootstrapScript } from "@solana-com/ui-chrome";
 import { config } from "src/config";
 
 const GTMTrackingSnippet = () => {
@@ -20,38 +21,7 @@ const GTMTrackingSnippet = () => {
 
       {/* The consent */}
       <Script strategy="afterInteractive" id="gtag-invocation">
-        {`
-        window.dataLayer = window.dataLayer || [];
-        window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
-        var rawConsent = localStorage.getItem('cookie_consent');
-        var parsedConsent = null;
-        try {
-          parsedConsent = JSON.parse(rawConsent || 'null');
-        } catch (_) {
-          parsedConsent = rawConsent;
-        }
-        var consentValue =
-          typeof parsedConsent === 'boolean' ? parsedConsent :
-          parsedConsent === 1 || parsedConsent === '1' || parsedConsent === 'true' ? true :
-          parsedConsent === 0 || parsedConsent === '0' || parsedConsent === 'false' ? false :
-          parsedConsent && typeof parsedConsent === 'object' && typeof parsedConsent.value === 'boolean' ? parsedConsent.value :
-          null;
-        window.gtag('js', new Date());
-        window.gtag('consent', 'default', {
-          'ad_storage': 'denied',
-          'ad_user_data': 'denied',
-          'ad_personalization': 'denied',
-          'analytics_storage': 'denied'
-        });
-        if (consentValue !== null) {
-          window.gtag('consent', 'update', {
-            'ad_storage': consentValue ? 'granted' : 'denied',
-            'ad_user_data': consentValue ? 'granted' : 'denied',
-            'ad_personalization': consentValue ? 'granted' : 'denied',
-            'analytics_storage': consentValue ? 'granted' : 'denied'
-          });
-        }
-        `}
+        {getCookieConsentBootstrapScript()}
       </Script>
     </>
   );

--- a/apps/web/src/components/GTMTrackingSnippet.js
+++ b/apps/web/src/components/GTMTrackingSnippet.js
@@ -22,14 +22,35 @@ const GTMTrackingSnippet = () => {
       <Script strategy="afterInteractive" id="gtag-invocation">
         {`
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('consent', 'default', {
+        window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
+        var rawConsent = localStorage.getItem('cookie_consent');
+        var parsedConsent = null;
+        try {
+          parsedConsent = JSON.parse(rawConsent || 'null');
+        } catch (_) {
+          parsedConsent = rawConsent;
+        }
+        var consentValue =
+          typeof parsedConsent === 'boolean' ? parsedConsent :
+          parsedConsent === 1 || parsedConsent === '1' || parsedConsent === 'true' ? true :
+          parsedConsent === 0 || parsedConsent === '0' || parsedConsent === 'false' ? false :
+          parsedConsent && typeof parsedConsent === 'object' && typeof parsedConsent.value === 'boolean' ? parsedConsent.value :
+          null;
+        window.gtag('js', new Date());
+        window.gtag('consent', 'default', {
           'ad_storage': 'denied',
           'ad_user_data': 'denied',
           'ad_personalization': 'denied',
           'analytics_storage': 'denied'
         });
+        if (consentValue !== null) {
+          window.gtag('consent', 'update', {
+            'ad_storage': consentValue ? 'granted' : 'denied',
+            'ad_user_data': consentValue ? 'granted' : 'denied',
+            'ad_personalization': consentValue ? 'granted' : 'denied',
+            'analytics_storage': consentValue ? 'granted' : 'denied'
+          });
+        }
         `}
       </Script>
     </>

--- a/packages/ui-chrome/src/__tests__/cookie-consent.test.ts
+++ b/packages/ui-chrome/src/__tests__/cookie-consent.test.ts
@@ -1,9 +1,12 @@
+import vm from "node:vm";
 import { describe, expect, it, vi } from "vitest";
 
 import {
   applyCookieConsent,
+  COOKIE_CONSENT_EVENT,
   COOKIE_CONSENT_KEY,
   COOKIE_CONSENT_TTL_MS,
+  getCookieConsentBootstrapScript,
   persistCookieConsent,
   readCookieConsent,
 } from "../cookie-consent";
@@ -48,6 +51,23 @@ describe("cookie consent helpers", () => {
 
     expect(consent).toBeNull();
     expect(removeItem).toHaveBeenCalledWith(COOKIE_CONSENT_KEY);
+  });
+
+  it("removes malformed consent when parsing fails", () => {
+    const removeItem = vi.fn();
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    const consent = readCookieConsent({
+      storage: {
+        getItem: vi.fn(() => "{"),
+        removeItem,
+      },
+    });
+
+    expect(consent).toBeNull();
+    expect(removeItem).toHaveBeenCalledWith(COOKIE_CONSENT_KEY);
+    consoleError.mockRestore();
   });
 
   it("accepts legacy numeric consent values", () => {
@@ -111,10 +131,21 @@ describe("cookie consent helpers", () => {
 
   it("updates gtag consent when available", () => {
     const gtag = vi.fn();
+    const dispatchEvent = vi.fn();
+    class CookieConsentCustomEvent extends Event {
+      detail: { value: boolean };
+
+      constructor(type: string, init: { detail: { value: boolean } }) {
+        super(type);
+        this.detail = init.detail;
+      }
+    }
 
     applyCookieConsent({
       value: true,
       targetWindow: {
+        CustomEvent: CookieConsentCustomEvent as unknown as typeof CustomEvent,
+        dispatchEvent,
         gtag,
       },
     });
@@ -125,5 +156,60 @@ describe("cookie consent helpers", () => {
       ad_personalization: "granted",
       analytics_storage: "granted",
     });
+    expect(dispatchEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchEvent.mock.calls[0]?.[0]).toMatchObject({
+      detail: { value: true },
+      type: COOKIE_CONSENT_EVENT,
+    });
+  });
+
+  it("bootstrap script keeps denied consent when stored value is expired", () => {
+    const gtag = vi.fn();
+    const removeItem = vi.fn();
+    const script = getCookieConsentBootstrapScript();
+    class MockDate extends Date {
+      static now() {
+        return 11;
+      }
+    }
+    const windowObject: {
+      builderNoTrack: boolean;
+      dataLayer: unknown[];
+      gtag: typeof gtag;
+      localStorage?: object;
+      window?: object;
+    } = {
+      dataLayer: [],
+      builderNoTrack: false,
+      gtag,
+    };
+    const context = {
+      Date: MockDate,
+      localStorage: {
+        getItem: vi.fn(() =>
+          JSON.stringify({
+            value: true,
+            timeToExpire: 10,
+          }),
+        ),
+        removeItem,
+      },
+      window: windowObject,
+    };
+
+    windowObject.window = windowObject;
+    windowObject.localStorage = context.localStorage;
+    vm.runInNewContext(script, context);
+
+    expect(removeItem).toHaveBeenCalledWith(COOKIE_CONSENT_KEY);
+    expect(windowObject.builderNoTrack).toBe(true);
+    expect(gtag).toHaveBeenNthCalledWith(1, "js", expect.any(Date));
+    expect(gtag).toHaveBeenNthCalledWith(2, "consent", "default", {
+      ad_storage: "denied",
+      ad_user_data: "denied",
+      ad_personalization: "denied",
+      analytics_storage: "denied",
+    });
+    expect(gtag).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/ui-chrome/src/__tests__/cookie-consent.test.ts
+++ b/packages/ui-chrome/src/__tests__/cookie-consent.test.ts
@@ -50,6 +50,34 @@ describe("cookie consent helpers", () => {
     expect(removeItem).toHaveBeenCalledWith(COOKIE_CONSENT_KEY);
   });
 
+  it("accepts legacy numeric consent values", () => {
+    const consent = readCookieConsent({
+      storage: {
+        getItem: vi.fn(() => "1"),
+        removeItem: vi.fn(),
+      },
+    });
+
+    expect(consent).toBe(true);
+  });
+
+  it("accepts legacy string values inside the consent object", () => {
+    const consent = readCookieConsent({
+      now: 10,
+      storage: {
+        getItem: vi.fn(() =>
+          JSON.stringify({
+            value: "0",
+            timeToExpire: 100,
+          }),
+        ),
+        removeItem: vi.fn(),
+      },
+    });
+
+    expect(consent).toBe(false);
+  });
+
   it("persists consent with the shared ttl", () => {
     const setItem = vi.fn();
 

--- a/packages/ui-chrome/src/__tests__/cookie-consent.test.ts
+++ b/packages/ui-chrome/src/__tests__/cookie-consent.test.ts
@@ -11,6 +11,59 @@ import {
   readCookieConsent,
 } from "../cookie-consent";
 
+const evaluateBootstrapConsent = ({
+  now,
+  storedValue,
+}: {
+  now: number;
+  storedValue: string | null;
+}) => {
+  const gtag = vi.fn();
+  const removeItem = vi.fn();
+  const script = getCookieConsentBootstrapScript();
+
+  class MockDate extends Date {
+    static now() {
+      return now;
+    }
+  }
+
+  const windowObject: {
+    builderNoTrack: boolean;
+    dataLayer: unknown[];
+    gtag: typeof gtag;
+    localStorage?: object;
+    window?: object;
+  } = {
+    dataLayer: [],
+    builderNoTrack: false,
+    gtag,
+  };
+  const context = {
+    Date: MockDate,
+    localStorage: {
+      getItem: vi.fn(() => storedValue),
+      removeItem,
+    },
+    window: windowObject,
+  };
+
+  windowObject.window = windowObject;
+  windowObject.localStorage = context.localStorage;
+  vm.runInNewContext(script, context);
+
+  const consentUpdateCall = gtag.mock.calls.find(
+    ([command, action]) => command === "consent" && action === "update",
+  );
+
+  return {
+    consentUpdateCall,
+    gtag,
+    removeItem,
+    windowObject,
+  };
+};
+
 describe("cookie consent helpers", () => {
   it("returns null and removes expired consent instead of reviving it", () => {
     const removeItem = vi.fn();
@@ -163,53 +216,114 @@ describe("cookie consent helpers", () => {
     });
   });
 
-  it("bootstrap script keeps denied consent when stored value is expired", () => {
-    const gtag = vi.fn();
-    const removeItem = vi.fn();
-    const script = getCookieConsentBootstrapScript();
-    class MockDate extends Date {
-      static now() {
-        return 11;
-      }
-    }
-    const windowObject: {
-      builderNoTrack: boolean;
-      dataLayer: unknown[];
-      gtag: typeof gtag;
-      localStorage?: object;
-      window?: object;
-    } = {
-      dataLayer: [],
-      builderNoTrack: false,
-      gtag,
-    };
-    const context = {
-      Date: MockDate,
-      localStorage: {
-        getItem: vi.fn(() =>
-          JSON.stringify({
-            value: true,
-            timeToExpire: 10,
-          }),
-        ),
-        removeItem,
+  it("bootstrap script stays in parity with readCookieConsent across storage shapes", () => {
+    const cases = [
+      { label: "no value", now: 10, storedValue: null },
+      { label: "legacy numeric true", now: 10, storedValue: "1" },
+      { label: "legacy numeric false", now: 10, storedValue: "0" },
+      { label: "legacy string true", now: 10, storedValue: '"true"' },
+      { label: "legacy string false", now: 10, storedValue: '"false"' },
+      {
+        label: "object true",
+        now: 10,
+        storedValue: JSON.stringify({
+          value: true,
+          timeToExpire: 100,
+        }),
       },
-      window: windowObject,
-    };
+      {
+        label: "object false via string",
+        now: 10,
+        storedValue: JSON.stringify({
+          value: "0",
+          timeToExpire: 100,
+        }),
+      },
+      {
+        label: "expired object",
+        now: 11,
+        storedValue: JSON.stringify({
+          value: true,
+          timeToExpire: 10,
+        }),
+      },
+      {
+        label: "malformed object",
+        now: 10,
+        storedValue: JSON.stringify({
+          timeToExpire: 100,
+        }),
+      },
+      { label: "invalid json", now: 10, storedValue: "{" },
+    ] as const;
 
-    windowObject.window = windowObject;
-    windowObject.localStorage = context.localStorage;
-    vm.runInNewContext(script, context);
+    for (const testCase of cases) {
+      const removeItem = vi.fn();
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => undefined);
+      const expectedConsent = readCookieConsent({
+        now: testCase.now,
+        storage: {
+          getItem: vi.fn(() => testCase.storedValue),
+          removeItem,
+        },
+      });
+      consoleError.mockRestore();
 
-    expect(removeItem).toHaveBeenCalledWith(COOKIE_CONSENT_KEY);
-    expect(windowObject.builderNoTrack).toBe(true);
-    expect(gtag).toHaveBeenNthCalledWith(1, "js", expect.any(Date));
-    expect(gtag).toHaveBeenNthCalledWith(2, "consent", "default", {
-      ad_storage: "denied",
-      ad_user_data: "denied",
-      ad_personalization: "denied",
-      analytics_storage: "denied",
-    });
-    expect(gtag).toHaveBeenCalledTimes(2);
+      const bootstrapResult = evaluateBootstrapConsent(testCase);
+
+      expect(
+        bootstrapResult.gtag.mock.calls[0],
+        `${testCase.label}: initializes gtag`,
+      ).toMatchObject(["js", expect.any(Date)]);
+      expect(
+        bootstrapResult.gtag.mock.calls[1],
+        `${testCase.label}: sets denied default`,
+      ).toEqual([
+        "consent",
+        "default",
+        {
+          ad_storage: "denied",
+          ad_user_data: "denied",
+          ad_personalization: "denied",
+          analytics_storage: "denied",
+        },
+      ]);
+
+      if (expectedConsent === null) {
+        expect(
+          bootstrapResult.consentUpdateCall,
+          `${testCase.label}: should not grant consent`,
+        ).toBeUndefined();
+        expect(
+          bootstrapResult.windowObject.builderNoTrack,
+          `${testCase.label}: builder should stay blocked`,
+        ).toBe(true);
+      } else {
+        expect(
+          bootstrapResult.consentUpdateCall,
+          `${testCase.label}: should update consent`,
+        ).toEqual([
+          "consent",
+          "update",
+          {
+            ad_storage: expectedConsent ? "granted" : "denied",
+            ad_user_data: expectedConsent ? "granted" : "denied",
+            ad_personalization: expectedConsent ? "granted" : "denied",
+            analytics_storage: expectedConsent ? "granted" : "denied",
+          },
+        ]);
+        expect(
+          bootstrapResult.windowObject.builderNoTrack,
+          `${testCase.label}: builder should match consent`,
+        ).toBe(!expectedConsent);
+      }
+
+      expect(
+        bootstrapResult.removeItem.mock.calls,
+        `${testCase.label}: cleanup parity`,
+      ).toEqual(removeItem.mock.calls);
+    }
   });
 });

--- a/packages/ui-chrome/src/cookie-consent.ts
+++ b/packages/ui-chrome/src/cookie-consent.ts
@@ -1,4 +1,5 @@
 export const COOKIE_CONSENT_KEY = "cookie_consent";
+export const COOKIE_CONSENT_EVENT = "solana:cookie-consent-change";
 // ~182.6 days (~6 months); 15778476000 = 6 × 30.436875d in ms
 export const COOKIE_CONSENT_TTL_MS = 15778476000;
 
@@ -30,6 +31,8 @@ const normalizeCookieConsentValue = (value: unknown): CookieConsentValue => {
 
 export type CookieConsentWindow = {
   builderNoTrack?: boolean;
+  dispatchEvent?: (event: Event) => boolean;
+  CustomEvent?: typeof CustomEvent;
   gtag?: (
     command: "consent",
     action: "update",
@@ -57,6 +60,7 @@ export const readCookieConsent = ({
     sticky = JSON.parse(storage.getItem(key) || "null") as CookieConsentStore;
   } catch (error) {
     console.error(error);
+    storage.removeItem(key);
     return null;
   }
 
@@ -121,6 +125,10 @@ export const applyCookieConsent = ({
   targetWindow.builderNoTrack = !value;
 
   if (typeof targetWindow.gtag === "undefined") {
+    dispatchCookieConsentChange({
+      targetWindow,
+      value,
+    });
     return;
   }
 
@@ -130,4 +138,122 @@ export const applyCookieConsent = ({
     ad_personalization: value ? "granted" : "denied",
     analytics_storage: value ? "granted" : "denied",
   });
+
+  dispatchCookieConsentChange({
+    targetWindow,
+    value,
+  });
 };
+
+const dispatchCookieConsentChange = ({
+  targetWindow,
+  value,
+}: {
+  targetWindow: CookieConsentWindow;
+  value: boolean;
+}) => {
+  if (
+    typeof targetWindow.dispatchEvent !== "function" ||
+    typeof targetWindow.CustomEvent === "undefined"
+  ) {
+    return;
+  }
+
+  targetWindow.dispatchEvent(
+    new targetWindow.CustomEvent(COOKIE_CONSENT_EVENT, {
+      detail: { value },
+    }),
+  );
+};
+
+export const getCookieConsentBootstrapScript = ({
+  gaMeasurementId,
+}: {
+  gaMeasurementId?: string;
+} = {}) => `
+window.dataLayer = window.dataLayer || [];
+window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
+(function () {
+  var consentKey = ${JSON.stringify(COOKIE_CONSENT_KEY)};
+  var rawConsent = localStorage.getItem(consentKey);
+  var parsedConsent = null;
+
+  try {
+    parsedConsent = JSON.parse(rawConsent || 'null');
+  } catch (_) {
+    localStorage.removeItem(consentKey);
+  }
+
+  function normalizeConsentValue(value) {
+    if (typeof value === 'boolean') {
+      return value;
+    }
+
+    if (value === 1 || value === '1' || value === 'true') {
+      return true;
+    }
+
+    if (value === 0 || value === '0' || value === 'false') {
+      return false;
+    }
+
+    return null;
+  }
+
+  function readConsentValue(value) {
+    var legacyValue = normalizeConsentValue(value);
+    if (legacyValue !== null) {
+      return legacyValue;
+    }
+
+    if (!value || typeof value !== 'object') {
+      localStorage.removeItem(consentKey);
+      return null;
+    }
+
+    var normalizedValue = normalizeConsentValue(value.value);
+    if (
+      normalizedValue === null ||
+      typeof value.timeToExpire !== 'number' ||
+      Number.isNaN(value.timeToExpire)
+    ) {
+      localStorage.removeItem(consentKey);
+      return null;
+    }
+
+    if (Date.now() > value.timeToExpire) {
+      localStorage.removeItem(consentKey);
+      return null;
+    }
+
+    return normalizedValue;
+  }
+
+  var consentValue = readConsentValue(parsedConsent);
+
+  window.gtag('js', new Date());
+  window.gtag('consent', 'default', {
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+    analytics_storage: 'denied'
+  });
+
+  if (consentValue !== null) {
+    window.builderNoTrack = !consentValue;
+    window.gtag('consent', 'update', {
+      ad_storage: consentValue ? 'granted' : 'denied',
+      ad_user_data: consentValue ? 'granted' : 'denied',
+      ad_personalization: consentValue ? 'granted' : 'denied',
+      analytics_storage: consentValue ? 'granted' : 'denied'
+    });
+  } else {
+    window.builderNoTrack = true;
+  }
+
+  ${
+    gaMeasurementId
+      ? `window.gtag('config', ${JSON.stringify(gaMeasurementId)});`
+      : ""
+  }
+})();`;

--- a/packages/ui-chrome/src/cookie-consent.ts
+++ b/packages/ui-chrome/src/cookie-consent.ts
@@ -9,7 +9,6 @@ type CookieConsentStore = {
 };
 
 type ConsentMode = "granted" | "denied";
-type CookieConsentLegacyValue = CookieConsentValue | 0 | 1 | string;
 
 export type CookieConsentValue = boolean | null;
 
@@ -54,10 +53,10 @@ export const readCookieConsent = ({
   now?: number;
   storage: Pick<Storage, "getItem" | "removeItem">;
 }): CookieConsentValue => {
-  let sticky: CookieConsentStore | CookieConsentLegacyValue | null = null;
+  let sticky: unknown = null;
 
   try {
-    sticky = JSON.parse(storage.getItem(key) || "null") as CookieConsentStore;
+    sticky = JSON.parse(storage.getItem(key) || "null");
   } catch (error) {
     console.error(error);
     storage.removeItem(key);
@@ -78,17 +77,19 @@ export const readCookieConsent = ({
     return null;
   }
 
-  const consentValue = normalizeCookieConsentValue(sticky.value);
+  const stickyStore = sticky as Partial<CookieConsentStore>;
+
+  const consentValue = normalizeCookieConsentValue(stickyStore.value);
   if (
     consentValue === null ||
-    typeof sticky.timeToExpire !== "number" ||
-    Number.isNaN(sticky.timeToExpire)
+    typeof stickyStore.timeToExpire !== "number" ||
+    Number.isNaN(stickyStore.timeToExpire)
   ) {
     storage.removeItem(key);
     return null;
   }
 
-  if (now > sticky.timeToExpire) {
+  if (now > stickyStore.timeToExpire) {
     storage.removeItem(key);
     return null;
   }
@@ -124,20 +125,14 @@ export const applyCookieConsent = ({
 }) => {
   targetWindow.builderNoTrack = !value;
 
-  if (typeof targetWindow.gtag === "undefined") {
-    dispatchCookieConsentChange({
-      targetWindow,
-      value,
+  if (typeof targetWindow.gtag !== "undefined") {
+    targetWindow.gtag("consent", "update", {
+      ad_storage: value ? "granted" : "denied",
+      ad_user_data: value ? "granted" : "denied",
+      ad_personalization: value ? "granted" : "denied",
+      analytics_storage: value ? "granted" : "denied",
     });
-    return;
   }
-
-  targetWindow.gtag("consent", "update", {
-    ad_storage: value ? "granted" : "denied",
-    ad_user_data: value ? "granted" : "denied",
-    ad_personalization: value ? "granted" : "denied",
-    analytics_storage: value ? "granted" : "denied",
-  });
 
   dispatchCookieConsentChange({
     targetWindow,
@@ -204,6 +199,10 @@ window.gtag = window.gtag || function gtag(){window.dataLayer.push(arguments);};
     var legacyValue = normalizeConsentValue(value);
     if (legacyValue !== null) {
       return legacyValue;
+    }
+
+    if (value === null) {
+      return null;
     }
 
     if (!value || typeof value !== 'object') {

--- a/packages/ui-chrome/src/cookie-consent.ts
+++ b/packages/ui-chrome/src/cookie-consent.ts
@@ -8,8 +8,25 @@ type CookieConsentStore = {
 };
 
 type ConsentMode = "granted" | "denied";
+type CookieConsentLegacyValue = CookieConsentValue | 0 | 1 | string;
 
 export type CookieConsentValue = boolean | null;
+
+const normalizeCookieConsentValue = (value: unknown): CookieConsentValue => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (value === 1 || value === "1" || value === "true") {
+    return true;
+  }
+
+  if (value === 0 || value === "0" || value === "false") {
+    return false;
+  }
+
+  return null;
+};
 
 export type CookieConsentWindow = {
   builderNoTrack?: boolean;
@@ -34,7 +51,7 @@ export const readCookieConsent = ({
   now?: number;
   storage: Pick<Storage, "getItem" | "removeItem">;
 }): CookieConsentValue => {
-  let sticky: CookieConsentStore | null = null;
+  let sticky: CookieConsentStore | CookieConsentLegacyValue | null = null;
 
   try {
     sticky = JSON.parse(storage.getItem(key) || "null") as CookieConsentStore;
@@ -47,9 +64,19 @@ export const readCookieConsent = ({
     return null;
   }
 
-  // Clear malformed consent objects instead of treating them as a valid choice.
+  const legacyValue = normalizeCookieConsentValue(sticky);
+  if (legacyValue !== null) {
+    return legacyValue;
+  }
+
+  if (typeof sticky !== "object") {
+    storage.removeItem(key);
+    return null;
+  }
+
+  const consentValue = normalizeCookieConsentValue(sticky.value);
   if (
-    typeof sticky.value !== "boolean" ||
+    consentValue === null ||
     typeof sticky.timeToExpire !== "number" ||
     Number.isNaN(sticky.timeToExpire)
   ) {
@@ -62,7 +89,7 @@ export const readCookieConsent = ({
     return null;
   }
 
-  return sticky.value;
+  return consentValue;
 };
 
 export const persistCookieConsent = ({

--- a/packages/ui-chrome/src/index.ts
+++ b/packages/ui-chrome/src/index.ts
@@ -23,11 +23,14 @@ export { NewsletterModal } from "./newsletter-modal";
 export { CookieConsentBanner } from "./cookie-consent-banner";
 export {
   applyCookieConsent,
+  COOKIE_CONSENT_EVENT,
   COOKIE_CONSENT_KEY,
   COOKIE_CONSENT_TTL_MS,
+  getCookieConsentBootstrapScript,
   persistCookieConsent,
   readCookieConsent,
 } from "./cookie-consent";
+export type { CookieConsentValue, CookieConsentWindow } from "./cookie-consent";
 export { useCookieConsent } from "./use-cookie-consent";
 export { PersistentPodcastPlayer } from "./persistent-podcast-player";
 export {


### PR DESCRIPTION
### Problem
Legacy cookie consent values were not normalized consistently across GTM tracking snippets and shared consent helpers, which could leave analytics/ad storage in the wrong state after consent updates.

### Summary of Changes
- normalize legacy consent values in `packages/ui-chrome` cookie consent helpers
- update GTM tracking snippets across web, docs, media, templates, and accelerate to use the normalized consent state
- add tests covering legacy consent value handling

Fixes #