### PR TITLE
docs: remove link to deprecated solana mcp

### DIFF
--- a/apps/docs/content/docs/en/intro/installation/dependencies.mdx
+++ b/apps/docs/content/docs/en/intro/installation/dependencies.mdx
@@ -515,13 +515,3 @@ surfpool 0.12.0
 
 </Step>
 </Steps>
-
-### Set up AI tooling for Solana development
-
-This section details optional AI tooling setup you can use to accelerate your
-Solana development.
-
-| Tool     | Description                                                                               | Link                        |
-| -------- | ----------------------------------------------------------------------------------------- | --------------------------- |
-| MCP      | MCP server that you can connect to with cursor to improve Solana AI assisted development. | https://mcp.solana.com/     |
-| LLMs.txt | LLM optimized documentation that you can use to train LLMs on Solana docs.                | https://solana.com/llms.txt |

--- a/apps/docs/content/docs/en/payments/developer-tools.mdx
+++ b/apps/docs/content/docs/en/payments/developer-tools.mdx
@@ -114,13 +114,6 @@ processing:
 Get started with our guide on
 [how to get started with AI tools on Solana](/developers/guides/getstarted/intro-to-ai).
 
-### Solana MCP
-
-[Solana MCP](https://mcp.solana.com/) (Machine Conversation Protocol) integrates
-Solana knowledge directly into AI-supported coding tools like Claude, Cursor,
-and Windsurf. It's trained on Solana docs, Anchor framework, program examples,
-and Stack Exchange Q&A - useful for building payment integrations faster.
-
 ### AI Agent Frameworks
 
 AI agents can autonomously execute payment transactions on Solana. These


### PR DESCRIPTION
remove dead link to solana mcp, https://mcp.solana.com/