### PR TITLE
docs(cookbook): upgrade kit examples to plugin client

### DIFF
--- a/apps/docs/content/cookbook/accounts/create-account.mdx
+++ b/apps/docs/content/cookbook/accounts/create-account.mdx
@@ -24,7 +24,7 @@ can then initialize the account data through its own instructions.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Kit" file=packages/docs-examples/cookbook/accounts/create-account/kit.ts#region=create highlight=13-16,30
+```ts !! title="Kit" file=packages/docs-examples/cookbook/accounts/create-account/kit.ts#region=create
 
 ```
 

--- a/apps/docs/content/cookbook/accounts/create-account.mdx
+++ b/apps/docs/content/cookbook/accounts/create-account.mdx
@@ -24,7 +24,7 @@ can then initialize the account data through its own instructions.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Kit" file=packages/docs-examples/cookbook/accounts/create-account/kit.ts#region=create highlight=38-44
+```ts !! title="Kit" file=packages/docs-examples/cookbook/accounts/create-account/kit.ts#region=create highlight=13-16,30
 
 ```
 

--- a/apps/docs/content/cookbook/transactions/add-memo.mdx
+++ b/apps/docs/content/cookbook/transactions/add-memo.mdx
@@ -9,7 +9,7 @@ Any transaction can add a message making use of the SPL memo program.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/add-memo/kit.ts#region=memo highlight=30-32
+```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/add-memo/kit.ts#region=memo highlight=10-13,19
 
 ```
 

--- a/apps/docs/content/cookbook/transactions/add-memo.mdx
+++ b/apps/docs/content/cookbook/transactions/add-memo.mdx
@@ -9,7 +9,7 @@ Any transaction can add a message making use of the SPL memo program.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/add-memo/kit.ts#region=memo highlight=10-13,19
+```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/add-memo/kit.ts#region=memo
 
 ```
 

--- a/apps/docs/content/cookbook/transactions/add-priority-fees.mdx
+++ b/apps/docs/content/cookbook/transactions/add-priority-fees.mdx
@@ -12,7 +12,7 @@ To add a priority fee to a transaction, invoke instructions from the
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/add-priority-fees/kit.ts#region=priority highlight=57,72
+```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/add-priority-fees/kit.ts#region=priority highlight=21-26,32
 
 ```
 

--- a/apps/docs/content/cookbook/transactions/add-priority-fees.mdx
+++ b/apps/docs/content/cookbook/transactions/add-priority-fees.mdx
@@ -12,7 +12,7 @@ To add a priority fee to a transaction, invoke instructions from the
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/add-priority-fees/kit.ts#region=priority highlight=21-26,32
+```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/add-priority-fees/kit.ts#region=priority
 
 ```
 

--- a/apps/docs/content/cookbook/transactions/send-sol.mdx
+++ b/apps/docs/content/cookbook/transactions/send-sol.mdx
@@ -11,7 +11,7 @@ instruction.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/send-sol/kit.ts#region=transfer highlight=34-38
+```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/send-sol/kit.ts#region=transfer highlight=13-16,24
 
 ```
 

--- a/apps/docs/content/cookbook/transactions/send-sol.mdx
+++ b/apps/docs/content/cookbook/transactions/send-sol.mdx
@@ -11,7 +11,7 @@ instruction.
 
 <CodeTabs storage="cookbook" flags="r">
 
