### PR TITLE
docs: migrate kit RPC snippets to solanaRpcConnection({ rpcUrl })

### DIFF
--- a/apps/docs/content/docs/en/core/accounts/account-types.mdx
+++ b/apps/docs/content/docs/en/core/accounts/account-types.mdx
@@ -63,13 +63,13 @@ is `true`, confirming it is a program account.
 
 ```ts !! title="Kit"
 import { Address, createClient } from "@solana/kit";
-import { solanaRpc } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection } from "@solana/kit-plugin-rpc";
 import { generatedPayer } from "@solana/kit-plugin-signer";
 
 const client = await createClient()
   .use(generatedPayer())
   .use(
-    solanaRpc({
+    solanaRpcConnection({
       rpcUrl: "https://api.mainnet.solana.com"
     })
   );
@@ -161,7 +161,7 @@ Token 2022 program.
 
 ```ts !! title="Kit"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 import {
@@ -173,12 +173,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   .use(systemProgram());
@@ -421,17 +416,12 @@ the account. The `owner` field is `11111111111111111111111111111111` (the
 
 ```ts !! title="Kit"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection } from "@solana/kit-plugin-rpc";
 import { generatedPayer } from "@solana/kit-plugin-signer";
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  );
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }));
 
 // Generate a new keypair
 const keypair = await generateKeyPairSigner();
@@ -534,14 +524,14 @@ The following example fetches and deserializes the Sysvar Clock account.
 
 ```ts !! title="Kit"
 import { createClient } from "@solana/kit";
-import { solanaRpc } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection } from "@solana/kit-plugin-rpc";
 import { generatedPayer } from "@solana/kit-plugin-signer";
 import { fetchSysvarClock, SYSVAR_CLOCK_ADDRESS } from "@solana/sysvars";
 
 const client = await createClient()
   .use(generatedPayer())
   .use(
-    solanaRpc({
+    solanaRpcConnection({
       rpcUrl: "https://api.mainnet.solana.com"
     })
   );

--- a/apps/docs/content/docs/en/core/instructions/instruction-structure.mdx
+++ b/apps/docs/content/docs/en/core/instructions/instruction-structure.mdx
@@ -138,18 +138,13 @@ The example below shows the structure of a SOL transfer instruction.
 
 ```ts !! title="Kit"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   .use(systemProgram());

--- a/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
+++ b/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
@@ -317,18 +317,13 @@ Program's
 
 ```ts !! title="Kit"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   .use(systemProgram());
@@ -546,18 +541,13 @@ import {
   signTransactionMessageWithSigners,
   getCompiledTransactionMessageDecoder
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   .use(systemProgram());

--- a/apps/docs/content/docs/en/tokens/basics/approve-delegate.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/approve-delegate.mdx
@@ -54,7 +54,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
@@ -64,12 +64,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -125,7 +120,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchToken,
@@ -138,12 +133,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/burn-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/burn-tokens.mdx
@@ -56,7 +56,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
@@ -66,12 +66,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -126,7 +121,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchMint,
@@ -140,12 +135,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/close-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/close-account.mdx
@@ -52,7 +52,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
@@ -63,12 +63,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -120,7 +115,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchMaybeToken,
@@ -133,12 +128,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/create-mint.mdx
@@ -90,18 +90,13 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { tokenProgram } from "@solana-program/token";
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -128,18 +123,13 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instruction Plan"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { fetchMint, getCreateMintInstructionPlan } from "@solana-program/token";
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -165,7 +155,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -177,12 +167,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/create-token-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/create-token-account.mdx
@@ -135,7 +135,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   associatedTokenProgram,
@@ -146,12 +146,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -199,7 +194,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -213,12 +208,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -690,7 +680,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 import {
@@ -701,12 +691,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(systemProgram\(\)\)/]
@@ -759,7 +744,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -773,12 +758,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/freeze-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/freeze-account.mdx
@@ -59,7 +59,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
@@ -69,12 +69,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -125,7 +120,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchToken,
@@ -138,12 +133,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/mint-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/mint-tokens.mdx
@@ -53,7 +53,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
@@ -63,12 +63,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -116,7 +111,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instruction Plan"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchMint,
@@ -129,12 +124,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -182,7 +172,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchMint,
@@ -196,12 +186,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/revoke-delegate.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/revoke-delegate.mdx
@@ -50,7 +50,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
@@ -60,12 +60,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -125,7 +120,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchToken,
@@ -139,12 +134,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/set-authority.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/set-authority.mdx
@@ -57,18 +57,13 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { AuthorityType, tokenProgram } from "@solana-program/token";
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -114,7 +109,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   AuthorityType,
@@ -125,12 +120,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/sync-native.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/sync-native.mdx
@@ -58,7 +58,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { address, createClient, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { systemProgram } from "@solana-program/system";
 import {
@@ -70,12 +70,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(systemProgram\(\)\)/]
@@ -122,7 +117,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { address, createClient, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getTransferSolInstruction } from "@solana-program/system";
 import {
@@ -135,12 +130,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/thaw-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/thaw-account.mdx
@@ -51,7 +51,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
@@ -61,12 +61,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -122,7 +117,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchToken,
@@ -136,12 +131,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/basics/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/transfer-tokens.mdx
@@ -59,7 +59,7 @@ Legacy examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Plugin"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   findAssociatedTokenPda,
@@ -69,12 +69,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   // !mark[/\.use\(tokenProgram\(\)\)/]
@@ -140,7 +135,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instruction Plan"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchAllToken,
@@ -153,12 +148,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -225,7 +215,7 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 ```ts !! title="Instructions"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import {
   fetchAllToken,
@@ -239,12 +229,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/close-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/close-mint.mdx
@@ -50,12 +50,7 @@ _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -81,12 +76,7 @@ _rs`MintCloseAuthority`_ extension.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -114,12 +104,7 @@ Create the mint account with the calculated space and lamports.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -157,12 +142,7 @@ Initialize the _rs`MintCloseAuthority`_ extension on the mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -204,12 +184,7 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -278,7 +253,7 @@ reference.
 
 ```ts !! title="Instructions"
 import { lamports, createClient, generateKeyPairSigner } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -296,12 +271,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/cpi-guard.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/cpi-guard.mdx
@@ -70,12 +70,7 @@ Create and initialize the mint that the token account will use.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -115,12 +110,7 @@ _rs`CpiGuard`_ extension. This is the size used in _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -165,12 +155,7 @@ extension.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -219,12 +204,7 @@ it for the mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -287,12 +267,7 @@ Enable _rs`CpiGuard`_ on the token account.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -362,12 +337,7 @@ Disable _rs`CpiGuard`_ on the token account.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -463,7 +433,7 @@ import {
   generateKeyPairSigner,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -480,12 +450,7 @@ import {
 } from "@solana-program/token-2022";
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/default-state.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/default-state.mdx
@@ -49,12 +49,7 @@ _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -80,12 +75,7 @@ _rs`DefaultAccountState`_ extension.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -113,12 +103,7 @@ Create the mint account with the calculated space and lamports.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -156,12 +141,7 @@ Initialize the _rs`DefaultAccountState`_ extension on the mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -203,12 +183,7 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -257,12 +232,7 @@ _rs`Frozen`_, the new token account starts frozen.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -325,12 +295,7 @@ accounts no longer start frozen.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -427,7 +392,7 @@ import {
   generateKeyPairSigner,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -446,12 +411,7 @@ import {
 } from "@solana-program/token-2022";
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/group-member.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/group-member.mdx
@@ -61,12 +61,7 @@ Calculate the size and rent needed for the group mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -103,12 +98,7 @@ mint, and initialize _rs`TokenGroup`_ in one transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -173,12 +163,7 @@ Calculate the size and rent needed for the member mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -261,12 +246,7 @@ the mint, and initialize _rs`TokenGroupMember`_ in one transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -437,7 +417,7 @@ import {
   generateKeyPairSigner,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -454,12 +434,7 @@ import {
 } from "@solana-program/token-2022";
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/immutable-owner.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/immutable-owner.mdx
@@ -49,12 +49,7 @@ _rs`ImmutableOwner`_ extension. This is the size used in _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -99,12 +94,7 @@ extension.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -151,12 +141,7 @@ Create the token account with the calculated space and lamports.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -213,12 +198,7 @@ Initialize the _rs`ImmutableOwner`_ extension on the token account.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -279,12 +259,7 @@ transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -375,7 +350,7 @@ import {
   generateKeyPairSigner,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -394,12 +369,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/interest-bearing-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/interest-bearing-tokens.mdx
@@ -83,12 +83,7 @@ _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -117,12 +112,7 @@ _rs`InterestBearingConfig`_ extension.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -153,12 +143,7 @@ Create the mint account with the calculated space and lamports.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -199,12 +184,7 @@ Initialize the _rs`InterestBearingConfig`_ extension on the mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -250,12 +230,7 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -307,12 +282,7 @@ Create a token account for the mint, then mint tokens to that token account.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -387,12 +357,7 @@ sending a transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -511,7 +476,7 @@ import {
   signTransactionMessageWithSigners,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -532,12 +497,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/memo-transfer.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/memo-transfer.mdx
@@ -44,12 +44,7 @@ Create and initialize the mint that the token account will use.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -90,12 +85,7 @@ _rs`MemoTransfer`_ extension. This is the size used in _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -141,12 +131,7 @@ extension.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -196,12 +181,7 @@ it for the mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -265,12 +245,7 @@ Enable _rs`MemoTransfer`_ on the token account.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -360,7 +335,7 @@ import {
   generateKeyPairSigner,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getAddMemoInstruction } from "@solana-program/memo";
 import { getCreateAccountInstruction } from "@solana-program/system";
@@ -383,12 +358,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/metadata.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/metadata.mdx
@@ -75,12 +75,7 @@ extension. This is the size used in _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -106,12 +101,7 @@ on the mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -152,12 +142,7 @@ Create the mint account with the calculated space and lamports.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -209,12 +194,7 @@ address.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -270,12 +250,7 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -338,12 +313,7 @@ metadata; if the field does not exist, _rs`UpdateField`_ adds it.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -423,12 +393,7 @@ _rs`Emit`_ to return the current metadata.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -578,7 +543,7 @@ import {
   generateKeyPairSigner,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { unpack as unpackTokenMetadata } from "@solana/spl-token-metadata";
 import { getCreateAccountInstruction } from "@solana-program/system";
@@ -601,12 +566,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/non-transferrable-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/non-transferrable-tokens.mdx
@@ -66,12 +66,7 @@ extension. This is the size used in _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -95,12 +90,7 @@ extension.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -126,12 +116,7 @@ Create the mint account with the calculated space and lamports.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -167,12 +152,7 @@ Initialize the _rs`NonTransferable`_ extension on the mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -211,12 +191,7 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -282,7 +257,7 @@ examples using `@solana/web3.js` are included for reference.
 
 ```ts !! title="Instructions"
 import { lamports, createClient, generateKeyPairSigner } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -301,12 +276,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/pausable.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/pausable.mdx
@@ -50,12 +50,7 @@ extension. This is the size used in _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -82,12 +77,7 @@ extension.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -116,12 +106,7 @@ Create the mint account with the calculated space and lamports.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -160,12 +145,7 @@ Initialize the _rs`PausableConfig`_ extension on the mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -208,12 +188,7 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -262,12 +237,7 @@ Pause the mint with _rs`Pause`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -323,12 +293,7 @@ Resume the mint with _rs`Resume`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -418,7 +383,7 @@ import {
   generateKeyPairSigner,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -439,12 +404,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/permanent-delegate.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/permanent-delegate.mdx
@@ -51,12 +51,7 @@ _rs`PermanentDelegate`_ extension. This is the size used in _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -84,12 +79,7 @@ _rs`PermanentDelegate`_ extension.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -119,12 +109,7 @@ Create the mint account with the calculated space and lamports.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -164,12 +149,7 @@ Initialize the _rs`PermanentDelegate`_ extension on the mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -213,12 +193,7 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -269,12 +244,7 @@ token account.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -355,12 +325,7 @@ Transfer tokens with _rs`TransferChecked`_ signed by the permanent delegate.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -480,7 +445,7 @@ import {
   generateKeyPairSigner,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -499,12 +464,7 @@ import {
 } from "@solana-program/token-2022";
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/scaled-ui-amount/index.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/scaled-ui-amount/index.mdx
@@ -118,7 +118,7 @@ import {
   generateKeyPairSigner,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -138,12 +138,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/content/docs/en/tokens/extensions/transfer-fees.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/transfer-fees.mdx
@@ -72,12 +72,7 @@ _rs`TransferFeeConfig`_ extension. This is the size used in _rs`CreateAccount`_.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -114,12 +109,7 @@ _rs`TransferFeeConfig`_ extension.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -158,12 +148,7 @@ Create the mint account with the calculated space and lamports.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -212,12 +197,7 @@ Initialize the _rs`TransferFeeConfig`_ extension on the mint.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -273,12 +253,7 @@ Initialize the mint with _rs`InitializeMint`_ in the same transaction.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -341,12 +316,7 @@ tokens to the source token account.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -465,12 +435,7 @@ Transfer tokens with _rs`TransferCheckedWithFee`_ and verify the expected fee.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -602,12 +567,7 @@ on the destination token account.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -750,12 +710,7 @@ token accounts to the fee receiver token account.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -908,12 +863,7 @@ to the mint account's withheld accumulator.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -1073,12 +1023,7 @@ account to the fee receiver token account.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -1245,12 +1190,7 @@ Use _rs`SetTransferFee`_ to update the next transfer fee configuration.
 ```ts !! title="Example"
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
@@ -1461,7 +1401,7 @@ import {
   generateKeyPairSigner,
   unwrapOption
 } from "@solana/kit";
-import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { solanaRpcConnection, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
 import { getCreateAccountInstruction } from "@solana-program/system";
 import {
@@ -1485,12 +1425,7 @@ import {
 
 const client = await createClient()
   .use(generatedPayer())
-  .use(
-    solanaRpc({
-      rpcUrl: "http://localhost:8899",
-      rpcSubscriptionsUrl: "ws://localhost:8900"
-    })
-  )
+  .use(solanaRpcConnection({ rpcUrl: "http://localhost:8899" }))
   .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 

--- a/apps/docs/src/app/[locale]/docs/api/route.tsx
+++ b/apps/docs/src/app/[locale]/docs/api/route.tsx
@@ -20,10 +20,22 @@ const TXTX_WS_RPC_URL = isEnvConfigured ? `wss://${TXTX_SURFNET_URL}:8900` : "";
 const LOCALHOST_RPC_URL = "http://localhost:8899";
 const LOCALHOST_WS_URL = "ws://localhost:8900";
 
+const LOCALHOST_SOLANA_RPC_CONNECTION = `solanaRpcConnection({ rpcUrl: "${LOCALHOST_RPC_URL}" })`;
+const TXTX_SOLANA_RPC_CONNECTION = [
+  "solanaRpcConnection({",
+  `  rpcUrl: "${TXTX_RPC_URL}",`,
+  `  rpcSubscriptionsUrl: "${TXTX_WS_RPC_URL}",`,
+  "})",
+].join("\n");
+
 const replaceLocalUrls = (code: string): string => {
-  return code
-    .replaceAll(LOCALHOST_RPC_URL, TXTX_RPC_URL)
-    .replaceAll(LOCALHOST_WS_URL, TXTX_WS_RPC_URL);
+  return (
+    code
+      // Kit snippets that only set rpcUrl still need Surfnet's websocket endpoint.
+      .replaceAll(LOCALHOST_SOLANA_RPC_CONNECTION, TXTX_SOLANA_RPC_CONNECTION)
+      .replaceAll(LOCALHOST_RPC_URL, TXTX_RPC_URL)
+      .replaceAll(LOCALHOST_WS_URL, TXTX_WS_RPC_URL)
+  );
 };
 
 const getAPIRoute = (language: CodeRunPayload["language"]): string => {


### PR DESCRIPTION
## Summary

- Migrate 28 `/en/` MDX docs from `solanaRpc({ rpcUrl, rpcSubscriptionsUrl })` to the unified `solanaRpcConnection({ rpcUrl })` plugin from `@solana/kit-plugin-rpc@0.11`.
- Drops `rpcSubscriptionsUrl: "ws://localhost:8900"` from localhost snippets — derived correctly from `rpcUrl` thanks to the canonical-localhost allowlist landed in [anza-xyz/kit-plugins#210](https://github.com/anza-xyz/kit-plugins/pull/210) (shipped in [`@solana/kit-plugin-rpc@0.11.1`](https://www.npmjs.com/package/@solana/kit-plugin-rpc/v/0.11.1)). (Requires backend bump)
- Other locales auto-regenerate on PR.

## References

- Upstream API change: [anza-xyz/kit-plugins#201](https://github.com/anza-xyz/kit-plugins/pull/201)
- Upstream localhost-derivation fix: [anza-xyz/kit-plugins#210](https://github.com/anza-xyz/kit-plugins/pull/210)
- Linear: DEV-485 (parent: DEV-477)

## Test plan

- [x] `pnpm exec prettier --write 'apps/docs/content/docs/en/**/*.mdx'` clean
- [x] `pnpm lint --filter solana-docs` passes
- [x] Spot-check `grep -rn '\bsolanaRpc\b'` and `rpcSubscriptionsUrl` → 0 hits in `/en/`
- [ ] Reviewer: render `/en/core/transactions/transaction-structure` and one tokens page