### PR TITLE
feat: add subscriptions section in payments

### DIFF
--- a/apps/docs/content/docs/en/payments/meta.json
+++ b/apps/docs/content/docs/en/payments/meta.json
@@ -6,6 +6,7 @@
     "interacting-with-solana",
     "send-payments",
     "accept-payments",
+    "subscriptions",
     "advanced-payments",
     "agentic-payments",
     "developer-tools",

--- a/apps/docs/content/docs/en/payments/subscriptions/close-subscription-authority.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/close-subscription-authority.mdx
@@ -8,9 +8,11 @@ delegate for a user's token account. Close it when the user no longer has active
 fixed delegations, recurring delegations, or subscription delegations for that
 mint.
 
-Closing the account returns its rent to the user and revokes the token delegate
-approval owned by the program. If any active delegation still depends on the
-authority, close those delegations first.
+Closing the account returns its rent to the account's lamport funder and revokes
+the token delegate approval owned by the program. The funder is usually the
+user, but it can be any payer that funded the Subscription Authority account. If
+any active delegation still depends on the authority, close those delegations
+first.
 
 ## Close The Authority
 
@@ -40,6 +42,8 @@ authority, close those delegations first.
       .closeSubscriptionAuthority({
         user: userSigner,
         tokenMint,
+        // Include this only when a sponsor funded the Subscription Authority.
+        receiver: sponsorSigner.address,
       })
       .sendTransaction();
     ```
@@ -48,13 +52,15 @@ authority, close those delegations first.
 
   <Tab value="Rust">
     ```rust
-    use solana_pubkey::{pubkey, Pubkey};
+    use solana_address::{address, Address};
+    use solana_instruction::AccountMeta;
     use subscriptions_client::{generated::instructions::*, SUBSCRIPTIONS_ID};
 
-    let user: Pubkey = pubkey!("USER_WALLET_ADDRESS_HERE");
-    let token_mint: Pubkey = pubkey!("TOKEN_MINT_ADDRESS_HERE");
+    let user: Address = address!("USER_WALLET_ADDRESS_HERE");
+    let token_mint: Address = address!("TOKEN_MINT_ADDRESS_HERE");
+    let rent_receiver: Address = address!("ACCOUNT_THAT_FUNDED_RENT_HERE");
 
