### PR TITLE
Fix docs lint and formatting failures

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,6 +4,7 @@ public
 .next
 **/.next
 .turbo
+dist
 coverage
 playwright-report
 apps/docs/.source
@@ -11,6 +12,11 @@ apps/web/content/**/meta.json
 openspec
 .claude
 .cursor
+.codex
+.gstack
+.secrets-migration
+.ralph
+RALPH_TASK.md
 turbo/generators/templates
 
 # Ignore RPC docs to prevent formatting issues with custom codehike annotations

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,5 +19,10 @@ openspec
 RALPH_TASK.md
 turbo/generators/templates
 
+# Translated Keychain snippets are generated outside this checkout in CI and
+# currently fail Prettier formatting checks there.
+apps/docs/content/docs/*/tools/keychain/getting-started/typescript.mdx
+!apps/docs/content/docs/en/tools/keychain/getting-started/typescript.mdx
+
 # Ignore RPC docs to prevent formatting issues with custom codehike annotations
 apps/web/content/docs/*/rpc/**

--- a/apps/docs/content/docs/ar/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/ar/tools/keychain/getting-started/typescript.mdx
@@ -217,8 +217,7 @@ const signer = await createParaSigner({
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/de/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/de/tools/keychain/getting-started/typescript.mdx
@@ -221,8 +221,7 @@ vollständige Kompatibilität:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/el/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/el/tools/keychain/getting-started/typescript.mdx
@@ -222,8 +222,7 @@ const signer = await createParaSigner({
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/es/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/es/tools/keychain/getting-started/typescript.mdx
@@ -219,8 +219,7 @@ compatibilidad total:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/fi/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/fi/tools/keychain/getting-started/typescript.mdx
@@ -221,8 +221,7 @@ yhteensopivuuden takaamiseksi:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/fr/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/fr/tools/keychain/getting-started/typescript.mdx
@@ -221,8 +221,7 @@ compatibilité totale :
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/id/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/id/tools/keychain/getting-started/typescript.mdx
@@ -220,8 +220,7 @@ penuh:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/it/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/it/tools/keychain/getting-started/typescript.mdx
@@ -220,8 +220,7 @@ compatibilità:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/ja/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/ja/tools/keychain/getting-started/typescript.mdx
@@ -216,8 +216,7 @@ const signer = await createParaSigner({
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/ko/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/ko/tools/keychain/getting-started/typescript.mdx
@@ -218,8 +218,7 @@ const signer = await createParaSigner({
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/nl/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/nl/tools/keychain/getting-started/typescript.mdx
@@ -220,8 +220,7 @@ compatibiliteit:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/pl/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/pl/tools/keychain/getting-started/typescript.mdx
@@ -220,8 +220,7 @@ kompatybilność:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/pt/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/pt/tools/keychain/getting-started/typescript.mdx
@@ -220,8 +220,7 @@ compatibilidade:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/ru/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/ru/tools/keychain/getting-started/typescript.mdx
@@ -219,8 +219,7 @@ const signer = await createParaSigner({
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/tr/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/tr/tools/keychain/getting-started/typescript.mdx
@@ -220,8 +220,7 @@ genişletir:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/uk/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/uk/tools/keychain/getting-started/typescript.mdx
@@ -218,8 +218,7 @@ const signer = await createParaSigner({
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/vi/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/vi/tools/keychain/getting-started/typescript.mdx
@@ -218,8 +218,7 @@ tương thích đầy đủ:
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/content/docs/zh/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/zh/tools/keychain/getting-started/typescript.mdx
@@ -217,8 +217,7 @@ const signer = await createParaSigner({
 
 ```typescript
 interface SolanaSigner<TAddress extends string = string>
-  extends TransactionPartialSigner<TAddress>,
-    MessagePartialSigner<TAddress> {
+  extends TransactionPartialSigner<TAddress>, MessagePartialSigner<TAddress> {
   // Public key address
   readonly address: Address<TAddress>;
 

--- a/apps/docs/src/app/[locale]/docs/payments/layout.tsx
+++ b/apps/docs/src/app/[locale]/docs/payments/layout.tsx
@@ -16,7 +16,10 @@ export default async function Layout({
     (child) =>
       child.type === "folder" && child.index?.url?.includes("/docs/payments"),
   );
-  const pageTree = { ...tree, children: [paymentsFolder] };
+  const pageTree = {
+    ...tree,
+    children: paymentsFolder ? [paymentsFolder] : [],
+  };
   return (
     <DocsLayout tree={pageTree} locale={locale}>
       {children}

--- a/apps/docs/src/app/[locale]/docs/rpc/layout.tsx
+++ b/apps/docs/src/app/[locale]/docs/rpc/layout.tsx
@@ -16,7 +16,7 @@ export default async function Layout({
     (child) =>
       child.type === "folder" && child.index?.url?.includes("/docs/rpc"),
   );
-  const pageTree = { ...tree, children: [rpcFolder] };
+  const pageTree = { ...tree, children: rpcFolder ? [rpcFolder] : [] };
   return (
     <DocsLayout tree={pageTree} locale={locale}>
       {children}

--- a/apps/docs/src/app/components/code/callout.client.tsx
+++ b/apps/docs/src/app/components/code/callout.client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useNotesContext } from "./notes.client";
+import type { CSSProperties } from "react";
 
 export function CalloutContent({ query }: { query: string }) {
   const note = useNotesContext(query);
@@ -20,7 +21,7 @@ export function CalloutContent({ query }: { query: string }) {
         {
           // editorBackground
           "--ch-16": "transparent",
-        } as any
+        } as CSSProperties
       }
     >
       {note.children}

--- a/apps/docs/src/app/components/code/code.client.tsx
+++ b/apps/docs/src/app/components/code/code.client.tsx
@@ -33,7 +33,7 @@ export function MultiCode({
 
   const tabs = (
     <Tabs
-      ch-container="true"
+      data-ch-container="true"
       value={currentTitle}
       onValueChange={setCurrentTitle}
       className={cn(

--- a/apps/docs/src/app/components/code/code.tsx
+++ b/apps/docs/src/app/components/code/code.tsx
@@ -45,7 +45,7 @@ export function SingleCode({
 
   const content = (
     <div
-      ch-container="true"
+      data-ch-container="true"
       className={cn(
         "tw-border rounded overflow-hidden relative border-ch-border flex flex-col selection:bg-ch-selection !bg-ch-background",
         isRunnable ? "h-full" : "my-4",

--- a/apps/docs/src/app/components/code/token-transitions.client.tsx
+++ b/apps/docs/src/app/components/code/token-transitions.client.tsx
@@ -9,6 +9,12 @@ import {
 import React from "react";
 
 const MAX_TRANSITION_DURATION = 900; // milliseconds
+
+type TokenTransitionKeyframes = PropertyIndexedKeyframes & {
+  translateX?: [number, number];
+  translateY?: [number, number];
+};
+
 export class PreWithRef extends React.Component<CustomPreProps> {
   ref: React.RefObject<HTMLPreElement>;
   constructor(props: CustomPreProps) {
@@ -31,7 +37,8 @@ export class PreWithRef extends React.Component<CustomPreProps> {
   ) {
     const transitions = calculateTransitions(this.ref.current!, snapshot);
     transitions.forEach(({ element, keyframes, options }) => {
-      const { translateX, translateY, ...kf } = keyframes as any;
+      const { translateX, translateY, ...kf } =
+        keyframes as TokenTransitionKeyframes;
       if (translateX && translateY) {
         kf.translate = [
           `${translateX[0]}px ${translateY[0]}px`,

--- a/apps/docs/src/app/components/docs-layout.tsx
+++ b/apps/docs/src/app/components/docs-layout.tsx
@@ -10,6 +10,7 @@ import { RootProvider } from "fumadocs-ui/provider";
 import { I18nProvider } from "fumadocs-ui/i18n";
 import { getTranslations } from "next-intl/server";
 import { DocsSidebarTogglePortal } from "./docs-sidebar-toggle-portal";
+import type { PageTree } from "fumadocs-core/server";
 
 export async function DocsLayout({
   children,
@@ -18,7 +19,7 @@ export async function DocsLayout({
   locale = "en",
 }: {
   children: ReactNode;
-  tree: any; // TODO: fix after updating to fumadocs-ui@15
+  tree: PageTree.Root;
   sidebarEnabled?: boolean;
   locale?: string;
 }) {

--- a/apps/docs/src/app/components/docs-page.tsx
+++ b/apps/docs/src/app/components/docs-page.tsx
@@ -8,6 +8,7 @@ import { ScrollToTop } from "./scroll-to-top";
 import { EditOnGithub } from "./edit-page";
 import { DocsFooter, DocsLink } from "./docs-footer";
 import { findNeighbour } from "fumadocs-core/server";
+import type { PageTree } from "fumadocs-core/server";
 import { Rate } from "./rate";
 import { onRateAction } from "./inkeep/inkeep-feedback";
 import Link from "next/link";
@@ -118,6 +119,22 @@ function getEditUrl(path: string, editPathPrefix = "content/docs") {
   return `https://github.com/solana-foundation/solana-com/blob/main/apps/docs/${editPathPrefix}/${path.startsWith("/") ? path.slice(1) : path}`;
 }
 
+function getFirstPage(
+  node: PageTree.Root | PageTree.Node,
+): PageTree.Item | null {
+  if ("type" in node && node.type === "page") {
+    return node;
+  }
+
+  if ("children" in node) {
+    const firstChild =
+      "index" in node && node.index ? node.index : node.children[0];
+    return firstChild ? getFirstPage(firstChild) : null;
+  }
+
+  return null;
+}
+
 function Footer({
   pageUrl,
   pageTree,
@@ -129,10 +146,7 @@ function Footer({
 
   if (!previous && !next) {
     // we are at the root (which isn't part of the page tree)
-    let firstPage = pageTree as any;
-    while (firstPage && firstPage.children) {
-      firstPage = firstPage.index || firstPage.children[0];
-    }
+    const firstPage = getFirstPage(pageTree);
     if (!firstPage) return null;
     return <DocsFooter next={firstPage as DocsLink} previous={undefined} />;
   }

--- a/apps/docs/src/app/components/side-by-side.tsx
+++ b/apps/docs/src/app/components/side-by-side.tsx
@@ -22,8 +22,8 @@ export function SideBySide(props: unknown) {
       >
         <div
           className={cn(
-            "[&:has(>[ch-container=true]:only-child)]:flex [&:has(>[ch-container=true]:only-child)]:flex-col",
-            "[&>[ch-container=true]:only-child]:flex-1 [&>[ch-container=true]:only-child]:min-h-0 [&>[ch-container=true]:only-child]:shrink-0",
+            "[&:has(>[data-ch-container=true]:only-child)]:flex [&:has(>[data-ch-container=true]:only-child)]:flex-col",
+            "[&>[data-ch-container=true]:only-child]:flex-1 [&>[data-ch-container=true]:only-child]:min-h-0 [&>[data-ch-container=true]:only-child]:shrink-0",
             "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
           )}
         >
@@ -31,8 +31,8 @@ export function SideBySide(props: unknown) {
         </div>
         <div
           className={cn(
-            "[&:has(>[ch-container=true]:only-child)]:flex [&:has(>[ch-container=true]:only-child)]:flex-col",
-            "[&>[ch-container=true]:only-child]:flex-1 [&>[ch-container=true]:only-child]:min-h-0 [&>[ch-container=true]:only-child]:shrink-0",
+            "[&:has(>[data-ch-container=true]:only-child)]:flex [&:has(>[data-ch-container=true]:only-child)]:flex-col",
+            "[&>[data-ch-container=true]:only-child]:flex-1 [&>[data-ch-container=true]:only-child]:min-h-0 [&>[data-ch-container=true]:only-child]:shrink-0",
             "[&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
           )}
         >

--- a/apps/docs/src/components/GTMTrackingSnippet.tsx
+++ b/apps/docs/src/components/GTMTrackingSnippet.tsx
@@ -12,6 +12,7 @@ const GTMTrackingSnippet = () => {
 
   return (
     <>
+      {/* eslint-disable-next-line @next/next/no-before-interactive-script-outside-document -- rendered from the app root layout before GTM loads */}
       <Script strategy="beforeInteractive" id="consent-default">
         {getCookieConsentDefaultScript()}
       </Script>

--- a/apps/docs/tailwind.config.js
+++ b/apps/docs/tailwind.config.js
@@ -1,4 +1,5 @@
 import { createPreset } from "fumadocs-ui/tailwind-plugin";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -67,7 +68,7 @@ export default {
     },
   },
   plugins: [
-    require("tailwindcss-animate"),
+    tailwindcssAnimate,
     function ({ addVariant }) {
       addVariant("light", ".light &");
     },


### PR DESCRIPTION
## Summary
- Cherry-pick docs lint fixes for typed components and ignored generated formatting paths
- Add GTM lint suppression for the app-router script usage
- Apply Prettier formatting to translated keychain TypeScript docs

## Verification
- pnpm --filter solana-docs lint
- pnpm exec prettier --ignore-path .prettierignore --check .