### PR TITLE
ecosystem: add Sour Finance

### DIFF
--- a/packages/ecosystem-data/assets/companies/sour-finance/logo.svg
+++ b/packages/ecosystem-data/assets/companies/sour-finance/logo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 32 32" role="img" aria-label="Sour logo">
+  <defs>
+    <radialGradient id="lemon" cx="0.35" cy="0.35" r="0.7">
+      <stop offset="0%" stop-color="#f4f59c"/>
+      <stop offset="100%" stop-color="#daf07c"/>
+    </radialGradient>
+  </defs>
+  <rect width="32" height="32" fill="#0a0a0c"/>
+  <circle cx="16" cy="16" r="12" fill="url(#lemon)"/>
+  <circle cx="16" cy="16" r="12" fill="none" stroke="#7c8a3a" stroke-width="0.5" opacity="0.5"/>
+  <line x1="19" y1="16" x2="27" y2="16" stroke="#7c8a3a" stroke-width="0.5" opacity="0.4"/>
+  <line x1="18.121" y1="18.121" x2="23.778" y2="23.778" stroke="#7c8a3a" stroke-width="0.5" opacity="0.4"/>
+  <line x1="16" y1="19" x2="16" y2="27" stroke="#7c8a3a" stroke-width="0.5" opacity="0.4"/>
+  <line x1="13.879" y1="18.121" x2="8.222" y2="23.778" stroke="#7c8a3a" stroke-width="0.5" opacity="0.4"/>
+  <line x1="13" y1="16" x2="5" y2="16" stroke="#7c8a3a" stroke-width="0.5" opacity="0.4"/>
+  <line x1="13.879" y1="13.879" x2="8.222" y2="8.222" stroke="#7c8a3a" stroke-width="0.5" opacity="0.4"/>
+  <line x1="16" y1="13" x2="16" y2="5" stroke="#7c8a3a" stroke-width="0.5" opacity="0.4"/>
+  <line x1="18.121" y1="13.879" x2="23.778" y2="8.222" stroke="#7c8a3a" stroke-width="0.5" opacity="0.4"/>
+  <circle cx="16" cy="16" r="2.5" fill="#f4f59c" opacity="0.8"/>
+</svg>

--- a/packages/ecosystem-data/src/companies/records/sour-finance.ts
+++ b/packages/ecosystem-data/src/companies/records/sour-finance.ts
@@ -1,0 +1,37 @@
+import type { CompanyRecord } from "../../types";
+import sourFinanceLogo from "../../../assets/companies/sour-finance/logo.svg";
+
+export const sourFinance = {
+  id: "sour-finance",
+  slug: "sour-finance",
+  name: "Sour",
+  legalName: "Sour Finance",
+  profile: {
+    tagline: "The perp DEX that bites back.",
+    summary:
+      "Solana perpetuals DEX with batch clearing every 1.8 seconds, flat 3 bps fees, and formally verified settlement.",
+    description:
+      "Sour is a non-custodial perpetual futures DEX on Solana. Every order in a 1.8-second batch settles at one uniform clearing price, removing the front-run / back-run lanes that continuous orderbook perp DEXes leave open. Funding is computed inside every batch — no off-chain cron, no liquidation keeper. Trading fee is a flat 3 basis points per fill, regardless of size, taker/maker, or volume tier; 100% of fees route to the SOUR LP vault. Settlement and aggregate-budget math are formally verified with 18 Kani proofs, a Lean specification, and 15 property tests at github.com/GageBachik/sour-verification.",
+    founded: "2026",
+    sector: "DeFi",
+    type: "Protocol",
+    links: {
+      website: "https://sour.finance",
+      app: "https://app.sour.finance",
+      docs: "https://sour.finance/docs",
+    },
+    socials: {
+      x: "https://x.com/sourfinance",
+      github: "https://github.com/GageBachik/sour",
+    },
+  },
+  defaultLogoId: "logo",
+  logos: [
+    {
+      id: "logo",
+      fileName: "logo.svg",
+      format: "svg",
+      source: sourFinanceLogo,
+    },
+  ],
+} satisfies CompanyRecord;

--- a/packages/ecosystem-data/src/companies/registry.ts
+++ b/packages/ecosystem-data/src/companies/registry.ts
@@ -59,6 +59,7 @@ import { solanaSpaces } from "./records/solana-spaces";
 import { solayer } from "./records/solayer";
 import { solflare } from "./records/solflare";
 import { solpay } from "./records/solpay";
+import { sourFinance } from "./records/sour-finance";
 import { spi } from "./records/spi";
 import { squads } from "./records/squads";
 import { sunrise } from "./records/sunrise";
@@ -139,6 +140,7 @@ export const companies = [
   solayer,
   solflare,
   solpay,
+  sourFinance,
   spi,
   squads,
   sunrise,


### PR DESCRIPTION
Adds Sour Finance to the ecosystem registry.

Sour is a Solana perpetuals DEX live on mainnet since 2026-05-06 (program ID `souryQgnM1xiNuGcmVYLPGT3MKqnGN8QTqP8zk8eape`). It's the first production implementation of frequent batch auctions for perpetual futures on Solana — every order in a 1.8-second slot settles at one uniform clearing price, with funding computed inside every batch (no off-chain cron) and a flat 3 bps per-fill fee that routes 100% to the LP vault.

Three files added:
- `packages/ecosystem-data/assets/companies/sour-finance/logo.svg`
- `packages/ecosystem-data/src/companies/records/sour-finance.ts`
- `packages/ecosystem-data/src/companies/registry.ts` (alphabetical insert between `solpay` and `spi`)

Source: https://github.com/GageBachik/sour
Formal verification (Kani 18/18 + Lean spec + 15 proptests): https://github.com/GageBachik/sour-verification

Validated locally:
- `pnpm --filter @workspace/ecosystem-data exec tsc --noEmit` passes clean
- `pnpm --filter @workspace/ecosystem-data run audit:data` reports 79 records / 79 asset folders; sour-finance not in any error category. Pre-existing failures (mantle, matcha, pipe-network, the-graph asset references) are unrelated to this PR.