### PR TITLE
Fix Breakpoint social metadata routing

### DIFF
--- a/apps/breakpoint/src/app/[locale]/faq/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/faq/page.tsx
@@ -1,8 +1,16 @@
 import type { Metadata } from "next";
 import FAQPage from "@/components/pages/FAQPage";
 import { faqPageMetadata } from "@/content/faq-page";
+import { getPageMetadata } from "@/app/metadata";
 
-export const metadata: Metadata = faqPageMetadata;
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return getPageMetadata(locale, faqPageMetadata);
+}
 
 export default function LocaleFAQPage() {
   return <FAQPage />;

--- a/apps/breakpoint/src/app/[locale]/registration/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/registration/page.tsx
@@ -1,11 +1,22 @@
 import type { Metadata } from "next";
 import RegistrationPage from "@/components/pages/registration/RegistrationPage";
+import { getPageMetadata } from "@/app/metadata";
 
-export const metadata: Metadata = {
-  title: "Registration | Breakpoint 2026",
+const pageMetadata = {
+  path: "/registration",
+  title: "Registration",
   description:
     "Reserve Breakpoint 2026 tickets for general admission, developers, and students.",
 };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return getPageMetadata(locale, pageMetadata);
+}
 
 export default function LocaleRegistrationPage() {
   return <RegistrationPage />;

--- a/apps/breakpoint/src/app/[locale]/schedule/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/schedule/page.tsx
@@ -1,11 +1,22 @@
 import type { Metadata } from "next";
 import ComingSoonPage from "@/components/pages/ComingSoonPage";
+import { getPageMetadata } from "@/app/metadata";
 
-export const metadata: Metadata = {
-  title: "Schedule | Breakpoint 2026",
+const pageMetadata = {
+  path: "/schedule",
+  title: "Schedule",
   description:
     "The Breakpoint 2026 schedule is coming soon for the London conference.",
 };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return getPageMetadata(locale, pageMetadata);
+}
 
 export default function LocaleSchedulePage() {
   return (

--- a/apps/breakpoint/src/app/[locale]/speakers/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/speakers/page.tsx
@@ -1,11 +1,22 @@
 import type { Metadata } from "next";
 import ComingSoonPage from "@/components/pages/ComingSoonPage";
+import { getPageMetadata } from "@/app/metadata";
 
-export const metadata: Metadata = {
-  title: "Speakers | Breakpoint 2026",
+const pageMetadata = {
+  path: "/speakers",
+  title: "Speakers",
   description:
     "Breakpoint 2026 speaker announcements are coming soon for the London conference.",
 };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return getPageMetadata(locale, pageMetadata);
+}
 
 export default function LocaleSpeakersPage() {
   return (

--- a/apps/breakpoint/src/app/[locale]/sponsors/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/sponsors/page.tsx
@@ -1,11 +1,22 @@
 import type { Metadata } from "next";
 import ComingSoonPage from "@/components/pages/ComingSoonPage";
+import { getPageMetadata } from "@/app/metadata";
 
-export const metadata: Metadata = {
-  title: "Sponsors | Breakpoint 2026",
+const pageMetadata = {
+  path: "/sponsors",
+  title: "Sponsors",
   description:
     "Breakpoint 2026 sponsor announcements are coming soon for the London conference.",
 };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return getPageMetadata(locale, pageMetadata);
+}
 
 export default function LocaleSponsorsPage() {
   return (

--- a/apps/breakpoint/src/app/[locale]/travel/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/travel/page.tsx
@@ -1,11 +1,22 @@
 import type { Metadata } from "next";
 import TravelPage from "@/components/pages/travel/TravelPage";
+import { getPageMetadata } from "@/app/metadata";
 
-export const metadata: Metadata = {
-  title: "Travel | Breakpoint 2026",
+const pageMetadata = {
+  path: "/travel",
+  title: "Travel",
   description:
     "Plan travel to Breakpoint 2026 in London with airport, flight, hotel, visa, and local recommendations.",
 };
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  return getPageMetadata(locale, pageMetadata);
+}
 
 export default function LocaleTravelPage() {
   return <TravelPage />;

--- a/apps/breakpoint/src/app/metadata.ts
+++ b/apps/breakpoint/src/app/metadata.ts
@@ -4,19 +4,32 @@ import faviconSvg from "@solana-com/ui-chrome/assets/favicon.svg";
 import appleTouchIcon from "@solana-com/ui-chrome/assets/apple-touch-icon.png";
 import { locales, defaultLocale } from "@workspace/i18n/config";
 import { getTranslations } from "@workspace/i18n/server";
-import { config } from "@/config";
-
-const localePath = (locale: string) =>
-  locale === defaultLocale ? "" : `/${locale}`;
+import { config, localizedRouteUrl } from "@/config";
 
 const socialImageAlt =
   "Breakpoint 2026 social card with the Breakpoint logo over a purple London skyline";
 
+type PageMetadataConfig = {
+  description: string;
+  path: string;
+  title: string;
+};
+
+const getLanguageAlternates = (path: string) => {
+  const languages: Record<string, string> = Object.fromEntries(
+    locales.map((l) => [l, localizedRouteUrl(l, path)]),
+  );
+  languages["x-default"] = localizedRouteUrl(defaultLocale, path);
+
+  return languages;
+};
+
 export async function getBaseMetadata(
   locale: string = defaultLocale,
+  path: string = "/",
 ): Promise<Metadata> {
   const t = await getTranslations({ locale, namespace: "breakpoint.metadata" });
-  const { siteUrl, siteMetadata, social } = config;
+  const { siteOrigin, siteMetadata, social } = config;
 
   const title = t("title");
   const titleTemplate = t("titleTemplate");
@@ -29,14 +42,11 @@ export async function getBaseMetadata(
     .map((k) => k.trim())
     .filter(Boolean);
 
-  const canonical = `${siteUrl}${localePath(locale)}`;
-  const languages: Record<string, string> = Object.fromEntries(
-    locales.map((l) => [l, `${siteUrl}${localePath(l)}`]),
-  );
-  languages["x-default"] = siteUrl;
+  const canonical = localizedRouteUrl(locale, path);
+  const languages = getLanguageAlternates(path);
 
   return {
-    metadataBase: new URL(siteUrl),
+    metadataBase: new URL(siteOrigin),
     alternates: { canonical, languages },
     title: { default: title, template: titleTemplate },
     description,
@@ -81,5 +91,33 @@ export async function getBaseMetadata(
       { url: faviconSvg, rel: "icon", type: "image/svg+xml" },
       { url: appleTouchIcon.src, rel: "apple-touch-icon", sizes: "180x180" },
     ],
+  };
+}
+
+export async function getPageMetadata(
+  locale: string = defaultLocale,
+  { description, path, title }: PageMetadataConfig,
+): Promise<Metadata> {
+  const base = await getBaseMetadata(locale, path);
+  const t = await getTranslations({ locale, namespace: "breakpoint.metadata" });
+  const siteName = t("siteName");
+  const socialTitle = `${title} | ${siteName}`;
+  const openGraph = base.openGraph ?? {};
+  const twitter = base.twitter ?? {};
+
+  return {
+    ...base,
+    title,
+    description,
+    openGraph: {
+      ...openGraph,
+      title: socialTitle,
+      description,
+    },
+    twitter: {
+      ...twitter,
+      title: socialTitle,
+      description,
+    },
   };
 }

--- a/apps/breakpoint/src/config.ts
+++ b/apps/breakpoint/src/config.ts
@@ -1,3 +1,5 @@
+import { defaultLocale } from "@workspace/i18n/config";
+
 const routePrefix = "/breakpoint";
 const assetPrefix = "/breakpoint-assets";
 const publicAssetDirectories = [
@@ -48,6 +50,17 @@ export const routePath = (path: string) => {
     : `${routePrefix}${normalizedPath}`;
 };
 
+export const localizedRoutePath = (
+  locale: string = defaultLocale,
+  path: string = "/",
+) =>
+  locale === defaultLocale ? routePath(path) : `/${locale}${routePath(path)}`;
+
+export const localizedRouteUrl = (
+  locale: string = defaultLocale,
+  path: string = "/",
+) => `${siteOrigin}${localizedRoutePath(locale, path)}`;
+
 export function publicAssetPath(path: string) {
   if (
     !path.startsWith("/") ||
@@ -65,7 +78,8 @@ export function publicAssetPath(path: string) {
 
 export const config = {
   assetPrefix,
-  siteUrl: `${siteOrigin}${routePrefix}`,
+  siteOrigin,
+  siteUrl: localizedRouteUrl(defaultLocale),
   siteMetadata: {
     title: "Breakpoint 2026",
     description:

--- a/apps/breakpoint/src/content/faq-page.ts
+++ b/apps/breakpoint/src/content/faq-page.ts
@@ -15,7 +15,8 @@ export type FAQPageSection = {
 };
 
 export const faqPageMetadata = {
-  title: "FAQ | Breakpoint 2026",
+  path: "/faq",
+  title: "FAQ",
   description:
     "Answers to common Breakpoint 2026 questions about the event, tickets, travel, and attending in London.",
 };

--- a/apps/breakpoint/src/lib/structured-data.ts
+++ b/apps/breakpoint/src/lib/structured-data.ts
@@ -1,4 +1,4 @@
-import { config } from "@/config";
+import { config, localizedRouteUrl } from "@/config";
 import { homepageFaqItems } from "@/content/faq-page";
 import { GENERAL_ADMISSION_HREF } from "@/content/links";
 
@@ -24,7 +24,7 @@ const TICKET_OFFERS: OfferSeed[] = [
 
 export function buildBreakpointJsonLd(locale: string): JsonLd {
   const { siteUrl, siteMetadata, event } = config;
-  const pageUrl = locale === "en" ? siteUrl : `${siteUrl}/${locale}`;
+  const pageUrl = localizedRouteUrl(locale);
   const socialImage = new URL(siteMetadata.socialShare, siteUrl).toString();
 
   const eventNode: JsonLd = {

--- a/apps/breakpoint/src/tests/publicAssetPath.test.ts
+++ b/apps/breakpoint/src/tests/publicAssetPath.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { config, publicAssetPath, routePath } from "@/config";
+import {
+  config,
+  localizedRoutePath,
+  localizedRouteUrl,
+  publicAssetPath,
+  routePath,
+} from "@/config";
 
 describe("routePath", () => {
   it("prefixes Breakpoint app routes", () => {
@@ -15,6 +21,22 @@ describe("routePath", () => {
     );
     expect(routePath("#flights")).toBe("#flights");
     expect(routePath("https://example.com")).toBe("https://example.com");
+  });
+});
+
+describe("localizedRoutePath", () => {
+  it("matches the public Breakpoint rewrites for default and localized routes", () => {
+    expect(localizedRoutePath("en")).toBe("/breakpoint");
+    expect(localizedRoutePath("en", "/travel")).toBe("/breakpoint/travel");
+    expect(localizedRoutePath("ar")).toBe("/ar/breakpoint");
+    expect(localizedRoutePath("ar", "/travel")).toBe("/ar/breakpoint/travel");
+  });
+
+  it("builds absolute localized Breakpoint URLs", () => {
+    expect(localizedRouteUrl("en")).toBe("https://solana.com/breakpoint");
+    expect(localizedRouteUrl("de", "/registration")).toBe(
+      "https://solana.com/de/breakpoint/registration",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- align Breakpoint canonical, hreflang, and social URLs with the public rewrites in apps/web/rewrites-redirects.ts
- add route-aware metadata for Breakpoint subpages so canonical and og:url point at the current page
- fix localized JSON-LD URLs and add tests for the localized Breakpoint route helper

## Validation
- pnpm --filter solana-com-breakpoint test -- publicAssetPath.test.ts
- pnpm --filter solana-com-breakpoint check-types
- pnpm --filter solana-com-breakpoint lint
- pnpm --filter solana-com-breakpoint build