### PR TITLE
docs(cookbook): upgrade pay-fees-with-any-token kit example to plugin client

### DIFF
--- a/apps/docs/content/docs/en/references/terminology.mdx
+++ b/apps/docs/content/docs/en/references/terminology.mdx
@@ -118,9 +118,9 @@ the account data to avoid recalculating it.
 
 ## central limit order book (CLOB)
 
-An exchange model that maintains a sorted list of resting bids and asks; a
-trade occurs when an incoming order crosses an order on the opposite side.
-Contrast with [automated market maker](#automated-market-maker-amm).
+An exchange model that maintains a sorted list of resting bids and asks; a trade
+occurs when an incoming order crosses an order on the opposite side. Contrast
+with [automated market maker](#automated-market-maker-amm).
 
 ## client
 
@@ -232,9 +232,9 @@ The time, i.e. number of [slots](#slot), for which a
 ## escrow
 
 A pattern in which an [onchain program](#onchain-program) holds tokens in a
-[vault](#vault) on behalf of two or more parties until conditions defined by
-the program are met, then releases them. Used to remove the need for the
-parties to trust each other directly.
+[vault](#vault) on behalf of two or more parties until conditions defined by the
+program are met, then releases them. Used to remove the need for the parties to
+trust each other directly.
 
 ## fee account
 
@@ -346,12 +346,11 @@ A type of [client](#client) that can verify it's pointing to a valid
 
 ## liquidity
 
-The depth of orders or pooled reserves available to trade against at or near
-the current price. Deeper liquidity reduces [slippage](#slippage). On a
+The depth of orders or pooled reserves available to trade against at or near the
+current price. Deeper liquidity reduces [slippage](#slippage). On a
 [CLOB](#central-limit-order-book-clob) liquidity is supplied by
-[maker orders](#maker); on an
-[AMM](#automated-market-maker-amm) it is supplied by liquidity providers who
-deposit token pairs into the pool.
+[maker orders](#maker); on an [AMM](#automated-market-maker-amm) it is supplied
+by liquidity providers who deposit token pairs into the pool.
 
 ## loader
 
@@ -367,16 +366,15 @@ The duration of time for which a [validator](#validator) is unable to
 
 A trader whose order adds [liquidity](#liquidity) to a
 [CLOB](#central-limit-order-book-clob) by resting on the book rather than
-immediately crossing the opposite side. Such an order is called a maker
-order. Makers typically pay no fee or receive a rebate from the venue.
+immediately crossing the opposite side. Such an order is called a maker order.
+Makers typically pay no fee or receive a rebate from the venue.
 
 ## market maker
 
 An entity that supplies [liquidity](#liquidity) by continuously posting both
 bids and asks. On Solana, market makers are either programs (such as
-[AMMs](#automated-market-maker-amm)) or offchain firms running bots that
-post [maker orders](#maker) on
-[CLOBs](#central-limit-order-book-clob).
+[AMMs](#automated-market-maker-amm)) or offchain firms running bots that post
+[maker orders](#maker) on [CLOBs](#central-limit-order-book-clob).
 
 ## message
 
@@ -414,9 +412,9 @@ The number of [validators](#validator) participating in a [cluster](#cluster).
 ## offchain
 
 Describes data, processes, or services that exist or run outside the Solana
-blockchain, such as RPC clients, indexers, frontends, and offchain order
-book makers. Complement of [onchain](#onchain). "Offchain" (no hyphen) is
-the preferred spelling.
+blockchain, such as RPC clients, indexers, frontends, and offchain order book
+makers. Complement of [onchain](#onchain). "Offchain" (no hyphen) is the
+preferred spelling.
 
 ## onchain
 
@@ -582,8 +580,8 @@ An [account](#account) that has authorized an [instruction](#instruction) or
 cryptographic [signature](#signature) over the transaction. For a
 [program derived address](#program-derived-address-pda), authorization is
 asserted by the [owning program](#owning-program) when it makes a
-[cross-program invocation](#cross-program-invocation-cpi), since a PDA has
-no private key.
+[cross-program invocation](#cross-program-invocation-cpi), since a PDA has no
+private key.
 
 ## skip rate
 
@@ -606,11 +604,11 @@ than the latest [rooted](#root) (thus not-skipped) slot.
 
 ## slippage
 
-The difference between the price a trader expected and the price at which
-their trade actually executed. On [AMMs](#automated-market-maker-amm) it
-arises from the pricing curve moving as reserves change; on
-[CLOBs](#central-limit-order-book-clob) it arises from a single order
-consuming several resting orders at successively worse prices.
+The difference between the price a trader expected and the price at which their
+trade actually executed. On [AMMs](#automated-market-maker-amm) it arises from
+the pricing curve moving as reserves change; on
+[CLOBs](#central-limit-order-book-clob) it arises from a single order consuming
+several resting orders at successively worse prices.
 
 ## slot
 
@@ -665,9 +663,9 @@ provide cluster state information such as current tick height, rewards
 ## taker
 
 A trader whose order removes [liquidity](#liquidity) from a
-[CLOB](#central-limit-order-book-clob) by crossing the opposite side of the
-book and matching against one or more resting orders. Such an order is
-called a taker order, and the taker typically pays the venue's trading fee.
+[CLOB](#central-limit-order-book-clob) by crossing the opposite side of the book
+and matching against one or more resting orders. Such an order is called a taker
+order, and the taker typically pays the venue's trading fee.
 
 ## thin client
 
@@ -755,13 +753,13 @@ A full participant in a Solana network [cluster](#cluster) that produces new
 ## vault
 
 A [token account](#token-account) owned by an
-[onchain program](#onchain-program) that holds pooled assets on behalf of
-users — for example the base and quote reserves of an
-[AMM](#automated-market-maker-amm), the locked tokens in an
-[escrow](#escrow), or the resting balances and accumulated fees of a
-[CLOB](#central-limit-order-book-clob). Only the owning program can move
-tokens out of the vault, typically into a user's own
-[token account](#token-account) once a trade or release condition is met.
+[onchain program](#onchain-program) that holds pooled assets on behalf of users
+— for example the base and quote reserves of an
+[AMM](#automated-market-maker-amm), the locked tokens in an [escrow](#escrow),
+or the resting balances and accumulated fees of a
+[CLOB](#central-limit-order-book-clob). Only the owning program can move tokens
+out of the vault, typically into a user's own [token account](#token-account)
+once a trade or release condition is met.
 
 ## VDF
 

--- a/packages/docs-examples/cookbook/transactions/pay-fees-with-any-token/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/pay-fees-with-any-token/kit.ts
@@ -1,238 +1,117 @@
 // #region pay-fees
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { payer } from "@solana/kit-plugin-signer";
 import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  assertIsTransactionWithBlockhashLifetime,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  sendAndConfirmTransactionFactory,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-} from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import {
-  getCreateAssociatedTokenInstructionAsync,
-  getInitializeMintInstruction,
-  getMintSize,
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-  getMintToInstruction,
-  getTransferInstruction,
   fetchToken,
+  findAssociatedTokenPda,
+  TOKEN_PROGRAM_ADDRESS,
+  tokenProgram,
 } from "@solana-program/token";
 
-// Create Connection, local validator in this example
-const rpc = createSolanaRpc("http://localhost:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
-
-// Generate keypairs for fee payer, sender and recipient
+// Generate keypairs for fee payer, sender, recipient, and mint
 const feePayer = await generateKeyPairSigner();
 const sender = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
+const mint = await generateKeyPairSigner();
 
-console.log("Fee Payer Address:", feePayer.address.toString());
-console.log("Sender Address:", sender.address.toString());
-console.log("Recipient Address:", recipient.address.toString());
+console.log("Fee Payer Address:", feePayer.address);
+console.log("Sender Address:", sender.address);
+console.log("Recipient Address:", recipient.address);
+console.log("Mint Address:", mint.address);
+
+// Build a Kit client: fee payer, local RPC + airdrop + planner + executor,
+// and the token program plugin
+const client = createClient()
+  .use(payer(feePayer))
+  .use(solanaLocalRpc())
+  .use(tokenProgram());
 
 // Fund fee payer
-await airdropFactory({ rpc, rpcSubscriptions })({
-  recipientAddress: feePayer.address,
-  lamports: lamports(1_000_000_000n),
-  commitment: "confirmed",
-});
+await client.airdrop(feePayer.address, lamports(1_000_000_000n));
 
-// Generate keypair to use as address of mint
-const mint = await generateKeyPairSigner();
-console.log("Mint Address:", mint.address.toString());
-
-// Get default mint account size (in bytes), no extensions enabled
-const space = BigInt(getMintSize());
-
-// Get minimum balance for rent exemption
-const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
-
-// Get latest blockhash to include in transaction
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-
-// Instruction to create new account for mint (token  program)
-const createAccountInstruction = getCreateAccountInstruction({
-  payer: feePayer,
-  newAccount: mint,
-  lamports: rent,
-  space,
-  programAddress: TOKEN_PROGRAM_ADDRESS,
-});
-
-// Instruction to initialize mint account data
-const initializeMintInstruction = getInitializeMintInstruction({
-  mint: mint.address,
+// Create the mint and mint 1.00 tokens to sender's ATA
+const createMintIx = client.token.instructions.createMint({
+  newMint: mint,
   decimals: 2,
   mintAuthority: sender.address,
 });
+const mintToSenderIx = await client.token.instructions.mintToATA({
+  mint: mint.address,
+  owner: sender.address,
+  mintAuthority: sender,
+  amount: 100n,
+  decimals: 2,
+});
+
+const setup = await client.sendTransaction([createMintIx, mintToSenderIx]);
+console.log("Transaction Signature:", setup.context.signature);
+console.log("Successfully minted 1.0 tokens");
 
 // Derive the ATAs for fee payer, sender and recipient
-const [feePayerAssociatedTokenAddress] = await findAssociatedTokenPda({
+const [senderAta] = await findAssociatedTokenPda({
+  mint: mint.address,
+  owner: sender.address,
+  tokenProgram: TOKEN_PROGRAM_ADDRESS,
+});
+const [recipientAta] = await findAssociatedTokenPda({
+  mint: mint.address,
+  owner: recipient.address,
+  tokenProgram: TOKEN_PROGRAM_ADDRESS,
+});
+const [feePayerAta] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: feePayer.address,
   tokenProgram: TOKEN_PROGRAM_ADDRESS,
 });
 
-const [senderAssociatedTokenAddress] = await findAssociatedTokenPda({
-  mint: mint.address,
-  owner: sender.address,
-  tokenProgram: TOKEN_PROGRAM_ADDRESS,
-});
-
-const [recipientAssociatedTokenAddress] = await findAssociatedTokenPda({
-  mint: mint.address,
-  owner: recipient.address,
-  tokenProgram: TOKEN_PROGRAM_ADDRESS,
-});
-
-// Create instruction for fee payer's ATA
-const createFeePayerAtaInstruction =
-  await getCreateAssociatedTokenInstructionAsync({
-    payer: feePayer,
-    mint: mint.address,
-    owner: feePayer.address,
-  });
-
-// Create instruction for sender's ATA
-const createSenderAtaInstruction =
-  await getCreateAssociatedTokenInstructionAsync({
-    payer: feePayer,
-    mint: mint.address,
-    owner: sender.address,
-  });
-
-// Create instruction for recipient's ATA
-const createRecipientAtaInstruction =
-  await getCreateAssociatedTokenInstructionAsync({
-    payer: feePayer,
-    mint: mint.address,
-    owner: recipient.address,
-  });
-
-// Create instruction to mint tokens to sender
-const mintToInstruction = getMintToInstruction({
-  mint: mint.address,
-  token: senderAssociatedTokenAddress,
-  mintAuthority: sender,
-  amount: 100n,
-});
-
-// Combine all instructions in order
-const instructions = [
-  createAccountInstruction, // Create mint account
-  initializeMintInstruction, // Initialize mint
-  createFeePayerAtaInstruction, // Create fee payer's ATA
-  createSenderAtaInstruction, // Create sender's ATA
-  createRecipientAtaInstruction, // Create recipient's ATA
-  mintToInstruction, // Mint tokens to sender
-];
-
-// Create transaction message
-const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(feePayer, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions(instructions, tx),
-);
-
-// Sign transaction message with all required signers
-const signedTransaction =
-  await signTransactionMessageWithSigners(transactionMessage);
-assertIsTransactionWithBlockhashLifetime(signedTransaction);
-
-// Send and confirm transaction
-await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-  signedTransaction,
-  { commitment: "confirmed" },
-);
-
-const transactionSignature = getSignatureFromTransaction(signedTransaction);
-console.log("Transaction Signature:", transactionSignature);
-console.log("Successfully minted 1.0 tokens");
-
-// Get a fresh blockhash for the transfer transaction
-const { value: transferBlockhash } = await rpc.getLatestBlockhash().send();
-
 // Transfer tokens to recipient
-const transferInstruction = getTransferInstruction({
-  source: senderAssociatedTokenAddress,
-  destination: recipientAssociatedTokenAddress,
+const transferToRecipientIx = await client.token.instructions.transferToATA({
+  mint: mint.address,
+  source: senderAta,
   authority: sender,
-  amount: 50n, // 0.50 tokens with 2 decimals
+  recipient: recipient.address,
+  amount: 50n,
+  decimals: 2,
 });
 
 // Pay the fee payer in tokens to cover the transaction fees.
 // For a real-world application, calculate this from the SOL fee.
-const transferFeePayerInstruction = getTransferInstruction({
-  source: senderAssociatedTokenAddress,
-  destination: feePayerAssociatedTokenAddress,
+const reimburseFeePayerIx = await client.token.instructions.transferToATA({
+  mint: mint.address,
+  source: senderAta,
   authority: sender,
+  recipient: feePayer.address,
   amount: 50n,
+  decimals: 2,
 });
 
-// Create transaction message for token transfer
-const transferTxMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(feePayer, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(transferBlockhash, tx),
-  (tx) =>
-    appendTransactionMessageInstructions(
-      [transferInstruction, transferFeePayerInstruction],
-      tx,
-    ),
+const transfer = await client.sendTransaction([
+  transferToRecipientIx,
+  reimburseFeePayerIx,
+]);
+console.log("Transaction Signature:", transfer.context.signature);
+console.log(
+  "Successfully transferred 0.5 tokens to recipient + 0.5 to fee payer",
 );
 
-const signedTransferTx =
-  await signTransactionMessageWithSigners(transferTxMessage);
-assertIsTransactionWithBlockhashLifetime(signedTransferTx);
-
-await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-  signedTransferTx,
-  { commitment: "confirmed" },
-);
-
-const transactionSignature2 = getSignatureFromTransaction(signedTransferTx);
-console.log("Transaction Signature:", transactionSignature2);
-console.log("Successfully transferred 0.5 tokens");
-
-const feePayerTokenAccount = await fetchToken(
-  rpc,
-  feePayerAssociatedTokenAddress,
-  { commitment: "confirmed" },
-);
-const senderTokenAccount = await fetchToken(rpc, senderAssociatedTokenAddress, {
-  commitment: "confirmed",
-});
-const recipientTokenAccount = await fetchToken(
-  rpc,
-  recipientAssociatedTokenAddress,
-  { commitment: "confirmed" },
-);
+// Final balances
+const [feePayerAcct, senderAcct, recipientAcct] = await Promise.all([
+  fetchToken(client.rpc, feePayerAta, { commitment: "confirmed" }),
+  fetchToken(client.rpc, senderAta, { commitment: "confirmed" }),
+  fetchToken(client.rpc, recipientAta, { commitment: "confirmed" }),
+]);
 
 console.log("=== Final Balances ===");
 console.log(
   "Fee Payer balance:",
-  Number(feePayerTokenAccount.data.amount) / 100,
+  Number(feePayerAcct.data.amount) / 100,
   "tokens",
 );
-console.log(
-  "Sender balance:",
-  Number(senderTokenAccount.data.amount) / 100,
-  "tokens",
-);
+console.log("Sender balance:", Number(senderAcct.data.amount) / 100, "tokens");
 console.log(
   "Recipient balance:",
-  Number(recipientTokenAccount.data.amount) / 100,
+  Number(recipientAcct.data.amount) / 100,
   "tokens",
 );
 // #endregion pay-fees

--- a/packages/docs-examples/cookbook/transactions/pay-fees-with-any-token/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/pay-fees-with-any-token/kit.ts
@@ -2,12 +2,7 @@
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
 import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
 import { payer } from "@solana/kit-plugin-signer";
-import {
-  fetchToken,
-  findAssociatedTokenPda,
-  TOKEN_PROGRAM_ADDRESS,
-  tokenProgram,
-} from "@solana-program/token";
+import { tokenProgram } from "@solana-program/token";
 
 // Generate keypairs for fee payer, sender, recipient, and mint
 const feePayer = await generateKeyPairSigner();
@@ -48,27 +43,9 @@ const setup = await client.sendTransaction([createMintIx, mintToSenderIx]);
 console.log("Transaction Signature:", setup.context.signature);
 console.log("Successfully minted 1.0 tokens");
 
-// Derive the ATAs for fee payer, sender and recipient
-const [senderAta] = await findAssociatedTokenPda({
-  mint: mint.address,
-  owner: sender.address,
-  tokenProgram: TOKEN_PROGRAM_ADDRESS,
-});
-const [recipientAta] = await findAssociatedTokenPda({
-  mint: mint.address,
-  owner: recipient.address,
-  tokenProgram: TOKEN_PROGRAM_ADDRESS,
-});
-const [feePayerAta] = await findAssociatedTokenPda({
-  mint: mint.address,
-  owner: feePayer.address,
-  tokenProgram: TOKEN_PROGRAM_ADDRESS,
-});
-
 // Transfer tokens to recipient
 const transferToRecipientIx = await client.token.instructions.transferToATA({
   mint: mint.address,
-  source: senderAta,
   authority: sender,
   recipient: recipient.address,
   amount: 50n,
@@ -79,7 +56,6 @@ const transferToRecipientIx = await client.token.instructions.transferToATA({
 // For a real-world application, calculate this from the SOL fee.
 const reimburseFeePayerIx = await client.token.instructions.transferToATA({
   mint: mint.address,
-  source: senderAta,
   authority: sender,
   recipient: feePayer.address,
   amount: 50n,
@@ -95,23 +71,4 @@ console.log(
   "Successfully transferred 0.5 tokens to recipient + 0.5 to fee payer",
 );
 
-// Final balances
-const [feePayerAcct, senderAcct, recipientAcct] = await Promise.all([
-  fetchToken(client.rpc, feePayerAta, { commitment: "confirmed" }),
-  fetchToken(client.rpc, senderAta, { commitment: "confirmed" }),
-  fetchToken(client.rpc, recipientAta, { commitment: "confirmed" }),
-]);
-
-console.log("=== Final Balances ===");
-console.log(
-  "Fee Payer balance:",
-  Number(feePayerAcct.data.amount) / 100,
-  "tokens",
-);
-console.log("Sender balance:", Number(senderAcct.data.amount) / 100, "tokens");
-console.log(
-  "Recipient balance:",
-  Number(recipientAcct.data.amount) / 100,
-  "tokens",
-);
 // #endregion pay-fees

--- a/packages/docs-examples/cookbook/transactions/pay-fees-with-any-token/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/pay-fees-with-any-token/kit.ts
@@ -1,7 +1,7 @@
 // #region pay-fees
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
-import { payer } from "@solana/kit-plugin-signer";
+import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
+import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import { tokenProgram } from "@solana-program/token";
 
 // Generate keypairs for fee payer, sender, recipient, and mint
@@ -15,15 +15,18 @@ console.log("Sender Address:", sender.address);
 console.log("Recipient Address:", recipient.address);
 console.log("Mint Address:", mint.address);
 
-// Build a Kit client: fee payer, local RPC + airdrop + planner + executor,
-// and the token program plugin
-const client = createClient()
+// Build a Kit client: fee payer (funded with 1 SOL), local RPC, and the token program plugin
+const client = await createClient()
   .use(payer(feePayer))
-  .use(solanaLocalRpc())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900",
+    }),
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)))
   .use(tokenProgram());
-
-// Fund fee payer
-await client.airdrop(feePayer.address, lamports(1_000_000_000n));
 
 // Create the mint and mint 1.00 tokens to sender's ATA
 const createMintIx = client.token.instructions.createMint({

--- a/packages/docs-examples/package.json
+++ b/packages/docs-examples/package.json
@@ -17,6 +17,8 @@
     "@solana-program/token": "^0.13.0",
     "@solana-program/token-2022": "^0.9.0",
     "@solana/kit": "^6.8.0",
+    "@solana/kit-plugin-rpc": "^0.11.1",
+    "@solana/kit-plugin-signer": "^0.10.0",
     "@solana/spl-memo": "^0.2.5",
     "@solana/spl-token": "^0.4.14",
     "@solana/web3.js": "^1.98.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,7 +53,7 @@ importers:
         version: 3.8.1
       turbo:
         specifier: latest
-        version: 2.9.10
+        version: 2.9.14
 
   apps/accelerate:
     dependencies:
@@ -1049,7 +1049,7 @@ importers:
         version: 5.2.0(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-turbo:
         specifier: ^2.8.20
-        version: 2.8.20(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.10)
+        version: 2.8.20(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.14)
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -1085,6 +1085,12 @@ importers:
       "@solana/kit":
         specifier: ^6.8.0
         version: 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6)
+      "@solana/kit-plugin-rpc":
+        specifier: ^0.11.1
+        version: 0.11.1(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6))
+      "@solana/kit-plugin-signer":
+        specifier: ^0.10.0
+        version: 0.10.0(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6))
       "@solana/spl-memo":
         specifier: ^0.2.5
         version: 0.2.5(@solana/web3.js@1.98.4(bufferutil@4.1.0)(typescript@5.8.3)(utf-8-validate@6.0.6))
@@ -7884,6 +7890,30 @@ packages:
       typescript:
         optional: true
 
+  "@solana/kit-plugin-instruction-plan@0.10.0":
+    resolution:
+      {
+        integrity: sha512-h99B+1Vp5QWU/M/q0UXlTxKJt781vWw5aAopnbgVCy0F3hNaSDZ/gio126Oz0/cipGOnyaJf3NnV79GvxaEqZA==,
+      }
+    peerDependencies:
+      "@solana/kit": ^6.8.0
+
+  "@solana/kit-plugin-rpc@0.11.1":
+    resolution:
+      {
+        integrity: sha512-NpCKBY6y3lmOOZjzm5dvk/+iZsKOH+Wc9TQx5yKZ0RzNOXC6V9i0Inn+niVdkX5ECDJOmClfa64bLcImFJWLuQ==,
+      }
+    peerDependencies:
+      "@solana/kit": ^6.8.0
+
+  "@solana/kit-plugin-signer@0.10.0":
+    resolution:
+      {
+        integrity: sha512-3Gw3R6nQg/2r2+4cSaUZHj5zdbtb0SuA1mkDMd6uH7B+fdH1Ouxnulv1/sN8J0VxBo7tS+YDQA5t0arxX5gj+w==,
+      }
+    peerDependencies:
+      "@solana/kit": ^6.8.0
+
   "@solana/kit@6.9.0":
     resolution:
       {
@@ -8777,18 +8807,18 @@ packages:
         integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==,
       }
 
-  "@turbo/darwin-64@2.9.10":
+  "@turbo/darwin-64@2.9.14":
     resolution:
       {
-        integrity: sha512-5BVJnes8/zMPydF8ktfBBWqCCpUeWVxwZ6avYHRqLzk2PuTAsLz0TlaKdDe1nk1cz3/o0c+7CEf6zqNXdB2N7Q==,
+        integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@turbo/darwin-arm64@2.9.10":
+  "@turbo/darwin-arm64@2.9.14":
     resolution:
       {
-        integrity: sha512-MwaJl+vsxlkkDJYWN87GWKYD64kOvZFFlrDtGmCDeEx/488Kola5TVgS0VQkEUwnbDPjaDIB7kBMIzdzJRElbg==,
+        integrity: sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==,
       }
     cpu: [arm64]
     os: [darwin]
@@ -8800,34 +8830,34 @@ packages:
       }
     hasBin: true
 
-  "@turbo/linux-64@2.9.10":
+  "@turbo/linux-64@2.9.14":
     resolution:
       {
-        integrity: sha512-HWrCKR+kUicEf4awj1EVRh5LI2hiDncpWZSXqhVj+wQT3SolBSXqXiSPYHgdh6hkmyfvz75Ex/+axXGcgQGdeA==,
+        integrity: sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==,
       }
     cpu: [x64]
     os: [linux]
 
-  "@turbo/linux-arm64@2.9.10":
+  "@turbo/linux-arm64@2.9.14":
     resolution:
       {
-        integrity: sha512-edJINoZcDn4g1zkOZHFrGtLX0EWTryoNJSlZK5SEVux4hITT6hTCzugVGtOUmdI+PuJ/xRRL3jKGa+JgjSoq5A==,
+        integrity: sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==,
       }
     cpu: [arm64]
     os: [linux]
 
-  "@turbo/windows-64@2.9.10":
+  "@turbo/windows-64@2.9.14":
     resolution:
       {
-        integrity: sha512-rkASn89ATUtSyKvhGaWSyqVHBwtqFEUV1rFNKCtthSoix0T/kUHLJDKpepE/Wh6CtSnhxAfsY8cODtevD/hR7A==,
+        integrity: sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==,
       }
     cpu: [x64]
     os: [win32]
 
-  "@turbo/windows-arm64@2.9.10":
+  "@turbo/windows-arm64@2.9.14":
     resolution:
       {
-        integrity: sha512-cblXqub7uABXKNMzvPB1IyOuSQpeMo7zZHSREB2C0mtIVn4lUSd2CfaGBtOrDqmkC9dsan3itxY4IejChQvfpg==,
+        integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==,
       }
     cpu: [arm64]
     os: [win32]
@@ -9467,6 +9497,7 @@ packages:
       {
         integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==,
       }
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   "@urql/core@5.2.0":
     resolution:
@@ -18644,10 +18675,10 @@ packages:
     engines: { node: ">=18.0.0" }
     hasBin: true
 
-  turbo@2.9.10:
+  turbo@2.9.14:
     resolution:
       {
-        integrity: sha512-YBLeNT0wLoysGgQEkvBWE2GA1liGGZ1j13wa7xHTwELJx4ZhM+c2szeXj6wUOUGO86BmyhY0Q/ELWwU3WDXzZA==,
+        integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==,
       }
     hasBin: true
 
@@ -24939,6 +24970,19 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
+  "@solana/kit-plugin-instruction-plan@0.10.0(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6))":
+    dependencies:
+      "@solana/kit": 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6)
+
+  "@solana/kit-plugin-rpc@0.11.1(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6))":
+    dependencies:
+      "@solana/kit": 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6)
+      "@solana/kit-plugin-instruction-plan": 0.10.0(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6))
+
+  "@solana/kit-plugin-signer@0.10.0(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6))":
+    dependencies:
+      "@solana/kit": 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6)
+
   "@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6)":
     dependencies:
       "@solana/accounts": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -25670,10 +25714,10 @@ snapshots:
 
   "@tsconfig/node16@1.0.4": {}
 
-  "@turbo/darwin-64@2.9.10":
+  "@turbo/darwin-64@2.9.14":
     optional: true
 
-  "@turbo/darwin-arm64@2.9.10":
+  "@turbo/darwin-arm64@2.9.14":
     optional: true
 
   "@turbo/gen@2.5.8(@types/node@24.6.2)(typescript@5.9.2)":
@@ -25696,16 +25740,16 @@ snapshots:
       - supports-color
       - typescript
 
-  "@turbo/linux-64@2.9.10":
+  "@turbo/linux-64@2.9.14":
     optional: true
 
-  "@turbo/linux-arm64@2.9.10":
+  "@turbo/linux-arm64@2.9.14":
     optional: true
 
-  "@turbo/windows-64@2.9.10":
+  "@turbo/windows-64@2.9.14":
     optional: true
 
-  "@turbo/windows-arm64@2.9.10":
+  "@turbo/windows-arm64@2.9.14":
     optional: true
 
   "@turbo/workspaces@2.5.8(@types/node@24.6.2)":
@@ -27895,11 +27939,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-turbo@2.8.20(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.10):
+  eslint-plugin-turbo@2.8.20(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.14):
     dependencies:
       dotenv: 16.0.3
       eslint: 9.39.4(jiti@2.6.1)
-      turbo: 2.9.10
+      turbo: 2.9.14
 
   eslint-scope@5.1.1:
     dependencies:
@@ -32514,14 +32558,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo@2.9.10:
+  turbo@2.9.14:
     optionalDependencies:
-      "@turbo/darwin-64": 2.9.10
-      "@turbo/darwin-arm64": 2.9.10
-      "@turbo/linux-64": 2.9.10
-      "@turbo/linux-arm64": 2.9.10
-      "@turbo/windows-64": 2.9.10
-      "@turbo/windows-arm64": 2.9.10
+      "@turbo/darwin-64": 2.9.14
+      "@turbo/darwin-arm64": 2.9.14
+      "@turbo/linux-64": 2.9.14
+      "@turbo/linux-arm64": 2.9.14
+      "@turbo/windows-64": 2.9.14
+      "@turbo/windows-arm64": 2.9.14
 
   tw-animate-css@1.4.0: {}
 


### PR DESCRIPTION
## Summary

- Rewrite `packages/docs-examples/cookbook/transactions/pay-fees-with-any-token/kit.ts` using `createClient().use(payer(...)).use(solanaLocalRpc()).use(tokenProgram())` and `client.token.instructions.{createMint,mintToATA,transferToATA}` + `client.sendTransaction([...])` instead of manual pipe/blockhash/signing/ATA wiring.
- Adds `@solana/kit-plugin-rpc@^0.11.1` and `@solana/kit-plugin-signer@^0.10.0` to `@workspace/docs-examples`.
- 238 → 115 lines, same on-chain behavior.

## Test plan

- [x] `pnpm --filter @workspace/docs-examples lint`
- [x] `pnpm --filter @workspace/docs-examples test` (kit + legacy both pass, final balances match)