### PR TITLE
feat(accelerate): add Miami agenda page

### DIFF
--- a/apps/accelerate/src/app/[locale]/miami/agenda/MiamiAgendaPageContent.tsx
+++ b/apps/accelerate/src/app/[locale]/miami/agenda/MiamiAgendaPageContent.tsx
@@ -1,0 +1,344 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Link } from "@workspace/i18n/routing";
+import Image from "next/image";
+import { motion, AnimatePresence } from "framer-motion";
+import { useTranslations } from "next-intl";
+import { Agenda } from "@/components/Agenda";
+import { LumaModal } from "@/components/LumaModal";
+import { LanguageSelector } from "@solana-com/ui-chrome";
+import { getImagePath } from "@/config";
+import { fadeInUp, stagger } from "@/lib/animations";
+import type { AgendaData } from "@/lib/miami-agenda";
+
+export function MiamiAgendaPageContent({ data }: { data: AgendaData }) {
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const t = useTranslations("accelerate.miami");
+  const tPage = useTranslations("accelerate.miami.agendaPage");
+
+  useEffect(() => {
+    if (mobileMenuOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [mobileMenuOpen]);
+
+  return (
+    <div className="min-h-screen bg-black">
+      <header className="relative z-20">
+        <div className="container-accelerate flex items-center justify-between py-5 lg:py-5">
+          <Link href="/accelerate/miami" className="flex items-center">
+            <Image
+              src={getImagePath("/images/accelerate-usa-logo.svg")}
+              alt="Accelerate USA"
+              width={197}
+              height={100}
+              className="h-[60px] w-auto lg:h-[80px]"
+              priority
+            />
+          </Link>
+
+          <nav className="hidden items-center gap-[38px] md:flex">
+            <Link
+              href="/accelerate/miami#speakers"
+              className="font-semibold uppercase tracking-[0.05em] text-white transition-colors hover:text-white/80 text-button"
+            >
+              {t("nav.speakers")}
+            </Link>
+            <Link
+              href="/accelerate/miami/agenda"
+              className="font-semibold uppercase tracking-[0.05em] text-accelerate-green transition-colors hover:text-accelerate-green/80 text-button"
+            >
+              {t("nav.agenda")}
+            </Link>
+            <Link
+              href="/accelerate/miami#sponsors"
+              className="font-semibold uppercase tracking-[0.05em] text-white transition-colors hover:text-white/80 text-button"
+            >
+              {t("nav.sponsors")}
+            </Link>
+            <Link
+              href="/accelerate/miami#faq"
+              className="font-semibold uppercase tracking-[0.05em] text-white transition-colors hover:text-white/80 text-button"
+            >
+              {t("nav.faq")}
+            </Link>
+            <LanguageSelector className="!text-white/60 hover:!text-white" />
+            <LumaModal lumaId="accelerate-miami">
+              <button className="btn-outline-gradient px-7 py-4 text-button">
+                <span>{t("nav.requestToJoin")}</span>
+                <svg
+                  width="8"
+                  height="8"
+                  viewBox="0 0 11 11"
+                  fill="none"
+                  className="ml-2"
+                >
+                  <path
+                    d="M2 9L9 2M9 2H4M9 2V7"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </button>
+            </LumaModal>
+          </nav>
+
+          <button
+            type="button"
+            aria-label={mobileMenuOpen ? t("nav.closeMenu") : t("nav.openMenu")}
+            aria-expanded={mobileMenuOpen}
+            className="flex h-10 w-10 items-center justify-center text-white md:hidden"
+            onClick={() => setMobileMenuOpen(true)}
+          >
+            <svg
+              width="24"
+              height="24"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+            >
+              <path d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
+        </div>
+      </header>
+
+      <AnimatePresence>
+        {mobileMenuOpen && (
+          <div key="mobile-menu" className="fixed inset-0 z-30 md:hidden">
+            <motion.div
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.2 }}
+              className="absolute inset-0 bg-black/80 backdrop-blur-sm"
+              aria-hidden="true"
+              onClick={() => setMobileMenuOpen(false)}
+            />
+            <motion.div
+              initial={{ opacity: 0, x: "100%" }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: "100%" }}
+              transition={{ type: "tween", duration: 0.25 }}
+              className="absolute right-0 top-0 z-40 flex h-full w-full max-w-[320px] flex-col bg-accelerate-dark px-6 py-5"
+            >
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-white/60">
+                  {t("nav.menu")}
+                </span>
+                <button
+                  type="button"
+                  aria-label={t("nav.closeMenu")}
+                  className="flex h-10 w-10 items-center justify-center text-white"
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  <svg
+                    width="24"
+                    height="24"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                  >
+                    <path d="M18 6L6 18M6 6l12 12" />
+                  </svg>
+                </button>
+              </div>
+              <nav className="mt-8 flex flex-col gap-6">
+                <Link
+                  href="/accelerate/miami#speakers"
+                  className="font-semibold uppercase tracking-[0.05em] text-white transition-colors hover:text-white/80 text-button"
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  {t("nav.speakers")}
+                </Link>
+                <Link
+                  href="/accelerate/miami/agenda"
+                  className="font-semibold uppercase tracking-[0.05em] text-accelerate-green transition-colors hover:text-accelerate-green/80 text-button"
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  {t("nav.agenda")}
+                </Link>
+                <Link
+                  href="/accelerate/miami#sponsors"
+                  className="font-semibold uppercase tracking-[0.05em] text-white transition-colors hover:text-white/80 text-button"
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  {t("nav.sponsors")}
+                </Link>
+                <Link
+                  href="/accelerate/miami#faq"
+                  className="font-semibold uppercase tracking-[0.05em] text-white transition-colors hover:text-white/80 text-button"
+                  onClick={() => setMobileMenuOpen(false)}
+                >
+                  {t("nav.faq")}
+                </Link>
+                <div className="mt-2">
+                  <LanguageSelector className="!text-white/60 hover:!text-white" />
+                </div>
+                <LumaModal lumaId="accelerate-miami">
+                  <button
+                    type="button"
+                    className="btn-outline-gradient mt-2 w-full px-7 py-4 text-button"
+                  >
+                    <span>{t("nav.requestToJoin")}</span>
+                    <svg
+                      width="8"
+                      height="8"
+                      viewBox="0 0 11 11"
+                      fill="none"
+                      className="ml-2"
+                    >
+                      <path
+                        d="M2 9L9 2M9 2H4M9 2V7"
+                        stroke="currentColor"
+                        strokeWidth="1.5"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </button>
+                </LumaModal>
+              </nav>
+            </motion.div>
+          </div>
+        )}
+      </AnimatePresence>
+
+      <section className="relative overflow-hidden bg-black py-12 lg:py-20">
+        <div className="pointer-events-none absolute -left-[200px] top-0 h-full w-[600px]">
+          <div
+            className="absolute inset-0"
+            style={{
+              background:
+                "radial-gradient(ellipse 60% 50% at 30% 50%, rgba(153, 69, 255, 0.4) 0%, rgba(137, 58, 233, 0.2) 40%, transparent 70%)",
+              filter: "blur(80px)",
+            }}
+          />
+        </div>
+
+        <div className="container-accelerate relative z-10">
+          <motion.div initial="hidden" animate="visible" variants={stagger}>
+            <motion.div variants={fadeInUp}>
+              <Link
+                href="/accelerate/miami"
+                className="mb-6 inline-flex items-center gap-2 text-sm font-medium text-white/60 transition-colors hover:text-white"
+              >
+                <svg
+                  width="16"
+                  height="16"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  className="rotate-180"
+                >
+                  <path
+                    d="M6 12L10 8L6 4"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                {tPage("backToAccelerate")}
+              </Link>
+            </motion.div>
+
+            <motion.p
+              variants={fadeInUp}
+              className="mb-4 text-base font-medium uppercase tracking-[0.08em] text-white/70"
+            >
+              {tPage("dateLocation")}
+            </motion.p>
+
+            <motion.h1
+              variants={fadeInUp}
+              className="max-w-[900px] text-[52px] font-normal leading-none tracking-[-0.03em] text-white sm:text-[72px] lg:text-[96px]"
+            >
+              {tPage("conference")}{" "}
+              <span className="text-accelerate-green">
+                {tPage("agendaHighlight")}
+              </span>
+            </motion.h1>
+
+            <motion.p
+              variants={fadeInUp}
+              className="mt-6 max-w-[650px] text-lg leading-relaxed text-white/70 lg:text-xl"
+            >
+              {tPage("description")}
+            </motion.p>
+          </motion.div>
+        </div>
+      </section>
+
+      {data.sessions.length > 0 ? (
+        <Agenda data={data} />
+      ) : (
+        <section className="bg-black py-12 lg:py-16">
+          <div className="mx-auto max-w-[1440px] px-6 lg:px-[60px]">
+            <p className="text-white/60">{tPage("comingSoon")}</p>
+          </div>
+        </section>
+      )}
+
+      <section className="relative overflow-hidden border-t border-white/10 bg-black py-20">
+        <div className="container-accelerate relative z-10">
+          <motion.div
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2 }}
+            variants={stagger}
+            className="mx-auto max-w-[900px] text-center"
+          >
+            <motion.h2
+              variants={fadeInUp}
+              className="text-[48px] font-normal leading-none tracking-[-0.03em] text-white sm:text-[72px] lg:text-[96px]"
+            >
+              {tPage("readyTo")}{" "}
+              <span className="text-accelerate-green">
+                {tPage("accelerateHighlight")}
+              </span>
+              ?
+            </motion.h2>
+            <motion.div variants={fadeInUp} className="mt-8">
+              <LumaModal lumaId="accelerate-miami">
+                <button className="btn-outline-gradient px-8 py-4 text-button">
+                  <span>{tPage("requestToJoin")}</span>
+                  <svg
+                    width="8"
+                    height="8"
+                    viewBox="0 0 11 11"
+                    fill="none"
+                    className="ml-2"
+                  >
+                    <path
+                      d="M2 9L9 2M9 2H4M9 2V7"
+                      stroke="currentColor"
+                      strokeWidth="1.5"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </button>
+              </LumaModal>
+            </motion.div>
+            <motion.p
+              variants={fadeInUp}
+              className="mt-12 text-sm text-white/40"
+            >
+              {tPage("copyright")}
+            </motion.p>
+          </motion.div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/accelerate/src/app/[locale]/miami/agenda/page.tsx
+++ b/apps/accelerate/src/app/[locale]/miami/agenda/page.tsx
@@ -1,0 +1,43 @@
+import type { Metadata } from "next";
+import { config } from "@/config";
+import { SeoJsonLd } from "@/components/SeoJsonLd";
+import { getPageMetadata } from "../../../metadata";
+import { buildEventStructuredData } from "../../../seo";
+import { getMiamiAgenda } from "@/lib/miami-agenda";
+import { MiamiAgendaPageContent } from "./MiamiAgendaPageContent";
+
+type PageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { locale } = await params;
+
+  return getPageMetadata({
+    locale,
+    path: "/miami/agenda",
+    title: "Solana Accelerate Miami Agenda 2026",
+    description:
+      "See the full Solana Accelerate Miami agenda, with sessions on payments, institutional finance, tokenization, DeFi, and AI infrastructure.",
+    keywords: [
+      "Solana Accelerate Miami agenda",
+      "Miami Solana conference schedule",
+      "USA blockchain event agenda",
+    ],
+  });
+}
+
+export default async function MiamiAgendaPage() {
+  const data = await getMiamiAgenda();
+
+  return (
+    <>
+      <SeoJsonLd
+        data={buildEventStructuredData(config.events.miami, "/miami/agenda")}
+      />
+      <MiamiAgendaPageContent data={data} />
+    </>
+  );
+}

