### PR TITLE
fix(media): resolve runtime content regressions

### DIFF
--- a/apps/media/__tests__/podcast-rss.test.ts
+++ b/apps/media/__tests__/podcast-rss.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchEpisodeByIdFromRSS } from "@/lib/podcast-rss";
+
+describe("fetchEpisodeByIdFromRSS", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the Buzzsprout HTML fallback for episode lookups by slug or id", async () => {
+    const html = `<h2>1 episodes</h2><div id="episode_19027082" class="flex gap-4 py-5 md:py-8"><a class="w-12 h-12" href="/2092514/episodes/19027082-irina-chuchkina-on-wallet-in-telegram-how-crypto-wallets-are-reaching-100m-users?t=0"></a><a class="w-full" href="/2092514/episodes/19027082-irina-chuchkina-on-wallet-in-telegram-how-crypto-wallets-are-reaching-100m-users"><img src="https://example.com/cover.jpg" /><h3 id="title_episode_19027082">Irina Chuchkina on Wallet in Telegram: How Crypto Wallets Are Reaching 100M+ Users</h3><div id="description_episode_19027082">Episode description</div><time datetime="2026-04-20T00:00:00Z" class="whitespace-nowrap"></time><span>•</span> 44:12</a></div>`;
+
+    const fetchMock = vi.fn().mockImplementation(
+      async () =>
+        new Response(html, {
+          status: 200,
+          headers: {
+            "content-type": "text/html",
+          },
+        }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const bySlug = await fetchEpisodeByIdFromRSS(
+      "19027082-irina-chuchkina-on-wallet-in-telegram-how-crypto-wallets-are-reaching-100m-users",
+      "https://rss.buzzsprout.com/2092514.rss",
+      "the-index",
+    );
+    const byId = await fetchEpisodeByIdFromRSS(
+      "19027082",
+      "https://rss.buzzsprout.com/2092514.rss",
+      "the-index",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://www.buzzsprout.com/2092514/episodes",
+      expect.any(Object),
+    );
+    expect(bySlug?.id).toBe("19027082");
+    expect(bySlug?.slug).toBe(
+      "19027082-irina-chuchkina-on-wallet-in-telegram-how-crypto-wallets-are-reaching-100m-users",
+    );
+    expect(byId?.title).toContain("Irina Chuchkina");
+    expect(byId?.audioUrl).toContain("/2092514/episodes/19027082");
+  });
+});

--- a/apps/media/components/mdx-components.tsx
+++ b/apps/media/components/mdx-components.tsx
@@ -598,7 +598,6 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   Gallery: GalleryBlock,
   Stats: StatsBlock,
   Blockquote: BlockquoteBlock,
-  BlockQuote: BlockquoteBlock,
   Datetime: DatetimeBlock,
   Newslettersignup: NewslettersignupBlock,
   Footnotes: FootnotesBlock,