-    let (subscription_authority, _) = Pubkey::find_program_address(
+    let (subscription_authority, _) = Address::find_program_address(
         &[b"SubscriptionAuthority", user.as_ref(), token_mint.as_ref()],
         &SUBSCRIPTIONS_ID,
     );
@@ -62,6 +68,8 @@ authority, close those delegations first.
     let close_ix = CloseSubscriptionAuthorityBuilder::new()
         .user(user)
         .subscription_authority(subscription_authority)
+        // Include this only when a sponsor funded the Subscription Authority.
+        .add_remaining_account(AccountMeta::new(rent_receiver, false))
         .instruction();
     ```
 
@@ -71,6 +79,8 @@ authority, close those delegations first.
 ## Notes
 
 - The user signs the close transaction.
+- If a sponsor funded the Subscription Authority, pass that sponsor account as
+  `receiver` so rent returns to the recorded payer.
 - Close fixed, recurring, and subscription delegation PDAs before closing the
   Subscription Authority.
 - If the user creates a new delegation later, initialize a new Subscription

--- a/apps/docs/content/docs/en/payments/subscriptions/close-subscription-authority.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/close-subscription-authority.mdx
@@ -25,7 +25,7 @@ first.
     import {
       findSubscriptionAuthorityPda,
       subscriptionsProgram,
-    } from '@subscriptions/client';
+    } from '@solana/subscriptions';
 
     const client = createClient()
       .use(signer(userSigner))
@@ -54,7 +54,7 @@ first.
     ```rust
     use solana_address::{address, Address};
     use solana_instruction::AccountMeta;
-    use subscriptions_client::{generated::instructions::*, SUBSCRIPTIONS_ID};
+    use subscriptions::{generated::instructions::*, SUBSCRIPTIONS_ID};
 
     let user: Address = address!("USER_WALLET_ADDRESS_HERE");
     let token_mint: Address = address!("TOKEN_MINT_ADDRESS_HERE");

--- a/apps/docs/content/docs/en/payments/subscriptions/close-subscription-authority.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/close-subscription-authority.mdx
@@ -1,0 +1,77 @@
+---
+title: Close Subscription Authority
+description: Guide for closing a user's Subscription Authority account.
+---
+
+A Subscription Authority is the PDA that the program uses as the SPL Token
+delegate for a user's token account. Close it when the user no longer has active
+fixed delegations, recurring delegations, or subscription delegations for that
+mint.
+
+Closing the account returns its rent to the user and revokes the token delegate
+approval owned by the program. If any active delegation still depends on the
+authority, close those delegations first.
+
+## Close The Authority
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    import { address, createClient } from '@solana/kit';
+    import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+    import { signer } from '@solana/kit-plugin-signer';
+    import {
+      findSubscriptionAuthorityPda,
+      subscriptionsProgram,
+    } from '@subscriptions/client';
+
+    const client = createClient()
+      .use(signer(userSigner))
+      .use(solanaLocalRpc({ rpcUrl: 'http://127.0.0.1:8899' }))
+      .use(subscriptionsProgram());
+
+    const tokenMint = address('TOKEN_MINT_ADDRESS_HERE');
+    const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({
+      user: userSigner.address,
+      tokenMint,
+    });
+
+    await client.subscriptions.instructions
+      .closeSubscriptionAuthority({
+        user: userSigner,
+        tokenMint,
+      })
+      .sendTransaction();
+    ```
+
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use solana_pubkey::{pubkey, Pubkey};
+    use subscriptions_client::{generated::instructions::*, SUBSCRIPTIONS_ID};
+
+    let user: Pubkey = pubkey!("USER_WALLET_ADDRESS_HERE");
+    let token_mint: Pubkey = pubkey!("TOKEN_MINT_ADDRESS_HERE");
+
+    let (subscription_authority, _) = Pubkey::find_program_address(
+        &[b"SubscriptionAuthority", user.as_ref(), token_mint.as_ref()],
+        &SUBSCRIPTIONS_ID,
+    );
+
+    let close_ix = CloseSubscriptionAuthorityBuilder::new()
+        .user(user)
+        .subscription_authority(subscription_authority)
+        .instruction();
+    ```
+
+  </Tab>
+</Tabs>
+
+## Notes
+
+- The user signs the close transaction.
+- Close fixed, recurring, and subscription delegation PDAs before closing the
+  Subscription Authority.
+- If the user creates a new delegation later, initialize a new Subscription
+  Authority for the same mint.

--- a/apps/docs/content/docs/en/payments/subscriptions/create-subscription-authority.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/create-subscription-authority.mdx
@@ -1,0 +1,102 @@
+---
+title: Create Subscription Authority
+description: Guide for initializing a user's Subscription Authority account.
+---
+
+A Subscription Authority is a PDA that the program uses as the SPL Token
+delegate for one user's token account and one token mint. Create it before
+creating fixed delegations, recurring delegations, or subscription plan
+subscriptions for that mint.
+
+The user's token account must already exist. Initialization creates the
+Subscription Authority PDA and approves it as the token delegate on the user's
+token account.
+
+## Create The Authority
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    import { address, createClient } from '@solana/kit';
+    import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+    import { signer } from '@solana/kit-plugin-signer';
+    import { findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
+    import {
+      fetchMaybeSubscriptionAuthority,
+      findSubscriptionAuthorityPda,
+      subscriptionsProgram,
+    } from '@subscriptions/client';
+
+    const client = createClient()
+      .use(signer(userSigner))
+      .use(solanaLocalRpc({ rpcUrl: 'http://127.0.0.1:8899' }))
+      .use(subscriptionsProgram());
+
+    const tokenMint = address('TOKEN_MINT_ADDRESS_HERE');
+    const [userAta] = await findAssociatedTokenPda({
+      mint: tokenMint,
+      owner: userSigner.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({
+      user: userSigner.address,
+      tokenMint,
+    });
+
+    const subscriptionAuthority = await fetchMaybeSubscriptionAuthority(
+      client.rpc,
+      subscriptionAuthorityPda,
+    );
+
+    if (!subscriptionAuthority.exists) {
+      await client.subscriptions.instructions
+        .initSubscriptionAuthority({
+          tokenMint,
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+          userAta,
+        })
+        .sendTransaction();
+    }
+    ```
+
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use solana_pubkey::{pubkey, Pubkey};
+    use subscriptions_client::{generated::instructions::*, SUBSCRIPTIONS_ID};
+
+    const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
+    const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+    let user: Pubkey = pubkey!("USER_WALLET_ADDRESS_HERE");
+    let user_ata: Pubkey = pubkey!("USER_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let token_mint: Pubkey = pubkey!("TOKEN_MINT_ADDRESS_HERE");
+
+    let (subscription_authority, _) = Pubkey::find_program_address(
+        &[b"SubscriptionAuthority", user.as_ref(), token_mint.as_ref()],
+        &SUBSCRIPTIONS_ID,
+    );
+
+    let init_ix = InitSubscriptionAuthorityBuilder::new()
+        .owner(user)
+        .subscription_authority(subscription_authority)
+        .token_mint(token_mint)
+        .user_ata(user_ata)
+        .system_program(SYSTEM_PROGRAM_ID)
+        .token_program(TOKEN_PROGRAM_ID)
+        .instruction();
+    ```
+
+  </Tab>
+</Tabs>
+
+## Notes
+
+- The user signs the initialization transaction.
+- Create one Subscription Authority per user and token mint pair.
+- Reuse the existing Subscription Authority for later delegations on the same
+  mint.
+- Close the Subscription Authority only after every delegation that depends on
+  it has been revoked or closed.

--- a/apps/docs/content/docs/en/payments/subscriptions/create-subscription-authority.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/create-subscription-authority.mdx
@@ -64,17 +64,17 @@ token account.
 
   <Tab value="Rust">
     ```rust
-    use solana_pubkey::{pubkey, Pubkey};
+    use solana_address::{address, Address};
     use subscriptions_client::{generated::instructions::*, SUBSCRIPTIONS_ID};
 
-    const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
-    const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+    const SYSTEM_PROGRAM_ID: Address = address!("11111111111111111111111111111111");
+    const TOKEN_PROGRAM_ID: Address = address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
-    let user: Pubkey = pubkey!("USER_WALLET_ADDRESS_HERE");
-    let user_ata: Pubkey = pubkey!("USER_TOKEN_ACCOUNT_ADDRESS_HERE");
-    let token_mint: Pubkey = pubkey!("TOKEN_MINT_ADDRESS_HERE");
+    let user: Address = address!("USER_WALLET_ADDRESS_HERE");
+    let user_ata: Address = address!("USER_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let token_mint: Address = address!("TOKEN_MINT_ADDRESS_HERE");
 
-    let (subscription_authority, _) = Pubkey::find_program_address(
+    let (subscription_authority, _) = Address::find_program_address(
         &[b"SubscriptionAuthority", user.as_ref(), token_mint.as_ref()],
         &SUBSCRIPTIONS_ID,
     );

--- a/apps/docs/content/docs/en/payments/subscriptions/create-subscription-authority.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/create-subscription-authority.mdx
@@ -25,7 +25,7 @@ token account.
       fetchMaybeSubscriptionAuthority,
       findSubscriptionAuthorityPda,
       subscriptionsProgram,
-    } from '@subscriptions/client';
+    } from '@solana/subscriptions';
 
     const client = createClient()
       .use(signer(userSigner))
@@ -65,7 +65,7 @@ token account.
   <Tab value="Rust">
     ```rust
     use solana_address::{address, Address};
-    use subscriptions_client::{generated::instructions::*, SUBSCRIPTIONS_ID};
+    use subscriptions::{generated::instructions::*, SUBSCRIPTIONS_ID};
 
     const SYSTEM_PROGRAM_ID: Address = address!("11111111111111111111111111111111");
     const TOKEN_PROGRAM_ID: Address = address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");

--- a/apps/docs/content/docs/en/payments/subscriptions/fixed-delegation.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/fixed-delegation.mdx
@@ -1,0 +1,218 @@
+---
+title: Fixed Delegation
+description: Guide for setting up fixed delegation transactions.
+---
+
+A fixed delegation lets a user approve another wallet or service to pull up to a
+fixed token amount. Each successful transfer reduces the remaining allowance.
+Use `expiryTs = 0` for no expiry.
+
+## Install
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```bash
+    pnpm add @subscriptions/client @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
+    ```
+  </Tab>
+
+  <Tab value="Rust">
+    ```toml
+    [dependencies]
+    subscriptions-client = { path = "clients/rust" }
+    solana-instruction = "^2"
+    solana-pubkey = "^2"
+    ```
+  </Tab>
+</Tabs>
+
+## Create The Delegation
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    import { address, createClient, type Address, type TransactionSigner } from '@solana/kit';
+    import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+    import { signer } from '@solana/kit-plugin-signer';
+    import { findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
+    import {
+      fetchMaybeSubscriptionAuthority,
+      findFixedDelegationPda,
+      findSubscriptionAuthorityPda,
+      subscriptionsProgram,
+    } from '@subscriptions/client';
+
+    export async function createFixedDelegation({
+      rpcUrl,
+      user,
+      tokenMint,
+      delegatee,
+      amount,
+      nonce = 0n,
+      expiryTs = BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30),
+      tokenProgram = TOKEN_PROGRAM_ADDRESS,
+    }: {
+      rpcUrl: string;
+      user: TransactionSigner;
+      tokenMint: Address;
+      delegatee: Address;
+      amount: bigint;
+      nonce?: bigint;
+      expiryTs?: bigint;
+      tokenProgram?: Address;
+    }) {
+      const client = createClient()
+        .use(signer(user))
+        .use(solanaLocalRpc({ rpcUrl }))
+        .use(subscriptionsProgram());
+
+      const [userAta] = await findAssociatedTokenPda({ mint: tokenMint, owner: user.address, tokenProgram });
+      const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({ user: user.address, tokenMint });
+      const subscriptionAuthority = await fetchMaybeSubscriptionAuthority(client.rpc, subscriptionAuthorityPda);
+
+      if (!subscriptionAuthority.exists) {
+        await client.subscriptions.instructions
+          .initSubscriptionAuthority({ tokenMint, tokenProgram, userAta })
+          .sendTransaction();
+      }
+
+      await client.subscriptions.instructions
+        .createFixedDelegation({ tokenMint, delegatee, nonce, amount, expiryTs })
+        .sendTransaction();
+
+      const [delegationPda] = await findFixedDelegationPda({
+        subscriptionAuthority: subscriptionAuthorityPda,
+        delegator: user.address,
+        delegatee,
+        nonce,
+      });
+
+      return { delegationPda, subscriptionAuthorityPda, userAta };
+    }
+
+    const result = await createFixedDelegation({
+      rpcUrl: 'http://127.0.0.1:8899',
+      user: userSigner,
+      tokenMint: address('TOKEN_MINT_ADDRESS_HERE'),
+      delegatee: address('DELEGATEE_WALLET_ADDRESS_HERE'),
+      amount: 1_000_000n,
+    });
+    ```
+
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use solana_instruction::Instruction;
+    use solana_pubkey::{pubkey, Pubkey};
+    use subscriptions_client::{
+        CreateFixedDelegationBuilder, CreateFixedDelegationData,
+        InitSubscriptionAuthorityBuilder, SUBSCRIPTIONS_ID,
+    };
+
+    const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
+    const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+    fn subscription_authority_pda(user: &Pubkey, mint: &Pubkey) -> Pubkey {
+        Pubkey::find_program_address(&[b"SubscriptionAuthority", user.as_ref(), mint.as_ref()], &SUBSCRIPTIONS_ID).0
+    }
+
+    fn fixed_delegation_pda(
+        subscription_authority: &Pubkey,
+        delegator: &Pubkey,
+        delegatee: &Pubkey,
+        nonce: u64,
+    ) -> Pubkey {
+        Pubkey::find_program_address(
+            &[
+                b"delegation",
+                subscription_authority.as_ref(),
+                delegator.as_ref(),
+                delegatee.as_ref(),
+                &nonce.to_le_bytes(),
+            ],
+            &SUBSCRIPTIONS_ID,
+        ).0
+    }
+
+    pub fn fixed_delegation_setup_ixs(
+        user: Pubkey,
+        user_ata: Pubkey,
+        token_mint: Pubkey,
+        delegatee: Pubkey,
+        amount: u64,
+        nonce: u64,
+        expiry_ts: i64,
+    ) -> (Vec<Instruction>, Pubkey) {
+        let subscription_authority = subscription_authority_pda(&user, &token_mint);
+        let delegation_pda = fixed_delegation_pda(&subscription_authority, &user, &delegatee, nonce);
+
+        let init_ix = InitSubscriptionAuthorityBuilder::new()
+            .owner(user)
+            .subscription_authority(subscription_authority)
+            .token_mint(token_mint)
+            .user_ata(user_ata)
+            .system_program(SYSTEM_PROGRAM_ID)
+            .token_program(TOKEN_PROGRAM_ID)
+            .instruction();
+
+        let create_ix = CreateFixedDelegationBuilder::new()
+            .delegator(user)
+            .subscription_authority(subscription_authority)
+            .delegation_account(delegation_pda)
+            .delegatee(delegatee)
+            .fixed_delegation(CreateFixedDelegationData { nonce, amount, expiry_ts })
+            .instruction();
+
+        (vec![init_ix, create_ix], delegation_pda)
+    }
+    ```
+
+  </Tab>
+</Tabs>
+
+## Transfer From The Delegation
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    await client.subscriptions.instructions
+      .transferFixed({
+        delegatee: delegateeSigner,
+        delegator: userAddress,
+        delegatorAta: userAta,
+        tokenMint,
+        delegationPda,
+        amount: 100_000n,
+        receiverAta,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      })
+      .sendTransaction();
+    ```
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use subscriptions_client::{TransferData, TransferFixedBuilder};
+
+    let transfer_ix = TransferFixedBuilder::new()
+        .delegation_pda(delegation_pda)
+        .subscription_authority(subscription_authority)
+        .delegator_ata(user_ata)
+        .receiver_ata(receiver_ata)
+        .token_program(TOKEN_PROGRAM_ID)
+        .delegatee(delegatee)
+        .transfer_data(TransferData { amount: 100_000, delegator: user, mint: token_mint })
+        .instruction();
+    ```
+
+  </Tab>
+</Tabs>
+
+## Notes
+
+- The user's token account must exist before initialization.
+- Amounts are in base units. For a 6-decimal token, `1_000_000` means `1` token.
+- Reuse `initSubscriptionAuthority` only if the Subscription Authority does not
+  already exist.
+- The user signs setup and revoke transactions. The delegatee signs transfers.

--- a/apps/docs/content/docs/en/payments/subscriptions/fixed-delegation.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/fixed-delegation.mdx
@@ -7,6 +7,10 @@ A fixed delegation lets a user approve another wallet or service to pull up to a
 fixed token amount. Each successful transfer reduces the remaining allowance.
 Use `expiryTs = 0` for no expiry.
 
+This guide keeps the flow visible. Each snippet uses the SDK functions directly
+so you can see which account is derived, which instruction is sent, and which
+signer pays or authorizes each step.
+
 ## Install
 
 <Tabs items={["TypeScript", "Rust"]}>
@@ -28,10 +32,17 @@ Use `expiryTs = 0` for no expiry.
 
 ## Create The Delegation
 
+The setup has four parts:
+
+1. Create a client with the user signer and subscriptions plugin.
+2. Derive the user's token account and Subscription Authority PDA.
+3. Initialize the Subscription Authority if it does not exist yet.
+4. Create the fixed delegation and derive its PDA for later transfers.
+
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```ts
-    import { address, createClient, type Address, type TransactionSigner } from '@solana/kit';
+    import { address, createClient } from '@solana/kit';
     import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
     import { signer } from '@solana/kit-plugin-signer';
     import { findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
@@ -42,60 +53,58 @@ Use `expiryTs = 0` for no expiry.
       subscriptionsProgram,
     } from '@subscriptions/client';
 
-    export async function createFixedDelegation({
-      rpcUrl,
-      user,
+    const client = createClient()
+      .use(signer(userSigner))
+      .use(solanaLocalRpc({ rpcUrl: 'http://127.0.0.1:8899' }))
+      .use(subscriptionsProgram());
+
+    const tokenMint = address('TOKEN_MINT_ADDRESS_HERE');
+    const delegatee = address('DELEGATEE_WALLET_ADDRESS_HERE');
+    const nonce = 0n;
+    const amount = 1_000_000n;
+    const expiryTs = BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30);
+
+    const [userAta] = await findAssociatedTokenPda({
+      mint: tokenMint,
+      owner: userSigner.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({
+      user: userSigner.address,
       tokenMint,
-      delegatee,
-      amount,
-      nonce = 0n,
-      expiryTs = BigInt(Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 30),
-      tokenProgram = TOKEN_PROGRAM_ADDRESS,
-    }: {
-      rpcUrl: string;
-      user: TransactionSigner;
-      tokenMint: Address;
-      delegatee: Address;
-      amount: bigint;
-      nonce?: bigint;
-      expiryTs?: bigint;
-      tokenProgram?: Address;
-    }) {
-      const client = createClient()
-        .use(signer(user))
-        .use(solanaLocalRpc({ rpcUrl }))
-        .use(subscriptionsProgram());
+    });
 
-      const [userAta] = await findAssociatedTokenPda({ mint: tokenMint, owner: user.address, tokenProgram });
-      const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({ user: user.address, tokenMint });
-      const subscriptionAuthority = await fetchMaybeSubscriptionAuthority(client.rpc, subscriptionAuthorityPda);
+    const subscriptionAuthority = await fetchMaybeSubscriptionAuthority(
+      client.rpc,
+      subscriptionAuthorityPda,
+    );
 
-      if (!subscriptionAuthority.exists) {
-        await client.subscriptions.instructions
-          .initSubscriptionAuthority({ tokenMint, tokenProgram, userAta })
-          .sendTransaction();
-      }
-
+    if (!subscriptionAuthority.exists) {
       await client.subscriptions.instructions
-        .createFixedDelegation({ tokenMint, delegatee, nonce, amount, expiryTs })
+        .initSubscriptionAuthority({
+          tokenMint,
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+          userAta,
+        })
         .sendTransaction();
-
-      const [delegationPda] = await findFixedDelegationPda({
-        subscriptionAuthority: subscriptionAuthorityPda,
-        delegator: user.address,
-        delegatee,
-        nonce,
-      });
-
-      return { delegationPda, subscriptionAuthorityPda, userAta };
     }
 
-    const result = await createFixedDelegation({
-      rpcUrl: 'http://127.0.0.1:8899',
-      user: userSigner,
-      tokenMint: address('TOKEN_MINT_ADDRESS_HERE'),
-      delegatee: address('DELEGATEE_WALLET_ADDRESS_HERE'),
-      amount: 1_000_000n,
+    await client.subscriptions.instructions
+      .createFixedDelegation({
+        tokenMint,
+        delegatee,
+        nonce,
+        amount,
+        expiryTs,
+      })
+      .sendTransaction();
+
+    const [delegationPda] = await findFixedDelegationPda({
+      subscriptionAuthority: subscriptionAuthorityPda,
+      delegator: userSigner.address,
+      delegatee,
+      nonce,
     });
     ```
 
@@ -103,7 +112,6 @@ Use `expiryTs = 0` for no expiry.
 
   <Tab value="Rust">
     ```rust
-    use solana_instruction::Instruction;
     use solana_pubkey::{pubkey, Pubkey};
     use subscriptions_client::{
         CreateFixedDelegationBuilder, CreateFixedDelegationData,
@@ -113,59 +121,46 @@ Use `expiryTs = 0` for no expiry.
     const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
     const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
-    fn subscription_authority_pda(user: &Pubkey, mint: &Pubkey) -> Pubkey {
-        Pubkey::find_program_address(&[b"SubscriptionAuthority", user.as_ref(), mint.as_ref()], &SUBSCRIPTIONS_ID).0
-    }
+    let user: Pubkey = pubkey!("USER_WALLET_ADDRESS_HERE");
+    let user_ata: Pubkey = pubkey!("USER_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let token_mint: Pubkey = pubkey!("TOKEN_MINT_ADDRESS_HERE");
+    let delegatee: Pubkey = pubkey!("DELEGATEE_WALLET_ADDRESS_HERE");
+    let nonce = 0u64;
+    let amount = 1_000_000u64;
+    let expiry_ts = 1_734_249_600i64;
 
-    fn fixed_delegation_pda(
-        subscription_authority: &Pubkey,
-        delegator: &Pubkey,
-        delegatee: &Pubkey,
-        nonce: u64,
-    ) -> Pubkey {
-        Pubkey::find_program_address(
-            &[
-                b"delegation",
-                subscription_authority.as_ref(),
-                delegator.as_ref(),
-                delegatee.as_ref(),
-                &nonce.to_le_bytes(),
-            ],
-            &SUBSCRIPTIONS_ID,
-        ).0
-    }
+    let (subscription_authority, _) = Pubkey::find_program_address(
+        &[b"SubscriptionAuthority", user.as_ref(), token_mint.as_ref()],
+        &SUBSCRIPTIONS_ID,
+    );
 
-    pub fn fixed_delegation_setup_ixs(
-        user: Pubkey,
-        user_ata: Pubkey,
-        token_mint: Pubkey,
-        delegatee: Pubkey,
-        amount: u64,
-        nonce: u64,
-        expiry_ts: i64,
-    ) -> (Vec<Instruction>, Pubkey) {
-        let subscription_authority = subscription_authority_pda(&user, &token_mint);
-        let delegation_pda = fixed_delegation_pda(&subscription_authority, &user, &delegatee, nonce);
+    let (delegation_pda, _) = Pubkey::find_program_address(
+        &[
+            b"delegation",
+            subscription_authority.as_ref(),
+            user.as_ref(),
+            delegatee.as_ref(),
+            &nonce.to_le_bytes(),
+        ],
+        &SUBSCRIPTIONS_ID,
+    );
 
-        let init_ix = InitSubscriptionAuthorityBuilder::new()
-            .owner(user)
-            .subscription_authority(subscription_authority)
-            .token_mint(token_mint)
-            .user_ata(user_ata)
-            .system_program(SYSTEM_PROGRAM_ID)
-            .token_program(TOKEN_PROGRAM_ID)
-            .instruction();
+    let init_ix = InitSubscriptionAuthorityBuilder::new()
+        .owner(user)
+        .subscription_authority(subscription_authority)
+        .token_mint(token_mint)
+        .user_ata(user_ata)
+        .system_program(SYSTEM_PROGRAM_ID)
+        .token_program(TOKEN_PROGRAM_ID)
+        .instruction();
 
-        let create_ix = CreateFixedDelegationBuilder::new()
-            .delegator(user)
-            .subscription_authority(subscription_authority)
-            .delegation_account(delegation_pda)
-            .delegatee(delegatee)
-            .fixed_delegation(CreateFixedDelegationData { nonce, amount, expiry_ts })
-            .instruction();
-
-        (vec![init_ix, create_ix], delegation_pda)
-    }
+    let create_ix = CreateFixedDelegationBuilder::new()
+        .delegator(user)
+        .subscription_authority(subscription_authority)
+        .delegation_account(delegation_pda)
+        .delegatee(delegatee)
+        .fixed_delegation(CreateFixedDelegationData { nonce, amount, expiry_ts })
+        .instruction();
     ```
 
   </Tab>
@@ -173,13 +168,18 @@ Use `expiryTs = 0` for no expiry.
 
 ## Transfer From The Delegation
 
+The delegatee signs the transfer. The SDK needs the same delegation PDA, the
+user's token account, and the receiver token account.
+
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```ts
+    const receiverAta = address('RECEIVER_TOKEN_ACCOUNT_ADDRESS_HERE');
+
     await client.subscriptions.instructions
       .transferFixed({
         delegatee: delegateeSigner,
-        delegator: userAddress,
+        delegator: userSigner.address,
         delegatorAta: userAta,
         tokenMint,
         delegationPda,
@@ -189,11 +189,14 @@ Use `expiryTs = 0` for no expiry.
       })
       .sendTransaction();
     ```
+
   </Tab>
 
   <Tab value="Rust">
     ```rust
     use subscriptions_client::{TransferData, TransferFixedBuilder};
+
+    let receiver_ata: Pubkey = pubkey!("RECEIVER_TOKEN_ACCOUNT_ADDRESS_HERE");
 
     let transfer_ix = TransferFixedBuilder::new()
         .delegation_pda(delegation_pda)
@@ -213,6 +216,6 @@ Use `expiryTs = 0` for no expiry.
 
 - The user's token account must exist before initialization.
 - Amounts are in base units. For a 6-decimal token, `1_000_000` means `1` token.
-- Reuse `initSubscriptionAuthority` only if the Subscription Authority does not
-  already exist.
+- Run `initSubscriptionAuthority` only when the Subscription Authority account
+  does not already exist.
 - The user signs setup and revoke transactions. The delegatee signs transfers.

--- a/apps/docs/content/docs/en/payments/subscriptions/fixed-delegation.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/fixed-delegation.mdx
@@ -25,7 +25,7 @@ signer pays or authorizes each step.
     [dependencies]
     subscriptions-client = { path = "clients/rust" }
     solana-instruction = "^2"
-    solana-pubkey = "^2"
+    solana-address = { version = "^2", features = ["curve25519"] }
     ```
   </Tab>
 </Tabs>
@@ -112,26 +112,26 @@ The setup has four parts:
 
   <Tab value="Rust">
     ```rust
-    use solana_pubkey::{pubkey, Pubkey};
+    use solana_address::{address, Address};
     use subscriptions_client::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
 
-    const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
-    const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+    const SYSTEM_PROGRAM_ID: Address = address!("11111111111111111111111111111111");
+    const TOKEN_PROGRAM_ID: Address = address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
-    let user: Pubkey = pubkey!("USER_WALLET_ADDRESS_HERE");
-    let user_ata: Pubkey = pubkey!("USER_TOKEN_ACCOUNT_ADDRESS_HERE");
-    let token_mint: Pubkey = pubkey!("TOKEN_MINT_ADDRESS_HERE");
-    let delegatee: Pubkey = pubkey!("DELEGATEE_WALLET_ADDRESS_HERE");
+    let user: Address = address!("USER_WALLET_ADDRESS_HERE");
+    let user_ata: Address = address!("USER_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let token_mint: Address = address!("TOKEN_MINT_ADDRESS_HERE");
+    let delegatee: Address = address!("DELEGATEE_WALLET_ADDRESS_HERE");
     let nonce = 0u64;
     let amount = 1_000_000u64;
     let expiry_ts = 1_734_249_600i64;
 
-    let (subscription_authority, _) = Pubkey::find_program_address(
+    let (subscription_authority, _) = Address::find_program_address(
         &[b"SubscriptionAuthority", user.as_ref(), token_mint.as_ref()],
         &SUBSCRIPTIONS_ID,
     );
 
-    let (delegation_pda, _) = Pubkey::find_program_address(
+    let (delegation_pda, _) = Address::find_program_address(
         &[
             b"delegation",
             subscription_authority.as_ref(),
@@ -193,7 +193,7 @@ user's token account, and the receiver token account.
     ```rust
     use subscriptions_client::{TransferData, TransferFixedBuilder};
 
-    let receiver_ata: Pubkey = pubkey!("RECEIVER_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let receiver_ata: Address = address!("RECEIVER_TOKEN_ACCOUNT_ADDRESS_HERE");
 
     let transfer_ix = TransferFixedBuilder::new()
         .delegation_pda(delegation_pda)

--- a/apps/docs/content/docs/en/payments/subscriptions/fixed-delegation.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/fixed-delegation.mdx
@@ -113,10 +113,7 @@ The setup has four parts:
   <Tab value="Rust">
     ```rust
     use solana_pubkey::{pubkey, Pubkey};
-    use subscriptions_client::{
-        CreateFixedDelegationBuilder, CreateFixedDelegationData,
-        InitSubscriptionAuthorityBuilder, SUBSCRIPTIONS_ID,
-    };
+    use subscriptions_client::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
 
     const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
     const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
@@ -206,6 +203,37 @@ user's token account, and the receiver token account.
         .token_program(TOKEN_PROGRAM_ID)
         .delegatee(delegatee)
         .transfer_data(TransferData { amount: 100_000, delegator: user, mint: token_mint })
+        .instruction();
+    ```
+
+  </Tab>
+</Tabs>
+
+## Revoke The Delegation
+
+The delegator can revoke the delegation at any time. Revoking closes the
+delegation PDA and returns its rent to the signer.
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    await client.subscriptions.instructions
+      .revokeDelegation({
+        authority: userSigner,
+        delegationAccount: delegationPda,
+      })
+      .sendTransaction();
+    ```
+
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use subscriptions_client::generated::instructions::*;
+
+    let revoke_ix = RevokeDelegationBuilder::new()
+        .authority(user)
+        .delegation_account(delegation_pda)
         .instruction();
     ```
 

--- a/apps/docs/content/docs/en/payments/subscriptions/fixed-delegation.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/fixed-delegation.mdx
@@ -16,14 +16,14 @@ signer pays or authorizes each step.
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```bash
-    pnpm add @subscriptions/client @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
+    pnpm add @solana/subscriptions @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
     ```
   </Tab>
 
   <Tab value="Rust">
     ```toml
     [dependencies]
-    subscriptions-client = { path = "clients/rust" }
+    subscriptions = "^0.1"
     solana-instruction = "^2"
     solana-address = { version = "^2", features = ["curve25519"] }
     ```
@@ -51,7 +51,7 @@ The setup has four parts:
       findFixedDelegationPda,
       findSubscriptionAuthorityPda,
       subscriptionsProgram,
-    } from '@subscriptions/client';
+    } from '@solana/subscriptions';
 
     const client = createClient()
       .use(signer(userSigner))
@@ -113,7 +113,7 @@ The setup has four parts:
   <Tab value="Rust">
     ```rust
     use solana_address::{address, Address};
-    use subscriptions_client::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
+    use subscriptions::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
 
     const SYSTEM_PROGRAM_ID: Address = address!("11111111111111111111111111111111");
     const TOKEN_PROGRAM_ID: Address = address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
@@ -191,7 +191,7 @@ user's token account, and the receiver token account.
 
   <Tab value="Rust">
     ```rust
-    use subscriptions_client::{TransferData, TransferFixedBuilder};
+    use subscriptions::{TransferData, TransferFixedBuilder};
 
     let receiver_ata: Address = address!("RECEIVER_TOKEN_ACCOUNT_ADDRESS_HERE");
 
@@ -229,7 +229,7 @@ delegation PDA and returns its rent to the signer.
 
   <Tab value="Rust">
     ```rust
-    use subscriptions_client::generated::instructions::*;
+    use subscriptions::generated::instructions::*;
 
     let revoke_ix = RevokeDelegationBuilder::new()
         .authority(user)

--- a/apps/docs/content/docs/en/payments/subscriptions/meta.json
+++ b/apps/docs/content/docs/en/payments/subscriptions/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Subscriptions",
+  "pages": [
+    "overview",
+    "fixed-delegation",
+    "recurring-delegation",
+    "subscription-plan"
+  ],
+  "defaultOpen": false
+}

--- a/apps/docs/content/docs/en/payments/subscriptions/meta.json
+++ b/apps/docs/content/docs/en/payments/subscriptions/meta.json
@@ -2,9 +2,11 @@
   "title": "Subscriptions",
   "pages": [
     "overview",
+    "create-subscription-authority",
     "fixed-delegation",
     "recurring-delegation",
-    "subscription-plan"
+    "subscription-plan",
+    "close-subscription-authority"
   ],
   "defaultOpen": false
 }

--- a/apps/docs/content/docs/en/payments/subscriptions/overview.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/overview.mdx
@@ -1,0 +1,80 @@
+---
+title: Overview
+description: Overview of the Solana subscriptions program.
+---
+
+The Subscriptions Delegation Program enables developers to let users authorize
+future token transfers from their wallets with clear limits. It is designed for
+recurring payments, subscriptions, merchant billing, and other flows where a
+user should not have to sign every transfer manually.
+
+## Purpose
+
+Solana token accounts can approve another authority to move tokens, but each
+token account can only have one approved authority at a time. That makes it hard
+for one wallet to safely support several spending arrangements for the same
+token, such as a monthly subscription, a fixed spending allowance, and a
+merchant billing agreement.
+
+This program solves that by giving each `(user, token mint)` pair a
+program-controlled **Subscription Authority**. The user's token account approves
+that authority once. The program then checks each requested transfer against a
+separate record that defines who can pull funds, how much they can pull, and
+when the authorization expires or resets.
+
+The Subscription Authority cannot move funds by itself. A transfer only succeeds
+when it matches one of the user's active authorizations.
+
+## Program ID
+
+```text
+De1egAFMkMWZSN5rYXRj9CAdheBamobVNubTsi9avR44
+```
+
+The program ID is declared in `program/src/lib.rs`. Local Surfpool workflows
+install the program at this canonical address.
+
+## Delegation Models
+
+The program supports three authorization models:
+
+| Model                | Purpose                                                                                                                               |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Fixed delegation     | Let another wallet or service spend up to a fixed total amount, optionally until an expiry time.                                      |
+| Recurring delegation | Let another wallet or service spend up to a limit that resets every period, such as daily, weekly, or monthly.                        |
+| Subscription plan    | Let a merchant publish billing terms that users can accept, then allow approved collectors to charge subscribers each billing period. |
+
+## Supported Tokens
+
+The program supports tokens created with both SPL Token and Token-2022. For
+Token-2022 mints, it rejects extensions that would make scheduled or delegated
+transfers unsafe or unclear, including `ConfidentialTransfer`,
+`NonTransferable`, `PermanentDelegate`, `TransferHook`, `TransferFee`,
+`MintCloseAuthority`, and `Pausable`.
+
+## On-Chain Events
+
+The program emits on-chain events so indexers and applications can track
+important activity. These events cover subscription changes and transfers made
+through fixed, recurring, and subscription-plan flows.
+
+## Versioning
+
+Program-owned records include a version field. This gives the program a path to
+upgrade account data over time without breaking existing users. The migration
+strategy supports:
+
+- Lazy in-place update
+- Explicit migrate instruction
+- Revoke and recreate fallback
+
+## Contributors
+
+The project is maintained by contributors to the `solana-program/subscriptions`
+repository.
+
+## Audit Status
+
+The program has been audited by Cantina. Audit status, baseline commit,
+fix-verified commit, and current unaudited delta are tracked in the repository's
+[`audits/` directory](https://github.com/solana-program/subscriptions/tree/main/audits).

--- a/apps/docs/content/docs/en/payments/subscriptions/overview.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/overview.mdx
@@ -70,8 +70,8 @@ strategy supports:
 
 ## Contributors
 
-The project is maintained by contributors to the `solana-program/subscriptions`
-repository.
+The project is maintained by contributors to the
+[`solana-program/subscriptions` repository](https://github.com/solana-program/subscriptions).
 
 ## Audit Status
 

--- a/apps/docs/content/docs/en/payments/subscriptions/recurring-delegation.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/recurring-delegation.mdx
@@ -6,6 +6,10 @@ description: Guide for setting up recurring delegation transactions.
 A recurring delegation lets a user approve another wallet or service to pull up
 to a limit that resets every period.
 
+This guide keeps the moving parts visible. You derive the accounts first,
+initialize the Subscription Authority if needed, create the recurring
+delegation, then use that delegation PDA for transfers.
+
 ## Install
 
 <Tabs items={["TypeScript", "Rust"]}>
@@ -27,10 +31,19 @@ to a limit that resets every period.
 
 ## Create The Delegation
 
+The setup has four parts:
+
+1. Create a client with the user signer and subscriptions plugin.
+2. Derive the user's token account, Subscription Authority PDA, and recurring
+   delegation PDA.
+3. Initialize the Subscription Authority if it does not exist yet.
+4. Create the recurring delegation with the period amount, period length, start
+   time, and expiry.
+
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```ts
-    import { address, createClient, type Address, type TransactionSigner } from '@solana/kit';
+    import { address, createClient } from '@solana/kit';
     import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
     import { signer } from '@solana/kit-plugin-signer';
     import { findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
@@ -41,76 +54,70 @@ to a limit that resets every period.
       subscriptionsProgram,
     } from '@subscriptions/client';
 
-    export async function createRecurringDelegation({
-      rpcUrl,
-      user,
+    const client = createClient()
+      .use(signer(userSigner))
+      .use(solanaLocalRpc({ rpcUrl: 'http://127.0.0.1:8899' }))
+      .use(subscriptionsProgram());
+
+    const tokenMint = address('TOKEN_MINT_ADDRESS_HERE');
+    const delegatee = address('DELEGATEE_WALLET_ADDRESS_HERE');
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    const nonce = 0n;
+    const amountPerPeriod = 1_000_000n;
+    const periodLengthS = 86_400n;
+    const startTs = now;
+    const expiryTs = now + periodLengthS * 30n;
+
+    const [userAta] = await findAssociatedTokenPda({
+      mint: tokenMint,
+      owner: userSigner.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
+
+    const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({
+      user: userSigner.address,
       tokenMint,
+    });
+
+    const [delegationPda] = await findRecurringDelegationPda({
+      subscriptionAuthority: subscriptionAuthorityPda,
+      delegator: userSigner.address,
       delegatee,
-      amountPerPeriod,
-      periodLengthS,
-      startTs,
-      expiryTs,
-      nonce = 0n,
-      tokenProgram = TOKEN_PROGRAM_ADDRESS,
-    }: {
-      rpcUrl: string;
-      user: TransactionSigner;
-      tokenMint: Address;
-      delegatee: Address;
-      amountPerPeriod: bigint;
-      periodLengthS: bigint;
-      startTs: bigint;
-      expiryTs: bigint;
-      nonce?: bigint;
-      tokenProgram?: Address;
-    }) {
-      const client = createClient()
-        .use(signer(user))
-        .use(solanaLocalRpc({ rpcUrl }))
-        .use(subscriptionsProgram());
+      nonce,
+    });
 
-      const [userAta] = await findAssociatedTokenPda({ mint: tokenMint, owner: user.address, tokenProgram });
-      const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({ user: user.address, tokenMint });
-      const subscriptionAuthority = await fetchMaybeSubscriptionAuthority(client.rpc, subscriptionAuthorityPda);
+    const subscriptionAuthority = await fetchMaybeSubscriptionAuthority(
+      client.rpc,
+      subscriptionAuthorityPda,
+    );
 
-      if (!subscriptionAuthority.exists) {
-        await client.subscriptions.instructions
-          .initSubscriptionAuthority({ tokenMint, tokenProgram, userAta })
-          .sendTransaction();
-      }
-
+    if (!subscriptionAuthority.exists) {
       await client.subscriptions.instructions
-        .createRecurringDelegation({ tokenMint, delegatee, nonce, amountPerPeriod, periodLengthS, startTs, expiryTs })
+        .initSubscriptionAuthority({
+          tokenMint,
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+          userAta,
+        })
         .sendTransaction();
-
-      const [delegationPda] = await findRecurringDelegationPda({
-        subscriptionAuthority: subscriptionAuthorityPda,
-        delegator: user.address,
-        delegatee,
-        nonce,
-      });
-
-      return { delegationPda, subscriptionAuthorityPda, userAta };
     }
 
-    const now = BigInt(Math.floor(Date.now() / 1000));
-    const result = await createRecurringDelegation({
-      rpcUrl: 'http://127.0.0.1:8899',
-      user: userSigner,
-      tokenMint: address('TOKEN_MINT_ADDRESS_HERE'),
-      delegatee: address('DELEGATEE_WALLET_ADDRESS_HERE'),
-      amountPerPeriod: 1_000_000n,
-      periodLengthS: 86_400n,
-      startTs: now,
-      expiryTs: now + 86_400n * 30n,
-    });
+    await client.subscriptions.instructions
+      .createRecurringDelegation({
+        tokenMint,
+        delegatee,
+        nonce,
+        amountPerPeriod,
+        periodLengthS,
+        startTs,
+        expiryTs,
+      })
+      .sendTransaction();
     ```
 
   </Tab>
 
   <Tab value="Rust">
     ```rust
-    use solana_instruction::Instruction;
     use solana_pubkey::{pubkey, Pubkey};
     use subscriptions_client::{
         CreateRecurringDelegationBuilder, CreateRecurringDelegationData,
@@ -120,56 +127,54 @@ to a limit that resets every period.
     const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
     const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
-    fn subscription_authority_pda(user: &Pubkey, mint: &Pubkey) -> Pubkey {
-        Pubkey::find_program_address(&[b"SubscriptionAuthority", user.as_ref(), mint.as_ref()], &SUBSCRIPTIONS_ID).0
-    }
+    let user: Pubkey = pubkey!("USER_WALLET_ADDRESS_HERE");
+    let user_ata: Pubkey = pubkey!("USER_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let token_mint: Pubkey = pubkey!("TOKEN_MINT_ADDRESS_HERE");
+    let delegatee: Pubkey = pubkey!("DELEGATEE_WALLET_ADDRESS_HERE");
+    let nonce = 0u64;
+    let amount_per_period = 1_000_000u64;
+    let period_length_s = 86_400u64;
+    let start_ts = 1_731_657_600i64;
+    let expiry_ts = start_ts + 86_400 * 30;
 
-    fn recurring_delegation_pda(sa: &Pubkey, delegator: &Pubkey, delegatee: &Pubkey, nonce: u64) -> Pubkey {
-        Pubkey::find_program_address(
-            &[b"delegation", sa.as_ref(), delegator.as_ref(), delegatee.as_ref(), &nonce.to_le_bytes()],
-            &SUBSCRIPTIONS_ID,
-        ).0
-    }
+    let (subscription_authority, _) = Pubkey::find_program_address(
+        &[b"SubscriptionAuthority", user.as_ref(), token_mint.as_ref()],
+        &SUBSCRIPTIONS_ID,
+    );
 
-    pub fn recurring_delegation_setup_ixs(
-        user: Pubkey,
-        user_ata: Pubkey,
-        token_mint: Pubkey,
-        delegatee: Pubkey,
-        amount_per_period: u64,
-        period_length_s: u64,
-        start_ts: i64,
-        expiry_ts: i64,
-        nonce: u64,
-    ) -> (Vec<Instruction>, Pubkey) {
-        let subscription_authority = subscription_authority_pda(&user, &token_mint);
-        let delegation_pda = recurring_delegation_pda(&subscription_authority, &user, &delegatee, nonce);
+    let (delegation_pda, _) = Pubkey::find_program_address(
+        &[
+            b"delegation",
+            subscription_authority.as_ref(),
+            user.as_ref(),
+            delegatee.as_ref(),
+            &nonce.to_le_bytes(),
+        ],
+        &SUBSCRIPTIONS_ID,
+    );
 
-        let init_ix = InitSubscriptionAuthorityBuilder::new()
-            .owner(user)
-            .subscription_authority(subscription_authority)
-            .token_mint(token_mint)
-            .user_ata(user_ata)
-            .system_program(SYSTEM_PROGRAM_ID)
-            .token_program(TOKEN_PROGRAM_ID)
-            .instruction();
+    let init_ix = InitSubscriptionAuthorityBuilder::new()
+        .owner(user)
+        .subscription_authority(subscription_authority)
+        .token_mint(token_mint)
+        .user_ata(user_ata)
+        .system_program(SYSTEM_PROGRAM_ID)
+        .token_program(TOKEN_PROGRAM_ID)
+        .instruction();
 
-        let create_ix = CreateRecurringDelegationBuilder::new()
-            .delegator(user)
-            .subscription_authority(subscription_authority)
-            .delegation_account(delegation_pda)
-            .delegatee(delegatee)
-            .recurring_delegation(CreateRecurringDelegationData {
-                nonce,
-                amount_per_period,
-                period_length_s,
-                start_ts,
-                expiry_ts,
-            })
-            .instruction();
-
-        (vec![init_ix, create_ix], delegation_pda)
-    }
+    let create_ix = CreateRecurringDelegationBuilder::new()
+        .delegator(user)
+        .subscription_authority(subscription_authority)
+        .delegation_account(delegation_pda)
+        .delegatee(delegatee)
+        .recurring_delegation(CreateRecurringDelegationData {
+            nonce,
+            amount_per_period,
+            period_length_s,
+            start_ts,
+            expiry_ts,
+        })
+        .instruction();
     ```
 
   </Tab>
@@ -177,13 +182,18 @@ to a limit that resets every period.
 
 ## Transfer From The Delegation
 
+The delegatee signs each transfer. The program checks the current period and
+rejects transfers that would exceed the period's remaining allowance.
+
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```ts
+    const receiverAta = address('RECEIVER_TOKEN_ACCOUNT_ADDRESS_HERE');
+
     await client.subscriptions.instructions
       .transferRecurring({
         delegatee: delegateeSigner,
-        delegator: userAddress,
+        delegator: userSigner.address,
         delegatorAta: userAta,
         tokenMint,
         delegationPda,
@@ -193,11 +203,14 @@ to a limit that resets every period.
       })
       .sendTransaction();
     ```
+
   </Tab>
 
   <Tab value="Rust">
     ```rust
     use subscriptions_client::{TransferData, TransferRecurringBuilder};
+
+    let receiver_ata: Pubkey = pubkey!("RECEIVER_TOKEN_ACCOUNT_ADDRESS_HERE");
 
     let transfer_ix = TransferRecurringBuilder::new()
         .delegation_pda(delegation_pda)

--- a/apps/docs/content/docs/en/payments/subscriptions/recurring-delegation.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/recurring-delegation.mdx
@@ -119,10 +119,7 @@ The setup has four parts:
   <Tab value="Rust">
     ```rust
     use solana_pubkey::{pubkey, Pubkey};
-    use subscriptions_client::{
-        CreateRecurringDelegationBuilder, CreateRecurringDelegationData,
-        InitSubscriptionAuthorityBuilder, SUBSCRIPTIONS_ID,
-    };
+    use subscriptions_client::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
 
     const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
     const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
@@ -220,6 +217,36 @@ rejects transfers that would exceed the period's remaining allowance.
         .token_program(TOKEN_PROGRAM_ID)
         .delegatee(delegatee)
         .transfer_data(TransferData { amount: 100_000, delegator: user, mint: token_mint })
+        .instruction();
+    ```
+
+  </Tab>
+</Tabs>
+
+## Revoke The Delegation
+
+The delegator can revoke the recurring delegation at any time. Revoking closes
+the delegation PDA and returns its rent to the signer.
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    await client.subscriptions.instructions
+      .revokeDelegation({
+        authority: userSigner,
+        delegationAccount: delegationPda,
+      })
+      .sendTransaction();
+    ```
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use subscriptions_client::generated::instructions::*;
+
+    let revoke_ix = RevokeDelegationBuilder::new()
+        .authority(user)
+        .delegation_account(delegation_pda)
         .instruction();
     ```
 

--- a/apps/docs/content/docs/en/payments/subscriptions/recurring-delegation.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/recurring-delegation.mdx
@@ -24,7 +24,7 @@ delegation, then use that delegation PDA for transfers.
     [dependencies]
     subscriptions-client = { path = "clients/rust" }
     solana-instruction = "^2"
-    solana-pubkey = "^2"
+    solana-address = { version = "^2", features = ["curve25519"] }
     ```
   </Tab>
 </Tabs>
@@ -118,28 +118,28 @@ The setup has four parts:
 
   <Tab value="Rust">
     ```rust
-    use solana_pubkey::{pubkey, Pubkey};
+    use solana_address::{address, Address};
     use subscriptions_client::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
 
-    const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
-    const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+    const SYSTEM_PROGRAM_ID: Address = address!("11111111111111111111111111111111");
+    const TOKEN_PROGRAM_ID: Address = address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
-    let user: Pubkey = pubkey!("USER_WALLET_ADDRESS_HERE");
-    let user_ata: Pubkey = pubkey!("USER_TOKEN_ACCOUNT_ADDRESS_HERE");
-    let token_mint: Pubkey = pubkey!("TOKEN_MINT_ADDRESS_HERE");
-    let delegatee: Pubkey = pubkey!("DELEGATEE_WALLET_ADDRESS_HERE");
+    let user: Address = address!("USER_WALLET_ADDRESS_HERE");
+    let user_ata: Address = address!("USER_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let token_mint: Address = address!("TOKEN_MINT_ADDRESS_HERE");
+    let delegatee: Address = address!("DELEGATEE_WALLET_ADDRESS_HERE");
     let nonce = 0u64;
     let amount_per_period = 1_000_000u64;
     let period_length_s = 86_400u64;
     let start_ts = 1_731_657_600i64;
     let expiry_ts = start_ts + 86_400 * 30;
 
-    let (subscription_authority, _) = Pubkey::find_program_address(
+    let (subscription_authority, _) = Address::find_program_address(
         &[b"SubscriptionAuthority", user.as_ref(), token_mint.as_ref()],
         &SUBSCRIPTIONS_ID,
     );
 
-    let (delegation_pda, _) = Pubkey::find_program_address(
+    let (delegation_pda, _) = Address::find_program_address(
         &[
             b"delegation",
             subscription_authority.as_ref(),
@@ -207,7 +207,7 @@ rejects transfers that would exceed the period's remaining allowance.
     ```rust
     use subscriptions_client::{TransferData, TransferRecurringBuilder};
 
-    let receiver_ata: Pubkey = pubkey!("RECEIVER_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let receiver_ata: Address = address!("RECEIVER_TOKEN_ACCOUNT_ADDRESS_HERE");
 
     let transfer_ix = TransferRecurringBuilder::new()
         .delegation_pda(delegation_pda)

--- a/apps/docs/content/docs/en/payments/subscriptions/recurring-delegation.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/recurring-delegation.mdx
@@ -15,14 +15,14 @@ delegation, then use that delegation PDA for transfers.
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```bash
-    pnpm add @subscriptions/client @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
+    pnpm add @solana/subscriptions @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
     ```
   </Tab>
 
   <Tab value="Rust">
     ```toml
     [dependencies]
-    subscriptions-client = { path = "clients/rust" }
+    subscriptions = "^0.1"
     solana-instruction = "^2"
     solana-address = { version = "^2", features = ["curve25519"] }
     ```
@@ -52,7 +52,7 @@ The setup has four parts:
       findRecurringDelegationPda,
       findSubscriptionAuthorityPda,
       subscriptionsProgram,
-    } from '@subscriptions/client';
+    } from '@solana/subscriptions';
 
     const client = createClient()
       .use(signer(userSigner))
@@ -119,7 +119,7 @@ The setup has four parts:
   <Tab value="Rust">
     ```rust
     use solana_address::{address, Address};
-    use subscriptions_client::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
+    use subscriptions::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
 
     const SYSTEM_PROGRAM_ID: Address = address!("11111111111111111111111111111111");
     const TOKEN_PROGRAM_ID: Address = address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
@@ -205,7 +205,7 @@ rejects transfers that would exceed the period's remaining allowance.
 
   <Tab value="Rust">
     ```rust
-    use subscriptions_client::{TransferData, TransferRecurringBuilder};
+    use subscriptions::{TransferData, TransferRecurringBuilder};
 
     let receiver_ata: Address = address!("RECEIVER_TOKEN_ACCOUNT_ADDRESS_HERE");
 
@@ -242,7 +242,7 @@ the delegation PDA and returns its rent to the signer.
 
   <Tab value="Rust">
     ```rust
-    use subscriptions_client::generated::instructions::*;
+    use subscriptions::generated::instructions::*;
 
     let revoke_ix = RevokeDelegationBuilder::new()
         .authority(user)

--- a/apps/docs/content/docs/en/payments/subscriptions/recurring-delegation.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/recurring-delegation.mdx
@@ -1,0 +1,223 @@
+---
+title: Recurring Delegation
+description: Guide for setting up recurring delegation transactions.
+---
+
+A recurring delegation lets a user approve another wallet or service to pull up
+to a limit that resets every period.
+
+## Install
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```bash
+    pnpm add @subscriptions/client @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
+    ```
+  </Tab>
+
+  <Tab value="Rust">
+    ```toml
+    [dependencies]
+    subscriptions-client = { path = "clients/rust" }
+    solana-instruction = "^2"
+    solana-pubkey = "^2"
+    ```
+  </Tab>
+</Tabs>
+
+## Create The Delegation
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    import { address, createClient, type Address, type TransactionSigner } from '@solana/kit';
+    import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+    import { signer } from '@solana/kit-plugin-signer';
+    import { findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
+    import {
+      fetchMaybeSubscriptionAuthority,
+      findRecurringDelegationPda,
+      findSubscriptionAuthorityPda,
+      subscriptionsProgram,
+    } from '@subscriptions/client';
+
+    export async function createRecurringDelegation({
+      rpcUrl,
+      user,
+      tokenMint,
+      delegatee,
+      amountPerPeriod,
+      periodLengthS,
+      startTs,
+      expiryTs,
+      nonce = 0n,
+      tokenProgram = TOKEN_PROGRAM_ADDRESS,
+    }: {
+      rpcUrl: string;
+      user: TransactionSigner;
+      tokenMint: Address;
+      delegatee: Address;
+      amountPerPeriod: bigint;
+      periodLengthS: bigint;
+      startTs: bigint;
+      expiryTs: bigint;
+      nonce?: bigint;
+      tokenProgram?: Address;
+    }) {
+      const client = createClient()
+        .use(signer(user))
+        .use(solanaLocalRpc({ rpcUrl }))
+        .use(subscriptionsProgram());
+
+      const [userAta] = await findAssociatedTokenPda({ mint: tokenMint, owner: user.address, tokenProgram });
+      const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({ user: user.address, tokenMint });
+      const subscriptionAuthority = await fetchMaybeSubscriptionAuthority(client.rpc, subscriptionAuthorityPda);
+
+      if (!subscriptionAuthority.exists) {
+        await client.subscriptions.instructions
+          .initSubscriptionAuthority({ tokenMint, tokenProgram, userAta })
+          .sendTransaction();
+      }
+
+      await client.subscriptions.instructions
+        .createRecurringDelegation({ tokenMint, delegatee, nonce, amountPerPeriod, periodLengthS, startTs, expiryTs })
+        .sendTransaction();
+
+      const [delegationPda] = await findRecurringDelegationPda({
+        subscriptionAuthority: subscriptionAuthorityPda,
+        delegator: user.address,
+        delegatee,
+        nonce,
+      });
+
+      return { delegationPda, subscriptionAuthorityPda, userAta };
+    }
+
+    const now = BigInt(Math.floor(Date.now() / 1000));
+    const result = await createRecurringDelegation({
+      rpcUrl: 'http://127.0.0.1:8899',
+      user: userSigner,
+      tokenMint: address('TOKEN_MINT_ADDRESS_HERE'),
+      delegatee: address('DELEGATEE_WALLET_ADDRESS_HERE'),
+      amountPerPeriod: 1_000_000n,
+      periodLengthS: 86_400n,
+      startTs: now,
+      expiryTs: now + 86_400n * 30n,
+    });
+    ```
+
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use solana_instruction::Instruction;
+    use solana_pubkey::{pubkey, Pubkey};
+    use subscriptions_client::{
+        CreateRecurringDelegationBuilder, CreateRecurringDelegationData,
+        InitSubscriptionAuthorityBuilder, SUBSCRIPTIONS_ID,
+    };
+
+    const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
+    const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+    fn subscription_authority_pda(user: &Pubkey, mint: &Pubkey) -> Pubkey {
+        Pubkey::find_program_address(&[b"SubscriptionAuthority", user.as_ref(), mint.as_ref()], &SUBSCRIPTIONS_ID).0
+    }
+
+    fn recurring_delegation_pda(sa: &Pubkey, delegator: &Pubkey, delegatee: &Pubkey, nonce: u64) -> Pubkey {
+        Pubkey::find_program_address(
+            &[b"delegation", sa.as_ref(), delegator.as_ref(), delegatee.as_ref(), &nonce.to_le_bytes()],
+            &SUBSCRIPTIONS_ID,
+        ).0
+    }
+
+    pub fn recurring_delegation_setup_ixs(
+        user: Pubkey,
+        user_ata: Pubkey,
+        token_mint: Pubkey,
+        delegatee: Pubkey,
+        amount_per_period: u64,
+        period_length_s: u64,
+        start_ts: i64,
+        expiry_ts: i64,
+        nonce: u64,
+    ) -> (Vec<Instruction>, Pubkey) {
+        let subscription_authority = subscription_authority_pda(&user, &token_mint);
+        let delegation_pda = recurring_delegation_pda(&subscription_authority, &user, &delegatee, nonce);
+
+        let init_ix = InitSubscriptionAuthorityBuilder::new()
+            .owner(user)
+            .subscription_authority(subscription_authority)
+            .token_mint(token_mint)
+            .user_ata(user_ata)
+            .system_program(SYSTEM_PROGRAM_ID)
+            .token_program(TOKEN_PROGRAM_ID)
+            .instruction();
+
+        let create_ix = CreateRecurringDelegationBuilder::new()
+            .delegator(user)
+            .subscription_authority(subscription_authority)
+            .delegation_account(delegation_pda)
+            .delegatee(delegatee)
+            .recurring_delegation(CreateRecurringDelegationData {
+                nonce,
+                amount_per_period,
+                period_length_s,
+                start_ts,
+                expiry_ts,
+            })
+            .instruction();
+
+        (vec![init_ix, create_ix], delegation_pda)
+    }
+    ```
+
+  </Tab>
+</Tabs>
+
+## Transfer From The Delegation
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    await client.subscriptions.instructions
+      .transferRecurring({
+        delegatee: delegateeSigner,
+        delegator: userAddress,
+        delegatorAta: userAta,
+        tokenMint,
+        delegationPda,
+        amount: 100_000n,
+        receiverAta,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      })
+      .sendTransaction();
+    ```
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use subscriptions_client::{TransferData, TransferRecurringBuilder};
+
+    let transfer_ix = TransferRecurringBuilder::new()
+        .delegation_pda(delegation_pda)
+        .subscription_authority(subscription_authority)
+        .delegator_ata(user_ata)
+        .receiver_ata(receiver_ata)
+        .token_program(TOKEN_PROGRAM_ID)
+        .delegatee(delegatee)
+        .transfer_data(TransferData { amount: 100_000, delegator: user, mint: token_mint })
+        .instruction();
+    ```
+
+  </Tab>
+</Tabs>
+
+## Notes
+
+- `amountPerPeriod` is in base units. For a 6-decimal token, `1_000_000` means
+  `1` token.
+- The program rejects transfers that exceed the current period's remaining
+  allowance.
+- Once the next period starts, the pulled amount resets.
+- The user signs setup and revoke transactions. The delegatee signs transfers.

--- a/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
@@ -7,6 +7,10 @@ A subscription plan lets a merchant publish billing terms that users can accept.
 After a user subscribes, the merchant or an approved puller can collect up to
 the plan amount each billing period.
 
+This guide shows the full flow as building blocks. The merchant creates a plan,
+the subscriber accepts it, and the merchant or puller collects payments from the
+resulting subscription PDA.
+
 ## Install
 
 <Tabs items={["TypeScript", "Rust"]}>
@@ -28,55 +32,46 @@ the plan amount each billing period.
 
 ## Create A Plan
 
+The merchant owns the plan. The plan PDA is derived from the merchant address
+and `planId`.
+
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```ts
-    import { address, createClient, type Address, type TransactionSigner } from '@solana/kit';
+    import { address, createClient } from '@solana/kit';
     import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
     import { signer } from '@solana/kit-plugin-signer';
     import { findPlanPda, subscriptionsProgram } from '@subscriptions/client';
 
-    export async function createSubscriptionPlan({
-      rpcUrl,
-      merchant,
+    const merchantClient = createClient()
+      .use(signer(merchantSigner))
+      .use(solanaLocalRpc({ rpcUrl: 'http://127.0.0.1:8899' }))
+      .use(subscriptionsProgram());
+
+    const planId = 1n;
+    const tokenMint = address('TOKEN_MINT_ADDRESS_HERE');
+    const amount = 5_000_000n;
+    const periodHours = 720n;
+    const metadataUri = 'https://example.com/plan.json';
+    const destinations = [address('MERCHANT_TOKEN_ACCOUNT_ADDRESS_HERE')];
+    const pullers = [address('PULLER_WALLET_ADDRESS_HERE')];
+
+    await merchantClient.subscriptions.instructions
+      .createPlan({
+        planId,
+        mint: tokenMint,
+        amount,
+        periodHours,
+        endTs: 0n,
+        destinations,
+        pullers,
+        metadataUri,
+      })
+      .sendTransaction();
+
+    const [planPda] = await findPlanPda({
+      owner: merchantSigner.address,
       planId,
-      tokenMint,
-      amount,
-      periodHours,
-      pullers = [],
-      destinations = [],
-      metadataUri = 'https://example.com/plan.json',
-    }: {
-      rpcUrl: string;
-      merchant: TransactionSigner;
-      planId: bigint;
-      tokenMint: Address;
-      amount: bigint;
-      periodHours: bigint;
-      pullers?: Address[];
-      destinations?: Address[];
-      metadataUri?: string;
-    }) {
-      const client = createClient()
-        .use(signer(merchant))
-        .use(solanaLocalRpc({ rpcUrl }))
-        .use(subscriptionsProgram());
-
-      await client.subscriptions.instructions
-        .createPlan({ planId, mint: tokenMint, amount, periodHours, endTs: 0n, destinations, pullers, metadataUri })
-        .sendTransaction();
-
-      const [planPda] = await findPlanPda({ owner: merchant.address, planId });
-      return { planPda };
-    }
-
-    const { planPda } = await createSubscriptionPlan({
-      rpcUrl: 'http://127.0.0.1:8899',
-      merchant: merchantSigner,
-      planId: 1n,
-      tokenMint: address('TOKEN_MINT_ADDRESS_HERE'),
-      amount: 5_000_000n,
-      periodHours: 720n,
     });
     ```
 
@@ -84,52 +79,49 @@ the plan amount each billing period.
 
   <Tab value="Rust">
     ```rust
-    use solana_instruction::Instruction;
     use solana_pubkey::{pubkey, Pubkey};
     use subscriptions_client::{CreatePlanBuilder, PlanData, PlanTerms, SUBSCRIPTIONS_ID};
 
     const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
-    fn plan_pda(merchant: &Pubkey, plan_id: u64) -> (Pubkey, u8) {
-        Pubkey::find_program_address(&[b"plan", merchant.as_ref(), &plan_id.to_le_bytes()], &SUBSCRIPTIONS_ID)
-    }
+    let merchant: Pubkey = pubkey!("MERCHANT_WALLET_ADDRESS_HERE");
+    let token_mint: Pubkey = pubkey!("TOKEN_MINT_ADDRESS_HERE");
+    let merchant_token_account: Pubkey = pubkey!("MERCHANT_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let puller: Pubkey = pubkey!("PULLER_WALLET_ADDRESS_HERE");
+    let plan_id = 1u64;
+    let amount = 5_000_000u64;
+    let period_hours = 720u64;
 
-    fn metadata_uri_bytes(uri: &str) -> [u8; 128] {
-        let mut out = [0u8; 128];
-        let bytes = uri.as_bytes();
-        let len = bytes.len().min(128);
-        out[..len].copy_from_slice(&bytes[..len]);
-        out
-    }
+    let (plan_pda, _) = Pubkey::find_program_address(
+        &[b"plan", merchant.as_ref(), &plan_id.to_le_bytes()],
+        &SUBSCRIPTIONS_ID,
+    );
 
-    pub fn create_plan_ix(
-        merchant: Pubkey,
-        plan_id: u64,
-        token_mint: Pubkey,
-        amount: u64,
-        period_hours: u64,
-    ) -> (Instruction, Pubkey) {
-        let (plan_pda, _) = plan_pda(&merchant, plan_id);
-        let empty = Pubkey::default();
+    let mut metadata_uri = [0u8; 128];
+    let metadata_bytes = b"https://example.com/plan.json";
+    metadata_uri[..metadata_bytes.len()].copy_from_slice(metadata_bytes);
 
-        let ix = CreatePlanBuilder::new()
-            .merchant(merchant)
-            .plan_pda(plan_pda)
-            .token_mint(token_mint)
-            .token_program(TOKEN_PROGRAM_ID)
-            .plan_data(PlanData {
-                plan_id,
-                mint: token_mint,
-                terms: PlanTerms { amount, period_hours, created_at: 0 },
-                end_ts: 0,
-                destinations: [empty; 4],
-                pullers: [empty; 4],
-                metadata_uri: metadata_uri_bytes("https://example.com/plan.json"),
-            })
-            .instruction();
+    let mut destinations = [Pubkey::default(); 4];
+    destinations[0] = merchant_token_account;
 
-        (ix, plan_pda)
-    }
+    let mut pullers = [Pubkey::default(); 4];
+    pullers[0] = puller;
+
+    let create_plan_ix = CreatePlanBuilder::new()
+        .merchant(merchant)
+        .plan_pda(plan_pda)
+        .token_mint(token_mint)
+        .token_program(TOKEN_PROGRAM_ID)
+        .plan_data(PlanData {
+            plan_id,
+            mint: token_mint,
+            terms: PlanTerms { amount, period_hours, created_at: 0 },
+            end_ts: 0,
+            destinations,
+            pullers,
+            metadata_uri,
+        })
+        .instruction();
     ```
 
   </Tab>
@@ -137,53 +129,66 @@ the plan amount each billing period.
 
 ## Subscribe
 
+The subscriber accepts the current plan terms. The subscription PDA is derived
+from the plan PDA and subscriber address.
+
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```ts
-    import { createClient, type Address, type TransactionSigner } from '@solana/kit';
+    import { createClient } from '@solana/kit';
     import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
     import { signer } from '@solana/kit-plugin-signer';
     import { findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
     import {
       fetchMaybeSubscriptionAuthority,
-      findPlanPda,
       findSubscriptionAuthorityPda,
       findSubscriptionDelegationPda,
       subscriptionsProgram,
     } from '@subscriptions/client';
 
-    export async function subscribeToPlan({ rpcUrl, subscriber, merchant, planId, tokenMint }: {
-      rpcUrl: string;
-      subscriber: TransactionSigner;
-      merchant: Address;
-      planId: bigint;
-      tokenMint: Address;
-    }) {
-      const client = createClient()
-        .use(signer(subscriber))
-        .use(solanaLocalRpc({ rpcUrl }))
-        .use(subscriptionsProgram());
+    const subscriberClient = createClient()
+      .use(signer(subscriberSigner))
+      .use(solanaLocalRpc({ rpcUrl: 'http://127.0.0.1:8899' }))
+      .use(subscriptionsProgram());
 
-      const [subscriberAta] = await findAssociatedTokenPda({
-        mint: tokenMint,
-        owner: subscriber.address,
-        tokenProgram: TOKEN_PROGRAM_ADDRESS,
-      });
-      const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({ user: subscriber.address, tokenMint });
-      const subscriptionAuthority = await fetchMaybeSubscriptionAuthority(client.rpc, subscriptionAuthorityPda);
+    const [subscriberAta] = await findAssociatedTokenPda({
+      mint: tokenMint,
+      owner: subscriberSigner.address,
+      tokenProgram: TOKEN_PROGRAM_ADDRESS,
+    });
 
-      if (!subscriptionAuthority.exists) {
-        await client.subscriptions.instructions
-          .initSubscriptionAuthority({ tokenMint, tokenProgram: TOKEN_PROGRAM_ADDRESS, userAta: subscriberAta })
-          .sendTransaction();
-      }
+    const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({
+      user: subscriberSigner.address,
+      tokenMint,
+    });
 
-      await client.subscriptions.instructions.subscribe({ merchant, planId, tokenMint }).sendTransaction();
+    const subscriptionAuthority = await fetchMaybeSubscriptionAuthority(
+      subscriberClient.rpc,
+      subscriptionAuthorityPda,
+    );
 
-      const [planPda] = await findPlanPda({ owner: merchant, planId });
-      const [subscriptionPda] = await findSubscriptionDelegationPda({ planPda, subscriber: subscriber.address });
-      return { planPda, subscriptionPda, subscriptionAuthorityPda, subscriberAta };
+    if (!subscriptionAuthority.exists) {
+      await subscriberClient.subscriptions.instructions
+        .initSubscriptionAuthority({
+          tokenMint,
+          tokenProgram: TOKEN_PROGRAM_ADDRESS,
+          userAta: subscriberAta,
+        })
+        .sendTransaction();
     }
+
+    await subscriberClient.subscriptions.instructions
+      .subscribe({
+        merchant: merchantSigner.address,
+        planId,
+        tokenMint,
+      })
+      .sendTransaction();
+
+    const [subscriptionPda] = await findSubscriptionDelegationPda({
+      planPda,
+      subscriber: subscriberSigner.address,
+    });
     ```
 
   </Tab>
@@ -191,55 +196,56 @@ the plan amount each billing period.
   <Tab value="Rust">
     ```rust
     use subscriptions_client::{
-        InitSubscriptionAuthorityBuilder, SubscribeBuilder, SubscribeData, Plan,
+        InitSubscriptionAuthorityBuilder, Plan, SubscribeBuilder, SubscribeData,
     };
 
-    fn subscription_authority_pda(user: &Pubkey, mint: &Pubkey) -> Pubkey {
-        Pubkey::find_program_address(&[b"SubscriptionAuthority", user.as_ref(), mint.as_ref()], &SUBSCRIPTIONS_ID).0
-    }
+    const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
 
-    fn subscription_pda(plan_pda: &Pubkey, subscriber: &Pubkey) -> Pubkey {
-        Pubkey::find_program_address(&[b"subscription", plan_pda.as_ref(), subscriber.as_ref()], &SUBSCRIPTIONS_ID).0
-    }
+    let subscriber: Pubkey = pubkey!("SUBSCRIBER_WALLET_ADDRESS_HERE");
+    let subscriber_ata: Pubkey = pubkey!("SUBSCRIBER_TOKEN_ACCOUNT_ADDRESS_HERE");
 
-    pub fn subscribe_ixs(
-        subscriber: Pubkey,
-        subscriber_ata: Pubkey,
-        merchant: Pubkey,
-        plan_id: u64,
-        token_mint: Pubkey,
-        fetched_plan: Plan,
-    ) -> (Vec<Instruction>, Pubkey) {
-        let subscription_authority = subscription_authority_pda(&subscriber, &token_mint);
-        let (plan_pda, plan_bump) = plan_pda(&merchant, plan_id);
-        let subscription_pda = subscription_pda(&plan_pda, &subscriber);
+    let (subscription_authority, _) = Pubkey::find_program_address(
+        &[b"SubscriptionAuthority", subscriber.as_ref(), token_mint.as_ref()],
+        &SUBSCRIPTIONS_ID,
+    );
 
-        let init_ix = InitSubscriptionAuthorityBuilder::new()
-            .owner(subscriber)
-            .subscription_authority(subscription_authority)
-            .token_mint(token_mint)
-            .user_ata(subscriber_ata)
-            .token_program(TOKEN_PROGRAM_ID)
-            .instruction();
+    let (subscription_pda, _) = Pubkey::find_program_address(
+        &[b"subscription", plan_pda.as_ref(), subscriber.as_ref()],
+        &SUBSCRIPTIONS_ID,
+    );
 
-        let subscribe_ix = SubscribeBuilder::new()
-            .subscriber(subscriber)
-            .merchant(merchant)
-            .plan_pda(plan_pda)
-            .subscription_pda(subscription_pda)
-            .subscription_authority_pda(subscription_authority)
-            .subscribe_data(SubscribeData {
-                plan_id,
-                plan_bump,
-                expected_mint: fetched_plan.data.mint,
-                expected_amount: fetched_plan.data.terms.amount,
-                expected_period_hours: fetched_plan.data.terms.period_hours,
-                expected_created_at: fetched_plan.data.terms.created_at,
-            })
-            .instruction();
+    let (_, plan_bump) = Pubkey::find_program_address(
+        &[b"plan", merchant.as_ref(), &plan_id.to_le_bytes()],
+        &SUBSCRIPTIONS_ID,
+    );
 
-        (vec![init_ix, subscribe_ix], subscription_pda)
-    }
+    let init_ix = InitSubscriptionAuthorityBuilder::new()
+        .owner(subscriber)
+        .subscription_authority(subscription_authority)
+        .token_mint(token_mint)
+        .user_ata(subscriber_ata)
+        .system_program(SYSTEM_PROGRAM_ID)
+        .token_program(TOKEN_PROGRAM_ID)
+        .instruction();
+
+    // Fetch and decode the plan account before building SubscribeData.
+    let fetched_plan: Plan = fetched_plan;
+
+    let subscribe_ix = SubscribeBuilder::new()
+        .subscriber(subscriber)
+        .merchant(merchant)
+        .plan_pda(plan_pda)
+        .subscription_pda(subscription_pda)
+        .subscription_authority_pda(subscription_authority)
+        .subscribe_data(SubscribeData {
+            plan_id,
+            plan_bump,
+            expected_mint: fetched_plan.data.mint,
+            expected_amount: fetched_plan.data.terms.amount,
+            expected_period_hours: fetched_plan.data.terms.period_hours,
+            expected_created_at: fetched_plan.data.terms.created_at,
+        })
+        .instruction();
     ```
 
   </Tab>
@@ -247,13 +253,19 @@ the plan amount each billing period.
 
 ## Collect A Payment
 
+The merchant or a whitelisted puller signs collection. The receiver token
+account must match the plan's destination rules when the plan uses a destination
+allowlist.
+
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```ts
-    await client.subscriptions.instructions
+    const receiverAta = address('MERCHANT_TOKEN_ACCOUNT_ADDRESS_HERE');
+
+    await merchantClient.subscriptions.instructions
       .transferSubscription({
         caller: merchantOrPullerSigner,
-        delegator: subscriberAddress,
+        delegator: subscriberSigner.address,
         tokenMint,
         subscriptionPda,
         planPda,
@@ -263,11 +275,15 @@ the plan amount each billing period.
       })
       .sendTransaction();
     ```
+
   </Tab>
 
   <Tab value="Rust">
     ```rust
     use subscriptions_client::{TransferData, TransferSubscriptionBuilder};
+
+    let merchant_or_puller: Pubkey = merchant;
+    let receiver_ata: Pubkey = merchant_token_account;
 
     let collect_ix = TransferSubscriptionBuilder::new()
         .subscription_pda(subscription_pda)

--- a/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
@@ -25,7 +25,7 @@ resulting subscription PDA.
     [dependencies]
     subscriptions-client = { path = "clients/rust" }
     solana-instruction = "^2"
-    solana-pubkey = "^2"
+    solana-address = { version = "^2", features = ["curve25519"] }
     ```
   </Tab>
 </Tabs>
@@ -79,20 +79,20 @@ and `planId`.
 
   <Tab value="Rust">
     ```rust
-    use solana_pubkey::{pubkey, Pubkey};
+    use solana_address::{address, Address};
     use subscriptions_client::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
 
-    const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+    const TOKEN_PROGRAM_ID: Address = address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
-    let merchant: Pubkey = pubkey!("MERCHANT_WALLET_ADDRESS_HERE");
-    let token_mint: Pubkey = pubkey!("TOKEN_MINT_ADDRESS_HERE");
-    let merchant_token_account: Pubkey = pubkey!("MERCHANT_TOKEN_ACCOUNT_ADDRESS_HERE");
-    let puller: Pubkey = pubkey!("PULLER_WALLET_ADDRESS_HERE");
+    let merchant: Address = address!("MERCHANT_WALLET_ADDRESS_HERE");
+    let token_mint: Address = address!("TOKEN_MINT_ADDRESS_HERE");
+    let merchant_token_account: Address = address!("MERCHANT_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let puller: Address = address!("PULLER_WALLET_ADDRESS_HERE");
     let plan_id = 1u64;
     let amount = 5_000_000u64;
     let period_hours = 720u64;
 
-    let (plan_pda, _) = Pubkey::find_program_address(
+    let (plan_pda, _) = Address::find_program_address(
         &[b"plan", merchant.as_ref(), &plan_id.to_le_bytes()],
         &SUBSCRIPTIONS_ID,
     );
@@ -101,10 +101,10 @@ and `planId`.
     let metadata_bytes = b"https://example.com/plan.json";
     metadata_uri[..metadata_bytes.len()].copy_from_slice(metadata_bytes);
 
-    let mut destinations = [Pubkey::default(); 4];
+    let mut destinations = [Address::default(); 4];
     destinations[0] = merchant;
 
-    let mut pullers = [Pubkey::default(); 4];
+    let mut pullers = [Address::default(); 4];
     pullers[0] = puller;
 
     let create_plan_ix = CreatePlanBuilder::new()
@@ -120,6 +120,59 @@ and `planId`.
             destinations,
             pullers,
             metadata_uri,
+        })
+        .instruction();
+    ```
+
+  </Tab>
+</Tabs>
+
+## Update A Plan
+
+The merchant can update mutable plan fields after creation. Existing subscribers
+keep the terms they accepted, while new subscribers accept the current plan
+terms.
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    import { PlanStatus } from '@subscriptions/client';
+
+    const updatedMetadataUri = 'https://example.com/updated-plan.json';
+    const updatedPullers = [address('NEW_PULLER_WALLET_ADDRESS_HERE')];
+
+    await merchantClient.subscriptions.instructions
+      .updatePlan({
+        owner: merchantSigner,
+        planPda,
+        status: PlanStatus.Active,
+        endTs: 0n,
+        pullers: updatedPullers,
+        metadataUri: updatedMetadataUri,
+      })
+      .sendTransaction();
+    ```
+
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    let new_puller: Address = address!("NEW_PULLER_WALLET_ADDRESS_HERE");
+    let mut updated_pullers = [Address::default(); 4];
+    updated_pullers[0] = new_puller;
+
+    let mut updated_metadata_uri = [0u8; 128];
+    let updated_metadata_bytes = b"https://example.com/updated-plan.json";
+    updated_metadata_uri[..updated_metadata_bytes.len()].copy_from_slice(updated_metadata_bytes);
+
+    let update_plan_ix = UpdatePlanBuilder::new()
+        .owner(merchant)
+        .plan_pda(plan_pda)
+        .update_plan_data(UpdatePlanData {
+            status: PlanStatus::Active as u8,
+            end_ts: 0,
+            pullers: updated_pullers,
+            metadata_uri: updated_metadata_uri,
         })
         .instruction();
     ```
@@ -197,22 +250,22 @@ from the plan PDA and subscriber address.
     ```rust
     use subscriptions_client::{accounts::Plan, generated::{instructions::*, types::*}};
 
-    const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
+    const SYSTEM_PROGRAM_ID: Address = address!("11111111111111111111111111111111");
 
-    let subscriber: Pubkey = pubkey!("SUBSCRIBER_WALLET_ADDRESS_HERE");
-    let subscriber_ata: Pubkey = pubkey!("SUBSCRIBER_TOKEN_ACCOUNT_ADDRESS_HERE");
+    let subscriber: Address = address!("SUBSCRIBER_WALLET_ADDRESS_HERE");
+    let subscriber_ata: Address = address!("SUBSCRIBER_TOKEN_ACCOUNT_ADDRESS_HERE");
 
-    let (subscription_authority, _) = Pubkey::find_program_address(
+    let (subscription_authority, _) = Address::find_program_address(
         &[b"SubscriptionAuthority", subscriber.as_ref(), token_mint.as_ref()],
         &SUBSCRIPTIONS_ID,
     );
 
-    let (subscription_pda, _) = Pubkey::find_program_address(
+    let (subscription_pda, _) = Address::find_program_address(
         &[b"subscription", plan_pda.as_ref(), subscriber.as_ref()],
         &SUBSCRIPTIONS_ID,
     );
 
-    let (_, plan_bump) = Pubkey::find_program_address(
+    let (_, plan_bump) = Address::find_program_address(
         &[b"plan", merchant.as_ref(), &plan_id.to_le_bytes()],
         &SUBSCRIPTIONS_ID,
     );
@@ -280,8 +333,8 @@ destination allowlist, the owner of the receiver token account must be listed in
     ```rust
     use subscriptions_client::{TransferData, TransferSubscriptionBuilder};
 
-    let merchant_or_puller: Pubkey = merchant;
-    let receiver_ata: Pubkey = merchant_token_account;
+    let merchant_or_puller: Address = merchant;
+    let receiver_ata: Address = merchant_token_account;
 
     let collect_ix = TransferSubscriptionBuilder::new()
         .subscription_pda(subscription_pda)

--- a/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
@@ -1,0 +1,297 @@
+---
+title: Subscription Plan
+description: Guide for setting up subscription plan transactions.
+---
+
+A subscription plan lets a merchant publish billing terms that users can accept.
+After a user subscribes, the merchant or an approved puller can collect up to
+the plan amount each billing period.
+
+## Install
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```bash
+    pnpm add @subscriptions/client @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
+    ```
+  </Tab>
+
+  <Tab value="Rust">
+    ```toml
+    [dependencies]
+    subscriptions-client = { path = "clients/rust" }
+    solana-instruction = "^2"
+    solana-pubkey = "^2"
+    ```
+  </Tab>
+</Tabs>
+
+## Create A Plan
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    import { address, createClient, type Address, type TransactionSigner } from '@solana/kit';
+    import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+    import { signer } from '@solana/kit-plugin-signer';
+    import { findPlanPda, subscriptionsProgram } from '@subscriptions/client';
+
+    export async function createSubscriptionPlan({
+      rpcUrl,
+      merchant,
+      planId,
+      tokenMint,
+      amount,
+      periodHours,
+      pullers = [],
+      destinations = [],
+      metadataUri = 'https://example.com/plan.json',
+    }: {
+      rpcUrl: string;
+      merchant: TransactionSigner;
+      planId: bigint;
+      tokenMint: Address;
+      amount: bigint;
+      periodHours: bigint;
+      pullers?: Address[];
+      destinations?: Address[];
+      metadataUri?: string;
+    }) {
+      const client = createClient()
+        .use(signer(merchant))
+        .use(solanaLocalRpc({ rpcUrl }))
+        .use(subscriptionsProgram());
+
+      await client.subscriptions.instructions
+        .createPlan({ planId, mint: tokenMint, amount, periodHours, endTs: 0n, destinations, pullers, metadataUri })
+        .sendTransaction();
+
+      const [planPda] = await findPlanPda({ owner: merchant.address, planId });
+      return { planPda };
+    }
+
+    const { planPda } = await createSubscriptionPlan({
+      rpcUrl: 'http://127.0.0.1:8899',
+      merchant: merchantSigner,
+      planId: 1n,
+      tokenMint: address('TOKEN_MINT_ADDRESS_HERE'),
+      amount: 5_000_000n,
+      periodHours: 720n,
+    });
+    ```
+
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use solana_instruction::Instruction;
+    use solana_pubkey::{pubkey, Pubkey};
+    use subscriptions_client::{CreatePlanBuilder, PlanData, PlanTerms, SUBSCRIPTIONS_ID};
+
+    const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+    fn plan_pda(merchant: &Pubkey, plan_id: u64) -> (Pubkey, u8) {
+        Pubkey::find_program_address(&[b"plan", merchant.as_ref(), &plan_id.to_le_bytes()], &SUBSCRIPTIONS_ID)
+    }
+
+    fn metadata_uri_bytes(uri: &str) -> [u8; 128] {
+        let mut out = [0u8; 128];
+        let bytes = uri.as_bytes();
+        let len = bytes.len().min(128);
+        out[..len].copy_from_slice(&bytes[..len]);
+        out
+    }
+
+    pub fn create_plan_ix(
+        merchant: Pubkey,
+        plan_id: u64,
+        token_mint: Pubkey,
+        amount: u64,
+        period_hours: u64,
+    ) -> (Instruction, Pubkey) {
+        let (plan_pda, _) = plan_pda(&merchant, plan_id);
+        let empty = Pubkey::default();
+
+        let ix = CreatePlanBuilder::new()
+            .merchant(merchant)
+            .plan_pda(plan_pda)
+            .token_mint(token_mint)
+            .token_program(TOKEN_PROGRAM_ID)
+            .plan_data(PlanData {
+                plan_id,
+                mint: token_mint,
+                terms: PlanTerms { amount, period_hours, created_at: 0 },
+                end_ts: 0,
+                destinations: [empty; 4],
+                pullers: [empty; 4],
+                metadata_uri: metadata_uri_bytes("https://example.com/plan.json"),
+            })
+            .instruction();
+
+        (ix, plan_pda)
+    }
+    ```
+
+  </Tab>
+</Tabs>
+
+## Subscribe
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    import { createClient, type Address, type TransactionSigner } from '@solana/kit';
+    import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
+    import { signer } from '@solana/kit-plugin-signer';
+    import { findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
+    import {
+      fetchMaybeSubscriptionAuthority,
+      findPlanPda,
+      findSubscriptionAuthorityPda,
+      findSubscriptionDelegationPda,
+      subscriptionsProgram,
+    } from '@subscriptions/client';
+
+    export async function subscribeToPlan({ rpcUrl, subscriber, merchant, planId, tokenMint }: {
+      rpcUrl: string;
+      subscriber: TransactionSigner;
+      merchant: Address;
+      planId: bigint;
+      tokenMint: Address;
+    }) {
+      const client = createClient()
+        .use(signer(subscriber))
+        .use(solanaLocalRpc({ rpcUrl }))
+        .use(subscriptionsProgram());
+
+      const [subscriberAta] = await findAssociatedTokenPda({
+        mint: tokenMint,
+        owner: subscriber.address,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      });
+      const [subscriptionAuthorityPda] = await findSubscriptionAuthorityPda({ user: subscriber.address, tokenMint });
+      const subscriptionAuthority = await fetchMaybeSubscriptionAuthority(client.rpc, subscriptionAuthorityPda);
+
+      if (!subscriptionAuthority.exists) {
+        await client.subscriptions.instructions
+          .initSubscriptionAuthority({ tokenMint, tokenProgram: TOKEN_PROGRAM_ADDRESS, userAta: subscriberAta })
+          .sendTransaction();
+      }
+
+      await client.subscriptions.instructions.subscribe({ merchant, planId, tokenMint }).sendTransaction();
+
+      const [planPda] = await findPlanPda({ owner: merchant, planId });
+      const [subscriptionPda] = await findSubscriptionDelegationPda({ planPda, subscriber: subscriber.address });
+      return { planPda, subscriptionPda, subscriptionAuthorityPda, subscriberAta };
+    }
+    ```
+
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use subscriptions_client::{
+        InitSubscriptionAuthorityBuilder, SubscribeBuilder, SubscribeData, Plan,
+    };
+
+    fn subscription_authority_pda(user: &Pubkey, mint: &Pubkey) -> Pubkey {
+        Pubkey::find_program_address(&[b"SubscriptionAuthority", user.as_ref(), mint.as_ref()], &SUBSCRIPTIONS_ID).0
+    }
+
+    fn subscription_pda(plan_pda: &Pubkey, subscriber: &Pubkey) -> Pubkey {
+        Pubkey::find_program_address(&[b"subscription", plan_pda.as_ref(), subscriber.as_ref()], &SUBSCRIPTIONS_ID).0
+    }
+
+    pub fn subscribe_ixs(
+        subscriber: Pubkey,
+        subscriber_ata: Pubkey,
+        merchant: Pubkey,
+        plan_id: u64,
+        token_mint: Pubkey,
+        fetched_plan: Plan,
+    ) -> (Vec<Instruction>, Pubkey) {
+        let subscription_authority = subscription_authority_pda(&subscriber, &token_mint);
+        let (plan_pda, plan_bump) = plan_pda(&merchant, plan_id);
+        let subscription_pda = subscription_pda(&plan_pda, &subscriber);
+
+        let init_ix = InitSubscriptionAuthorityBuilder::new()
+            .owner(subscriber)
+            .subscription_authority(subscription_authority)
+            .token_mint(token_mint)
+            .user_ata(subscriber_ata)
+            .token_program(TOKEN_PROGRAM_ID)
+            .instruction();
+
+        let subscribe_ix = SubscribeBuilder::new()
+            .subscriber(subscriber)
+            .merchant(merchant)
+            .plan_pda(plan_pda)
+            .subscription_pda(subscription_pda)
+            .subscription_authority_pda(subscription_authority)
+            .subscribe_data(SubscribeData {
+                plan_id,
+                plan_bump,
+                expected_mint: fetched_plan.data.mint,
+                expected_amount: fetched_plan.data.terms.amount,
+                expected_period_hours: fetched_plan.data.terms.period_hours,
+                expected_created_at: fetched_plan.data.terms.created_at,
+            })
+            .instruction();
+
+        (vec![init_ix, subscribe_ix], subscription_pda)
+    }
+    ```
+
+  </Tab>
+</Tabs>
+
+## Collect A Payment
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    await client.subscriptions.instructions
+      .transferSubscription({
+        caller: merchantOrPullerSigner,
+        delegator: subscriberAddress,
+        tokenMint,
+        subscriptionPda,
+        planPda,
+        amount: 200_000n,
+        receiverAta,
+        tokenProgram: TOKEN_PROGRAM_ADDRESS,
+      })
+      .sendTransaction();
+    ```
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use subscriptions_client::{TransferData, TransferSubscriptionBuilder};
+
+    let collect_ix = TransferSubscriptionBuilder::new()
+        .subscription_pda(subscription_pda)
+        .plan_pda(plan_pda)
+        .subscription_authority(subscription_authority)
+        .delegator_ata(subscriber_ata)
+        .receiver_ata(receiver_ata)
+        .caller(merchant_or_puller)
+        .token_program(TOKEN_PROGRAM_ID)
+        .transfer_data(TransferData { amount: 200_000, delegator: subscriber, mint: token_mint })
+        .instruction();
+    ```
+
+  </Tab>
+</Tabs>
+
+## Notes
+
+- `amount` is in base units. For a 6-decimal token, `5_000_000` means `5`
+  tokens.
+- The TypeScript SDK fetches live plan terms during `subscribe` when you omit
+  them.
+- The Rust `SubscribeBuilder` needs the expected plan terms. Fetch and decode
+  the plan account first, then pass those fields through `SubscribeData`.
+- Only the merchant or a wallet listed in `pullers` can collect payments.
+- The subscriber signs setup, cancel, and revoke transactions. The merchant or
+  approved puller signs collection transactions.

--- a/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
@@ -80,7 +80,7 @@ and `planId`.
   <Tab value="Rust">
     ```rust
     use solana_pubkey::{pubkey, Pubkey};
-    use subscriptions_client::{CreatePlanBuilder, PlanData, PlanTerms, SUBSCRIPTIONS_ID};
+    use subscriptions_client::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
 
     const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
@@ -195,9 +195,7 @@ from the plan PDA and subscriber address.
 
   <Tab value="Rust">
     ```rust
-    use subscriptions_client::{
-        InitSubscriptionAuthorityBuilder, Plan, SubscribeBuilder, SubscribeData,
-    };
+    use subscriptions_client::{accounts::Plan, generated::{instructions::*, types::*}};
 
     const SYSTEM_PROGRAM_ID: Pubkey = pubkey!("11111111111111111111111111111111");
 
@@ -294,6 +292,57 @@ destination allowlist, the owner of the receiver token account must be listed in
         .caller(merchant_or_puller)
         .token_program(TOKEN_PROGRAM_ID)
         .transfer_data(TransferData { amount: 200_000, delegator: subscriber, mint: token_mint })
+        .instruction();
+    ```
+
+  </Tab>
+</Tabs>
+
+## Cancel And Revoke
+
+Cancelling marks the subscription as ending. Revoking closes the subscription
+PDA after the cancellation expiry has elapsed. The subscriber signs both
+transactions.
+
+<Tabs items={["TypeScript", "Rust"]}>
+  <Tab value="TypeScript">
+    ```ts
+    await subscriberClient.subscriptions.instructions
+      .cancelSubscription({
+        subscriber: subscriberSigner,
+        planPda,
+        subscriptionPda,
+      })
+      .sendTransaction();
+
+    // Run this after the cancelled subscription's expiresAtTs has elapsed.
+    await subscriberClient.subscriptions.instructions
+      .revokeSubscription({
+        authority: subscriberSigner,
+        planPda,
+        subscriptionPda,
+      })
+      .sendTransaction();
+    ```
+
+  </Tab>
+
+  <Tab value="Rust">
+    ```rust
+    use solana_instruction::AccountMeta;
+    use subscriptions_client::generated::instructions::*;
+
+    let cancel_ix = CancelSubscriptionBuilder::new()
+        .subscriber(subscriber)
+        .plan_pda(plan_pda)
+        .subscription_pda(subscription_pda)
+        .instruction();
+
+    // Send this after the cancelled subscription's expires_at_ts has elapsed.
+    let revoke_ix = RevokeDelegationBuilder::new()
+        .authority(subscriber)
+        .delegation_account(subscription_pda)
+        .add_remaining_account(AccountMeta::new_readonly(plan_pda, false))
         .instruction();
     ```
 

--- a/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
@@ -16,14 +16,14 @@ resulting subscription PDA.
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```bash
-    pnpm add @subscriptions/client @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
+    pnpm add @solana/subscriptions @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-signer @solana-program/token
     ```
   </Tab>
 
   <Tab value="Rust">
     ```toml
     [dependencies]
-    subscriptions-client = { path = "clients/rust" }
+    subscriptions = "^0.1"
     solana-instruction = "^2"
     solana-address = { version = "^2", features = ["curve25519"] }
     ```
@@ -41,7 +41,7 @@ and `planId`.
     import { address, createClient } from '@solana/kit';
     import { solanaLocalRpc } from '@solana/kit-plugin-rpc';
     import { signer } from '@solana/kit-plugin-signer';
-    import { findPlanPda, subscriptionsProgram } from '@subscriptions/client';
+    import { findPlanPda, subscriptionsProgram } from '@solana/subscriptions';
 
     const merchantClient = createClient()
       .use(signer(merchantSigner))
@@ -80,7 +80,7 @@ and `planId`.
   <Tab value="Rust">
     ```rust
     use solana_address::{address, Address};
-    use subscriptions_client::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
+    use subscriptions::{generated::{instructions::*, types::*}, SUBSCRIPTIONS_ID};
 
     const TOKEN_PROGRAM_ID: Address = address!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
 
@@ -136,7 +136,7 @@ terms.
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">
     ```ts
-    import { PlanStatus } from '@subscriptions/client';
+    import { PlanStatus } from '@solana/subscriptions';
 
     const updatedMetadataUri = 'https://example.com/updated-plan.json';
     const updatedPullers = [address('NEW_PULLER_WALLET_ADDRESS_HERE')];
@@ -197,7 +197,7 @@ from the plan PDA and subscriber address.
       findSubscriptionAuthorityPda,
       findSubscriptionDelegationPda,
       subscriptionsProgram,
-    } from '@subscriptions/client';
+    } from '@solana/subscriptions';
 
     const subscriberClient = createClient()
       .use(signer(subscriberSigner))
@@ -248,7 +248,7 @@ from the plan PDA and subscriber address.
 
   <Tab value="Rust">
     ```rust
-    use subscriptions_client::{accounts::Plan, generated::{instructions::*, types::*}};
+    use subscriptions::{accounts::Plan, generated::{instructions::*, types::*}};
 
     const SYSTEM_PROGRAM_ID: Address = address!("11111111111111111111111111111111");
 
@@ -331,7 +331,7 @@ destination allowlist, the owner of the receiver token account must be listed in
 
   <Tab value="Rust">
     ```rust
-    use subscriptions_client::{TransferData, TransferSubscriptionBuilder};
+    use subscriptions::{TransferData, TransferSubscriptionBuilder};
 
     let merchant_or_puller: Address = merchant;
     let receiver_ata: Address = merchant_token_account;
@@ -383,7 +383,7 @@ transactions.
   <Tab value="Rust">
     ```rust
     use solana_instruction::AccountMeta;
-    use subscriptions_client::generated::instructions::*;
+    use subscriptions::generated::instructions::*;
 
     let cancel_ix = CancelSubscriptionBuilder::new()
         .subscriber(subscriber)

--- a/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/subscription-plan.mdx
@@ -53,7 +53,7 @@ and `planId`.
     const amount = 5_000_000n;
     const periodHours = 720n;
     const metadataUri = 'https://example.com/plan.json';
-    const destinations = [address('MERCHANT_TOKEN_ACCOUNT_ADDRESS_HERE')];
+    const destinations = [merchantSigner.address];
     const pullers = [address('PULLER_WALLET_ADDRESS_HERE')];
 
     await merchantClient.subscriptions.instructions
@@ -102,7 +102,7 @@ and `planId`.
     metadata_uri[..metadata_bytes.len()].copy_from_slice(metadata_bytes);
 
     let mut destinations = [Pubkey::default(); 4];
-    destinations[0] = merchant_token_account;
+    destinations[0] = merchant;
 
     let mut pullers = [Pubkey::default(); 4];
     pullers[0] = puller;
@@ -253,9 +253,9 @@ from the plan PDA and subscriber address.
 
 ## Collect A Payment
 
-The merchant or a whitelisted puller signs collection. The receiver token
-account must match the plan's destination rules when the plan uses a destination
-allowlist.
+The merchant or a whitelisted puller signs collection. When the plan uses a
+destination allowlist, the owner of the receiver token account must be listed in
+`destinations`.
 
 <Tabs items={["TypeScript", "Rust"]}>
   <Tab value="TypeScript">


### PR DESCRIPTION
### Problem

We need to add documentation for the Subscriptions Program.

### Summary of Changes

Added the guides for using the Subscription Program via Typescript and Rust SDKs, including the following delegation models:

1. Fixed Delegation
2. Recurring Delegation
3. Subscription Plan

The code in the guides could be verified by cloning https://github.com/datasalaryman/subscriptions, switching to the `docs/site` branch and running the following, which does the steps on Devnet (please fund your devnet wallet):

```bash
pnpm run test:guides:devnet:typescript
pnpm run test:guides:devnet:rust
```