### PR TITLE
Add Loyal to ecosystem data

### DIFF
--- a/packages/ecosystem-data/assets/companies/loyal/logo.svg
+++ b/packages/ecosystem-data/assets/companies/loyal/logo.svg
@@ -1,0 +1,10 @@
+<svg width="400" height="320" viewBox="0 0 400 320" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M60 280L0 140H180V0L260 140L280 0L400 320L60 280Z" fill="#F9363C"/>
+<path d="M221.359 173.036C254.451 174.77 280.059 199.425 278.555 228.105L158.72 221.824C160.223 193.145 188.268 171.302 221.359 173.036Z" fill="white"/>
+<mask id="mask0_5_1302" style="mask-type:alpha" maskUnits="userSpaceOnUse" x="158" y="172" width="121" height="57">
+<path d="M221.36 173.036C254.452 174.77 280.059 199.425 278.556 228.105L158.721 221.824C160.224 193.145 188.268 171.302 221.36 173.036Z" fill="white"/>
+</mask>
+<g mask="url(#mask0_5_1302)">
+<circle cx="219.998" cy="199" r="27" transform="rotate(3 219.998 199)" fill="black"/>
+</g>
+</svg>

--- a/packages/ecosystem-data/src/companies/records/loyal.ts
+++ b/packages/ecosystem-data/src/companies/records/loyal.ts
@@ -1,0 +1,41 @@
+import type { CompanyRecord } from "../../types";
+import loyalLogo from "../../../assets/companies/loyal/logo.svg";
+
+export const loyal = {
+  id: "loyal",
+  slug: "loyal",
+  name: "Loyal",
+  legalName: "Loyal DAO LLC",
+  profile: {
+    tagline: "Financial tools for the agentic era",
+    summary:
+      "Loyal is a self-custody Solana smart-account wallet. It gives users policy guardrails for AI agents, plus private payments and yield on private assets.",
+    description:
+      "Loyal lets users set spending caps, token whitelists, and approved protocols for AI agents that handle Solana payments and capital workflows, enforced at the smart-account layer so an agent can act only inside the limits a user sets. It supports both agent-suggests-you-approve and autonomous-within-policy modes. Loyal ships as a web app, Chrome extension, Telegram mini app, and Android app, and is available on Seeker (Solana Mobile). Its code is open source under the loyal-labs GitHub organization. Beyond agent guardrails, Loyal offers private payments and yield on private assets.",
+    founded: "2025",
+    sector: "Wallet",
+    type: "Company",
+    links: {
+      website: "https://askloyal.com",
+      docs: "https://docs.askloyal.com",
+    },
+    socials: {
+      x: "https://x.com/loyal_hq",
+      linkedin: "https://www.linkedin.com/company/askloyal",
+      github: "https://github.com/loyal-labs",
+      discord: "https://discord.gg/tAwXsXwTv6",
+      telegram: "https://t.me/loyal_tgchat",
+      medium: "https://medium.com/@askloyal",
+    },
+  },
+  defaultLogoId: "logo",
+  logos: [
+    {
+      id: "logo",
+      fileName: "logo.svg",
+      format: "svg",
+      source: loyalLogo,
+      kind: "mark",
+    },
+  ],
+} satisfies CompanyRecord;

--- a/packages/ecosystem-data/src/companies/registry.ts
+++ b/packages/ecosystem-data/src/companies/registry.ts
@@ -39,6 +39,7 @@ import { kast } from "./records/kast";
 import { kazakhstan } from "./records/kazakhstan";
 import { libeara } from "./records/libeara";
 import { listingHelp } from "./records/listing-help";
+import { loyal } from "./records/loyal";
 import { matcha } from "./records/matcha";
 import { mantle } from "./records/mantle";
 import { mantleByreal } from "./records/mantle-byreal";
@@ -128,6 +129,7 @@ export const companies = [
   kazakhstan,
   libeara,
   listingHelp,
+  loyal,
   matcha,
   mantle,
   mantleByreal,


### PR DESCRIPTION
### Problem

Loyal isn't yet listed in the ecosystem-data company registry. Loyal is a self-custody Solana smart-account wallet: it gives users policy guardrails for AI agents (spending caps, token whitelists, and approved protocols enforced at the smart-account layer), plus private payments and yield on private assets. It's live as a web app, Chrome extension, Telegram mini app, and Android app, and on Seeker (Solana Mobile), with open-source code under the loyal-labs GitHub org.

### Summary of Changes

- Add company record `packages/ecosystem-data/src/companies/records/loyal.ts` with a full `profile` (tagline, summary, description, founded, sector `Wallet`, type `Company`, links, socials).
- Add logo asset `packages/ecosystem-data/assets/companies/loyal/logo.svg` (brand mark, SVG).
- Register the import and company-array entry in `registry.ts`, alphabetically after `listingHelp`.

Validation:

- `audit:data`: the new record adds no findings (slug matches filename, asset folder contains only the referenced `logo.svg`, `defaultLogoId` resolves, website and verified socials present).
- `tsc --noEmit` (strict): no type errors.
- `prettier --check`: passes.

Links: https://askloyal.com · https://docs.askloyal.com · https://github.com/loyal-labs/loyal-app