### PR TITLE
Update /docs/tokens/basics/freeze-account

### DIFF
--- a/apps/docs/content/docs/en/tokens/basics/freeze-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/freeze-account.mdx
@@ -17,7 +17,7 @@ related:
 ## What Does Freezing a Token Account Do?
 
 Freezing a token account keeps the same owner, mint, and balance, but prevents
-the token account from transferring or burning tokens until the token account is
+the token account from receiving, transferring, or burning tokens until the token account is
 thawed.
 
 A frozen account can still be closed if the frozen account has a zero token

--- a/apps/docs/content/docs/en/tokens/basics/thaw-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/thaw-account.mdx
@@ -18,7 +18,7 @@ related:
 Thawing changes a token account from the frozen state back to the initialized
 state.
 
-After a thaw succeeds, the account can transfer, burn, and close tokens again.
+After a thaw succeeds, the account can receive, transfer, and burn tokens again.
 Only the mint's freeze authority can thaw token accounts.
 
 ## How to Thaw a Token Account


### PR DESCRIPTION
### Problem
A frozen token account also prevents receiving tokens, not just transferring and burning.

### Summary of Changes
Updated the description to include 'receiving' in the list of restricted operations.
