### PR TITLE
Add Venum Agent Trading Workflows community skill

### DIFF
--- a/apps/web/src/data/skills/communitySkills.ts
+++ b/apps/web/src/data/skills/communitySkills.ts
@@ -84,6 +84,14 @@ export const COMMUNITY_SKILLS: CommunitySkill[] = [
     category: DEFI,
   },
   {
+    slug: "venum-skills",
+    title: "Venum Skills",
+    description:
+      "Agent skills for Venum covering prices, quotes, swap build and submit, tx monitoring, and end-to-end Solana execution workflows.",
+    url: "https://github.com/venumhq/solana-venum-skills/tree/v0.1.0/skills/venum-agent-trading-workflows",
+    category: DEFI,
+  },
+  {
     slug: "kamino-skill",
     title: "Kamino Skill",
     description:


### PR DESCRIPTION
## Summary

- Add `Venum Agent Trading Workflows` to the community skills listing on `solana.com/skills`
- Use an immutable, tag-pinned GitHub URL that follows the community skills submission rules
- List a Venum skill focused on end-to-end Solana execution workflows for coding agents and trading agents

## Submission Metadata

- Repo: `https://github.com/venumhq/solana-venum-skills`
- Tag: `v0.1.0`
- Commit: `bd4afaa05a25604ff008fa027fe41e7fce161c5a`
- Path: `skills/venum-agent-trading-workflows`
- Maintainer: `venumhq`
- Security contact: `hello@venum.dev`

## Listed URL

- `https://github.com/venumhq/solana-venum-skills/tree/v0.1.0/skills/venum-agent-trading-workflows`

## Description

Venum Agent Trading Workflows is a skill for Venum, the Solana execution layer for coding agents and trading agents. It covers end-to-end execution flows across prices, quotes, swap build/sign/submit, and transaction monitoring.

## Secrets / Credentials

- Required secrets:
  - `VENUM_API_KEY`
- No seed phrase or raw private key is requested by this skill
- Wallet-backed execution examples are explicit and require user action

## Install / Execution Behavior

- Install:
  - `npx skills add venumhq/solana-venum-skills --skill venum-agent-trading-workflows`
- The listing URL is pinned to a reviewed tag
- No `curl | sh`, `wget | sh`, `bash <(curl ...)`, or remote bootstrap scripts are used
- The skill instructs agents to prefer:
  1. `Venum MCP`
  2. `Venum CLI`
  3. direct API usage only as a fallback

## Notes

- This PR adds a single Venum skill entry to `apps/web/src/data/skills/communitySkills.ts`
- The skill comes from the broader Venum skills repository:
  - `https://github.com/venumhq/solana-venum-skills`
- This submission is for one pinned skill path from that repo
- The listing is pinned to a reviewed tag as required by `apps/web/src/data/skills/CONTRIBUTING.md`

Thank you.