--- a/apps/media/components/mdx-components.tsx
+++ b/apps/media/components/mdx-components.tsx
@@ -598,6 +598,7 @@ export const mdxComponents: Record<string, React.ComponentType<any>> = {
   Gallery: GalleryBlock,
   Stats: StatsBlock,
   Blockquote: BlockquoteBlock,
+  BlockQuote: BlockquoteBlock,
   Datetime: DatetimeBlock,
   Newslettersignup: NewslettersignupBlock,
   Footnotes: FootnotesBlock,

--- a/apps/media/content/posts/happy-solstice-2021-celebrating-solanas-sunny-year.mdx
+++ b/apps/media/content/posts/happy-solstice-2021-celebrating-solanas-sunny-year.mdx
@@ -51,8 +51,6 @@ Wow! The total value of USDT and USDC on Solana passed $1 billion on April 20th,
 
 Things were looking bright in May — Solana Season finally arrived. The hackathon [spurred the formation of 326 new projects](https://solana.com/news/announcing-winners-of-the-solana-season-hackathon), supercharging the growth of the Solana ecosystem to new heights.
 
-<tweet id="1387411221717176323" />
-
 Some notable participants include [Zeta](https://twitter.com/ZetaMarkets), an under-collateralized DeFi options platform, [Solend](https://twitter.com/solendprotocol), a decentralized protocol for lending and borrowing, and [DeFiLand](https://twitter.com/defi_land), a multi-chain agriculture simulation that gamifies DeFi.
 
 ## **June**

--- a/apps/media/content/posts/solana-summer.mdx
+++ b/apps/media/content/posts/solana-summer.mdx
@@ -71,10 +71,10 @@ Last Saturday, I waited over two hours with a bunch of furious wannabe-Ape-owner
 
 ![](/uploads/posts/solana-summer/image-3.webp)
 
-<BlockQuote>
+<Blockquote>
   When the mint finally launched, I was locked out, stuck looking at this screen no matter how many
   ways I tried to get around it.
-</BlockQuote>
+</Blockquote>
 
 ![](/uploads/posts/solana-summer/image-4.webp)
 
@@ -303,10 +303,10 @@ I sent 0.2 SOL to a Break account (you need SOL because these are real transacti
 
 ![](/uploads/posts/solana-summer/image-12.gif)
 
-<BlockQuote>
+<Blockquote>
   The black squares represent transactions I put through by smashing my space bar. When they turn
   green, they’re confirmed. In 15 seconds, I sent 80 real transactions through Solana.
-</BlockQuote>
+</Blockquote>
 
 ![](/uploads/posts/solana-summer/image-13.webp)
 
@@ -384,10 +384,10 @@ fter seeing the rapid maturity of the Solana ecosystem, the Macalinaos decided t
 
 Since Saber built on Solana’s existing [Token Swap Program](https://spl.solana.com/token-swap), they launched on mainnet in under three months, on June 1st:
 
-<BlockQuote>
+<Blockquote>
   Already, Saber has $621M in Total Value Locked (TVL), the most commonly used measure of activity
   in DeFi. That ranks third among all Solana projects, including Solana itself.
-</BlockQuote>
+</Blockquote>
 
 ![](/uploads/posts/solana-summer/image-19.webp)
 

--- a/apps/media/lib/podcast-rss.ts
+++ b/apps/media/lib/podcast-rss.ts
@@ -433,7 +433,7 @@ export async function fetchEpisodeByIdFromRSS(
   podcastSlug: string,
 ): Promise<PodcastEpisode | null> {
   try {
-    const episodes = await fetchEpisodesFromRSS(rssFeedUrl, podcastSlug);
+    const episodes = await fetchEpisodesFromRSSCached(rssFeedUrl, podcastSlug);
     return (
       episodes.find(
         (ep) => ep.id === episodeIdOrSlug || ep.slug === episodeIdOrSlug,


### PR DESCRIPTION
## Summary
- add a `BlockQuote` MDX alias so legacy post content renders instead of throwing at runtime
- remove the private tweet embed from the 2021 solstice post
- make Buzzsprout single-episode lookups use the same HTML fallback path as listing pages
- add a regression test for Buzzsprout episode lookup by slug and id

## Validation
- `pnpm exec vitest run __tests__/podcast-rss.test.ts` in `apps/media`
- `pnpm exec eslint components/mdx-components.tsx lib/podcast-rss.ts __tests__/podcast-rss.test.ts` in `apps/media` (warnings only, no errors)
- `pnpm -w exec prettier --check apps/media/components/mdx-components.tsx apps/media/lib/podcast-rss.ts apps/media/__tests__/podcast-rss.test.ts apps/media/content/posts/happy-solstice-2021-celebrating-solanas-sunny-year.mdx`

## Notes
- `pnpm --filter solana-com-media test` still has unrelated pre-existing failures on `main` in `google-news-sitemap.test.ts` and `latest-content-filters.test.ts`
- `pnpm --filter solana-com-media typecheck` still fails on `main` because asset module declarations in `@solana-com/ui-chrome` are unresolved in this workspace state