### PR TITLE
docs: remove createLocalClient() from kit examples

### DIFF
--- a/apps/docs/content/docs/en/core/accounts/account-types.mdx
+++ b/apps/docs/content/docs/en/core/accounts/account-types.mdx
@@ -421,10 +421,17 @@ the account. The `owner` field is `11111111111111111111111111111111` (the
 
 ```ts !! title="Kit"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { solanaRpc } from "@solana/kit-plugin-rpc";
 import { generatedPayer } from "@solana/kit-plugin-signer";
 
-const client = await createClient().use(generatedPayer()).use(solanaLocalRpc());
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  );
 
 // Generate a new keypair
 const keypair = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/core/accounts/account-types.mdx
+++ b/apps/docs/content/docs/en/core/accounts/account-types.mdx
@@ -62,14 +62,17 @@ is `true`, confirming it is a program account.
 <CodeTabs storage="accounts" flags="r">
 
 ```ts !! title="Kit"
-import { Address, generateKeyPairSigner } from "@solana/kit";
-import { createClient } from "@solana/kit-client-rpc";
+import { Address, createClient } from "@solana/kit";
+import { solanaRpc } from "@solana/kit-plugin-rpc";
+import { generatedPayer } from "@solana/kit-plugin-signer";
 
-const feePayer = await generateKeyPairSigner();
-const client = createClient({
-  url: "https://api.mainnet.solana.com",
-  payer: feePayer
-});
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "https://api.mainnet.solana.com"
+    })
+  );
 
 const programId = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA" as Address;
 
@@ -157,8 +160,9 @@ Token 2022 program.
 <CodeTabs storage="accounts" flags="r">
 
 ```ts !! title="Kit"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 import {
   getInitializeMintInstruction,
@@ -167,7 +171,17 @@ import {
   fetchMint
 } from "@solana-program/token-2022";
 
-const client = await createLocalClient().use(systemProgram());
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
+  .use(systemProgram());
 
 // Generate keypair to use as address of mint
 const mint = await generateKeyPairSigner();
@@ -406,10 +420,11 @@ the account. The `owner` field is `11111111111111111111111111111111` (the
 <CodeTabs storage="accounts" flags="r">
 
 ```ts !! title="Kit"
-import { generateKeyPairSigner, lamports } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { generatedPayer } from "@solana/kit-plugin-signer";
 
-const client = await createLocalClient();
+const client = await createClient().use(generatedPayer()).use(solanaLocalRpc());
 
 // Generate a new keypair
 const keypair = await generateKeyPairSigner();
@@ -511,15 +526,18 @@ The following example fetches and deserializes the Sysvar Clock account.
 <CodeTabs storage="accounts" flags="r">
 
 ```ts !! title="Kit"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createClient } from "@solana/kit-client-rpc";
+import { createClient } from "@solana/kit";
+import { solanaRpc } from "@solana/kit-plugin-rpc";
+import { generatedPayer } from "@solana/kit-plugin-signer";
 import { fetchSysvarClock, SYSVAR_CLOCK_ADDRESS } from "@solana/sysvars";
 
-const feePayer = await generateKeyPairSigner();
-const client = createClient({
-  url: "https://api.mainnet.solana.com",
-  payer: feePayer
-});
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "https://api.mainnet.solana.com"
+    })
+  );
 
 const accountInfo = await client.rpc
   .getAccountInfo(SYSVAR_CLOCK_ADDRESS, { encoding: "base64" })

--- a/apps/docs/content/docs/en/core/instructions/instruction-structure.mdx
+++ b/apps/docs/content/docs/en/core/instructions/instruction-structure.mdx
@@ -137,11 +137,22 @@ The example below shows the structure of a SOL transfer instruction.
 <CodeTabs storage="sol-transfer" flags="r">
 
 ```ts !! title="Kit"
-import { generateKeyPairSigner, lamports } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 
-const client = await createLocalClient().use(systemProgram());
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
+  .use(systemProgram());
 
 // Generate sender and recipient keypairs
 const sender = client.payer;

