### PR TITLE
docs(terminology): add finance and offchain/signer entries

### DIFF
--- a/apps/docs/content/docs/en/references/terminology.mdx
+++ b/apps/docs/content/docs/en/references/terminology.mdx
@@ -68,6 +68,13 @@ For example:
 - The ability to upgrade a program is given to the account that is the 'upgrade
   authority' of a program.
 
+## automated market maker (AMM)
+
+An onchain exchange model where users trade against a pool of token reserves
+governed by a pricing formula rather than against a counterparty's resting
+order. Prices move as a function of the reserves, so trades incur
+[slippage](#slippage) proportional to size.
+
 ## bank state
 
 The result of interpreting all programs on the ledger at a given
@@ -108,6 +115,12 @@ A single byte (0–255) appended to [seeds](#seed) when deriving a
 address falls off the ed25519 curve and is therefore a valid PDA. The canonical
 bump is the highest value that produces a valid PDA and is typically saved in
 the account data to avoid recalculating it.
+
+## central limit order book (CLOB)
+
+An exchange model that maintains a sorted list of resting bids and asks; a
+trade occurs when an incoming order crosses an order on the opposite side.
+Contrast with [automated market maker](#automated-market-maker-amm).
 
 ## client
 
@@ -215,6 +228,13 @@ See [proof of history](#proof-of-history-poh).
 
 The time, i.e. number of [slots](#slot), for which a
 [leader schedule](#leader-schedule) is valid.
+
+## escrow
+
+A pattern in which an [onchain program](#onchain-program) holds tokens in a
+[vault](#vault) on behalf of two or more parties until conditions defined by
+the program are met, then releases them. Used to remove the need for the
+parties to trust each other directly.
 
 ## fee account
 
@@ -324,6 +344,15 @@ A type of [client](#client) that can verify it's pointing to a valid
 [cluster](#cluster). It performs more ledger verification than a
 [thin client](#thin-client) and less than a [validator](#validator).
 
+## liquidity
+
+The depth of orders or pooled reserves available to trade against at or near
+the current price. Deeper liquidity reduces [slippage](#slippage). On a
+[CLOB](#central-limit-order-book-clob) liquidity is supplied by
+[maker orders](#maker); on an
+[AMM](#automated-market-maker-amm) it is supplied by liquidity providers who
+deposit token pairs into the pool.
+
 ## loader
 
 A [program](#program) with the ability to interpret the binary encoding of other
@@ -333,6 +362,21 @@ A [program](#program) with the ability to interpret the binary encoding of other
 
 The duration of time for which a [validator](#validator) is unable to
 [vote](#ledger-vote) on another [fork](#fork).
+
+## maker
+
+A trader whose order adds [liquidity](#liquidity) to a
+[CLOB](#central-limit-order-book-clob) by resting on the book rather than
+immediately crossing the opposite side. Such an order is called a maker
+order. Makers typically pay no fee or receive a rebate from the venue.
+
+## market maker
+
+An entity that supplies [liquidity](#liquidity) by continuously posting both
+bids and asks. On Solana, market makers are either programs (such as
+[AMMs](#automated-market-maker-amm)) or offchain firms running bots that
+post [maker orders](#maker) on
+[CLOBs](#central-limit-order-book-clob).
 
 ## message
 
@@ -378,6 +422,11 @@ The executable code on Solana blockchain that interprets the
 [instructions](#instruction) sent inside of each [transaction](#transaction) to
 read and modify accounts over which it has control. These programs are often
 referred to as "[_smart contracts_](/docs/core/programs)" on other blockchains.
+
+## oracle
+
+An [onchain program](#onchain-program) that publishes data from outside the
+chain — most often prices of real-world assets — for other programs to read.
 
 ## owner
 
@@ -538,6 +587,14 @@ nor expire the oldest `recent_blockhash`.
 Whether a slot has been skipped can only be determined when it becomes older
 than the latest [rooted](#root) (thus not-skipped) slot.
 
+## slippage
+
+The difference between the price a trader expected and the price at which
+their trade actually executed. On [AMMs](#automated-market-maker-amm) it
+arises from the pricing curve moving as reserves change; on
+[CLOBs](#central-limit-order-book-clob) it arises from a single order
+consuming several resting orders at successively worse prices.
+
 ## slot
 
 The period of time for which each [leader](#leader) ingests transactions and
@@ -587,6 +644,13 @@ A system [account](#account). [Sysvars](https://docs.anza.xyz/runtime/sysvars)
 provide cluster state information such as current tick height, rewards
 [points](#point) values, etc. Programs can access Sysvars via a Sysvar account
 (pubkey) or by querying via a syscall.
+
+## taker
+
+A trader whose order removes [liquidity](#liquidity) from a
+[CLOB](#central-limit-order-book-clob) by crossing the opposite side of the
+book and matching against one or more resting orders. Such an order is
+called a taker order, and the taker typically pays the venue's trading fee.
 
 ## thin client
 
@@ -670,6 +734,17 @@ A set of [transactions](#transaction) that may be executed in parallel.
 A full participant in a Solana network [cluster](#cluster) that produces new
 [blocks](#block). A validator validates the transactions added to the
 [ledger](#ledger)
+
+## vault
+
+A [token account](#token-account) owned by an
+[onchain program](#onchain-program) that holds pooled assets on behalf of
+users — for example the base and quote reserves of an
+[AMM](#automated-market-maker-amm), the locked tokens in an
+[escrow](#escrow), or the resting balances and accumulated fees of a
+[CLOB](#central-limit-order-book-clob). Only the owning program can move
+tokens out of the vault, typically into a user's own
+[token account](#token-account) once a trade or release condition is met.
 
 ## VDF
 

--- a/apps/docs/content/docs/en/references/terminology.mdx
+++ b/apps/docs/content/docs/en/references/terminology.mdx
@@ -411,6 +411,13 @@ A computer participating in a [cluster](#cluster).
 
 The number of [validators](#validator) participating in a [cluster](#cluster).
 
+## offchain
+
+Describes data, processes, or services that exist or run outside the Solana
+blockchain, such as RPC clients, indexers, frontends, and offchain order
+book makers. Complement of [onchain](#onchain). "Offchain" (no hyphen) is
+the preferred spelling.
+
 ## onchain
 
 Describes data or programs that exist or execute on a blockchain. "Onchain" (no
@@ -567,6 +574,16 @@ scalar in the range of `0 <= S < L`. This requirement ensures no signature
 malleability. Each transaction must have at least one signature for
 [fee account](#fee-account). Thus, the first signature in transaction can be
 treated as [transaction id](#transaction-id)
+
+## signer
+
+An [account](#account) that has authorized an [instruction](#instruction) or
+[transaction](#transaction). For a regular [keypair](#keypair) this means a
+cryptographic [signature](#signature) over the transaction. For a
+[program derived address](#program-derived-address-pda), authorization is
+asserted by the [owning program](#owning-program) when it makes a
+[cross-program invocation](#cross-program-invocation-cpi), since a PDA has
+no private key.
 
 ## skip rate
 


### PR DESCRIPTION
## Summary

Adds 12 terminology entries to `apps/docs/content/docs/en/references/terminology.mdx`. All entries are Solana-specific or Solana-finance-bridge concepts, framed in terms of Solana primitives (programs, accounts, vaults, PDAs). No existing entries are modified.

## Terms added

**DeFi vocabulary:**
- `automated market maker (AMM)`
- `central limit order book (CLOB)`
- `escrow`
- `liquidity`
- `maker`
- `market maker`
- `oracle`
- `slippage`
- `taker`
- `vault`

**Solana primitive gaps:**
- `offchain` — complement of the existing `onchain` entry; matches the page's "one word, no hyphen" convention
- `signer` — including the PDA-via-CPI case, which is the most common source of confusion for new Solana developers

## Conventions

- Concept-only entries — no specific projects named.
- One word: `offchain` and `onchain`, never hyphenated.
- "Token Extensions", not "Token-2022".
- American English (en-US directory).
- Cross-references use existing anchors where they exist.

## Why this scope

These are the terms that came up while writing READMEs for finance examples in the Solana program-examples repo, where I kept wanting to link to a definition that didn't exist.