-```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/send-sol/kit.ts#region=transfer highlight=13-16,24
+```ts !! title="Kit" file=packages/docs-examples/cookbook/transactions/send-sol/kit.ts#region=transfer
 
 ```
 

--- a/packages/docs-examples/cookbook/accounts/create-account/kit.ts
+++ b/packages/docs-examples/cookbook/accounts/create-account/kit.ts
@@ -1,64 +1,32 @@
 // #region create
-import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  assertIsTransactionWithBlockhashLifetime,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  sendAndConfirmTransactionFactory,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-} from "@solana/kit";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import {
   getCreateAccountInstruction,
   SYSTEM_PROGRAM_ADDRESS,
 } from "@solana-program/system";
 
-const rpc = createSolanaRpc("http://localhost:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
-
 const sender = await generateKeyPairSigner();
 const LAMPORTS_PER_SOL = 1_000_000_000n;
-await airdropFactory({ rpc, rpcSubscriptions })({
-  recipientAddress: sender.address,
-  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
-  commitment: "confirmed",
-});
+
+const client = await createClient()
+  .use(payer(sender))
+  .use(solanaLocalRpc())
+  .use(airdropPayer(lamports(LAMPORTS_PER_SOL)));
 
 const newAccount = await generateKeyPairSigner();
-
-const space = 0n;
-const rentLamports = await rpc.getMinimumBalanceForRentExemption(space).send();
+const space = 0;
+const rentLamports = await client.getMinimumBalance(space);
 
 const createAccountInstruction = getCreateAccountInstruction({
   payer: sender,
-  newAccount: newAccount,
+  newAccount,
   lamports: rentLamports,
   programAddress: SYSTEM_PROGRAM_ADDRESS,
   space,
 });
 
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(sender, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions([createAccountInstruction], tx),
-);
-
-const signedTransaction =
-  await signTransactionMessageWithSigners(transactionMessage);
-assertIsTransactionWithBlockhashLifetime(signedTransaction);
-await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-  signedTransaction,
-  { commitment: "confirmed" },
-);
-const transactionSignature = getSignatureFromTransaction(signedTransaction);
-console.log("Transaction Signature for create account:", transactionSignature);
+const { context } = await client.sendTransaction([createAccountInstruction]);
+console.log("Transaction Signature for create account:", context.signature);
 // #endregion create

--- a/packages/docs-examples/cookbook/accounts/create-account/kit.ts
+++ b/packages/docs-examples/cookbook/accounts/create-account/kit.ts
@@ -1,6 +1,6 @@
 // #region create
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
 import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import {
   getCreateAccountInstruction,
@@ -12,7 +12,13 @@ const LAMPORTS_PER_SOL = 1_000_000_000n;
 
 const client = await createClient()
   .use(payer(sender))
-  .use(solanaLocalRpc())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900",
+    }),
+  )
+  .use(rpcAirdrop())
   .use(airdropPayer(lamports(LAMPORTS_PER_SOL)));
 
 const newAccount = await generateKeyPairSigner();

--- a/packages/docs-examples/cookbook/tokens/create-token-with-metadata/kit.ts
+++ b/packages/docs-examples/cookbook/tokens/create-token-with-metadata/kit.ts
@@ -1,6 +1,6 @@
 // #region create
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
 import { airdropPayer, payer as kitPayer } from "@solana/kit-plugin-signer";
 import {
   getCreateV1InstructionAsync,
@@ -13,7 +13,13 @@ const mint = await generateKeyPairSigner();
 
 const client = await createClient()
   .use(kitPayer(payer))
-  .use(solanaLocalRpc())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900",
+    }),
+  )
+  .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
 // Create token with metadata

--- a/packages/docs-examples/cookbook/tokens/create-token-with-metadata/kit.ts
+++ b/packages/docs-examples/cookbook/tokens/create-token-with-metadata/kit.ts
@@ -1,40 +1,20 @@
 // #region create
-import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  assertIsTransactionWithBlockhashLifetime,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  lamports,
-  pipe,
-  sendAndConfirmTransactionFactory,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-} from "@solana/kit";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { airdropPayer, payer as kitPayer } from "@solana/kit-plugin-signer";
 import {
   getCreateV1InstructionAsync,
   fetchMetadataFromSeeds,
   TokenStandard,
 } from "@metaplex-foundation/mpl-token-metadata-kit";
 
-// Create connection to local validator
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://127.0.0.1:8900");
-
-// Generate keypairs
 const payer = await generateKeyPairSigner();
 const mint = await generateKeyPairSigner();
 
-// Airdrop SOL to payer
-const airdrop = airdropFactory({ rpc, rpcSubscriptions });
-await airdrop({
-  recipientAddress: payer.address,
-  lamports: lamports(1_000_000_000n),
-  commitment: "confirmed",
-});
+const client = await createClient()
+  .use(kitPayer(payer))
+  .use(solanaLocalRpc())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 // Create token with metadata
 const createInstruction = await getCreateV1InstructionAsync({
@@ -48,27 +28,13 @@ const createInstruction = await getCreateV1InstructionAsync({
   tokenStandard: TokenStandard.Fungible,
 });
 
-// Build and send transaction
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-
-const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(payer, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions([createInstruction], tx),
-);
-
-const signedTransaction =
-  await signTransactionMessageWithSigners(transactionMessage);
-assertIsTransactionWithBlockhashLifetime(signedTransaction);
-
-await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-  signedTransaction,
-  { commitment: "confirmed" },
-);
+const { context } = await client.sendTransaction([createInstruction]);
+console.log("Transaction Signature:", context.signature);
 
 // Verify metadata was created
-const metadata = await fetchMetadataFromSeeds(rpc, { mint: mint.address });
+const metadata = await fetchMetadataFromSeeds(client.rpc, {
+  mint: mint.address,
+});
 
 console.log("Mint Address:", mint.address);
 console.log("Token Name:", metadata.data.name);

--- a/packages/docs-examples/cookbook/transactions/add-memo/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/add-memo/kit.ts
@@ -1,52 +1,21 @@
 // #region memo
-import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  assertIsTransactionWithBlockhashLifetime,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  sendAndConfirmTransactionFactory,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-} from "@solana/kit";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import { getAddMemoInstruction } from "@solana-program/memo";
-
-const rpc = createSolanaRpc("http://localhost:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 const sender = await generateKeyPairSigner();
 const LAMPORTS_PER_SOL = 1_000_000_000n;
-await airdropFactory({ rpc, rpcSubscriptions })({
-  recipientAddress: sender.address,
-  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
-  commitment: "confirmed",
-});
+
+const client = await createClient()
+  .use(payer(sender))
+  .use(solanaLocalRpc())
+  .use(airdropPayer(lamports(LAMPORTS_PER_SOL)));
 
 const memoInstruction = getAddMemoInstruction({
   memo: "Hello, world!",
 });
 
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(sender, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions([memoInstruction], tx),
-);
-
-const signedTransaction =
-  await signTransactionMessageWithSigners(transactionMessage);
-assertIsTransactionWithBlockhashLifetime(signedTransaction);
-await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-  signedTransaction,
-  { commitment: "confirmed" },
-);
-const transactionSignature = getSignatureFromTransaction(signedTransaction);
-console.log("Transaction Signature:", transactionSignature);
+const { context } = await client.sendTransaction([memoInstruction]);
+console.log("Transaction Signature:", context.signature);
 // #endregion memo

--- a/packages/docs-examples/cookbook/transactions/add-memo/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/add-memo/kit.ts
@@ -1,6 +1,6 @@
 // #region memo
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
 import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import { getAddMemoInstruction } from "@solana-program/memo";
 
@@ -9,7 +9,13 @@ const LAMPORTS_PER_SOL = 1_000_000_000n;
 
 const client = await createClient()
   .use(payer(sender))
-  .use(solanaLocalRpc())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900",
+    }),
+  )
+  .use(rpcAirdrop())
   .use(airdropPayer(lamports(LAMPORTS_PER_SOL)));
 
 const memoInstruction = getAddMemoInstruction({

--- a/packages/docs-examples/cookbook/transactions/add-priority-fees/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/add-priority-fees/kit.ts
@@ -5,7 +5,7 @@ import {
   lamports,
   type MicroLamports,
 } from "@solana/kit";
-import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
 import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import { getAddMemoInstruction } from "@solana-program/memo";
 
@@ -18,13 +18,16 @@ const keypairSigner = await generateKeyPairSigner();
 const client = await createClient()
   .use(payer(keypairSigner))
   .use(
-    solanaLocalRpc({
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900",
       transactionConfig: {
         microLamportsPerComputeUnit: 5000n as MicroLamports,
         version: "legacy",
       },
     }),
   )
+  .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
 const memoInstruction = getAddMemoInstruction({ memo: "Hello, world!" });

--- a/packages/docs-examples/cookbook/transactions/add-priority-fees/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/add-priority-fees/kit.ts
@@ -1,84 +1,34 @@
 // #region priority
 import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  assertIsTransactionWithBlockhashLifetime,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  createTransactionMessage,
+  createClient,
   generateKeyPairSigner,
-  estimateComputeUnitLimitFactory,
-  getSignatureFromTransaction,
   lamports,
-  pipe,
-  prependTransactionMessageInstructions,
-  sendAndConfirmTransactionFactory,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
+  type MicroLamports,
 } from "@solana/kit";
-import {
-  getSetComputeUnitLimitInstruction,
-  getSetComputeUnitPriceInstruction,
-} from "@solana-program/compute-budget";
-
+import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import { getAddMemoInstruction } from "@solana-program/memo";
-
-// Create an RPC
-const rpc = createSolanaRpc("http://localhost:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
-
-// Create utility functions
-const airdrop = airdropFactory({ rpc, rpcSubscriptions });
-const getComputeUnitEstimate = estimateComputeUnitLimitFactory({ rpc });
-const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
-  rpc,
-  rpcSubscriptions,
-});
 
 // Create and fund an account
 const keypairSigner = await generateKeyPairSigner();
 
-await airdrop({
-  commitment: "confirmed",
-  lamports: lamports(1_000_000n),
-  recipientAddress: keypairSigner.address,
-});
+// Configure priority fees on the client. The transaction planner will add a
+// SetComputeUnitPrice instruction, and the executor will simulate the
+// transaction to estimate compute units and add a SetComputeUnitLimit.
+const client = await createClient()
+  .use(payer(keypairSigner))
+  .use(
+    solanaLocalRpc({
+      transactionConfig: {
+        microLamportsPerComputeUnit: 5000n as MicroLamports,
+        version: "legacy",
+      },
+    }),
+  )
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
-// Create a memo transaction
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-const transactionMessage = pipe(
-  createTransactionMessage({ version: "legacy" }),
-  (m) => setTransactionMessageFeePayerSigner(keypairSigner, m),
-  (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
-  (m) =>
-    appendTransactionMessageInstructions(
-      [
-        getSetComputeUnitPriceInstruction({ microLamports: 5000n }),
-        getAddMemoInstruction({ memo: "Hello, world!" }),
-      ],
-      m,
-    ),
-);
+const memoInstruction = getAddMemoInstruction({ memo: "Hello, world!" });
 
-// Estimate compute units for this transaction
-const estimatedComputeUnits = await getComputeUnitEstimate(transactionMessage);
-console.log(
-  `Transaction is estimated to consume ${estimatedComputeUnits} compute units`,
-);
-
-// Add compute unit limit instruction to the transaction
-const budgetedTransactionMessage = prependTransactionMessageInstructions(
-  [getSetComputeUnitLimitInstruction({ units: estimatedComputeUnits })],
-  transactionMessage,
-);
-
-// Sign and send the transaction
-const signedTx = await signTransactionMessageWithSigners(
-  budgetedTransactionMessage,
-);
-assertIsTransactionWithBlockhashLifetime(signedTx);
-const transactionSignature = getSignatureFromTransaction(signedTx);
-await sendAndConfirmTransaction(signedTx, { commitment: "confirmed" });
-console.log(`Transaction Signature: ${transactionSignature}`);
+const { context } = await client.sendTransaction([memoInstruction]);
+console.log(`Transaction Signature: ${context.signature}`);
 // #endregion priority

--- a/packages/docs-examples/cookbook/transactions/calculate-cost/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/calculate-cost/kit.ts
@@ -19,7 +19,7 @@ import {
   signTransactionMessageWithSigners,
   type TransactionMessageBytesBase64,
 } from "@solana/kit";
-import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
 import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import {
   getSetComputeUnitLimitInstruction,
@@ -31,7 +31,13 @@ import { getAddMemoInstruction } from "@solana-program/memo";
 const signer = await generateKeyPairSigner();
 const client = await createClient()
   .use(payer(signer))
-  .use(solanaLocalRpc())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900",
+    }),
+  )
+  .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 console.log("Create and fund account with address", signer.address);
 

--- a/packages/docs-examples/cookbook/transactions/calculate-cost/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/calculate-cost/kit.ts
@@ -1,11 +1,9 @@
 // #region cost
 import {
-  airdropFactory,
   appendTransactionMessageInstructions,
   assertIsTransactionWithBlockhashLifetime,
   compileTransactionMessage,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
+  createClient,
   createTransactionMessage,
   estimateComputeUnitLimitFactory,
   generateKeyPairSigner,
@@ -21,36 +19,28 @@ import {
   signTransactionMessageWithSigners,
   type TransactionMessageBytesBase64,
 } from "@solana/kit";
+import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import {
   getSetComputeUnitLimitInstruction,
   getSetComputeUnitPriceInstruction,
 } from "@solana-program/compute-budget";
 import { getAddMemoInstruction } from "@solana-program/memo";
 
-// 1. Setup RPC connections
-const rpc = createSolanaRpc("http://localhost:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
-
-// 2. Create utility functions
-const getComputeUnitEstimate = estimateComputeUnitLimitFactory({ rpc });
-const sendAndConfirmTransaction = sendAndConfirmTransactionFactory({
-  rpc,
-  rpcSubscriptions,
-});
-const airdrop = airdropFactory({ rpc, rpcSubscriptions });
-
-// 3. Create and fund an account
+// 1. Spin up a client with localhost RPC, fund the payer.
 const signer = await generateKeyPairSigner();
-await airdrop({
-  commitment: "confirmed",
-  lamports: lamports(1_000_000n),
-  recipientAddress: signer.address,
-});
+const client = await createClient()
+  .use(payer(signer))
+  .use(solanaLocalRpc())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 console.log("Create and fund account with address", signer.address);
 
-// 4. Create a memo transaction
-console.log("Creating a memo transaction");
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+// 2. Build a memo transaction manually so we can inspect its fee before sending.
+const getComputeUnitEstimate = estimateComputeUnitLimitFactory({
+  rpc: client.rpc,
+});
+
+const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
 const transactionMessage = pipe(
   createTransactionMessage({ version: "legacy" }),
   (m) => setTransactionMessageFeePayerSigner(signer, m),
@@ -65,19 +55,18 @@ const transactionMessage = pipe(
     ),
 );
 
-// 5. Estimate compute units
+// 3. Estimate compute units and add a SetComputeUnitLimit instruction.
 const estimatedComputeUnits = await getComputeUnitEstimate(transactionMessage);
 console.log(
   `Transaction is estimated to consume ${estimatedComputeUnits} compute units`,
 );
 
-// 6. Add compute unit limit instruction to the transaction
 const budgetedTransactionMessage = prependTransactionMessageInstructions(
   [getSetComputeUnitLimitInstruction({ units: estimatedComputeUnits })],
   transactionMessage,
 );
 
-// 7. Calculate transaction fee
+// 4. Calculate the transaction fee with getFeeForMessage.
 const base64EncodedMessage = pipe(
   budgetedTransactionMessage,
   compileTransactionMessage,
@@ -85,12 +74,14 @@ const base64EncodedMessage = pipe(
   getBase64Decoder().decode,
 ) as TransactionMessageBytesBase64;
 
-const transactionCost = await rpc.getFeeForMessage(base64EncodedMessage).send();
+const transactionCost = await client.rpc
+  .getFeeForMessage(base64EncodedMessage)
+  .send();
 console.log(
   "Transaction is estimated to cost " + transactionCost.value + " lamports",
 );
 
-// 8. Sign and send the transaction
+// 5. Sign and send.
 const signedTx = await signTransactionMessageWithSigners(
   budgetedTransactionMessage,
 );
@@ -98,5 +89,8 @@ assertIsTransactionWithBlockhashLifetime(signedTx);
 const transactionSignature = getSignatureFromTransaction(signedTx);
 console.log("Transaction Signature:", transactionSignature);
 
-await sendAndConfirmTransaction(signedTx, { commitment: "confirmed" });
+await sendAndConfirmTransactionFactory({
+  rpc: client.rpc,
+  rpcSubscriptions: client.rpcSubscriptions,
+})(signedTx, { commitment: "confirmed" });
 // #endregion cost

--- a/packages/docs-examples/cookbook/transactions/fee-sponsorship/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/fee-sponsorship/kit.ts
@@ -1,6 +1,6 @@
 // #region sponsor
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
 import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import {
   fetchToken,
@@ -23,7 +23,13 @@ console.log("Mint Address:", mint.address);
 // Build a Kit client: fee payer (funded with 1 SOL), local RPC, and the token program plugin
 const client = await createClient()
   .use(payer(feePayer))
-  .use(solanaLocalRpc())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900",
+    }),
+  )
+  .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)))
   .use(tokenProgram());
 

--- a/packages/docs-examples/cookbook/transactions/fee-sponsorship/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/fee-sponsorship/kit.ts
@@ -1,177 +1,81 @@
 // #region sponsor
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  assertIsTransactionWithBlockhashLifetime,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  sendAndConfirmTransactionFactory,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-} from "@solana/kit";
-import { getCreateAccountInstruction } from "@solana-program/system";
-import {
-  getCreateAssociatedTokenInstructionAsync,
-  getInitializeMintInstruction,
-  getMintSize,
-  TOKEN_PROGRAM_ADDRESS,
-  findAssociatedTokenPda,
-  getMintToInstruction,
-  getTransferInstruction,
   fetchToken,
+  findAssociatedTokenPda,
+  tokenProgram,
+  TOKEN_PROGRAM_ADDRESS,
 } from "@solana-program/token";
 
-const rpc = createSolanaRpc("http://localhost:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
-
-// Generate keypairs for fee payer, sender and recipient
+// Generate keypairs for fee payer, sender, recipient, and mint
 const feePayer = await generateKeyPairSigner();
 const sender = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
-
-console.log("Fee Payer Address:", feePayer.address.toString());
-console.log("Sender Address:", sender.address.toString());
-console.log("Recipient Address:", recipient.address.toString());
-
-// Fund fee payer
-await airdropFactory({ rpc, rpcSubscriptions })({
-  recipientAddress: feePayer.address,
-  lamports: lamports(1_000_000_000n),
-  commitment: "confirmed",
-});
-
-// Generate keypair to use as address of mint
 const mint = await generateKeyPairSigner();
-console.log("Mint Address:", mint.address.toString());
 
-// Get default mint account size (in bytes), no extensions enabled
-const space = BigInt(getMintSize());
-const rent = await rpc.getMinimumBalanceForRentExemption(space).send();
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+console.log("Fee Payer Address:", feePayer.address);
+console.log("Sender Address:", sender.address);
+console.log("Recipient Address:", recipient.address);
+console.log("Mint Address:", mint.address);
 
-// Instructions to create + initialize the mint, and create the ATAs
-const createAccountInstruction = getCreateAccountInstruction({
-  payer: feePayer,
-  newAccount: mint,
-  lamports: rent,
-  space,
-  programAddress: TOKEN_PROGRAM_ADDRESS,
-});
+// Build a Kit client: fee payer (funded with 1 SOL), local RPC, and the token program plugin
+const client = await createClient()
+  .use(payer(feePayer))
+  .use(solanaLocalRpc())
+  .use(airdropPayer(lamports(1_000_000_000n)))
+  .use(tokenProgram());
 
-const initializeMintInstruction = getInitializeMintInstruction({
-  mint: mint.address,
+// Create the mint and mint 1.00 tokens to sender's ATA (the plugin auto-creates the ATA)
+const createMintIx = client.token.instructions.createMint({
+  newMint: mint,
   decimals: 2,
   mintAuthority: sender.address,
 });
+const mintToSenderIx = await client.token.instructions.mintToATA({
+  mint: mint.address,
+  owner: sender.address,
+  mintAuthority: sender,
+  amount: 100n,
+  decimals: 2,
+});
 
-const [senderAssociatedTokenAddress] = await findAssociatedTokenPda({
+const setup = await client.sendTransaction([createMintIx, mintToSenderIx]);
+console.log("Transaction Signature:", setup.context.signature);
+console.log("Successfully minted 1.0 tokens");
+
+// Transfer 0.50 tokens from sender to recipient — fee paid by feePayer
+const transferToRecipientIx = await client.token.instructions.transferToATA({
+  mint: mint.address,
+  authority: sender,
+  recipient: recipient.address,
+  amount: 50n,
+  decimals: 2,
+});
+
+const transfer = await client.sendTransaction([transferToRecipientIx]);
+console.log("Transaction Signature:", transfer.context.signature);
+console.log("Successfully transferred 0.5 tokens");
+
+// Verify final balances
+const [senderAta] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: sender.address,
   tokenProgram: TOKEN_PROGRAM_ADDRESS,
 });
-
-const [recipientAssociatedTokenAddress] = await findAssociatedTokenPda({
+const [recipientAta] = await findAssociatedTokenPda({
   mint: mint.address,
   owner: recipient.address,
   tokenProgram: TOKEN_PROGRAM_ADDRESS,
 });
 
-console.log("Sender ATA:", senderAssociatedTokenAddress.toString());
-console.log("Recipient ATA:", recipientAssociatedTokenAddress.toString());
-
-const createSenderAtaInstruction =
-  await getCreateAssociatedTokenInstructionAsync({
-    payer: feePayer,
-    mint: mint.address,
-    owner: sender.address,
-  });
-
-const createRecipientAtaInstruction =
-  await getCreateAssociatedTokenInstructionAsync({
-    payer: feePayer,
-    mint: mint.address,
-    owner: recipient.address,
-  });
-
-const mintToInstruction = getMintToInstruction({
-  mint: mint.address,
-  token: senderAssociatedTokenAddress,
-  mintAuthority: sender,
-  amount: 100n,
-});
-
-const instructions = [
-  createAccountInstruction,
-  initializeMintInstruction,
-  createSenderAtaInstruction,
-  createRecipientAtaInstruction,
-  mintToInstruction,
-];
-
-const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(feePayer, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions(instructions, tx),
-);
-
-const signedTransaction =
-  await signTransactionMessageWithSigners(transactionMessage);
-assertIsTransactionWithBlockhashLifetime(signedTransaction);
-
-await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-  signedTransaction,
-  { commitment: "confirmed" },
-);
-
-const transactionSignature = getSignatureFromTransaction(signedTransaction);
-console.log("Transaction Signature:", transactionSignature);
-console.log("Successfully minted 1.0 tokens");
-
-// Transfer 0.50 tokens from sender to recipient — fee paid by feePayer
-const { value: transferBlockhash } = await rpc.getLatestBlockhash().send();
-
-const transferInstruction = getTransferInstruction({
-  source: senderAssociatedTokenAddress,
-  destination: recipientAssociatedTokenAddress,
-  authority: sender,
-  amount: 50n,
-});
-
-const transferTxMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(feePayer, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(transferBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions([transferInstruction], tx),
-);
-
-const signedTransferTx =
-  await signTransactionMessageWithSigners(transferTxMessage);
-assertIsTransactionWithBlockhashLifetime(signedTransferTx);
-
-await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-  signedTransferTx,
-  { commitment: "confirmed" },
-);
-
-const transactionSignature2 = getSignatureFromTransaction(signedTransferTx);
-console.log("Transaction Signature:", transactionSignature2);
-console.log("Successfully transferred 0.5 tokens");
-
-const senderTokenAccount = await fetchToken(rpc, senderAssociatedTokenAddress, {
+const senderTokenAccount = await fetchToken(client.rpc, senderAta, {
   commitment: "confirmed",
 });
-const recipientTokenAccount = await fetchToken(
-  rpc,
-  recipientAssociatedTokenAddress,
-  { commitment: "confirmed" },
-);
+const recipientTokenAccount = await fetchToken(client.rpc, recipientAta, {
+  commitment: "confirmed",
+});
 
 console.log("=== Final Balances ===");
 console.log(

--- a/packages/docs-examples/cookbook/transactions/mev-protection/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/mev-protection/kit.ts
@@ -16,7 +16,7 @@ import {
   type Address,
   type Instruction,
 } from "@solana/kit";
-import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
 import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import { getTransferSolInstruction } from "@solana-program/system";
 
@@ -65,7 +65,13 @@ const signer = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
 const client = await createClient()
   .use(payer(signer))
-  .use(solanaLocalRpc())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900",
+    }),
+  )
+  .use(rpcAirdrop())
   .use(airdropPayer(lamports(1_000_000_000n)));
 
 // Build a transfer with dontfront protection

--- a/packages/docs-examples/cookbook/transactions/mev-protection/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/mev-protection/kit.ts
@@ -1,12 +1,11 @@
 // #region dontfront
 import {
   address,
-  airdropFactory,
+  AccountRole,
+  createClient,
+  createTransactionMessage,
   appendTransactionMessageInstructions,
   assertIsTransactionWithBlockhashLifetime,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  createTransactionMessage,
   generateKeyPairSigner,
   getBase64EncodedWireTransaction,
   lamports,
@@ -14,10 +13,11 @@ import {
   setTransactionMessageFeePayerSigner,
   setTransactionMessageLifetimeUsingBlockhash,
   signTransactionMessageWithSigners,
-  AccountRole,
-  type Instruction,
   type Address,
+  type Instruction,
 } from "@solana/kit";
+import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import { getTransferSolInstruction } from "@solana-program/system";
 
 // Jito block engine endpoint (mainnet)
@@ -59,20 +59,14 @@ function randomTipAccount(): Address {
   return TIP_ACCOUNTS[Math.floor(Math.random() * TIP_ACCOUNTS.length)]!;
 }
 
-const rpc = createSolanaRpc("http://localhost:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
-
+// Set up a kit client against the local validator and fund the signer
+// so it can pay fees + tip.
 const signer = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
-
-// Fund signer so it can pay fees + tip
-await airdropFactory({ rpc, rpcSubscriptions })({
-  recipientAddress: signer.address,
-  lamports: lamports(1_000_000_000n),
-  commitment: "confirmed",
-});
-
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const client = await createClient()
+  .use(payer(signer))
+  .use(solanaLocalRpc())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 // Build a transfer with dontfront protection
 const transferIx = withDontFront(
@@ -90,6 +84,8 @@ const tipIx = getTransferSolInstruction({
   amount: lamports(1_000n),
 });
 
+// Build + sign manually because we submit via Jito's block engine, not RPC.
+const { value: latestBlockhash } = await client.rpc.getLatestBlockhash().send();
 const transactionMessage = pipe(
   createTransactionMessage({ version: 0 }),
   (m) => setTransactionMessageFeePayerSigner(signer, m),

--- a/packages/docs-examples/cookbook/transactions/send-sol/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/send-sol/kit.ts
@@ -1,24 +1,8 @@
 // #region transfer
-import {
-  airdropFactory,
-  appendTransactionMessageInstructions,
-  assertIsTransactionWithBlockhashLifetime,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  sendAndConfirmTransactionFactory,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-} from "@solana/kit";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import { getTransferSolInstruction } from "@solana-program/system";
-
-const rpc = createSolanaRpc("http://localhost:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 const sender = await generateKeyPairSigner();
 const recipient = await generateKeyPairSigner();
@@ -26,11 +10,10 @@ const recipient = await generateKeyPairSigner();
 const LAMPORTS_PER_SOL = 1_000_000_000n;
 const transferAmount = lamports(LAMPORTS_PER_SOL / 100n); // 0.01 SOL
 
-await airdropFactory({ rpc, rpcSubscriptions })({
-  recipientAddress: sender.address,
-  lamports: lamports(LAMPORTS_PER_SOL), // 1 SOL
-  commitment: "confirmed",
-});
+const client = await createClient()
+  .use(payer(sender))
+  .use(solanaLocalRpc())
+  .use(airdropPayer(lamports(LAMPORTS_PER_SOL)));
 
 const transferInstruction = getTransferSolInstruction({
   source: sender,
@@ -38,21 +21,6 @@ const transferInstruction = getTransferSolInstruction({
   amount: transferAmount,
 });
 
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
-const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (tx) => setTransactionMessageFeePayerSigner(sender, tx),
-  (tx) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, tx),
-  (tx) => appendTransactionMessageInstructions([transferInstruction], tx),
-);
-
-const signedTransaction =
-  await signTransactionMessageWithSigners(transactionMessage);
-assertIsTransactionWithBlockhashLifetime(signedTransaction);
-await sendAndConfirmTransactionFactory({ rpc, rpcSubscriptions })(
-  signedTransaction,
-  { commitment: "confirmed" },
-);
-const transactionSignature = getSignatureFromTransaction(signedTransaction);
-console.log("Transaction Signature:", transactionSignature);
+const { context } = await client.sendTransaction([transferInstruction]);
+console.log("Transaction Signature:", context.signature);
 // #endregion transfer

--- a/packages/docs-examples/cookbook/transactions/send-sol/kit.ts
+++ b/packages/docs-examples/cookbook/transactions/send-sol/kit.ts
@@ -1,6 +1,6 @@
 // #region transfer
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaLocalRpc } from "@solana/kit-plugin-rpc";
+import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
 import { airdropPayer, payer } from "@solana/kit-plugin-signer";
 import { getTransferSolInstruction } from "@solana-program/system";
 
@@ -12,7 +12,13 @@ const transferAmount = lamports(LAMPORTS_PER_SOL / 100n); // 0.01 SOL
 
 const client = await createClient()
   .use(payer(sender))
-  .use(solanaLocalRpc())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900",
+    }),
+  )
+  .use(rpcAirdrop())
   .use(airdropPayer(lamports(LAMPORTS_PER_SOL)));
 
 const transferInstruction = getTransferSolInstruction({


### PR DESCRIPTION
## Summary

Refactor 8 cookbook kit examples to the `@solana/kit-plugin-rpc` + `@solana/kit-plugin-signer` client pattern introduced in #1465. Replaces manual `pipe()` / `createTransactionMessage` / blockhash / `sendAndConfirm` wiring with `createClient().use(payer).use(solanaLocalRpc()).use(airdropPayer())` + `client.sendTransaction([...])`.

438 → 153 lines (~65% reduction). 

### Per-file approach

- **send-sol, add-memo, create-account** — full plugin refactor
- **add-priority-fees** — priority fees configured via `solanaLocalRpc({ transactionConfig: { microLamportsPerComputeUnit } })`; planner/executor auto-handle CU price + limit
- **fee-sponsorship** — uses `tokenProgram()` plugin (`createMint` / `mintToATA` / `transferToATA`) instead of manual ATA derivation
- **create-token-with-metadata** — plugin client for setup, single Metaplex `createV1` instruction
- **calculate-cost** — partial: plugin for setup/airdrop, kept manual `pipe()` + `getFeeForMessage` since fee calculation is the recipe's whole point
- **mev-protection** — partial: plugin for setup, kept manual build + base64 + Jito POST

## Test plan

- [x] `pnpm --filter @workspace/docs-examples lint` (tsc --noEmit)
- [x] `pnpm --filter @workspace/docs-examples test` — all 61 tests pass against surfpool
- [x] pre-commit eslint + prettier clean