### PR TITLE
docs: add solfaucet.io to devnet faucets list

### DIFF
--- a/apps/docs/content/guides/getstarted/solana-token-airdrop-and-faucets.mdx
+++ b/apps/docs/content/guides/getstarted/solana-token-airdrop-and-faucets.mdx
@@ -62,9 +62,9 @@ _Available for Devnet_
    [@Ferric](https://twitter.com/ferric)
 5. [Blueshift Faucet](https://faucet.blueshift.gg) - A web faucet for Blueshift
    NFT holders
-6. [solfaucet.io](https://solfaucet.io) - Send mainnet SOL to receive devnet SOL
-   at a fixed 1:1,000 rate, for developers needing large amounts of devnet SOL
-   beyond standard faucet limits
+6. [solfaucet.io](https://solfaucet.io) - Paid faucet (requires real mainnet
+   SOL) that returns devnet SOL at a fixed 1:1,000 rate, for developers needing
+   large amounts of devnet SOL beyond standard faucet limits
 
 _Available for Testnet_
 

--- a/apps/docs/content/guides/getstarted/solana-token-airdrop-and-faucets.mdx
+++ b/apps/docs/content/guides/getstarted/solana-token-airdrop-and-faucets.mdx
@@ -62,6 +62,9 @@ _Available for Devnet_
    [@Ferric](https://twitter.com/ferric)
 5. [Blueshift Faucet](https://faucet.blueshift.gg) - A web faucet for Blueshift
    NFT holders
+6. [solfaucet.io](https://solfaucet.io) - Send mainnet SOL to receive devnet SOL
+   at a fixed 1:1,000 rate, for developers needing large amounts of devnet SOL
+   beyond standard faucet limits
 
 _Available for Testnet_
 


### PR DESCRIPTION
## Summary

Adds solfaucet.io to the devnet faucets list in
`solana-token-airdrop-and-faucets.mdx`. Follow-up to #1447. Same addition,
with the copy rewritten to be neutral per @h4rkl's review.

## What it is

solfaucet.io lets developers send mainnet SOL and get devnet SOL back at a
fixed 1:1,000 rate. It's for people who need large amounts of devnet SOL well
beyond what the CLI airdrop or faucet.solana.com can hand out per request.

## Why it asks for mainnet SOL

This was the main concern on the last PR, so to explain it directly: the
mainnet cost is just there to stop the pool from being drained. A free,
unlimited devnet faucet doesn't survive. One person with a script can empty
the whole balance in minutes. Tying withdrawals to a mainnet amount keeps the
pool usable for everyone instead of getting wiped by a single actor. Other
faucets on this list gate access too; Blueshift requires NFT ownership, this
one requires sending some mainnet SOL.

## Transparency

- It's completely optional to use, only useful when the free faucets aren't enough.
- Every transaction shows up on the site's live feed, so all activity is public.
- You can test it with a single lamport first to confirm the 1:1,000 return
  before sending anything real.
- Terms: https://solfaucet.io/terms, Privacy: https://solfaucet.io/privacy

@h4rkl, I've dropped the "no rate limits / no captchas" wording so the listing
reads neutral now. If there's anything else I still need to cover, please let me know.