### PR TITLE
docs: clarify canonical PDA bump search range

### DIFF
--- a/apps/docs/content/docs/en/core/constants-reference.mdx
+++ b/apps/docs/content/docs/en/core/constants-reference.mdx
@@ -77,7 +77,7 @@ core concept pages. Each constant links to its source definition in the
 | ----------------------------- | ------------- | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------- |
 | `MAX_SEEDS`                   | 16            | Maximum number of seeds per PDA derivation | [`MAX_SEEDS`](https://github.com/anza-xyz/solana-sdk/blob/clock%40v2.2.3/pubkey/src/lib.rs#L47)                              |
 | `MAX_SEED_LEN`                | 32 bytes      | Maximum length of a single seed            | [`MAX_SEED_LEN`](https://github.com/anza-xyz/solana-sdk/blob/clock%40v2.2.3/pubkey/src/lib.rs#L45)                           |
-| Bump seed range               | 255 down to 0 | Range tried for canonical bump             | [`find_program_address`](https://github.com/anza-xyz/solana-sdk/blob/clock%40v2.2.3/pubkey/src/lib.rs#L800)                  |
+| Bump seed range               | 255 down to 1 | Range tried for canonical bump             | [`find_program_address`](https://github.com/anza-xyz/solana-sdk/blob/clock%40v2.2.3/pubkey/src/lib.rs#L800)                  |
 | `create_program_address` cost | 1,500 CUs     | CU cost per PDA derivation syscall         | [`create_program_address_units`](https://github.com/anza-xyz/agave/blob/v3.1.8/program-runtime/src/execution_budget.rs#L200) |
 
 ## CPI

--- a/apps/docs/content/docs/en/core/pda/pda-derivation.mdx
+++ b/apps/docs/content/docs/en/core/pda/pda-derivation.mdx
@@ -345,11 +345,15 @@ async fn main() -> anyhow::Result<()> {
 
 </CodeTabs>
 
-### Iterating All Bumps
+### Iterating All Possible Bumps
 
 The following examples show PDA derivation using all possible bump seeds (255 to
 0), illustrating how _rs`find_program_address`_ returns the
 [canonical bump](#bump-seed-search):
+
+<Callout type="warn">
+This is distinct from the current canonical search behavior documented for `sol_try_find_program_address`, which iterates from 255 down to 1.
+</Callout>
 
 <Callout type="info">
   Kit example is not included because the

--- a/apps/docs/content/docs/en/core/pda/pda-derivation.mdx
+++ b/apps/docs/content/docs/en/core/pda/pda-derivation.mdx
@@ -67,7 +67,7 @@ Seeds must follow these constraints:
 The bump seed is a single byte (0-255) appended to the optional seeds during
 derivation.
 [`find_program_address`](https://github.com/anza-xyz/solana-sdk/blob/clock%40v2.2.3/pubkey/src/lib.rs#L800)
-searches from 255 down to 0, calling _rs`create_program_address`_ with each
+searches from 255 down to 1, calling _rs`create_program_address`_ with each
 value until the result falls off the Ed25519 curve. The first value that
 succeeds is the **canonical bump**.
 

--- a/apps/docs/content/docs/en/core/pda/pda-derivation.mdx
+++ b/apps/docs/content/docs/en/core/pda/pda-derivation.mdx
@@ -64,7 +64,7 @@ Seeds must follow these constraints:
 
 ## Bump Seed
 
-The bump seed is a single byte (0-255) appended to the optional seeds during
+The bump seed is a single byte (u8) appended to the optional seeds during
 derivation.
 [`find_program_address`](https://github.com/anza-xyz/solana-sdk/blob/clock%40v2.2.3/pubkey/src/lib.rs#L800)
 searches from 255 down to 1, calling _rs`create_program_address`_ with each


### PR DESCRIPTION
### Problem

The PDA docs described bump seed behavior inconsistently.

Some docs described the canonical bump search as `255 down to 0`, while the syscall reference documents `sol_try_find_program_address` as iterating from `255 down to 1`. This also made the "Iterating All Bumps" example easy to misread as canonical search behavior instead of an exhaustive explicit-bump example. 

### Summary of Changes

- Update the documented canonical bump search range from `255 down to 0` to `255 down to 1`
- Align the PDA derivation docs and constants reference with the syscall reference
- Rename the example section to clarify that it iterates all possible explicit bump values
- Add a note explaining that the exhaustive `create_program_address` example is distinct from the current canonical search behavior of `sol_try_find_program_address`

Fixes https://github.com/solana-foundation/solana-com/issues/1381