--- a/apps/accelerate/src/app/[locale]/miami/page.tsx
+++ b/apps/accelerate/src/app/[locale]/miami/page.tsx
@@ -13,6 +13,7 @@ import {
 import { EventLineup } from "@/components/homepage";
 import sponsorsData from "@/data/miami/sponsors.json";
 import { composeSponsors, type SponsorAugmentation } from "@/lib/sponsor-data";
+import { getMiamiAgenda } from "@/lib/miami-agenda";
 import type { Sponsor } from "@/types/sponsors";
 import { MiamiHeroSymbols } from "./MiamiHeroSymbols";
 import { config } from "@/config";
@@ -50,6 +51,17 @@ export default async function MiamiPage({ params }: PageProps) {
     sponsorsData.sponsors as SponsorAugmentation[],
   );
 
+  const agenda = await getMiamiAgenda();
+  const sessionsCount = agenda.sessions.length;
+  const uniqueSpeakers = new Set<string>();
+  for (const session of agenda.sessions) {
+    for (const speaker of session.speakers) {
+      if (speaker.name) uniqueSpeakers.add(speaker.name);
+    }
+    if (session.moderator?.name) uniqueSpeakers.add(session.moderator.name);
+  }
+  const speakersCount = uniqueSpeakers.size;
+
   return (
     <>
       <SeoJsonLd
@@ -73,6 +85,8 @@ export default async function MiamiPage({ params }: PageProps) {
       <AgendaBanner
         translationPrefix="accelerate.miami.agendaBanner"
         agendaPath="/accelerate/miami/agenda"
+        sessionsCount={sessionsCount > 0 ? String(sessionsCount) : undefined}
+        speakersCount={speakersCount > 0 ? String(speakersCount) : undefined}
       />
       <MiamiSpeakers />
       <EventLineup futureOnly />

--- a/apps/accelerate/src/app/[locale]/miami/page.tsx
+++ b/apps/accelerate/src/app/[locale]/miami/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import {
   Hero,
   EventDetails,
+  AgendaBanner,
   Sponsors,
   FAQ,
   GettingThere,
@@ -68,6 +69,10 @@ export default async function MiamiPage({ params }: PageProps) {
         mapTitle="Miami Beach Convention Center - 1901 Convention Center Dr, Miami Beach, FL 33139"
         showFocusTopics={false}
         showTicketsRow={false}
+      />
+      <AgendaBanner
+        translationPrefix="accelerate.miami.agendaBanner"
+        agendaPath="/accelerate/miami/agenda"
       />
       <MiamiSpeakers />
       <EventLineup futureOnly />

--- a/apps/accelerate/src/components/Agenda.tsx
+++ b/apps/accelerate/src/components/Agenda.tsx
@@ -4,7 +4,7 @@ import { useState, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Search, X } from "lucide-react";
 import { useTranslations } from "next-intl";
-import agendaData from "@/data/agenda.json";
+import defaultAgendaData from "@/data/agenda.json";
 import { fadeInUp } from "@/lib/animations";
 import type { Variants } from "framer-motion";
 
@@ -334,8 +334,21 @@ function FilterBar({
   );
 }
 
-export function Agenda() {
-  const { event, focusTopics, sessions } = agendaData;
+interface AgendaData {
+  event: {
+    name: string;
+    date?: string;
+    venue?: string;
+    hall?: string;
+    mc?: string;
+  };
+  focusTopics: Array<{ title: string; description: string }>;
+  sessions: Session[];
+}
+
+export function Agenda({ data }: { data?: AgendaData } = {}) {
+  const { event, focusTopics, sessions } =
+    data ?? (defaultAgendaData as AgendaData);
   const t = useTranslations("accelerate.agenda");
 
   const [searchQuery, setSearchQuery] = useState("");
@@ -411,28 +424,34 @@ export function Agenda() {
           variants={staggerAgenda}
         >
           {/* Focus Topics */}
-          <motion.div variants={fadeInUp} className="mb-10 lg:mb-14">
-            <h2 className="mb-4 font-space-grotesk text-h2 text-white/80">
-              {t("focusTopics")}
-            </h2>
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-              {focusTopics.map((topic) => (
-                <motion.div
-                  key={topic.title}
-                  variants={fadeInUp}
-                  className="rounded-lg border border-white/10 bg-white/[0.02] p-4 transition-colors hover:border-white/20"
-                >
-                  <h3 className="gradient-text mb-1 font-space-grotesk text-base font-semibold">
-                    {topic.title}
-                  </h3>
-                  <p className="text-sm text-white/50">{topic.description}</p>
-                </motion.div>
-              ))}
-            </div>
-          </motion.div>
+          {focusTopics.length > 0 && (
+            <>
+              <motion.div variants={fadeInUp} className="mb-10 lg:mb-14">
+                <h2 className="mb-4 font-space-grotesk text-h2 text-white/80">
+                  {t("focusTopics")}
+                </h2>
+                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                  {focusTopics.map((topic) => (
+                    <motion.div
+                      key={topic.title}
+                      variants={fadeInUp}
+                      className="rounded-lg border border-white/10 bg-white/[0.02] p-4 transition-colors hover:border-white/20"
+                    >
+                      <h3 className="gradient-text mb-1 font-space-grotesk text-base font-semibold">
+                        {topic.title}
+                      </h3>
+                      <p className="text-sm text-white/50">
+                        {topic.description}
+                      </p>
+                    </motion.div>
+                  ))}
+                </div>
+              </motion.div>
 
-          {/* Divider */}
-          <div className="mb-8 border-t border-white/10 lg:mb-10" />
+              {/* Divider */}
+              <div className="mb-8 border-t border-white/10 lg:mb-10" />
+            </>
+          )}
 
           {/* Filter Bar */}
           <FilterBar
@@ -512,15 +531,17 @@ export function Agenda() {
           </div>
 
           {/* MC Note */}
-          <motion.div
-            variants={fadeInUp}
-            className="mt-10 border-t border-white/10 pt-6"
-          >
-            <p className="text-sm text-white/50">
-              <span className="font-medium text-white/70">{t("mc")}</span>{" "}
-              {event.mc}
-            </p>
-          </motion.div>
+          {event.mc && (
+            <motion.div
+              variants={fadeInUp}
+              className="mt-10 border-t border-white/10 pt-6"
+            >
+              <p className="text-sm text-white/50">
+                <span className="font-medium text-white/70">{t("mc")}</span>{" "}
+                {event.mc}
+              </p>
+            </motion.div>
+          )}
         </motion.div>
       </div>
     </section>

--- a/apps/accelerate/src/components/AgendaBanner.tsx
+++ b/apps/accelerate/src/components/AgendaBanner.tsx
@@ -10,18 +10,33 @@ import { fadeInUp, stagger } from "@/lib/animations";
 interface AgendaBannerProps {
   translationPrefix?: string;
   agendaPath?: string;
+  sessionsCount?: string;
+  speakersCount?: string;
+  fullDayCount?: string;
 }
 
 export function AgendaBanner({
   translationPrefix = "accelerate.agendaBanner",
   agendaPath = "/accelerate/hong-kong/agenda",
+  sessionsCount,
+  speakersCount,
+  fullDayCount,
 }: AgendaBannerProps = {}) {
   const t = useTranslations(translationPrefix);
 
   const highlights = [
-    { count: t("sessionsCount"), label: t("sessionsLabel") },
-    { count: t("speakersCount"), label: t("speakersLabel") },
-    { count: t("fullDayCount"), label: t("fullDayLabel") },
+    {
+      count: sessionsCount ?? t("sessionsCount"),
+      label: t("sessionsLabel"),
+    },
+    {
+      count: speakersCount ?? t("speakersCount"),
+      label: t("speakersLabel"),
+    },
+    {
+      count: fullDayCount ?? t("fullDayCount"),
+      label: t("fullDayLabel"),
+    },
   ];
 
   return (

--- a/apps/accelerate/src/components/AgendaBanner.tsx
+++ b/apps/accelerate/src/components/AgendaBanner.tsx
@@ -7,8 +7,16 @@ import { useTranslations } from "next-intl";
 import { getImagePath } from "@/config";
 import { fadeInUp, stagger } from "@/lib/animations";
 
-export function AgendaBanner() {
-  const t = useTranslations("accelerate.agendaBanner");
+interface AgendaBannerProps {
+  translationPrefix?: string;
+  agendaPath?: string;
+}
+
+export function AgendaBanner({
+  translationPrefix = "accelerate.agendaBanner",
+  agendaPath = "/accelerate/hong-kong/agenda",
+}: AgendaBannerProps = {}) {
+  const t = useTranslations(translationPrefix);
 
   const highlights = [
     { count: t("sessionsCount"), label: t("sessionsLabel") },
@@ -103,7 +111,7 @@ export function AgendaBanner() {
           {/* CTA Button */}
           <motion.div variants={fadeInUp}>
             <Link
-              href="/accelerate/hong-kong/agenda"
+              href={agendaPath}
               className="btn-cta h-[56px] px-8 sm:h-[66px]"
             >
               <span className="text-sm uppercase font-semibold sm:text-base sm:tracking-[0.9px]">

--- a/apps/accelerate/src/data/miami/agenda.json
+++ b/apps/accelerate/src/data/miami/agenda.json
@@ -1,0 +1,9 @@
+{
+  "event": {
+    "name": "Solana Accelerate USA - Miami",
+    "date": "5 May 2026",
+    "venue": "Miami Beach Convention Center",
+    "hall": ""
+  },
+  "focusTopics": []
+}

--- a/apps/accelerate/src/lib/miami-agenda.ts
+++ b/apps/accelerate/src/lib/miami-agenda.ts
@@ -3,6 +3,7 @@ import miamiAgendaStatic from "@/data/miami/agenda.json";
 
 const AIRTABLE_API_BASE = "https://api.airtable.com/v0";
 const AIRTABLE_CACHE_SECONDS = 60 * 30;
+const EVENT_TIMEZONE = "America/New_York";
 
 type SessionType =
   | "keynote"
@@ -13,15 +14,22 @@ type SessionType =
   | "demo"
   | "closing";
 
-const SESSION_TYPES: SessionType[] = [
-  "keynote",
-  "panel",
-  "fireside",
-  "lightning",
-  "break",
-  "demo",
-  "closing",
-];
+// Exact values from the Miami agenda table's Format single-select.
+const FORMAT_TO_TYPE: Record<string, SessionType> = {
+  "Break (15 min)": "break",
+  "Break (45 min)": "break",
+  "Debate (30 min)": "panel",
+  "Fireside (15 min)": "fireside",
+  "Fireside (20 min)": "fireside",
+  "Keynote (10 min)": "keynote",
+  "Keynote (15 min)": "keynote",
+  "Open/Close (5 min)": "keynote",
+  "Panel (20 min)": "panel",
+  "Panel (25 min)": "panel",
+  "Product Keynote (5 min)": "keynote",
+  "Product Keynote (7 min)": "keynote",
+  "Reacts (30 min)": "lightning",
+};
 
 export interface AgendaSpeaker {
   name?: string;
@@ -69,14 +77,14 @@ function asString(value: unknown): string | undefined {
   return trimmed || undefined;
 }
 
-function asStringArray(value: unknown): string[] | undefined {
-  if (Array.isArray(value)) {
-    const items = value
-      .map((item) => (typeof item === "string" ? item.trim() : undefined))
-      .filter((item): item is string => Boolean(item));
-    return items.length ? items : undefined;
+function asStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    const single = asString(value);
+    return single ? [single] : [];
   }
-  return undefined;
+  return value
+    .map((item) => (typeof item === "string" ? item.trim() : ""))
+    .filter(Boolean);
 }
 
 function asNumber(value: unknown): number | undefined {
@@ -88,125 +96,65 @@ function asNumber(value: unknown): number | undefined {
   return undefined;
 }
 
-function asBoolean(value: unknown): boolean | undefined {
-  if (typeof value === "boolean") return value;
-  if (typeof value === "string") {
-    const normalized = value.trim().toLowerCase();
-    if (["true", "yes", "1"].includes(normalized)) return true;
-    if (["false", "no", "0"].includes(normalized)) return false;
-  }
-  return undefined;
+function toTimeParts(iso: string): { time: string; period: string } | null {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  const formatted = date.toLocaleTimeString("en-US", {
+    timeZone: EVENT_TIMEZONE,
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  });
+  const match = formatted.match(/^(\d{1,2}:\d{2})\s*(AM|PM)$/i);
+  if (!match) return null;
+  return { time: match[1]!, period: match[2]!.toUpperCase() };
 }
 
-function getField<T>(
-  fields: Record<string, unknown>,
-  names: string[],
-  parser: (value: unknown) => T | undefined,
-): T | undefined {
-  for (const name of names) {
-    if (!(name in fields)) continue;
-    const parsed = parser(fields[name]);
-    if (parsed !== undefined) return parsed;
+function formatTimeRange(startISO?: string, endISO?: string): string {
+  const start = startISO ? toTimeParts(startISO) : null;
+  const end = endISO ? toTimeParts(endISO) : null;
+  if (!start) return "";
+  if (!end) return `${start.time} ${start.period}`;
+  if (start.period === end.period) {
+    return `${start.time} – ${end.time} ${end.period}`;
   }
-  return undefined;
+  return `${start.time} ${start.period} – ${end.time} ${end.period}`;
 }
 
-function isPublished(fields: Record<string, unknown>) {
-  const explicitHidden = getField(
-    fields,
-    ["Hidden", "hidden", "Hide", "hide"],
-    asBoolean,
-  );
-  if (explicitHidden === true) return false;
+function parseSpeakerString(entry: string): AgendaSpeaker | null {
+  const trimmed = entry.trim();
+  if (!trimmed) return null;
 
-  const publishToWeb = getField(
-    fields,
-    [
-      "Publish To Web",
-      "Publish to Web",
-      "publish to web",
-      "publishToWeb",
-      "publish_to_web",
-    ],
-    asBoolean,
-  );
-  if (publishToWeb === false) return false;
-
-  const explicitPublished = getField(
-    fields,
-    ["Published", "published", "Visible", "visible", "Live", "live"],
-    asBoolean,
-  );
-  if (explicitPublished === false) return false;
-
-  return true;
-}
-
-function normalizeType(value: string | undefined): SessionType {
-  if (!value) return "panel";
-  const normalized = value.trim().toLowerCase();
-  if (SESSION_TYPES.includes(normalized as SessionType)) {
-    return normalized as SessionType;
+  // "Name (Title, Company)" or "Name (Company)"
+  const paren = trimmed.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
+  if (paren?.[1] && paren[2]) {
+    const name = paren[1].trim();
+    const inside = paren[2].split(",").map((p) => p.trim());
+    if (inside.length >= 2) {
+      return { name, title: inside[0], company: inside.slice(1).join(", ") };
+    }
+    return { name, company: inside[0] };
   }
-  if (normalized.includes("keynote")) return "keynote";
-  if (normalized.includes("fireside")) return "fireside";
-  if (normalized.includes("lightning")) return "lightning";
-  if (normalized.includes("demo")) return "demo";
-  if (normalized.includes("closing")) return "closing";
-  if (
-    normalized.includes("break") ||
-    normalized.includes("lunch") ||
-    normalized.includes("coffee") ||
-    normalized.includes("doors")
-  ) {
-    return "break";
+
+  // "Name, Company" (comma-separated)
+  const parts = trimmed.split(",").map((p) => p.trim());
+  if (parts.length >= 2) {
+    return { name: parts[0], company: parts.slice(1).join(", ") };
   }
-  if (normalized.includes("panel")) return "panel";
-  return "panel";
+
+  return { name: trimmed };
 }
 
 function parseSpeakers(value: unknown): AgendaSpeaker[] {
-  const raw =
-    asStringArray(value) ?? (asString(value) ? [asString(value)!] : []);
-  return raw
+  return asStringArray(value)
     .flatMap((entry) =>
       entry
         .split(/\s*(?:;|\n|\|)\s*/)
         .map((part) => part.trim())
         .filter(Boolean),
     )
-    .map((entry) => {
-      // Accept "Name (Title, Company)" or "Name - Title, Company" or plain "Name, Company"
-      const parenMatch = entry.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
-      if (parenMatch?.[1] && parenMatch[2]) {
-        const name = parenMatch[1].trim();
-        const inside = parenMatch[2].split(",").map((p) => p.trim());
-        const [title, company] =
-          inside.length >= 2
-            ? [inside[0], inside.slice(1).join(", ")]
-            : [undefined, inside[0]];
-        return { name, title, company };
-      }
-      const dashMatch = entry.match(/^(.+?)\s*[-–]\s*(.+)$/);
-      if (dashMatch?.[1] && dashMatch[2]) {
-        const name = dashMatch[1].trim();
-        const rest = dashMatch[2].split(",").map((p) => p.trim());
-        const [title, company] =
-          rest.length >= 2
-            ? [rest[0], rest.slice(1).join(", ")]
-            : [undefined, rest[0]];
-        return { name, title, company };
-      }
-      const commaMatch = entry.split(",").map((p) => p.trim());
-      if (commaMatch.length >= 2) {
-        return {
-          name: commaMatch[0],
-          company: commaMatch.slice(1).join(", "),
-        };
-      }
-      return { name: entry };
-    })
-    .filter((s) => Boolean(s.name));
+    .map(parseSpeakerString)
+    .filter((s): s is AgendaSpeaker => Boolean(s?.name));
 }
 
 function slugify(value: string): string {
@@ -221,81 +169,30 @@ function normalizeSession(
   index: number,
 ): { session: AgendaSession; sortOrder: number } | null {
   const fields = record.fields ?? {};
-  if (!isPublished(fields)) return null;
 
-  const title = getField(
-    fields,
-    ["Title", "title", "Session", "session", "Name", "name"],
-    asString,
-  );
+  // Publish gate: only include rows where the checkbox is explicitly true.
+  if (fields["Publish to web"] !== true) return null;
+
+  const title = asString(fields["⚙️ Session Name"]);
   if (!title) return null;
 
-  const time =
-    getField(
-      fields,
-      ["Time", "time", "Start Time", "startTime", "Time Slot", "timeSlot"],
-      asString,
-    ) ?? "";
+  const startISO = asString(fields["Start Time"]);
+  const endISO = asString(fields["End Time"]);
+  const time = formatTimeRange(startISO, endISO);
 
-  const type = normalizeType(
-    getField(
-      fields,
-      ["Type", "type", "Session Type", "sessionType", "Format", "format"],
-      asString,
-    ),
-  );
+  const formatValue = asString(fields["Format"]);
+  const type: SessionType = formatValue
+    ? (FORMAT_TO_TYPE[formatValue] ?? "panel")
+    : "panel";
 
-  const location =
-    getField(
-      fields,
-      ["Location", "location", "Room", "room", "Stage", "stage"],
-      asString,
-    ) ?? "";
+  const location = asString(fields["Stage"]) ?? "";
+  const subtitle = asString(fields["Description"]);
 
-  const subtitle = getField(
-    fields,
-    [
-      "Subtitle",
-      "subtitle",
-      "Description",
-      "description",
-      "Summary",
-      "summary",
-    ],
-    asString,
-  );
+  const speakers = parseSpeakers(fields["Speaker Name and Company"]);
+  const moderator = parseSpeakers(fields["Moderator Name and Company"])[0];
 
-  const duration = getField(
-    fields,
-    ["Duration", "duration", "Length", "length"],
-    asString,
-  );
-
-  const speakers = parseSpeakers(
-    fields["Speakers"] ??
-      fields["speakers"] ??
-      fields["Panelists"] ??
-      fields["panelists"],
-  );
-
-  const moderatorList = parseSpeakers(
-    fields["Moderator"] ??
-      fields["moderator"] ??
-      fields["Host"] ??
-      fields["host"],
-  );
-  const moderator = moderatorList[0];
-
-  const slug =
-    getField(fields, ["Slug", "slug", "ID", "id"], asString) ??
-    (slugify(`${time}-${title}`) || record.id);
-
-  const sortOrder =
-    getField(
-      fields,
-      ["Sort Order", "sortOrder", "Order", "order", "Priority", "priority"],
-      asNumber,
-    ) ?? index;
+  const sortOrder = asNumber(fields["Sequence Ordinal"]) ?? index;
+  const slug = slugify(`${time}-${title}`) || record.id;
 
   return {
     sortOrder,
@@ -306,7 +203,6 @@ function normalizeSession(
       subtitle,
       type,
       location,
-      duration,
       moderator,
       speakers,
     },

--- a/apps/accelerate/src/lib/miami-agenda.ts
+++ b/apps/accelerate/src/lib/miami-agenda.ts
@@ -5,6 +5,13 @@ const AIRTABLE_API_BASE = "https://api.airtable.com/v0";
 const AIRTABLE_CACHE_SECONDS = 60 * 30;
 const EVENT_TIMEZONE = "America/New_York";
 
+// Defaults baked in so we don't need Miami-specific env vars.
+// Override via the matching AIRTABLE_*_MIAMI_AGENDA env var if the schema moves.
+const DEFAULT_BASE_ID = "apph4y5MDXBxJ2uZy";
+const DEFAULT_AGENDA_TABLE_ID = "tbl802700wD64jBNI";
+const DEFAULT_AGENDA_VIEW_ID = "viwphM46UvfUrP30z"; // "All Stages"
+const DEFAULT_FORMAT_TABLE_ID = "tbltJYMgzlVFeibNU";
+
 type SessionType =
   | "keynote"
   | "panel"
@@ -14,7 +21,7 @@ type SessionType =
   | "demo"
   | "closing";
 
-// Exact values from the Miami agenda table's Format single-select.
+// Exact values from the Format table's primary "Name" column.
 const FORMAT_TO_TYPE: Record<string, SessionType> = {
   "Break (15 min)": "break",
   "Break (45 min)": "break",
@@ -71,6 +78,52 @@ type AirtableListResponse = {
   offset?: string;
 };
 
+function getAirtableConfig() {
+  const token = process.env.AIRTABLE_PAT;
+  const baseId = process.env.AIRTABLE_BASE_ID_SPEAKERS ?? DEFAULT_BASE_ID;
+  const tableId =
+    process.env.AIRTABLE_TABLE_ID_MIAMI_AGENDA ?? DEFAULT_AGENDA_TABLE_ID;
+  const viewId =
+    process.env.AIRTABLE_VIEW_ID_MIAMI_AGENDA ?? DEFAULT_AGENDA_VIEW_ID;
+  const formatTableId = DEFAULT_FORMAT_TABLE_ID;
+  return { token, baseId, tableId, viewId, formatTableId };
+}
+
+async function fetchAll(
+  baseId: string,
+  tableId: string,
+  token: string,
+  viewId?: string,
+  tag?: string,
+): Promise<AirtableRecord[]> {
+  const records: AirtableRecord[] = [];
+  let offset: string | undefined;
+  do {
+    const params = new URLSearchParams({ pageSize: "100" });
+    if (viewId) params.set("view", viewId);
+    if (offset) params.set("offset", offset);
+    const response = await fetch(
+      `${AIRTABLE_API_BASE}/${baseId}/${encodeURIComponent(tableId)}?${params}`,
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        next: {
+          revalidate: AIRTABLE_CACHE_SECONDS,
+          tags: tag ? [tag] : undefined,
+        },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(
+        `Airtable ${tableId} request failed (${response.status})`,
+      );
+    }
+    const payload = (await response.json()) as AirtableListResponse;
+    for (const record of payload.records ?? []) records.push(record);
+    offset = payload.offset;
+  } while (offset);
+  return records;
+}
+
 function asString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
@@ -89,10 +142,6 @@ function asStringArray(value: unknown): string[] {
 
 function asNumber(value: unknown): number | undefined {
   if (typeof value === "number" && Number.isFinite(value)) return value;
-  if (typeof value === "string") {
-    const parsed = Number(value.trim());
-    if (Number.isFinite(parsed)) return parsed;
-  }
   return undefined;
 }
 
@@ -121,8 +170,14 @@ function formatTimeRange(startISO?: string, endISO?: string): string {
   return `${start.time} ${start.period} – ${end.time} ${end.period}`;
 }
 
+// Strip leading non-alphanumeric characters (status emoji like ⏰, ✅, ⚠️)
+// before the first letter or digit.
+function stripLeadingJunk(name: string): string {
+  return name.replace(/^[^A-Za-z0-9]+/u, "").trim();
+}
+
 function parseSpeakerString(entry: string): AgendaSpeaker | null {
-  const trimmed = entry.trim();
+  const trimmed = stripLeadingJunk(entry);
   if (!trimmed) return null;
 
   // "Name (Title, Company)" or "Name (Company)"
@@ -136,7 +191,13 @@ function parseSpeakerString(entry: string): AgendaSpeaker | null {
     return { name, company: inside[0] };
   }
 
-  // "Name, Company" (comma-separated)
+  // "Name - Company" (space-dash/en-dash-space separator)
+  const dash = trimmed.match(/^(.+?)\s+[-–]\s+(.+)$/);
+  if (dash?.[1] && dash[2]) {
+    return { name: dash[1].trim(), company: dash[2].trim() };
+  }
+
+  // "Name, Company"
   const parts = trimmed.split(",").map((p) => p.trim());
   if (parts.length >= 2) {
     return { name: parts[0], company: parts.slice(1).join(", ") };
@@ -164,13 +225,30 @@ function slugify(value: string): string {
     .replace(/^-|-$/g, "");
 }
 
+function resolveFormatType(
+  formatField: unknown,
+  formatMap: Map<string, string>,
+): SessionType {
+  const ids = Array.isArray(formatField) ? formatField : [];
+  for (const id of ids) {
+    if (typeof id !== "string") continue;
+    const name = formatMap.get(id);
+    if (name && FORMAT_TO_TYPE[name]) return FORMAT_TO_TYPE[name]!;
+  }
+  // Fallback: if someone enabled a string lookup instead of the linked record
+  const asText = asString(formatField);
+  if (asText && FORMAT_TO_TYPE[asText]) return FORMAT_TO_TYPE[asText]!;
+  return "panel";
+}
+
 function normalizeSession(
   record: AirtableRecord,
   index: number,
+  formatMap: Map<string, string>,
 ): { session: AgendaSession; sortOrder: number } | null {
   const fields = record.fields ?? {};
 
-  // Publish gate: only include rows where the checkbox is explicitly true.
+  // Publish gate: checkbox is only present on records where it's true.
   if (fields["Publish to web"] !== true) return null;
 
   const title = asString(fields["⚙️ Session Name"]);
@@ -180,11 +258,7 @@ function normalizeSession(
   const endISO = asString(fields["End Time"]);
   const time = formatTimeRange(startISO, endISO);
 
-  const formatValue = asString(fields["Format"]);
-  const type: SessionType = formatValue
-    ? (FORMAT_TO_TYPE[formatValue] ?? "panel")
-    : "panel";
-
+  const type = resolveFormatType(fields["Format"], formatMap);
   const location = asString(fields["Stage"]) ?? "";
   const subtitle = asString(fields["Description"]);
 
@@ -209,56 +283,47 @@ function normalizeSession(
   };
 }
 
-async function fetchAirtableSessions(): Promise<AgendaSession[] | null> {
-  const token = process.env.AIRTABLE_PAT;
-  const baseId = process.env.AIRTABLE_BASE_ID_SPEAKERS;
-  const tableId = process.env.AIRTABLE_TABLE_ID_SPEAKERS;
-  const viewId = process.env.AIRTABLE_VIEW_ID_SPEAKERS;
+async function fetchFormatMap(
+  baseId: string,
+  formatTableId: string,
+  token: string,
+): Promise<Map<string, string>> {
+  const records = await fetchAll(
+    baseId,
+    formatTableId,
+    token,
+    undefined,
+    "miami-agenda-formats",
+  );
+  const map = new Map<string, string>();
+  for (const record of records) {
+    const name =
+      asString(record.fields?.["Format"]) ?? asString(record.fields?.["Name"]);
+    if (name) map.set(record.id, name);
+  }
+  return map;
+}
 
-  if (!token || !baseId || !tableId) {
-    console.warn(
-      "Miami agenda Airtable configuration missing; returning empty sessions",
-    );
+async function fetchAirtableSessions(): Promise<AgendaSession[] | null> {
+  const { token, baseId, tableId, viewId, formatTableId } = getAirtableConfig();
+  if (!token) {
+    console.warn("Miami agenda: AIRTABLE_PAT missing");
     return null;
   }
 
   try {
-    const sessions: Array<{ session: AgendaSession; sortOrder: number }> = [];
-    let offset: string | undefined;
+    const [records, formatMap] = await Promise.all([
+      fetchAll(baseId, tableId, token, viewId, "miami-agenda"),
+      fetchFormatMap(baseId, formatTableId, token),
+    ]);
 
-    do {
-      const params = new URLSearchParams({ pageSize: "100" });
-      if (viewId) params.set("view", viewId);
-      if (offset) params.set("offset", offset);
-
-      const response = await fetch(
-        `${AIRTABLE_API_BASE}/${baseId}/${encodeURIComponent(tableId)}?${params.toString()}`,
-        {
-          headers: { Authorization: `Bearer ${token}` },
-          next: {
-            revalidate: AIRTABLE_CACHE_SECONDS,
-            tags: ["miami-agenda"],
-          },
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error(`Airtable request failed (${response.status})`);
-      }
-
-      const payload = (await response.json()) as AirtableListResponse;
-
-      for (const [index, record] of (payload.records ?? []).entries()) {
-        const normalized = normalizeSession(record, sessions.length + index);
-        if (normalized) sessions.push(normalized);
-      }
-
-      offset = payload.offset;
-    } while (offset);
-
-    return sessions
+    const sessions = records
+      .map((record, index) => normalizeSession(record, index, formatMap))
+      .filter((entry): entry is NonNullable<typeof entry> => entry !== null)
       .sort((a, b) => a.sortOrder - b.sortOrder)
       .map((entry) => entry.session);
+
+    return sessions;
   } catch (error) {
     console.error("Failed to load Miami agenda from Airtable", error);
     return null;

--- a/apps/accelerate/src/lib/miami-agenda.ts
+++ b/apps/accelerate/src/lib/miami-agenda.ts
@@ -1,0 +1,385 @@
+import { unstable_cache } from "next/cache";
+import miamiAgendaStatic from "@/data/miami/agenda.json";
+
+const AIRTABLE_API_BASE = "https://api.airtable.com/v0";
+const AIRTABLE_CACHE_SECONDS = 60 * 30;
+
+type SessionType =
+  | "keynote"
+  | "panel"
+  | "fireside"
+  | "lightning"
+  | "break"
+  | "demo"
+  | "closing";
+
+const SESSION_TYPES: SessionType[] = [
+  "keynote",
+  "panel",
+  "fireside",
+  "lightning",
+  "break",
+  "demo",
+  "closing",
+];
+
+export interface AgendaSpeaker {
+  name?: string;
+  title?: string;
+  company?: string;
+}
+
+export interface AgendaSession {
+  id: string;
+  time: string;
+  title: string;
+  subtitle?: string;
+  type: SessionType;
+  location: string;
+  duration?: string;
+  moderator?: AgendaSpeaker;
+  speakers: AgendaSpeaker[];
+}
+
+export interface AgendaData {
+  event: {
+    name: string;
+    date?: string;
+    venue?: string;
+    hall?: string;
+    mc?: string;
+  };
+  focusTopics: Array<{ title: string; description: string }>;
+  sessions: AgendaSession[];
+}
+
+type AirtableRecord = {
+  id: string;
+  fields?: Record<string, unknown>;
+};
+
+type AirtableListResponse = {
+  records?: AirtableRecord[];
+  offset?: string;
+};
+
+function asString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed || undefined;
+}
+
+function asStringArray(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const items = value
+      .map((item) => (typeof item === "string" ? item.trim() : undefined))
+      .filter((item): item is string => Boolean(item));
+    return items.length ? items : undefined;
+  }
+  return undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const parsed = Number(value.trim());
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (["true", "yes", "1"].includes(normalized)) return true;
+    if (["false", "no", "0"].includes(normalized)) return false;
+  }
+  return undefined;
+}
+
+function getField<T>(
+  fields: Record<string, unknown>,
+  names: string[],
+  parser: (value: unknown) => T | undefined,
+): T | undefined {
+  for (const name of names) {
+    if (!(name in fields)) continue;
+    const parsed = parser(fields[name]);
+    if (parsed !== undefined) return parsed;
+  }
+  return undefined;
+}
+
+function isPublished(fields: Record<string, unknown>) {
+  const explicitHidden = getField(
+    fields,
+    ["Hidden", "hidden", "Hide", "hide"],
+    asBoolean,
+  );
+  if (explicitHidden === true) return false;
+
+  const publishToWeb = getField(
+    fields,
+    [
+      "Publish To Web",
+      "Publish to Web",
+      "publish to web",
+      "publishToWeb",
+      "publish_to_web",
+    ],
+    asBoolean,
+  );
+  if (publishToWeb === false) return false;
+
+  const explicitPublished = getField(
+    fields,
+    ["Published", "published", "Visible", "visible", "Live", "live"],
+    asBoolean,
+  );
+  if (explicitPublished === false) return false;
+
+  return true;
+}
+
+function normalizeType(value: string | undefined): SessionType {
+  if (!value) return "panel";
+  const normalized = value.trim().toLowerCase();
+  if (SESSION_TYPES.includes(normalized as SessionType)) {
+    return normalized as SessionType;
+  }
+  if (normalized.includes("keynote")) return "keynote";
+  if (normalized.includes("fireside")) return "fireside";
+  if (normalized.includes("lightning")) return "lightning";
+  if (normalized.includes("demo")) return "demo";
+  if (normalized.includes("closing")) return "closing";
+  if (
+    normalized.includes("break") ||
+    normalized.includes("lunch") ||
+    normalized.includes("coffee") ||
+    normalized.includes("doors")
+  ) {
+    return "break";
+  }
+  if (normalized.includes("panel")) return "panel";
+  return "panel";
+}
+
+function parseSpeakers(value: unknown): AgendaSpeaker[] {
+  const raw =
+    asStringArray(value) ?? (asString(value) ? [asString(value)!] : []);
+  return raw
+    .flatMap((entry) =>
+      entry
+        .split(/\s*(?:;|\n|\|)\s*/)
+        .map((part) => part.trim())
+        .filter(Boolean),
+    )
+    .map((entry) => {
+      // Accept "Name (Title, Company)" or "Name - Title, Company" or plain "Name, Company"
+      const parenMatch = entry.match(/^(.+?)\s*\(([^)]+)\)\s*$/);
+      if (parenMatch?.[1] && parenMatch[2]) {
+        const name = parenMatch[1].trim();
+        const inside = parenMatch[2].split(",").map((p) => p.trim());
+        const [title, company] =
+          inside.length >= 2
+            ? [inside[0], inside.slice(1).join(", ")]
+            : [undefined, inside[0]];
+        return { name, title, company };
+      }
+      const dashMatch = entry.match(/^(.+?)\s*[-–]\s*(.+)$/);
+      if (dashMatch?.[1] && dashMatch[2]) {
+        const name = dashMatch[1].trim();
+        const rest = dashMatch[2].split(",").map((p) => p.trim());
+        const [title, company] =
+          rest.length >= 2
+            ? [rest[0], rest.slice(1).join(", ")]
+            : [undefined, rest[0]];
+        return { name, title, company };
+      }
+      const commaMatch = entry.split(",").map((p) => p.trim());
+      if (commaMatch.length >= 2) {
+        return {
+          name: commaMatch[0],
+          company: commaMatch.slice(1).join(", "),
+        };
+      }
+      return { name: entry };
+    })
+    .filter((s) => Boolean(s.name));
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+function normalizeSession(
+  record: AirtableRecord,
+  index: number,
+): { session: AgendaSession; sortOrder: number } | null {
+  const fields = record.fields ?? {};
+  if (!isPublished(fields)) return null;
+
+  const title = getField(
+    fields,
+    ["Title", "title", "Session", "session", "Name", "name"],
+    asString,
+  );
+  if (!title) return null;
+
+  const time =
+    getField(
+      fields,
+      ["Time", "time", "Start Time", "startTime", "Time Slot", "timeSlot"],
+      asString,
+    ) ?? "";
+
+  const type = normalizeType(
+    getField(
+      fields,
+      ["Type", "type", "Session Type", "sessionType", "Format", "format"],
+      asString,
+    ),
+  );
+
+  const location =
+    getField(
+      fields,
+      ["Location", "location", "Room", "room", "Stage", "stage"],
+      asString,
+    ) ?? "";
+
+  const subtitle = getField(
+    fields,
+    [
+      "Subtitle",
+      "subtitle",
+      "Description",
+      "description",
+      "Summary",
+      "summary",
+    ],
+    asString,
+  );
+
+  const duration = getField(
+    fields,
+    ["Duration", "duration", "Length", "length"],
+    asString,
+  );
+
+  const speakers = parseSpeakers(
+    fields["Speakers"] ??
+      fields["speakers"] ??
+      fields["Panelists"] ??
+      fields["panelists"],
+  );
+
+  const moderatorList = parseSpeakers(
+    fields["Moderator"] ??
+      fields["moderator"] ??
+      fields["Host"] ??
+      fields["host"],
+  );
+  const moderator = moderatorList[0];
+
+  const slug =
+    getField(fields, ["Slug", "slug", "ID", "id"], asString) ??
+    (slugify(`${time}-${title}`) || record.id);
+
+  const sortOrder =
+    getField(
+      fields,
+      ["Sort Order", "sortOrder", "Order", "order", "Priority", "priority"],
+      asNumber,
+    ) ?? index;
+
+  return {
+    sortOrder,
+    session: {
+      id: slug,
+      time,
+      title,
+      subtitle,
+      type,
+      location,
+      duration,
+      moderator,
+      speakers,
+    },
+  };
+}
+
+async function fetchAirtableSessions(): Promise<AgendaSession[] | null> {
+  const token = process.env.AIRTABLE_PAT;
+  const baseId = process.env.AIRTABLE_BASE_ID_SPEAKERS;
+  const tableId = process.env.AIRTABLE_TABLE_ID_SPEAKERS;
+  const viewId = process.env.AIRTABLE_VIEW_ID_SPEAKERS;
+
+  if (!token || !baseId || !tableId) {
+    console.warn(
+      "Miami agenda Airtable configuration missing; returning empty sessions",
+    );
+    return null;
+  }
+
+  try {
+    const sessions: Array<{ session: AgendaSession; sortOrder: number }> = [];
+    let offset: string | undefined;
+
+    do {
+      const params = new URLSearchParams({ pageSize: "100" });
+      if (viewId) params.set("view", viewId);
+      if (offset) params.set("offset", offset);
+
+      const response = await fetch(
+        `${AIRTABLE_API_BASE}/${baseId}/${encodeURIComponent(tableId)}?${params.toString()}`,
+        {
+          headers: { Authorization: `Bearer ${token}` },
+          next: {
+            revalidate: AIRTABLE_CACHE_SECONDS,
+            tags: ["miami-agenda"],
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error(`Airtable request failed (${response.status})`);
+      }
+
+      const payload = (await response.json()) as AirtableListResponse;
+
+      for (const [index, record] of (payload.records ?? []).entries()) {
+        const normalized = normalizeSession(record, sessions.length + index);
+        if (normalized) sessions.push(normalized);
+      }
+
+      offset = payload.offset;
+    } while (offset);
+
+    return sessions
+      .sort((a, b) => a.sortOrder - b.sortOrder)
+      .map((entry) => entry.session);
+  } catch (error) {
+    console.error("Failed to load Miami agenda from Airtable", error);
+    return null;
+  }
+}
+
+const loadSessions =
+  process.env.NODE_ENV === "production"
+    ? unstable_cache(fetchAirtableSessions, ["miami-agenda-airtable"], {
+        revalidate: AIRTABLE_CACHE_SECONDS,
+      })
+    : fetchAirtableSessions;
+
+export async function getMiamiAgenda(): Promise<AgendaData> {
+  const sessions = (await loadSessions()) ?? [];
+  return {
+    ...(miamiAgendaStatic as Omit<AgendaData, "sessions">),
+    sessions,
+  };
+}

--- a/packages/i18n/messages/accelerate/en/common.json
+++ b/packages/i18n/messages/accelerate/en/common.json
@@ -147,6 +147,19 @@
         "requestToJoin": "Request to Join",
         "copyright": "© Solana Foundation 2026"
       },
+      "agendaBanner": {
+        "eyebrow": "Full Day Conference",
+        "heading": "Explore the",
+        "headingHighlight": "Agenda",
+        "description": "Keynotes, panels, and lightning talks covering payments, institutional finance, DeFi, tokenization, AI infrastructure, and more.",
+        "sessionsCount": "45+",
+        "sessionsLabel": "Sessions",
+        "speakersCount": "80+",
+        "speakersLabel": "Speakers",
+        "fullDayCount": "1",
+        "fullDayLabel": "Full Day",
+        "viewFullAgenda": "View Full Agenda"
+      },
       "hero": {
         "title": "Solana Accelerate USA",
         "dateLocation": "May 5 / Miami"

--- a/packages/i18n/messages/accelerate/en/common.json
+++ b/packages/i18n/messages/accelerate/en/common.json
@@ -127,12 +127,25 @@
     "miami": {
       "nav": {
         "speakers": "Speakers",
+        "agenda": "Agenda",
         "sponsors": "Sponsors",
         "faq": "FAQ",
         "requestToJoin": "Request to Join",
         "menu": "Menu",
         "closeMenu": "Close menu",
         "openMenu": "Open menu"
+      },
+      "agendaPage": {
+        "backToAccelerate": "Back to Accelerate USA",
+        "dateLocation": "5 May 2026 / Miami",
+        "conference": "Conference",
+        "agendaHighlight": "Agenda",
+        "description": "A full day of keynotes, panels, and lightning talks covering payments, DeFi, tokenization, AI infrastructure, and more.",
+        "comingSoon": "The full agenda will be published soon. Check back for updates.",
+        "readyTo": "Ready to",
+        "accelerateHighlight": "Accelerate",
+        "requestToJoin": "Request to Join",
+        "copyright": "© Solana Foundation 2026"
       },
       "hero": {
         "title": "Solana Accelerate USA",


### PR DESCRIPTION
## Summary
- add a dedicated `/accelerate/miami/agenda` page with its own hero, navigation, and CTA flow
- load Miami agenda sessions from Airtable with a JSON fallback shape for event metadata
- make the shared `Agenda` component accept injected data so the new page can reuse the existing UI

## Validation
- `pnpm --filter solana-com-accelerate lint`
- `pnpm --filter solana-com-accelerate check-types`

## Notes
- lint completed with warnings only, including existing accelerate Airtable env warnings and the same warning pattern for the new Miami agenda loader
