### PR TITLE
feat(docs): enable run button on create-token-with-metadata cookbook

### DIFF
--- a/apps/docs/content/cookbook/tokens/create-token-with-metadata.mdx
+++ b/apps/docs/content/cookbook/tokens/create-token-with-metadata.mdx
@@ -18,7 +18,7 @@ Derived Address (PDA).
   guide](/docs/tokens/extensions/metadata).
 </Callout>
 
-<CodeTabs storage="cookbook">
+<CodeTabs storage="cookbook" flags="r">
 
 ```ts !! title="Kit" file=packages/docs-examples/cookbook/tokens/create-token-with-metadata/kit.ts#region=create
 


### PR DESCRIPTION
## Summary
- Add `flags="r"` to the `<CodeTabs>` block on `create-token-with-metadata.mdx` so the snippet is executable via the docs code runner.
- Metaplex Token Metadata is now reachable in the surfpool/surfnet sandbox via lazy account cloning, so the example runs end-to-end.

## Test Plan
- Locally: `pnpm --filter @workspace/docs-examples test -- create-token-with-metadata` against surfpool.
- On Vercel preview: open the page and click Run, confirm output shows transaction signature, mint address, and metadata fields.

## Audit notes
Other `/en/` cookbook pages still missing `flags="r"` were reviewed; most are intentional (filesystem access, long-running subscriptions, offline flow, RPC-only construction). `tokens/fetch-token-metadata.mdx` is a candidate for a follow-up if we want to enable it (uses a mainnet USDC mint that surfpool would need to clone).

Closes DEV-596