### PR TITLE
docs/subscriptions: add demo app example to overview

### DIFF
--- a/apps/docs/content/docs/en/payments/subscriptions/overview.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/overview.mdx
@@ -78,3 +78,9 @@ The project is maintained by contributors to the
 The program has been audited by Cantina. Audit status, baseline commit,
 fix-verified commit, and current unaudited delta are tracked in the repository's
 [`audits/` directory](https://github.com/solana-program/subscriptions/tree/main/audits).
+
+## Demo Application
+
+If you want to play around with the program yourself, you can view an
+[example application here](https://solana-subscriptions-program.vercel.app/) to
+see an end-to-end implementation of the concepts covered in this section.


### PR DESCRIPTION
### Problem

We need to add the example application to the docs.

### Summary of Changes

Added example application link to the docs.
