### PR TITLE
cookbook tokens: point Token-2022 fetch examples at mainnet

### DIFF
--- a/packages/docs-examples/cookbook/tokens/get-token-account/kit.ts
+++ b/packages/docs-examples/cookbook/tokens/get-token-account/kit.ts
@@ -6,7 +6,7 @@ import {
 } from "@solana-program/token-2022";
 import { address, createSolanaRpc } from "@solana/kit";
 
-const rpc = createSolanaRpc("http://localhost:8899");
+const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 
 const mintAddress = address("2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo");
 const authority = address("AC5RDfQFmDS1deWZos921JfqscXdByf8BKHs5ACWjtW2");

--- a/packages/docs-examples/cookbook/tokens/get-token-account/legacy.ts
+++ b/packages/docs-examples/cookbook/tokens/get-token-account/legacy.ts
@@ -2,7 +2,10 @@
 import { Connection, PublicKey } from "@solana/web3.js";
 import { getAccount, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
 
-const connection = new Connection("http://localhost:8899", "confirmed");
+const connection = new Connection(
+  "https://api.mainnet.solana.com",
+  "confirmed",
+);
 
 const tokenAccountPubkey = new PublicKey(
   "GfVPzUxMDvhFJ1Xs6C9i47XQRSapTd8LHw5grGuTquyQ",

--- a/packages/docs-examples/cookbook/tokens/get-token-account/rust/src/main.rs
+++ b/packages/docs-examples/cookbook/tokens/get-token-account/rust/src/main.rs
@@ -14,7 +14,7 @@ use spl_token_2022_interface::{
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
+        String::from("https://api.mainnet.solana.com"),
         CommitmentConfig::confirmed(),
     );
 

--- a/packages/docs-examples/cookbook/tokens/get-token-balance/kit.ts
+++ b/packages/docs-examples/cookbook/tokens/get-token-balance/kit.ts
@@ -1,7 +1,7 @@
 // #region balance
 import { address, createSolanaRpc } from "@solana/kit";
 
-const rpc = createSolanaRpc("http://localhost:8899");
+const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 
 const tokenAccountAddress = address(
   "GfVPzUxMDvhFJ1Xs6C9i47XQRSapTd8LHw5grGuTquyQ",

--- a/packages/docs-examples/cookbook/tokens/get-token-balance/legacy.ts
+++ b/packages/docs-examples/cookbook/tokens/get-token-balance/legacy.ts
@@ -1,7 +1,10 @@
 // #region balance
 import { Connection, PublicKey } from "@solana/web3.js";
 
-const connection = new Connection("http://localhost:8899", "confirmed");
+const connection = new Connection(
+  "https://api.mainnet.solana.com",
+  "confirmed",
+);
 
 const tokenAccount = new PublicKey(
   "GfVPzUxMDvhFJ1Xs6C9i47XQRSapTd8LHw5grGuTquyQ",

--- a/packages/docs-examples/cookbook/tokens/get-token-balance/rust/src/main.rs
+++ b/packages/docs-examples/cookbook/tokens/get-token-balance/rust/src/main.rs
@@ -6,7 +6,7 @@ use solana_sdk::pubkey;
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
+        String::from("https://api.mainnet.solana.com"),
         CommitmentConfig::confirmed(),
     );
 

--- a/packages/docs-examples/cookbook/tokens/get-token-mint/kit.ts
+++ b/packages/docs-examples/cookbook/tokens/get-token-mint/kit.ts
@@ -2,7 +2,7 @@
 import { Address, createSolanaRpc } from "@solana/kit";
 import { fetchMint } from "@solana-program/token-2022";
 
-const rpc = createSolanaRpc("http://localhost:8899");
+const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 const address = "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo" as Address;
 
 const mint = await fetchMint(rpc, address);

--- a/packages/docs-examples/cookbook/tokens/get-token-mint/legacy.ts
+++ b/packages/docs-examples/cookbook/tokens/get-token-mint/legacy.ts
@@ -2,7 +2,10 @@
 import { Connection, PublicKey } from "@solana/web3.js";
 import { getMint, TOKEN_2022_PROGRAM_ID } from "@solana/spl-token";
 
-const connection = new Connection("http://localhost:8899", "confirmed");
+const connection = new Connection(
+  "https://api.mainnet.solana.com",
+  "confirmed",
+);
 
 const mintAddress = new PublicKey(
   "2b1kV6DkPAnxd5ixfnxCpjxmKwqjjaYmCZfHsFu24GXo",

--- a/packages/docs-examples/cookbook/tokens/get-token-mint/rust/src/main.rs
+++ b/packages/docs-examples/cookbook/tokens/get-token-mint/rust/src/main.rs
@@ -16,7 +16,7 @@ use spl_token_2022_interface::{
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let client = RpcClient::new_with_commitment(
-        String::from("http://localhost:8899"),
+        String::from("https://api.mainnet.solana.com"),
         CommitmentConfig::confirmed(),
     );
 


### PR DESCRIPTION
### Problem 

 get-token-account, get-token-balance, and get-token-mint hit Token-2022 accounts that the surfnet doesn't lazy-clone cleanly (the rewriter swaps localhost for the hosted surfnet, which returns null for these two)

Other read-only pages still work because their accounts are classic-Token / Token Program itself, which surfnet does have

### Summary of Changes

Switch the URL to api.mainnet.solana.com so the Run button leaves it alone and the code hits mainnet
