### PR TITLE
Add Venum MCP ecosystem link

### DIFF
--- a/apps/media/content/links/venum-mcp-solana-execution-tools.mdx
+++ b/apps/media/content/links/venum-mcp-solana-execution-tools.mdx
@@ -1,0 +1,17 @@
+---
+title: "Venum MCP brings Solana execution tools to coding agents"
+url: "https://github.com/venumhq/solana-venum-mcp"
+linkType: github
+description: >
+  Venum MCP exposes Solana execution primitives for coding agents, including
+  prices, pools, quotes, swap build and submit flows, and tx status.
+source: GitHub
+publishedAt: 2026-04-12T15:00:00.000Z
+categories:
+  - category: developers
+  - category: ecosystem
+tags: []
+featured: false
+---
+
+Venum MCP brings Solana execution tools to coding agents.


### PR DESCRIPTION
## Summary

- Add a Venum MCP link entry to the Solana ecosystem/developer links feed
- Surface Venum MCP as a GitHub-based tool for coding agents using Solana execution primitives

## Description

Venum MCP is an MCP server for Venum, the Solana execution layer for coding agents and trading agents. It exposes stable tools for prices, pools, quotes, swap build/sign/submit flows, and transaction status.

## Linked Project

- GitHub: https://github.com/venumhq/solana-venum-mcp
- npm: https://www.npmjs.com/package/@venumdev/mcp
- Website: https://www.venum.dev

## Notes

- This PR adds one file under `apps/media/content/links/`
- The entry uses the existing supported `github` link type
- Category fit:
  - `developers`
  - `ecosystem`