### PR TITLE
docs(payments): add AUDM to common stablecoin mint tables

### DIFF
--- a/apps/docs/content/docs/en/payments/how-payments-work.mdx
+++ b/apps/docs/content/docs/en/payments/how-payments-work.mdx
@@ -40,12 +40,13 @@ When building payment systems, you'll reference these mint addresses to identify
 the asset you are interacting with. Here are some common stablecoin mints on
 mainnet:
 
-| Token | Issuer | Mint Address                                   |
-| ----- | ------ | ---------------------------------------------- |
-| USDC  | Circle | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` |
-| USDT  | Tether | `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB` |
-| PYUSD | PayPal | `2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo` |
-| USDG  | Paxos  | `2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH` |
+| Token | Issuer   | Mint Address                                   |
+| ----- | -------- | ---------------------------------------------- |
+| USDC  | Circle   | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` |
+| USDT  | Tether   | `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB` |
+| PYUSD | PayPal   | `2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo` |
+| USDG  | Paxos    | `2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH` |
+| AUDM  | Macropod | `CiYXBwHPrdNkMtxR8YEWKv78K6bQjFoEWhPQrZqEmubi` |
 
 For more information on stablecoins on Solana, see the
 [Stablecoins](https://solana.com/solutions/stablecoins) solution page.

--- a/apps/docs/content/docs/en/payments/production-readiness.mdx
+++ b/apps/docs/content/docs/en/payments/production-readiness.mdx
@@ -467,12 +467,13 @@ them during testing, or worse, ship devnet addresses to production.
 
 Some common stablecoin mints are:
 
-| Token | Issuer | Mint Address                                   |
-| ----- | ------ | ---------------------------------------------- |
-| USDC  | Circle | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` |
-| USDT  | Tether | `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB` |
-| PYUSD | PayPal | `2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo` |
-| USDG  | Paxos  | `2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH` |
+| Token | Issuer   | Mint Address                                   |
+| ----- | -------- | ---------------------------------------------- |
+| USDC  | Circle   | `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` |
+| USDT  | Tether   | `Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB` |
+| PYUSD | PayPal   | `2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo` |
+| USDG  | Paxos    | `2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH` |
+| AUDM  | Macropod | `CiYXBwHPrdNkMtxR8YEWKv78K6bQjFoEWhPQrZqEmubi` |
 
 Program addresses matter too. Sending instructions to the wrong program will
 fail—or worse, result in irreversible loss of funds. The Token Program addresses


### PR DESCRIPTION
## Problem

The \"common stablecoin mints on mainnet\" tables in the payments docs reference USDC, USDT, PYUSD and USDG, but no AUD-denominated stablecoin. Developers building multi-currency payment flows for Australian users have no canonical reference in the docs.

## Summary of changes

Adds AUDM, the AUD-pegged stablecoin issued by Macropod (Australian AFSL 566313), to the two stablecoin tables in the English payments docs:

- \`apps/docs/content/docs/en/payments/how-payments-work.mdx\`
- \`apps/docs/content/docs/en/payments/production-readiness.mdx\`

Each table gains one row:

\`\`\`
| AUDM  | Macropod | \`CiYXBwHPrdNkMtxR8YEWKv78K6bQjFoEWhPQrZqEmubi\` |
\`\`\`

## AUDM mint facts (verified via mainnet RPC)

- **Mint**: \`CiYXBwHPrdNkMtxR8YEWKv78K6bQjFoEWhPQrZqEmubi\`
- **Token program**: Token-2022 (\`TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb\`) — same family as PYUSD and USDG
- **Decimals**: 6
- **Symbol / Name**: AUDM / Macropod (per token-2022 \`tokenMetadata\` extension)
- **Issuer**: Macropod (https://www.macropod.com/), AFSL 566313, registered with ASIC and AUSTRAC, AUD reserves held in trust with a Big 4 Australian bank
- **Live supply**: ✓ (non-zero, queryable)

## Scope

- Only the English (\`en/\`) MDX files are touched. Other locales are managed via Crowdin.
- Faucet table in \`developer-tools.mdx\` is **not** modified — Macropod doesn't publish a public devnet faucet.
- Explorer-link examples in \`interacting-with-solana.mdx\` are **not** modified — those are illustrative, not exhaustive.

## Validation

\`\`\`
pnpm -w exec prettier --check apps/docs/content/docs/en/payments/how-payments-work.mdx apps/docs/content/docs/en/payments/production-readiness.mdx   # clean (lint-staged ran on commit)
\`\`\`

## Companion PR

A separate PR (#1436) adds Macropod to \`packages/ecosystem-data\`. The two are independent and can be reviewed/merged separately.