### PR TITLE
Add Birdeye community skill

### DIFF
--- a/apps/web/src/data/skills/communitySkills.ts
+++ b/apps/web/src/data/skills/communitySkills.ts
@@ -198,6 +198,14 @@ export const COMMUNITY_SKILLS: CommunitySkill[] = [
     category: INFRASTRUCTURE,
   },
   {
+    slug: "birdeye-skill",
+    title: "Birdeye Skill",
+    description:
+      "AI coding skill for Birdeye API covering real-time token prices, OHLCV charts, market discovery, wallet portfolio and P&L, trader intelligence, and live WebSocket streams.",
+    url: "https://github.com/sendaifun/skills/tree/ff8d226b5a99615d9bed24c549631ba791dec529/skills/birdeye",
+    category: INFRASTRUCTURE,
+  },
+  {
     slug: "debridge-skill",
     title: "deBridge Skill",
     description:


### PR DESCRIPTION
## Summary

Adds Birdeye to the community skill listings on `/skills`.

## Submission metadata

- Repository: https://github.com/sendaifun/skills
- Submitted URL: https://github.com/sendaifun/skills/tree/ff8d226b5a99615d9bed24c549631ba791dec529/skills/birdeye
- Commit: ff8d226b5a99615d9bed24c549631ba791dec529
- Path: skills/birdeye
- Maintainer: SendAI / sendaifun
- Secrets required: BIRDEYE_API_KEY for API-key mode; the skill also documents optional x402 pay-per-request flows
- Install behavior: listing links to reviewed repository content; no Solana.com runtime behavior changes

## Validation

- `pnpm --filter solana-com test -- src/__tests__/skills/SkillsGrid.test.tsx`
- `pnpm -w exec prettier --ignore-path .prettierignore --check apps/web/src/data/skills/communitySkills.ts`
- `git diff --check`
