### PR TITLE
docs(x402): add AlgoVoi — multi-chain x402 facilitator with Solana Pay reference binding

### DIFF
--- a/apps/docs/content/guides/getstarted/intro-to-x402.mdx
+++ b/apps/docs/content/guides/getstarted/intro-to-x402.mdx
@@ -328,6 +328,28 @@ across different networks. Site: https://x402scan.com/
 Thirdweb Nexus develops a x402 wrapper around API keys (currently in
 development). Site: https://nexus.thirdweb.com/
 
+### AlgoVoi
+
+Multi-chain x402 facilitator with first-class Solana support via **Solana Pay
+`reference` pubkey binding**. Every hosted checkout on Solana is exposed as a
+spec-compliant Solana Action at `/actions/checkout/{token}` — the merchant (or
+agent) receives an unsigned SPL USDC transfer that includes a fresh ed25519
+`reference` pubkey as a non-signer account, and AlgoVoi's facilitator catches
+settlement deterministically via `getSignaturesForAddress(reference)`. This
+avoids memo parsing (unreliable across Solana wallets) and amount-uniqueness
+collisions while still giving agent-initiated flows a cryptographic link
+between the on-chain tx and the merchant's `PaymentMandate`.
+
+Same endpoint also spans Algorand, VOI, Hedera, Stellar, Base, and Tempo — so
+agents wanting multi-chain settlement through a single x402 facilitator can use
+it without wiring separate gateways. Also implements Google AP2 and IETF MPP at
+the same URL for agents that need richer mandate semantics.
+
+Live at https://api1.ilovechicken.co.uk. Agent card:
+https://api1.ilovechicken.co.uk/.well-known/agent.json. Open-source MCP adapter
++ plugin for `solana-agent-kit`:
+https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters.
+
 ## Native example
 
 A native example without dependencies and with a minimal server and client.

--- a/apps/docs/content/guides/getstarted/intro-to-x402.mdx
+++ b/apps/docs/content/guides/getstarted/intro-to-x402.mdx
@@ -330,13 +330,9 @@ development). Site: https://nexus.thirdweb.com/
 
 ### AlgoVoi
 
-Multi-chain x402 facilitator with Solana support via Solana Pay `reference`
-pubkey binding — each hosted checkout includes a fresh ed25519 reference as a
-non-signer account on the SPL transfer, with settlement detected via
-`getSignaturesForAddress(reference)`. Hosted checkouts are also exposed as
-Solana Actions at `/actions/checkout/{token}` for Phantom, Solflare, Backpack,
-and Dialect Blink rendering. The same endpoint also covers Algorand, VOI,
-Hedera, Stellar, Base, and Tempo. Site: https://algovoi.co.uk
+Multi-chain x402 facilitator with Solana support, including Solana Actions and
+Solana Pay integration. Also covers Algorand, VOI, Hedera, Stellar, Base, and
+Tempo. Site: https://algovoi.co.uk
 
 ## Native example
 

--- a/apps/docs/content/guides/getstarted/intro-to-x402.mdx
+++ b/apps/docs/content/guides/getstarted/intro-to-x402.mdx
@@ -330,25 +330,13 @@ development). Site: https://nexus.thirdweb.com/
 
 ### AlgoVoi
 
-Multi-chain x402 facilitator with first-class Solana support via **Solana Pay
-`reference` pubkey binding**. Every hosted checkout on Solana is exposed as a
-spec-compliant Solana Action at `/actions/checkout/{token}` — the merchant (or
-agent) receives an unsigned SPL USDC transfer that includes a fresh ed25519
-`reference` pubkey as a non-signer account, and AlgoVoi's facilitator catches
-settlement deterministically via `getSignaturesForAddress(reference)`. This
-avoids memo parsing (unreliable across Solana wallets) and amount-uniqueness
-collisions while still giving agent-initiated flows a cryptographic link
-between the on-chain tx and the merchant's `PaymentMandate`.
-
-Same endpoint also spans Algorand, VOI, Hedera, Stellar, Base, and Tempo — so
-agents wanting multi-chain settlement through a single x402 facilitator can use
-it without wiring separate gateways. Also implements Google AP2 and IETF MPP at
-the same URL for agents that need richer mandate semantics.
-
-Live at https://api1.ilovechicken.co.uk. Agent card:
-https://api1.ilovechicken.co.uk/.well-known/agent.json. Open-source MCP adapter
-+ plugin for `solana-agent-kit`:
-https://github.com/chopmob-cloud/AlgoVoi-Platform-Adapters.
+Multi-chain x402 facilitator with Solana support via Solana Pay `reference`
+pubkey binding — each hosted checkout includes a fresh ed25519 reference as a
+non-signer account on the SPL transfer, with settlement detected via
+`getSignaturesForAddress(reference)`. Hosted checkouts are also exposed as
+Solana Actions at `/actions/checkout/{token}` for Phantom, Solflare, Backpack,
+and Dialect Blink rendering. The same endpoint covers Algorand, VOI, Hedera,
+Stellar, Base, and Tempo. Site: https://algovoi.co.uk
 
 ## Native example
 

--- a/apps/docs/content/guides/getstarted/intro-to-x402.mdx
+++ b/apps/docs/content/guides/getstarted/intro-to-x402.mdx
@@ -335,8 +335,8 @@ pubkey binding — each hosted checkout includes a fresh ed25519 reference as a
 non-signer account on the SPL transfer, with settlement detected via
 `getSignaturesForAddress(reference)`. Hosted checkouts are also exposed as
 Solana Actions at `/actions/checkout/{token}` for Phantom, Solflare, Backpack,
-and Dialect Blink rendering. The same endpoint covers Algorand, VOI, Hedera,
-Stellar, Base, and Tempo. Site: https://algovoi.co.uk
+and Dialect Blink rendering. The same endpoint also covers Algorand, VOI,
+Hedera, Stellar, Base, and Tempo. Site: https://algovoi.co.uk
 
 ## Native example
 


### PR DESCRIPTION
Adds AlgoVoi to the *SDKs and their Solana support* section of `intro-to-x402.mdx`, alongside the existing Corbits, Coinbase, PayAI, A2A x402, Crossmint, x402scan, and Nexus entries.

Single-file docs add (~9 lines) under the existing h3 pattern. No new dependencies. No code changes.

## Revised per @h4rkl review

Collapsed the original multi-paragraph copy into a single neutral paragraph matching the PayAI / x402scan / Nexus / Crossmint pattern (short description + Site URL). Dropped promotional wording ("first-class", "every hosted checkout", "spec-compliant", "richer mandate semantics"), removed the secondary live-URL / agent-card / MCP-adapter link cluster, and replaced the previous example host with the canonical `https://algovoi.co.uk` Site URL.

**IETF Internet-Draft:** [`draft-hopley-x402-canonicalisation-jcs-v1-00`](https://datatracker.ietf.org/doc/draft-hopley-x402-canonicalisation-jcs-v1/) (Independent Submission, Informational, sole AlgoVoi authorship, live on IETF datatracker 2026-05-24)

---

*AlgoVoi (chopmob-cloud) - chopmob@gmail.com - Acquisition enquiries: https://docs.algovoi.co.uk/acquisition*