--- a/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
+++ b/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
@@ -316,11 +316,22 @@ Program's
 <CodeTabs storage="sol-transfer" flags="r">
 
 ```ts !! title="Kit"
-import { generateKeyPairSigner, lamports } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 
-const client = await createLocalClient().use(systemProgram());
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
+  .use(systemProgram());
 
 const sender = client.payer;
 const recipient = await generateKeyPairSigner();
@@ -524,6 +535,7 @@ single SOL transfer instruction.
 
 ```ts !! title="Kit"
 import {
+  createClient,
   generateKeyPairSigner,
   lamports,
   createTransactionMessage,
@@ -534,10 +546,22 @@ import {
   signTransactionMessageWithSigners,
   getCompiledTransactionMessageDecoder
 } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 
-const client = await createLocalClient().use(systemProgram());
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
+  .use(systemProgram());
+
 const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
 
 const sender = client.payer;

--- a/apps/docs/content/docs/en/tokens/basics/approve-delegate.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/approve-delegate.mdx
@@ -53,15 +53,25 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
   tokenProgram,
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
   .use(tokenProgram());
 
@@ -114,8 +124,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchToken,
   findAssociatedTokenPda,
@@ -125,7 +136,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const delegate = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/basics/burn-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/burn-tokens.mdx
@@ -55,15 +55,25 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
   tokenProgram,
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
   .use(tokenProgram());
 
@@ -115,8 +125,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchMint,
   fetchToken,
@@ -127,7 +138,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 

--- a/apps/docs/content/docs/en/tokens/basics/close-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/close-account.mdx
@@ -51,8 +51,9 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
   getCreateAssociatedTokenInstructionAsync,
@@ -60,7 +61,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
   .use(tokenProgram());
 
@@ -109,8 +119,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchMaybeToken,
   findAssociatedTokenPda,
@@ -120,7 +131,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const destination = client.payer.address;

--- a/apps/docs/content/docs/en/tokens/basics/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/create-mint.mdx
@@ -89,12 +89,23 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { tokenProgram } from "@solana-program/token";
 
-// !mark[/\.use\(tokenProgram\(\)\)/]
-const client = await createLocalClient().use(tokenProgram());
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
+  // !mark[/\.use\(tokenProgram\(\)\)/]
+  .use(tokenProgram());
 
 const mint = await generateKeyPairSigner();
 
@@ -116,11 +127,21 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instruction Plan"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { fetchMint, getCreateMintInstructionPlan } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 
@@ -143,8 +164,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   fetchMint,
@@ -153,7 +175,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 // Generate keypair to use as address of mint
 const mint = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/basics/create-token-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/create-token-account.mdx
@@ -134,8 +134,9 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   associatedTokenProgram,
   findAssociatedTokenPda,
@@ -143,7 +144,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
   .use(tokenProgram())
   // !mark[/\.use\(associatedTokenProgram\(\)\)/]
@@ -188,8 +198,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   fetchToken,
@@ -200,7 +211,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 // !collapse(1:27) collapsed
 // Setup: Create a mint for this example.
@@ -669,8 +689,9 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 import {
   getTokenSize,
@@ -678,7 +699,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(systemProgram\(\)\)/]
   .use(systemProgram())
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -728,8 +758,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   fetchToken,
@@ -740,7 +771,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 // !collapse(1:28) collapsed
 // Setup: Create a mint for this example.

--- a/apps/docs/content/docs/en/tokens/basics/freeze-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/freeze-account.mdx
@@ -58,15 +58,25 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
   tokenProgram,
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
   .use(tokenProgram());
 
@@ -114,8 +124,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchToken,
   findAssociatedTokenPda,
@@ -125,7 +136,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 

--- a/apps/docs/content/docs/en/tokens/basics/mint-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/mint-tokens.mdx
@@ -52,15 +52,25 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
   tokenProgram,
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
   .use(tokenProgram());
 
@@ -105,8 +115,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instruction Plan"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchMint,
   fetchToken,
@@ -116,7 +127,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 
@@ -161,8 +181,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchMint,
   fetchToken,
@@ -173,7 +194,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 

--- a/apps/docs/content/docs/en/tokens/basics/revoke-delegate.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/revoke-delegate.mdx
@@ -49,15 +49,25 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
   tokenProgram,
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
   .use(tokenProgram());
 
@@ -114,8 +124,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchToken,
   findAssociatedTokenPda,
@@ -126,7 +137,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const delegate = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/basics/set-authority.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/set-authority.mdx
@@ -56,11 +56,21 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { AuthorityType, tokenProgram } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
   .use(tokenProgram());
 
@@ -103,8 +113,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   AuthorityType,
   fetchMint,
@@ -112,7 +123,16 @@ import {
   getSetAuthorityInstruction
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const newAuthority = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/basics/sync-native.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/sync-native.mdx
@@ -57,8 +57,9 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { address } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { address, createClient, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 import {
   findAssociatedTokenPda,
@@ -67,7 +68,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(systemProgram\(\)\)/]
   .use(systemProgram())
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -111,8 +121,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { address } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { address, createClient, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getTransferSolInstruction } from "@solana-program/system";
 import {
   fetchToken,
@@ -122,7 +133,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const NATIVE_MINT = address("So11111111111111111111111111111111111111112");
 

--- a/apps/docs/content/docs/en/tokens/basics/thaw-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/thaw-account.mdx
@@ -50,15 +50,25 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
   tokenProgram,
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
   .use(tokenProgram());
 
@@ -111,8 +121,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchToken,
   findAssociatedTokenPda,
@@ -123,7 +134,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 

--- a/apps/docs/content/docs/en/tokens/basics/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/transfer-tokens.mdx
@@ -58,15 +58,25 @@ Legacy examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Plugin"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
   tokenProgram,
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient()
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
   .use(tokenProgram());
 
@@ -129,8 +139,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instruction Plan"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchAllToken,
   findAssociatedTokenPda,
@@ -140,7 +151,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
@@ -204,8 +224,9 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchAllToken,
   findAssociatedTokenPda,
@@ -216,7 +237,16 @@ import {
   TOKEN_PROGRAM_ADDRESS
 } from "@solana-program/token";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/extensions/close-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/close-mint.mdx
@@ -48,7 +48,17 @@ _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const destination = await generateKeyPairSigner();
 
@@ -69,7 +79,17 @@ _rs`MintCloseAuthority`_ extension.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const destination = await generateKeyPairSigner();
 
@@ -92,7 +112,17 @@ Create the mint account with the calculated space and lamports.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const destination = await generateKeyPairSigner();
 
@@ -125,7 +155,17 @@ Initialize the _rs`MintCloseAuthority`_ extension on the mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const destination = await generateKeyPairSigner();
 
@@ -162,7 +202,17 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const destination = await generateKeyPairSigner();
 
@@ -227,8 +277,9 @@ reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { lamports, createClient, generateKeyPairSigner } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   extension,
@@ -243,7 +294,16 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const destination = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/extensions/cpi-guard.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/cpi-guard.mdx
@@ -68,7 +68,17 @@ Create and initialize the mint that the token account will use.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
 
@@ -103,7 +113,17 @@ _rs`CpiGuard`_ extension. This is the size used in _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
 
@@ -143,7 +163,17 @@ extension.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
 
@@ -187,7 +217,17 @@ it for the mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
 
@@ -245,7 +285,17 @@ Enable _rs`CpiGuard`_ on the token account.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
 
@@ -310,7 +360,17 @@ Disable _rs`CpiGuard`_ on the token account.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
 
@@ -397,8 +457,14 @@ reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner, unwrapOption } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import {
+  lamports,
+  createClient,
+  generateKeyPairSigner,
+  unwrapOption
+} from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   extension,
@@ -412,7 +478,16 @@ import {
   isExtension,
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/extensions/default-state.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/default-state.mdx
@@ -47,7 +47,17 @@ _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -68,7 +78,17 @@ _rs`DefaultAccountState`_ extension.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -91,7 +111,17 @@ Create the mint account with the calculated space and lamports.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -124,7 +154,17 @@ Initialize the _rs`DefaultAccountState`_ extension on the mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -161,7 +201,17 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -205,7 +255,17 @@ _rs`Frozen`_, the new token account starts frozen.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -263,7 +323,17 @@ accounts no longer start frozen.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -351,8 +421,14 @@ reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner, unwrapOption } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import {
+  lamports,
+  createClient,
+  generateKeyPairSigner,
+  unwrapOption
+} from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   AccountState,
@@ -368,7 +444,16 @@ import {
   isExtension,
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 

--- a/apps/docs/content/docs/en/tokens/extensions/group-member.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/group-member.mdx
@@ -59,7 +59,17 @@ Calculate the size and rent needed for the group mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const groupMint = await generateKeyPairSigner();
 const memberMint = await generateKeyPairSigner();
 
@@ -91,7 +101,17 @@ mint, and initialize _rs`TokenGroup`_ in one transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const groupMint = await generateKeyPairSigner();
 const memberMint = await generateKeyPairSigner();
 
@@ -151,7 +171,17 @@ Calculate the size and rent needed for the member mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const groupMint = await generateKeyPairSigner();
 const memberMint = await generateKeyPairSigner();
 
@@ -229,7 +259,17 @@ the mint, and initialize _rs`TokenGroupMember`_ in one transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const groupMint = await generateKeyPairSigner();
 const memberMint = await generateKeyPairSigner();
 
@@ -391,8 +431,14 @@ helpers are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner, unwrapOption } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import {
+  lamports,
+  createClient,
+  generateKeyPairSigner,
+  unwrapOption
+} from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   extension,
@@ -406,7 +452,16 @@ import {
   isExtension,
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const groupMint = await generateKeyPairSigner();
 const memberMint = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/extensions/immutable-owner.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/immutable-owner.mdx
@@ -47,7 +47,16 @@ _rs`ImmutableOwner`_ extension. This is the size used in _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
@@ -88,7 +97,16 @@ extension.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
@@ -131,7 +149,16 @@ Create the token account with the calculated space and lamports.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
@@ -184,7 +211,16 @@ Initialize the _rs`ImmutableOwner`_ extension on the token account.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
@@ -241,7 +277,16 @@ transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
@@ -324,8 +369,14 @@ reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner, unwrapOption } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import {
+  lamports,
+  createClient,
+  generateKeyPairSigner,
+  unwrapOption
+} from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   AuthorityType,
@@ -341,7 +392,16 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/extensions/interest-bearing-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/interest-bearing-tokens.mdx
@@ -81,7 +81,17 @@ _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 // !focus(1:7)
@@ -105,7 +115,17 @@ _rs`InterestBearingConfig`_ extension.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const interestBearingExtension = extension("InterestBearingConfig", {
@@ -131,7 +151,17 @@ Create the mint account with the calculated space and lamports.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const interestBearingExtension = extension("InterestBearingConfig", {
@@ -167,7 +197,17 @@ Initialize the _rs`InterestBearingConfig`_ extension on the mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const interestBearingExtension = extension("InterestBearingConfig", {
@@ -208,7 +248,17 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const interestBearingExtension = extension("InterestBearingConfig", {
@@ -255,7 +305,17 @@ Create a token account for the mint, then mint tokens to that token account.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const interestBearingExtension = extension("InterestBearingConfig", {
@@ -325,7 +385,17 @@ sending a transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const interestBearingExtension = extension("InterestBearingConfig", {
@@ -429,6 +499,8 @@ reference.
 
 ```ts !! title="Instructions"
 import {
+  lamports,
+  createClient,
   appendTransactionMessageInstructions,
   createTransactionMessage,
   generateKeyPairSigner,
@@ -439,7 +511,8 @@ import {
   signTransactionMessageWithSigners,
   unwrapOption
 } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   amountToUiAmountForMintWithoutSimulation,
@@ -457,7 +530,16 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/extensions/memo-transfer.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/memo-transfer.mdx
@@ -42,7 +42,17 @@ Create and initialize the mint that the token account will use.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenOwner = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
@@ -78,7 +88,17 @@ _rs`MemoTransfer`_ extension. This is the size used in _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenOwner = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
@@ -119,7 +139,17 @@ extension.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenOwner = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
@@ -164,7 +194,17 @@ it for the mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenOwner = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
@@ -223,7 +263,17 @@ Enable _rs`MemoTransfer`_ on the token account.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const tokenOwner = await generateKeyPairSigner();
 const tokenAccount = await generateKeyPairSigner();
@@ -304,8 +354,14 @@ are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner, unwrapOption } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import {
+  lamports,
+  createClient,
+  generateKeyPairSigner,
+  unwrapOption
+} from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getAddMemoInstruction } from "@solana-program/memo";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -325,7 +381,16 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const tokenOwner = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/extensions/metadata.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/metadata.mdx
@@ -73,7 +73,17 @@ extension. This is the size used in _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 // !focus(1:4)
@@ -94,7 +104,17 @@ on the mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const metadataPointerExtension = extension("MetadataPointer", {
@@ -130,7 +150,17 @@ Create the mint account with the calculated space and lamports.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const metadataPointerExtension = extension("MetadataPointer", {
@@ -177,7 +207,17 @@ address.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const metadataPointerExtension = extension("MetadataPointer", {
@@ -228,7 +268,17 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const metadataPointerExtension = extension("MetadataPointer", {
@@ -286,7 +336,17 @@ metadata; if the field does not exist, _rs`UpdateField`_ adds it.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const metadataPointerExtension = extension("MetadataPointer", {
@@ -361,7 +421,17 @@ _rs`Emit`_ to return the current metadata.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const metadataPointerExtension = extension("MetadataPointer", {
@@ -502,8 +572,14 @@ examples using `@solana/web3.js`, `@solana/spl-token`, and
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner, unwrapOption } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import {
+  lamports,
+  createClient,
+  generateKeyPairSigner,
+  unwrapOption
+} from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { unpack as unpackTokenMetadata } from "@solana/spl-token-metadata";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -523,7 +599,17 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const metadataPointerExtension = extension("MetadataPointer", {

--- a/apps/docs/content/docs/en/tokens/extensions/non-transferrable-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/non-transferrable-tokens.mdx
@@ -64,7 +64,17 @@ extension. This is the size used in _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -83,7 +93,17 @@ extension.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -104,7 +124,17 @@ Create the mint account with the calculated space and lamports.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -135,7 +165,17 @@ Initialize the _rs`NonTransferable`_ extension on the mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -169,7 +209,17 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -231,8 +281,9 @@ examples using `@solana/web3.js` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import { lamports, createClient, generateKeyPairSigner } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   extension,
@@ -248,7 +299,16 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/extensions/pausable.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/pausable.mdx
@@ -48,7 +48,17 @@ extension. This is the size used in _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -70,7 +80,17 @@ extension.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -94,7 +114,17 @@ Create the mint account with the calculated space and lamports.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -128,7 +158,17 @@ Initialize the _rs`PausableConfig`_ extension on the mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -166,7 +206,17 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -210,7 +260,17 @@ Pause the mint with _rs`Pause`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -261,7 +321,17 @@ Resume the mint with _rs`Resume`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 
@@ -342,8 +412,14 @@ reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner, unwrapOption } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import {
+  lamports,
+  createClient,
+  generateKeyPairSigner,
+  unwrapOption
+} from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   extension,
@@ -361,7 +437,16 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/extensions/permanent-delegate.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/permanent-delegate.mdx
@@ -49,7 +49,17 @@ _rs`PermanentDelegate`_ extension. This is the size used in _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const owner = await generateKeyPairSigner();
 const delegate = await generateKeyPairSigner();
@@ -72,7 +82,17 @@ _rs`PermanentDelegate`_ extension.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const owner = await generateKeyPairSigner();
 const delegate = await generateKeyPairSigner();
@@ -97,7 +117,17 @@ Create the mint account with the calculated space and lamports.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const owner = await generateKeyPairSigner();
 const delegate = await generateKeyPairSigner();
@@ -132,7 +162,17 @@ Initialize the _rs`PermanentDelegate`_ extension on the mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const owner = await generateKeyPairSigner();
 const delegate = await generateKeyPairSigner();
@@ -171,7 +211,17 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const owner = await generateKeyPairSigner();
 const delegate = await generateKeyPairSigner();
@@ -217,7 +267,17 @@ token account.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const owner = await generateKeyPairSigner();
 const delegate = await generateKeyPairSigner();
@@ -293,7 +353,17 @@ Transfer tokens with _rs`TransferChecked`_ signed by the permanent delegate.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const owner = await generateKeyPairSigner();
 const delegate = await generateKeyPairSigner();
@@ -404,8 +474,14 @@ reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner, unwrapOption } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import {
+  lamports,
+  createClient,
+  generateKeyPairSigner,
+  unwrapOption
+} from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   extension,
@@ -421,7 +497,16 @@ import {
   isExtension,
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const owner = await generateKeyPairSigner();

--- a/apps/docs/content/docs/en/tokens/extensions/scaled-ui-amount/index.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/scaled-ui-amount/index.mdx
@@ -112,8 +112,14 @@ reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner, unwrapOption } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import {
+  lamports,
+  createClient,
+  generateKeyPairSigner,
+  unwrapOption
+} from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   amountToUiAmountForMintWithoutSimulation,
@@ -130,7 +136,17 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 const initialMultiplier = 5.0;

--- a/apps/docs/content/docs/en/tokens/extensions/transfer-fees.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/transfer-fees.mdx
@@ -70,7 +70,17 @@ _rs`TransferFeeConfig`_ extension. This is the size used in _rs`CreateAccount`_.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 // !focus(1:14)
@@ -102,7 +112,17 @@ _rs`TransferFeeConfig`_ extension.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const transferFeeConfigExtension = extension("TransferFeeConfig", {
@@ -136,7 +156,17 @@ Create the mint account with the calculated space and lamports.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const transferFeeConfigExtension = extension("TransferFeeConfig", {
@@ -180,7 +210,17 @@ Initialize the _rs`TransferFeeConfig`_ extension on the mint.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const transferFeeConfigExtension = extension("TransferFeeConfig", {
@@ -231,7 +271,17 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 
 const transferFeeConfigExtension = extension("TransferFeeConfig", {
@@ -289,7 +339,17 @@ tokens to the source token account.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipientA = await generateKeyPairSigner();
 const recipientB = await generateKeyPairSigner();
@@ -403,7 +463,17 @@ Transfer tokens with _rs`TransferCheckedWithFee`_ and verify the expected fee.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipientA = await generateKeyPairSigner();
 const recipientB = await generateKeyPairSigner();
@@ -530,7 +600,17 @@ on the destination token account.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipientA = await generateKeyPairSigner();
 const recipientB = await generateKeyPairSigner();
@@ -668,7 +748,17 @@ token accounts to the fee receiver token account.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipientA = await generateKeyPairSigner();
 const recipientB = await generateKeyPairSigner();
@@ -816,7 +906,17 @@ to the mint account's withheld accumulator.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipientA = await generateKeyPairSigner();
 const recipientB = await generateKeyPairSigner();
@@ -971,7 +1071,17 @@ account to the fee receiver token account.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipientA = await generateKeyPairSigner();
 const recipientB = await generateKeyPairSigner();
@@ -1133,7 +1243,17 @@ Use _rs`SetTransferFee`_ to update the next transfer fee configuration.
 <CodePlaceholder title="Example" />
 
 ```ts !! title="Example"
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
 const mint = await generateKeyPairSigner();
 const recipientA = await generateKeyPairSigner();
 const recipientB = await generateKeyPairSigner();
@@ -1335,8 +1455,14 @@ using `@solana/web3.js` and `@solana/spl-token` are included for reference.
 <CodeTabs storage="token-ts-kit" flags="r">
 
 ```ts !! title="Instructions"
-import { generateKeyPairSigner, unwrapOption } from "@solana/kit";
-import { createLocalClient } from "@solana/kit-client-rpc";
+import {
+  lamports,
+  createClient,
+  generateKeyPairSigner,
+  unwrapOption
+} from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
   extension,
@@ -1357,7 +1483,16 @@ import {
   TOKEN_2022_PROGRAM_ADDRESS
 } from "@solana-program/token-2022";
 
-const client = await createLocalClient();
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 const mint = await generateKeyPairSigner();
 const recipientA = await generateKeyPairSigner();

--- a/apps/docs/src/app/[locale]/docs/api/route.tsx
+++ b/apps/docs/src/app/[locale]/docs/api/route.tsx
@@ -19,118 +19,11 @@ const TXTX_RPC_URL = isEnvConfigured ? `https://${TXTX_SURFNET_URL}:8899` : "";
 const TXTX_WS_RPC_URL = isEnvConfigured ? `wss://${TXTX_SURFNET_URL}:8900` : "";
 const LOCALHOST_RPC_URL = "http://localhost:8899";
 const LOCALHOST_WS_URL = "ws://localhost:8900";
-const CREATE_LOCAL_CLIENT_SETUP_REGEX =
-  /const\s+client\s*=\s*await\s+createLocalClient\(\)([\s\S]*?)\s*;/;
 
-const createExplicitClientSetup = (pluginChain = ""): string => {
-  const baseClientName = pluginChain ? "baseClient" : "client";
-
-  return [
-    "const feePayer = await generateKeyPairSigner();",
-    "",
-    `const ${baseClientName} = createClient({`,
-    `  url: ${JSON.stringify(TXTX_RPC_URL)},`,
-    "  payer: feePayer,",
-    "  rpcSubscriptionsConfig: {",
-    `    url: ${JSON.stringify(TXTX_WS_RPC_URL)},`,
-    "  },",
-    "});",
-    "",
-    "await airdropFactory({",
-    `  rpc: ${baseClientName}.rpc,`,
-    `  rpcSubscriptions: ${baseClientName}.rpcSubscriptions,`,
-    "})({",
-    "  recipientAddress: feePayer.address,",
-    "  lamports: lamports(5_000_000_000n),",
-    '  commitment: "confirmed",',
-    "});",
-    ...(pluginChain
-      ? ["", `const client = ${baseClientName}${pluginChain};`]
-      : []),
-  ].join("\n");
-};
-
-const replaceCreateLocalClientSetup = (code: string): string | null => {
-  const match = code.match(CREATE_LOCAL_CLIENT_SETUP_REGEX);
-  if (!match) {
-    return null;
-  }
-
-  const pluginChain = match[1]?.trim() ? match[1] : "";
-
-  return code.replace(
-    CREATE_LOCAL_CLIENT_SETUP_REGEX,
-    createExplicitClientSetup(pluginChain),
-  );
-};
-
-const replaceLocalHostUrl = (code: string): string => {
+const replaceLocalUrls = (code: string): string => {
   return code
     .replaceAll(LOCALHOST_RPC_URL, TXTX_RPC_URL)
     .replaceAll(LOCALHOST_WS_URL, TXTX_WS_RPC_URL);
-};
-
-const upsertNamedImport = (
-  code: string,
-  moduleName: string,
-  additions: string[],
-  removals: string[] = [],
-): string => {
-  const escapedModuleName = moduleName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const importRegex = new RegExp(
-    `import\\s*{\\s*([^}]*)\\s*}\\s*from\\s*["']${escapedModuleName}["'];?`,
-  );
-
-  const existingImport = code.match(importRegex);
-  if (!existingImport) {
-    return `import { ${additions.join(", ")} } from "${moduleName}";\n${code}`;
-  }
-
-  return code.replace(importRegex, (_match, specifierBlock: string) => {
-    const nextSpecifiers = specifierBlock
-      .split(",")
-      .map((specifier) => specifier.trim())
-      .filter(Boolean)
-      .filter((specifier) => !removals.includes(specifier));
-
-    for (const addition of additions) {
-      if (!nextSpecifiers.includes(addition)) {
-        nextSpecifiers.push(addition);
-      }
-    }
-
-    return `import { ${nextSpecifiers.join(", ")} } from "${moduleName}";`;
-  });
-};
-
-// `createLocalClient()` assumes the snippet is running with a local validator
-// with an auto-funded payer. The docs runner executes against a remote Surfnet
-// endpoint instead, so we rewrite the local-client assignment to an explicit
-// RPC client setup while preserving any chained `.use(...)` plugins.
-const replaceCreateLocalClientSnippet = (code: string): string => {
-  const nextClientSetup = replaceCreateLocalClientSetup(code);
-
-  if (!nextClientSetup) {
-    return code;
-  }
-
-  let nextCode = nextClientSetup;
-
-  nextCode = upsertNamedImport(nextCode, "@solana/kit", [
-    "generateKeyPairSigner",
-    "airdropFactory",
-    "lamports",
-  ]);
-  nextCode = upsertNamedImport(
-    nextCode,
-    "@solana/kit-client-rpc",
-    ["createClient"],
-    ["createLocalClient"],
-  );
-  nextCode = nextCode.replaceAll("client.payer.address", "feePayer.address");
-  nextCode = nextCode.replaceAll("client.payer", "feePayer");
-
-  return nextCode;
 };
 
 const getAPIRoute = (language: CodeRunPayload["language"]): string => {
@@ -172,11 +65,7 @@ export async function POST(req: Request) {
 
   const { code, language } = parseResult.data;
 
-  let executableCode = replaceLocalHostUrl(code);
-
-  if (language === "ts" || language === "typescript") {
-    executableCode = replaceCreateLocalClientSnippet(executableCode);
-  }
+  const executableCode = replaceLocalUrls(code);
 
   const url = getAPIRoute(language);
 


### PR DESCRIPTION
- `createLocalClient()` deprecated, replace with `createClient()`