### PR TITLE
fix: keep canonical URLs on solana.com

### DIFF
--- a/apps/accelerate/src/app/metadata.ts
+++ b/apps/accelerate/src/app/metadata.ts
@@ -5,10 +5,10 @@ import faviconSvg from "@solana-com/ui-chrome/assets/favicon.svg";
 import appleTouchIcon from "@solana-com/ui-chrome/assets/apple-touch-icon.png";
 
 export function getBaseMetadata(locale: string = "en"): Metadata {
-  const { siteMetadata, siteUrl, siteIcon, social } = config;
+  const { siteMetadata, publicUrl, siteIcon, social } = config;
 
   return {
-    metadataBase: new URL(siteUrl),
+    metadataBase: new URL(publicUrl),
     title: {
       default: siteMetadata.title,
       template: `%s | ${siteMetadata.title}`,
@@ -21,7 +21,7 @@ export function getBaseMetadata(locale: string = "en"): Metadata {
     openGraph: {
       type: "website",
       locale,
-      url: siteUrl,
+      url: publicUrl,
       siteName: siteMetadata.title,
       title: siteMetadata.title,
       description: siteMetadata.description,
@@ -62,7 +62,7 @@ export function getBaseMetadata(locale: string = "en"): Metadata {
       },
     },
     alternates: {
-      canonical: siteUrl,
+      canonical: publicUrl,
     },
     other: {
       language: locale,
@@ -71,14 +71,14 @@ export function getBaseMetadata(locale: string = "en"): Metadata {
 }
 
 function getCanonicalUrl(path: string = "/") {
-  const siteUrl = new URL(config.siteUrl);
+  const siteUrl = new URL(config.publicUrl);
   const normalizedPath = path === "/" ? "" : path;
 
   return `${siteUrl.origin}${siteUrl.pathname}${normalizedPath}`;
 }
 
 function getLocalizedUrl(path: string, locale: string) {
-  const siteUrl = new URL(config.siteUrl);
+  const siteUrl = new URL(config.publicUrl);
   const normalizedPath = path === "/" ? "" : path;
 
   return `${siteUrl.origin}/${locale}${siteUrl.pathname}${normalizedPath}`;

--- a/apps/accelerate/src/app/robots.ts
+++ b/apps/accelerate/src/app/robots.ts
@@ -8,6 +8,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: "/",
       disallow: ["/api/", "/_next/"],
     },
-    sitemap: `${config.siteUrl}/sitemap.xml`,
+    sitemap: `${config.publicUrl}/sitemap.xml`,
   };
 }

--- a/apps/accelerate/src/app/seo.ts
+++ b/apps/accelerate/src/app/seo.ts
@@ -13,10 +13,10 @@ type EventConfig = {
 
 function getAbsoluteUrl(path: string = "/") {
   if (!path || path === "/") {
-    return config.siteUrl;
+    return config.publicUrl;
   }
 
-  return `${config.siteUrl}${path}`;
+  return `${config.publicUrl}${path}`;
 }
 
 export function buildEventStructuredData(event: EventConfig, path: string) {
@@ -54,7 +54,7 @@ export function buildEventSeriesStructuredData() {
     "@type": "EventSeries",
     name: config.siteMetadata.title,
     description: config.siteMetadata.description,
-    url: config.siteUrl,
+    url: config.publicUrl,
     image: [config.siteMetadata.socialShare],
     organizer: {
       "@type": "Organization",

--- a/apps/accelerate/src/app/sitemap.ts
+++ b/apps/accelerate/src/app/sitemap.ts
@@ -9,7 +9,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority?: number;
     }[]
   ).map(({ path, changeFrequency, priority }) => ({
-    url: `${config.siteUrl}${path}`,
+    url: `${config.publicUrl}${path}`,
     changeFrequency,
     priority,
   }));

--- a/apps/accelerate/src/config.ts
+++ b/apps/accelerate/src/config.ts
@@ -28,6 +28,8 @@ export function getImagePath(path: string): string {
 
 import faviconPng from "@solana-com/ui-chrome/assets/favicon.png";
 
+const PUBLIC_SITE_URL = "https://solana.com/accelerate";
+
 const getSiteUrl = () => {
   if (process.env.NODE_ENV === `development`) {
     return `http://localhost:3004`;
@@ -35,7 +37,7 @@ const getSiteUrl = () => {
   if (process.env.VERCEL_ENV !== "production" && !!process.env.VERCEL_URL) {
     return `https://${process.env.VERCEL_URL}`;
   }
-  return `https://solana.com/accelerate`;
+  return PUBLIC_SITE_URL;
 };
 
 const siteUrl = getSiteUrl();
@@ -65,6 +67,7 @@ export const config = {
     author: `@solana`,
   },
   siteUrl,
+  publicUrl: PUBLIC_SITE_URL,
   social: {
     twitter: {
       name: `solana`,

--- a/apps/breakpoint/src/app/metadata.ts
+++ b/apps/breakpoint/src/app/metadata.ts
@@ -4,7 +4,7 @@ import faviconSvg from "@solana-com/ui-chrome/assets/favicon.svg";
 import appleTouchIcon from "@solana-com/ui-chrome/assets/apple-touch-icon.png";
 import { locales, defaultLocale } from "@workspace/i18n/config";
 import { getTranslations } from "@workspace/i18n/server";
-import { config, localizedRouteUrl } from "@/config";
+import { config, publicLocalizedRouteUrl } from "@/config";
 
 const socialImageAlt =
   "Breakpoint 2026 social card with the Breakpoint logo over a purple London skyline";
@@ -17,9 +17,9 @@ type PageMetadataConfig = {
 
 const getLanguageAlternates = (path: string) => {
   const languages: Record<string, string> = Object.fromEntries(
-    locales.map((l) => [l, localizedRouteUrl(l, path)]),
+    locales.map((l) => [l, publicLocalizedRouteUrl(l, path)]),
   );
-  languages["x-default"] = localizedRouteUrl(defaultLocale, path);
+  languages["x-default"] = publicLocalizedRouteUrl(defaultLocale, path);
 
   return languages;
 };
@@ -29,7 +29,7 @@ export async function getBaseMetadata(
   path: string = "/",
 ): Promise<Metadata> {
   const t = await getTranslations({ locale, namespace: "breakpoint.metadata" });
-  const { siteOrigin, siteMetadata, social } = config;
+  const { publicSiteOrigin, siteMetadata, social } = config;
 
   const title = t("title");
   const titleTemplate = t("titleTemplate");
@@ -42,11 +42,11 @@ export async function getBaseMetadata(
     .map((k) => k.trim())
     .filter(Boolean);
 
-  const canonical = localizedRouteUrl(locale, path);
+  const canonical = publicLocalizedRouteUrl(locale, path);
   const languages = getLanguageAlternates(path);
 
   return {
-    metadataBase: new URL(siteOrigin),
+    metadataBase: new URL(publicSiteOrigin),
     alternates: { canonical, languages },
     title: { default: title, template: titleTemplate },
     description,

--- a/apps/breakpoint/src/config.ts
+++ b/apps/breakpoint/src/config.ts
@@ -2,6 +2,7 @@ import { defaultLocale } from "@workspace/i18n/config";
 
 const routePrefix = "/breakpoint";
 const assetPrefix = "/breakpoint-assets";
+const PUBLIC_SITE_ORIGIN = "https://solana.com";
 const publicAssetDirectories = [
   "/_next/",
   "/assets/",
@@ -20,7 +21,7 @@ function getSiteOrigin() {
     return `https://${process.env.VERCEL_URL}`;
   }
 
-  return "https://solana.com";
+  return PUBLIC_SITE_ORIGIN;
 }
 
 const siteOrigin = getSiteOrigin();
@@ -61,6 +62,11 @@ export const localizedRouteUrl = (
   path: string = "/",
 ) => `${siteOrigin}${localizedRoutePath(locale, path)}`;
 
+export const publicLocalizedRouteUrl = (
+  locale: string = defaultLocale,
+  path: string = "/",
+) => `${PUBLIC_SITE_ORIGIN}${localizedRoutePath(locale, path)}`;
+
 export function publicAssetPath(path: string) {
   if (
     !path.startsWith("/") ||
@@ -79,7 +85,9 @@ export function publicAssetPath(path: string) {
 export const config = {
   assetPrefix,
   siteOrigin,
+  publicSiteOrigin: PUBLIC_SITE_ORIGIN,
   siteUrl: localizedRouteUrl(defaultLocale),
+  publicUrl: publicLocalizedRouteUrl(defaultLocale),
   siteMetadata: {
     title: "Breakpoint 2026",
     description:
@@ -92,7 +100,7 @@ export const config = {
       "Web3 event",
     ],
     author: "Solana Foundation",
-    socialShare: `${siteOrigin}${routePath("/social-card.jpg")}`,
+    socialShare: `${PUBLIC_SITE_ORIGIN}${routePath("/social-card.jpg")}`,
     googleAnalytics: {
       trackingId: "G-94WS0LRZRS",
       adWordsId: "AW-302884864",

--- a/apps/breakpoint/src/lib/structured-data.ts
+++ b/apps/breakpoint/src/lib/structured-data.ts
@@ -1,4 +1,4 @@
-import { config, localizedRouteUrl } from "@/config";
+import { config, publicLocalizedRouteUrl } from "@/config";
 import { homepageFaqItems } from "@/content/faq-page";
 import { GENERAL_ADMISSION_HREF } from "@/content/links";
 
@@ -23,13 +23,13 @@ const TICKET_OFFERS: OfferSeed[] = [
 ];
 
 export function buildBreakpointJsonLd(locale: string): JsonLd {
-  const { siteUrl, siteMetadata, event } = config;
-  const pageUrl = localizedRouteUrl(locale);
-  const socialImage = new URL(siteMetadata.socialShare, siteUrl).toString();
+  const { publicUrl, siteMetadata, event } = config;
+  const pageUrl = publicLocalizedRouteUrl(locale);
+  const socialImage = new URL(siteMetadata.socialShare, publicUrl).toString();
 
   const eventNode: JsonLd = {
     "@type": "Event",
-    "@id": `${siteUrl}#event`,
+    "@id": `${publicUrl}#event`,
     name: event.name,
     description: event.description,
     startDate: event.startDate,
@@ -50,7 +50,7 @@ export function buildBreakpointJsonLd(locale: string): JsonLd {
       },
     },
     organizer: {
-      "@id": `${siteUrl}#organization`,
+      "@id": `${publicUrl}#organization`,
     },
     offers: TICKET_OFFERS.map((offer) => ({
       "@type": "Offer",
@@ -65,7 +65,7 @@ export function buildBreakpointJsonLd(locale: string): JsonLd {
 
   const organizationNode: JsonLd = {
     "@type": "Organization",
-    "@id": `${siteUrl}#organization`,
+    "@id": `${publicUrl}#organization`,
     name: siteMetadata.author,
     url: "https://solana.com",
     logo: "https://solana.com/src/img/branding/solanaLogo.svg",

--- a/apps/breakpoint/src/tests/publicAssetPath.test.ts
+++ b/apps/breakpoint/src/tests/publicAssetPath.test.ts
@@ -3,6 +3,7 @@ import {
   config,
   localizedRoutePath,
   localizedRouteUrl,
+  publicLocalizedRouteUrl,
   publicAssetPath,
   routePath,
 } from "@/config";
@@ -35,6 +36,9 @@ describe("localizedRoutePath", () => {
   it("builds absolute localized Breakpoint URLs", () => {
     expect(localizedRouteUrl("en")).toBe("https://solana.com/breakpoint");
     expect(localizedRouteUrl("de", "/registration")).toBe(
+      "https://solana.com/de/breakpoint/registration",
+    );
+    expect(publicLocalizedRouteUrl("de", "/registration")).toBe(
       "https://solana.com/de/breakpoint/registration",
     );
   });

--- a/apps/docs/src/app/metadata.ts
+++ b/apps/docs/src/app/metadata.ts
@@ -8,7 +8,7 @@ import appleTouchIcon from "@solana-com/ui-chrome/assets/apple-touch-icon.png";
 import { Page } from "fumadocs-core/source";
 
 export function getBaseMetadata(locale: string) {
-  const { siteMetadata, siteUrl } = config;
+  const { siteMetadata, publicUrl } = config;
   return {
     other: {
       language: locale,
@@ -29,7 +29,7 @@ export function getBaseMetadata(locale: string) {
     },
     robots: "index, follow",
     manifest: "/site.webmanifest",
-    metadataBase: new URL(siteUrl),
+    metadataBase: new URL(publicUrl),
     icons: [
       {
         url: faviconPng.src,

--- a/apps/docs/src/components/shared/EmailSubscribeForm/IterableEmailSubscribeForm.tsx
+++ b/apps/docs/src/components/shared/EmailSubscribeForm/IterableEmailSubscribeForm.tsx
@@ -139,9 +139,7 @@ export default function IterableEmailSubscribeForm({
               disabled={isLoading}
               onClick={onSubmit}
             >
-              {ctaTextID
-                ? t({ ctaTextID })
-                : t("shared.mail-signup.form.signup")}
+              {ctaTextID ? t(ctaTextID) : t("shared.mail-signup.form.signup")}
             </Button>
           </div>
         </div>

--- a/apps/docs/src/config.ts
+++ b/apps/docs/src/config.ts
@@ -1,5 +1,7 @@
 import faviconPng from "@solana-com/ui-chrome/assets/favicon.png";
 
+const PUBLIC_SITE_URL = "https://solana.com";
+
 export const config = {
   siteMetadata: {
     title: `Solana`,
@@ -18,7 +20,9 @@ export const config = {
       ? `http://localhost:3000`
       : (process.env.VERCEL_ENV != "production" && !!process.env.VERCEL_URL
           ? `https://${process.env.VERCEL_URL}`
-          : `https://solana.com`) || `https://solana.com`,
+          : PUBLIC_SITE_URL) || PUBLIC_SITE_URL,
+
+  publicUrl: PUBLIC_SITE_URL,
 
   shareImageWidth: 1000,
   shareImageHeight: 523,

--- a/apps/docs/src/middleware.ts
+++ b/apps/docs/src/middleware.ts
@@ -1,5 +1,6 @@
 import {
   createMiddleware,
+  getEffectiveOrigin,
   routingWithoutDetection,
 } from "@workspace/i18n/middleware";
 import { NextFetchEvent, NextRequest, NextResponse } from "next/server";
@@ -59,6 +60,18 @@ function rewriteToMarkdownApi(req: NextRequest, segments: string[]) {
   return NextResponse.rewrite(url);
 }
 
+function redirectWithEffectiveOrigin(
+  req: NextRequest,
+  pathname: string,
+  status?: number,
+  search = "",
+) {
+  const url = getEffectiveOrigin(req);
+  url.pathname = pathname;
+  url.search = search;
+  return NextResponse.redirect(url, status);
+}
+
 // routingWithoutDetection: prevents redirects based on Accept-Language that would leak Vercel URL
 // preserveProxiedLocaleCookie: prevents overwriting the main app's NEXT_LOCALE cookie
 // when requests come through the web app's rewrite (fixes "random language" bug)
@@ -85,9 +98,7 @@ export default async function middleware(
   }
 
   if (pathname !== pathname.toLowerCase()) {
-    return NextResponse.redirect(
-      `${req.nextUrl.origin + pathname.toLowerCase()}`,
-    );
+    return redirectWithEffectiveOrigin(req, pathname.toLowerCase());
   }
 
   // Remove duplicate locale segments from path
@@ -106,8 +117,11 @@ export default async function middleware(
     );
 
     const cleanedPath = `/${cleanedSegments.join("/")}`;
-    return NextResponse.redirect(
-      `${req.nextUrl.origin}${cleanedPath}${req.nextUrl.search}`,
+    return redirectWithEffectiveOrigin(
+      req,
+      cleanedPath,
+      undefined,
+      req.nextUrl.search,
     );
   }
 
@@ -137,7 +151,7 @@ export default async function middleware(
     url.pathname = hasLocalePrefix
       ? `/${[pathSegments[0], ...redirectedSegments].join("/")}`
       : `/${redirectedSegments.join("/")}`;
-    return NextResponse.redirect(url, 308);
+    return redirectWithEffectiveOrigin(req, url.pathname, 308, url.search);
   }
 
   // Accept header content negotiation for markdown

--- a/apps/templates/src/app/developers/templates/[id]/page.tsx
+++ b/apps/templates/src/app/developers/templates/[id]/page.tsx
@@ -31,14 +31,21 @@ export async function generateMetadata({
   }
 
   const displayName = template.displayName || template.name;
+  const canonicalPath = `/developers/templates/${encodeURIComponent(
+    template.name,
+  )}`;
 
   return {
     title: `${displayName} - Solana Template`,
     description: template.description,
+    alternates: {
+      canonical: canonicalPath,
+    },
     openGraph: {
       title: `${displayName} - Solana Template`,
       description: template.description,
       type: "website",
+      url: canonicalPath,
     },
     twitter: {
       card: "summary_large_image",

--- a/apps/templates/src/app/developers/templates/page.tsx
+++ b/apps/templates/src/app/developers/templates/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { AppHero } from "@/components/app-hero";
 import { TemplatesUiLayoutList } from "@/components/templates/templates-ui-layout-list";
@@ -7,6 +8,22 @@ import { AppProviders } from "@/components/app-providers";
 import { TemplatesProviderWrapper } from "@/components/providers/templates-provider-wrapper";
 
 export const revalidate = 3600;
+
+export const metadata: Metadata = {
+  title: "Solana Developer Templates",
+  description:
+    "Build faster with production-ready templates for dApps, DeFi protocols, NFT marketplaces, and more.",
+  alternates: {
+    canonical: "/developers/templates",
+  },
+  openGraph: {
+    title: "Solana Developer Templates",
+    description:
+      "Build faster with production-ready templates for dApps, DeFi protocols, NFT marketplaces, and more.",
+    type: "website",
+    url: "/developers/templates",
+  },
+};
 
 export default async function TemplatesPage() {
   const templates = await fetchTemplatesFromGitHub();

--- a/apps/templates/src/app/layout.tsx
+++ b/apps/templates/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from "react";
+import type { Metadata } from "next";
 import { NextIntlClientProvider } from "next-intl";
 import {
   Header,
@@ -14,7 +15,8 @@ import { CookieConsent } from "@/components/cookie-consent";
 import "../scss/index.scss";
 import "./globals.css";
 
-export const metadata = {
+export const metadata: Metadata = {
+  metadataBase: new URL("https://solana.com"),
   title: "Solana Developer Templates",
   description:
     "Build faster with production-ready templates for dApps, DeFi protocols, NFT marketplaces, and more.",

--- a/apps/web/src/app/metadata.ts
+++ b/apps/web/src/app/metadata.ts
@@ -7,7 +7,7 @@ import faviconSvg from "@solana-com/ui-chrome/assets/favicon.svg";
 import appleTouchIcon from "@solana-com/ui-chrome/assets/apple-touch-icon.png";
 
 export function getBaseMetadata(locale: string) {
-  const { siteMetadata, siteUrl } = config;
+  const { siteMetadata, publicUrl } = config;
   return {
     other: {
       language: locale,
@@ -28,7 +28,7 @@ export function getBaseMetadata(locale: string) {
     },
     robots: "index, follow",
     manifest: "/site.webmanifest",
-    metadataBase: new URL(siteUrl),
+    metadataBase: new URL(publicUrl),
     icons: [
       {
         url: faviconPng.src,

--- a/apps/web/src/components/shared/EmailSubscribeForm/IterableEmailSubscribeForm.tsx
+++ b/apps/web/src/components/shared/EmailSubscribeForm/IterableEmailSubscribeForm.tsx
@@ -140,9 +140,7 @@ export default function IterableEmailSubscribeForm({
               disabled={isLoading}
               onClick={onSubmit}
             >
-              {ctaTextID
-                ? t({ ctaTextID })
-                : t("shared.mail-signup.form.signup")}
+              {ctaTextID ? t(ctaTextID) : t("shared.mail-signup.form.signup")}
             </Button>
           </div>
         </div>

--- a/apps/web/src/config.ts
+++ b/apps/web/src/config.ts
@@ -1,5 +1,7 @@
 import faviconPng from "@solana-com/ui-chrome/assets/favicon.png";
 
+const PUBLIC_SITE_URL = "https://solana.com";
+
 export const config = {
   siteMetadata: {
     title: `Solana`,
@@ -18,7 +20,9 @@ export const config = {
       ? `http://localhost:3000`
       : (process.env.VERCEL_ENV != "production" && !!process.env.VERCEL_URL
           ? `https://${process.env.VERCEL_URL}`
-          : `https://solana.com`) || `https://solana.com`,
+          : PUBLIC_SITE_URL) || PUBLIC_SITE_URL,
+
+  publicUrl: PUBLIC_SITE_URL,
 
   shareImageWidth: 1000,
   shareImageHeight: 523,

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,5 +1,8 @@
 import path from "path";
+import { createRequire } from "node:module";
 import { defineConfig } from "vitest/config";
+
+const require = createRequire(import.meta.url);
 
 const INLINE_SVG_MOCK_ID = "\0inline-svg-mock";
 const SVG_MOCK_ID = "\0svg-mock";
@@ -48,7 +51,18 @@ export default defineConfig({
         find: "@@",
         replacement: path.resolve(__dirname, "./"),
       },
+      {
+        find: "next/navigation",
+        replacement: require.resolve("next/navigation"),
+      },
+      {
+        find: "next/server",
+        replacement: require.resolve("next/server"),
+      },
     ],
+  },
+  ssr: {
+    noExternal: ["next-intl"],
   },
   test: {
     environment: "jsdom",

--- a/packages/i18n/src/middleware.test.ts
+++ b/packages/i18n/src/middleware.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   SHARED_LOCALE_COOKIE,
   buildSharedLocaleCookie,
+  getFixedProxiedLocation,
   getLocaleFromPathname,
   getLocaleRedirectPath,
   getPreferredLocaleCookie,
 } from "./middleware";
+import { getAlternates } from "./routing";
 
 describe("@workspace/i18n middleware", () => {
   it("extracts locale prefixes from localized paths", () => {
@@ -38,5 +40,36 @@ describe("@workspace/i18n middleware", () => {
     expect(buildSharedLocaleCookie("es")).toContain("Max-Age=31536000");
     expect(buildSharedLocaleCookie("es")).toContain("Expires=");
     expect(buildSharedLocaleCookie("es")).toContain("SameSite=Lax");
+  });
+
+  it("normalizes canonical and hreflang alternate paths", () => {
+    expect(getAlternates("/docs/tools", "es")).toEqual({
+      canonical: "/es/docs/tools",
+      languages: expect.objectContaining({
+        "x-default": "/docs/tools",
+        en: "/docs/tools",
+        es: "/es/docs/tools",
+      }),
+    });
+    expect(getAlternates("docs/tools", "en").canonical).toBe("/docs/tools");
+    expect(getAlternates("/", "fr")).toEqual({
+      canonical: "/fr",
+      languages: expect.objectContaining({
+        "x-default": "/",
+        en: "/",
+        fr: "/fr",
+      }),
+    });
+  });
+
+  it("rewrites proxied redirect locations to the forwarded public host", () => {
+    expect(
+      getFixedProxiedLocation({
+        currentHost: "solana-com-docs.vercel.app",
+        forwardedHost: "solana.com",
+        forwardedProto: "https",
+        location: "https://solana-com-docs.vercel.app/docs/tools",
+      }),
+    ).toBe("https://solana.com/docs/tools");
   });
 });

--- a/packages/i18n/src/middleware.ts
+++ b/packages/i18n/src/middleware.ts
@@ -68,7 +68,7 @@ export function buildSharedLocaleCookie(locale: string) {
   ].join("; ");
 }
 
-function getEffectiveOrigin(req: NextRequest) {
+export function getEffectiveOrigin(req: NextRequest) {
   const url = req.nextUrl.clone();
   const forwardedHost = req.headers.get("x-forwarded-host");
   const forwardedProto = req.headers.get("x-forwarded-proto");
@@ -82,6 +82,36 @@ function getEffectiveOrigin(req: NextRequest) {
   }
 
   return url;
+}
+
+export function getFixedProxiedLocation({
+  currentHost,
+  forwardedHost,
+  forwardedProto,
+  location,
+}: {
+  currentHost: string;
+  forwardedHost: string;
+  forwardedProto?: string | null;
+  location: string;
+}) {
+  try {
+    const locationUrl = new URL(location);
+
+    if (locationUrl.host !== currentHost) {
+      return location;
+    }
+
+    locationUrl.host = forwardedHost;
+
+    if (forwardedProto) {
+      locationUrl.protocol = `${forwardedProto}:`;
+    }
+
+    return locationUrl.toString();
+  } catch {
+    return location.replace(currentHost, forwardedHost);
+  }
 }
 
 function getResponseLocale(req: NextRequest, response: Response) {
@@ -180,7 +210,12 @@ export function createMiddleware<
 
     // Fix redirect URL if present
     if (location) {
-      const fixedLocation = location.replace(currentHost, forwardedHost);
+      const fixedLocation = getFixedProxiedLocation({
+        currentHost,
+        forwardedHost,
+        forwardedProto: req.headers.get("x-forwarded-proto"),
+        location,
+      });
       fixedResponse.headers.set("location", fixedLocation);
     }
 

--- a/packages/i18n/src/routing.ts
+++ b/packages/i18n/src/routing.ts
@@ -39,15 +39,32 @@ export function pathsWithLocales<T>(paths: { params: T }[]) {
   );
 }
 
+function normalizeAlternatePath(path: string) {
+  if (!path || path === "/") {
+    return "/";
+  }
+
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+function localizeAlternatePath(path: string, locale: string) {
+  if (locale === defaultLocale) {
+    return path;
+  }
+
+  return path === "/" ? `/${locale}` : `/${locale}${path}`;
+}
+
 export function getAlternates(path: string, locale: string) {
+  const normalizedPath = normalizeAlternatePath(path);
   const languages: Record<string, string> = {
-    "x-default": `/${path}`,
+    "x-default": normalizedPath,
   };
   locales.forEach((l) => {
-    languages[l] = l === defaultLocale ? `/${path}` : `/${l}${path}`;
+    languages[l] = localizeAlternatePath(normalizedPath, l);
   });
   return {
-    canonical: locale === defaultLocale ? `/${path}` : `/${locale}${path}`,
+    canonical: localizeAlternatePath(normalizedPath, locale),
     languages,
   };
 }

--- a/packages/i18n/vitest.config.ts
+++ b/packages/i18n/vitest.config.ts
@@ -1,13 +1,9 @@
-import path from "path";
 import { createRequire } from "node:module";
 import { defineConfig } from "vitest/config";
 
 const require = createRequire(import.meta.url);
 
 export default defineConfig({
-  esbuild: {
-    jsx: "automatic",
-  },
   resolve: {
     alias: [
       {
@@ -22,14 +18,5 @@ export default defineConfig({
   },
   ssr: {
     noExternal: ["next-intl"],
-  },
-  test: {
-    environment: "jsdom",
-    include: ["src/tests/**/*.test.tsx", "src/tests/**/*.test.ts"],
-    setupFiles: ["./src/tests/setup.ts"],
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@@": path.resolve(__dirname, "./"),
-    },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 15.5.18
       version: 15.5.18
     next-intl:
-      specifier: 3.26.5
-      version: 3.26.5
+      specifier: 4.13.0
+      version: 4.13.0
     react:
       specifier: 19.2.6
       version: 19.2.6
@@ -50,7 +50,7 @@ importers:
     devDependencies:
       "@turbo/gen":
         specifier: ^2.5.8
-        version: 2.5.8(@types/node@24.6.2)(typescript@5.9.2)
+        version: 2.5.8(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@24.6.2)(typescript@5.9.2)
       "@workspace/config-eslint":
         specifier: workspace:*
         version: link:packages/config-eslint
@@ -80,16 +80,16 @@ importers:
     dependencies:
       "@mdx-js/loader":
         specifier: ^3.1.1
-        version: 3.1.1(webpack@5.101.3)
+        version: 3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
       "@mdx-js/react":
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.1.12)(react@19.2.6)
       "@next/mdx":
         specifier: ^15.2.9
-        version: 15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))
+        version: 15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3)
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -128,7 +128,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 3.26.5(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -195,7 +195,7 @@ importers:
     dependencies:
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3)
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -222,7 +222,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 3.26.5(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -322,7 +322,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3)
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -385,7 +385,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 3.26.5(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-seo:
         specifier: ^6.6.0
         version: 6.8.0(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -491,7 +491,7 @@ importers:
         version: 3.4.19(tsx@4.22.3)(yaml@2.8.1)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.18.8)(typescript@5.8.3)
+        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@22.18.8)(typescript@5.8.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -515,7 +515,7 @@ importers:
         version: 1.2.4(@types/react@19.1.12)(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3)
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -566,7 +566,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 3.26.5(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -720,7 +720,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 3.26.5(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       nuqs:
         specifier: ^2.4.3
         version: 2.7.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6)
@@ -823,7 +823,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3)
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -895,7 +895,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 3.26.5(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -1031,10 +1031,10 @@ importers:
         version: 3.4.19(tsx@4.22.3)(yaml@2.8.1)
       ts-loader:
         specifier: ^9.5.7
-        version: 9.5.7(typescript@5.8.3)(webpack@5.101.3)
+        version: 9.5.7(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@22.18.1)(typescript@5.8.3)
+        version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@22.18.1)(typescript@5.8.3)
       tsx:
         specifier: ^4.21.1
         version: 4.22.3
@@ -1188,7 +1188,7 @@ importers:
         version: link:../config-typescript
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.22.3)(typescript@5.8.3)(yaml@2.8.1)
+        version: 8.5.1(@swc/core@1.15.40(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.15)(tsx@4.22.3)(typescript@5.8.3)(yaml@2.8.1)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -1200,7 +1200,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 3.26.5(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -1344,7 +1344,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 3.26.5(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -4044,10 +4044,22 @@ packages:
         integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==,
       }
 
+  "@formatjs/fast-memoize@3.1.5":
+    resolution:
+      {
+        integrity: sha512-KLi3fan6WnCHmigd9pmEEN8Hid0v4wiFBW576M/d07KMWYecf1CvyMI3n34vCmHT4AoVqG2n702kiHbXjzZX2A==,
+      }
+
   "@formatjs/icu-messageformat-parser@2.11.2":
     resolution:
       {
         integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==,
+      }
+
+  "@formatjs/icu-messageformat-parser@3.5.10":
+    resolution:
+      {
+        integrity: sha512-XeJihYLy1lCe19xfK1KWKG/betBOK2rB0luL8lSkjfvJj0zP+LTJvkC+RKd0jsFI8mWxN71LrarHSrEXE8xxOQ==,
       }
 
   "@formatjs/icu-skeleton-parser@1.8.14":
@@ -4056,16 +4068,22 @@ packages:
         integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==,
       }
 
-  "@formatjs/intl-localematcher@0.5.10":
+  "@formatjs/icu-skeleton-parser@2.1.9":
     resolution:
       {
-        integrity: sha512-af3qATX+m4Rnd9+wHcjJ4w2ijq+rAVP3CCinJQvFv1kgSu1W6jypUmvleJxcewdxmutM8dmIRZFxO/IQBZmP2Q==,
+        integrity: sha512-rsxswgHMfU1zUgB2byc08fesf83wLGjFnzLCEtuf00mx2doiqc6pYrf67raI37XqdRcGUviQepk2UKGqpng74Q==,
       }
 
   "@formatjs/intl-localematcher@0.6.1":
     resolution:
       {
         integrity: sha512-ePEgLgVCqi2BBFnTMWPfIghu6FkbZnnBVhO2sSxvLfrdFw7wCHAHiDoM2h4NRgjbaY7+B7HgOLZGkK187pZTZg==,
+      }
+
+  "@formatjs/intl-localematcher@0.8.9":
+    resolution:
+      {
+        integrity: sha512-GmB0F/gYh4Hdl4rLWjgDsgT+x4pB54fkJeRh8kAZ4XFzKeCK8dGs+SBJWXO42QZtOUni+IDWKNuCw6wiL4lTvw==,
       }
 
   "@fumadocs/mdx-remote@1.4.10":
@@ -7588,6 +7606,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  "@schummar/icu-type-parser@1.21.5":
+    resolution:
+      {
+        integrity: sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==,
+      }
+
   "@sentry-internal/browser-utils@10.11.0":
     resolution:
       {
@@ -8733,6 +8757,132 @@ packages:
       }
     engines: { node: ">=14" }
 
+  "@swc/core-darwin-arm64@1.15.40":
+    resolution:
+      {
+        integrity: sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm64]
+    os: [darwin]
+
+  "@swc/core-darwin-x64@1.15.40":
+    resolution:
+      {
+        integrity: sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x64]
+    os: [darwin]
+
+  "@swc/core-linux-arm-gnueabihf@1.15.40":
+    resolution:
+      {
+        integrity: sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm]
+    os: [linux]
+
+  "@swc/core-linux-arm64-gnu@1.15.40":
+    resolution:
+      {
+        integrity: sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm64]
+    os: [linux]
+
+  "@swc/core-linux-arm64-musl@1.15.40":
+    resolution:
+      {
+        integrity: sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm64]
+    os: [linux]
+
+  "@swc/core-linux-ppc64-gnu@1.15.40":
+    resolution:
+      {
+        integrity: sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [ppc64]
+    os: [linux]
+
+  "@swc/core-linux-s390x-gnu@1.15.40":
+    resolution:
+      {
+        integrity: sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==,
+      }
+    engines: { node: ">=10" }
+    cpu: [s390x]
+    os: [linux]
+
+  "@swc/core-linux-x64-gnu@1.15.40":
+    resolution:
+      {
+        integrity: sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x64]
+    os: [linux]
+
+  "@swc/core-linux-x64-musl@1.15.40":
+    resolution:
+      {
+        integrity: sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x64]
+    os: [linux]
+
+  "@swc/core-win32-arm64-msvc@1.15.40":
+    resolution:
+      {
+        integrity: sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==,
+      }
+    engines: { node: ">=10" }
+    cpu: [arm64]
+    os: [win32]
+
+  "@swc/core-win32-ia32-msvc@1.15.40":
+    resolution:
+      {
+        integrity: sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==,
+      }
+    engines: { node: ">=10" }
+    cpu: [ia32]
+    os: [win32]
+
+  "@swc/core-win32-x64-msvc@1.15.40":
+    resolution:
+      {
+        integrity: sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==,
+      }
+    engines: { node: ">=10" }
+    cpu: [x64]
+    os: [win32]
+
+  "@swc/core@1.15.40":
+    resolution:
+      {
+        integrity: sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==,
+      }
+    engines: { node: ">=10" }
+    peerDependencies:
+      "@swc/helpers": ">=0.5.17"
+    peerDependenciesMeta:
+      "@swc/helpers":
+        optional: true
+
+  "@swc/counter@0.1.3":
+    resolution:
+      {
+        integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==,
+      }
+
   "@swc/helpers@0.5.15":
     resolution:
       {
@@ -8743,6 +8893,12 @@ packages:
     resolution:
       {
         integrity: sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==,
+      }
+
+  "@swc/types@0.1.26":
+    resolution:
+      {
+        integrity: sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==,
       }
 
   "@tailwindcss/node@4.2.4":
@@ -13568,6 +13724,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
+  icu-minify@4.13.0:
+    resolution:
+      {
+        integrity: sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==,
+      }
+
   idb-keyval@6.2.2:
     resolution:
       {
@@ -13733,6 +13895,12 @@ packages:
     resolution:
       {
         integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==,
+      }
+
+  intl-messageformat@11.2.7:
+    resolution:
+      {
+        integrity: sha512-+q6Ktg119nULZEpZ8YTuGOst9MyEzFtjD63FTGBlN1mLz0Z/MOUYDIvnpVKwq17eezIEh+cfJIebfJoCetpiNw==,
       }
 
   ip-address@10.0.1:
@@ -15470,14 +15638,24 @@ packages:
       }
     engines: { node: ">= 0.4.0" }
 
-  next-intl@3.26.5:
+  next-intl-swc-plugin-extractor@4.13.0:
     resolution:
       {
-        integrity: sha512-EQlCIfY0jOhRldiFxwSXG+ImwkQtDEfQeSOEQp6ieAGSLWGlgjdb/Ck/O7wMfC430ZHGeUKVKax8KGusTPKCgg==,
+        integrity: sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==,
+      }
+
+  next-intl@4.13.0:
+    resolution:
+      {
+        integrity: sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==,
       }
     peerDependencies:
-      next: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0
+      next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+      typescript: "*"
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   next-mdx-remote@6.0.0:
     resolution:
@@ -16181,6 +16359,12 @@ packages:
       }
     engines: { node: ">=18" }
     hasBin: true
+
+  po-parser@2.1.1:
+    resolution:
+      {
+        integrity: sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==,
+      }
 
   points-on-curve@0.2.0:
     resolution:
@@ -19122,13 +19306,13 @@ packages:
       "@types/react":
         optional: true
 
-  use-intl@3.26.5:
+  use-intl@4.13.0:
     resolution:
       {
-        integrity: sha512-OdsJnC/znPvHCHLQH/duvQNXnP1w0hPfS+tkSi3mAbfjYBGh4JnyfdwkQBfIVf7t8gs9eSX/CntxUMvtKdG2MQ==,
+        integrity: sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==,
       }
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
+      react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
 
   use-isomorphic-layout-effect@1.2.1:
     resolution:
@@ -21592,24 +21776,32 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  "@formatjs/fast-memoize@3.1.5": {}
+
   "@formatjs/icu-messageformat-parser@2.11.2":
     dependencies:
       "@formatjs/ecma402-abstract": 2.3.4
       "@formatjs/icu-skeleton-parser": 1.8.14
       tslib: 2.8.1
 
+  "@formatjs/icu-messageformat-parser@3.5.10":
+    dependencies:
+      "@formatjs/icu-skeleton-parser": 2.1.9
+
   "@formatjs/icu-skeleton-parser@1.8.14":
     dependencies:
       "@formatjs/ecma402-abstract": 2.3.4
       tslib: 2.8.1
 
-  "@formatjs/intl-localematcher@0.5.10":
-    dependencies:
-      tslib: 2.8.1
+  "@formatjs/icu-skeleton-parser@2.1.9": {}
 
   "@formatjs/intl-localematcher@0.6.1":
     dependencies:
       tslib: 2.8.1
+
+  "@formatjs/intl-localematcher@0.8.9":
+    dependencies:
+      "@formatjs/fast-memoize": 3.1.5
 
   "@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)":
     dependencies:
@@ -22186,12 +22378,12 @@ snapshots:
       "@types/react": 19.1.12
       react: 19.2.6
 
-  "@mdx-js/loader@3.1.1(webpack@5.101.3)":
+  "@mdx-js/loader@3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))":
     dependencies:
       "@mdx-js/mdx": 3.1.1
       source-map: 0.7.6
     optionalDependencies:
-      webpack: 5.101.3
+      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))
     transitivePeerDependencies:
       - supports-color
 
@@ -22258,11 +22450,11 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  "@next/mdx@15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))":
+  "@next/mdx@15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))":
     dependencies:
       source-map: 0.7.6
     optionalDependencies:
-      "@mdx-js/loader": 3.1.1(webpack@5.101.3)
+      "@mdx-js/loader": 3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
       "@mdx-js/react": 3.1.1(@types/react@19.1.12)(react@19.2.6)
 
   "@next/swc-darwin-arm64@15.5.18":
@@ -22698,7 +22890,6 @@ snapshots:
       "@parcel/watcher-win32-arm64": 2.5.1
       "@parcel/watcher-win32-ia32": 2.5.1
       "@parcel/watcher-win32-x64": 2.5.1
-    optional: true
 
   "@pkgjs/parseargs@0.11.0":
     optional: true
@@ -24607,6 +24798,8 @@ snapshots:
   "@rollup/rollup-win32-x64-msvc@4.59.0":
     optional: true
 
+  "@schummar/icu-type-parser@1.21.5": {}
+
   "@sentry-internal/browser-utils@10.11.0":
     dependencies:
       "@sentry/core": 10.11.0
@@ -24695,7 +24888,7 @@ snapshots:
 
   "@sentry/core@10.11.0": {}
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3)":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -24707,7 +24900,7 @@ snapshots:
       "@sentry/opentelemetry": 10.11.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)
       "@sentry/react": 10.11.0(react@19.2.6)
       "@sentry/vercel-edge": 10.11.0
-      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3)
+      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
       chalk: 3.0.0
       next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
@@ -24797,12 +24990,12 @@ snapshots:
       "@opentelemetry/resources": 2.1.0(@opentelemetry/api@1.9.0)
       "@sentry/core": 10.11.0
 
-  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3)":
+  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))":
     dependencies:
       "@sentry/bundler-plugin-core": 4.3.0
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.101.3
+      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -25650,6 +25843,63 @@ snapshots:
       - supports-color
       - typescript
 
+  "@swc/core-darwin-arm64@1.15.40":
+    optional: true
+
+  "@swc/core-darwin-x64@1.15.40":
+    optional: true
+
+  "@swc/core-linux-arm-gnueabihf@1.15.40":
+    optional: true
+
+  "@swc/core-linux-arm64-gnu@1.15.40":
+    optional: true
+
+  "@swc/core-linux-arm64-musl@1.15.40":
+    optional: true
+
+  "@swc/core-linux-ppc64-gnu@1.15.40":
+    optional: true
+
+  "@swc/core-linux-s390x-gnu@1.15.40":
+    optional: true
+
+  "@swc/core-linux-x64-gnu@1.15.40":
+    optional: true
+
+  "@swc/core-linux-x64-musl@1.15.40":
+    optional: true
+
+  "@swc/core-win32-arm64-msvc@1.15.40":
+    optional: true
+
+  "@swc/core-win32-ia32-msvc@1.15.40":
+    optional: true
+
+  "@swc/core-win32-x64-msvc@1.15.40":
+    optional: true
+
+  "@swc/core@1.15.40(@swc/helpers@0.5.17)":
+    dependencies:
+      "@swc/counter": 0.1.3
+      "@swc/types": 0.1.26
+    optionalDependencies:
+      "@swc/core-darwin-arm64": 1.15.40
+      "@swc/core-darwin-x64": 1.15.40
+      "@swc/core-linux-arm-gnueabihf": 1.15.40
+      "@swc/core-linux-arm64-gnu": 1.15.40
+      "@swc/core-linux-arm64-musl": 1.15.40
+      "@swc/core-linux-ppc64-gnu": 1.15.40
+      "@swc/core-linux-s390x-gnu": 1.15.40
+      "@swc/core-linux-x64-gnu": 1.15.40
+      "@swc/core-linux-x64-musl": 1.15.40
+      "@swc/core-win32-arm64-msvc": 1.15.40
+      "@swc/core-win32-ia32-msvc": 1.15.40
+      "@swc/core-win32-x64-msvc": 1.15.40
+      "@swc/helpers": 0.5.17
+
+  "@swc/counter@0.1.3": {}
+
   "@swc/helpers@0.5.15":
     dependencies:
       tslib: 2.8.1
@@ -25657,6 +25907,10 @@ snapshots:
   "@swc/helpers@0.5.17":
     dependencies:
       tslib: 2.8.1
+
+  "@swc/types@0.1.26":
+    dependencies:
+      "@swc/counter": 0.1.3
 
   "@tailwindcss/node@4.2.4":
     dependencies:
@@ -25810,7 +26064,7 @@ snapshots:
   "@turbo/darwin-arm64@2.9.15":
     optional: true
 
-  "@turbo/gen@2.5.8(@types/node@24.6.2)(typescript@5.9.2)":
+  "@turbo/gen@2.5.8(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@24.6.2)(typescript@5.9.2)":
     dependencies:
       "@turbo/workspaces": 2.5.8(@types/node@24.6.2)
       commander: 10.0.1
@@ -25820,7 +26074,7 @@ snapshots:
       node-plop: 0.26.3
       picocolors: 1.0.1
       proxy-agent: 6.5.0
-      ts-node: 10.9.2(@types/node@24.6.2)(typescript@5.9.2)
+      ts-node: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@24.6.2)(typescript@5.9.2)
       update-check: 1.5.4
       validate-npm-package-name: 5.0.1
     transitivePeerDependencies:
@@ -27651,8 +27905,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  detect-libc@1.0.3:
-    optional: true
+  detect-libc@1.0.3: {}
 
   detect-libc@2.0.4: {}
 
@@ -28972,6 +29225,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  icu-minify@4.13.0:
+    dependencies:
+      "@formatjs/icu-messageformat-parser": 3.5.10
+
   idb-keyval@6.2.2: {}
 
   idb@7.1.1: {}
@@ -29073,6 +29330,11 @@ snapshots:
       "@formatjs/fast-memoize": 2.2.7
       "@formatjs/icu-messageformat-parser": 2.11.2
       tslib: 2.8.1
+
+  intl-messageformat@11.2.7:
+    dependencies:
+      "@formatjs/fast-memoize": 3.1.5
+      "@formatjs/icu-messageformat-parser": 3.5.10
 
   ip-address@10.0.1: {}
 
@@ -30259,13 +30521,24 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-intl@3.26.5(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6):
+  next-intl-swc-plugin-extractor@4.13.0: {}
+
+  next-intl@4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
     dependencies:
-      "@formatjs/intl-localematcher": 0.5.10
+      "@formatjs/intl-localematcher": 0.8.9
+      "@parcel/watcher": 2.5.1
+      "@swc/core": 1.15.40(@swc/helpers@0.5.17)
+      icu-minify: 4.13.0
       negotiator: 1.0.0
       next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next-intl-swc-plugin-extractor: 4.13.0
+      po-parser: 2.1.1
       react: 19.2.6
-      use-intl: 3.26.5(react@19.2.6)
+      use-intl: 4.13.0(react@19.2.6)
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - "@swc/helpers"
 
   next-mdx-remote@6.0.0(@types/react@19.1.12)(react@19.2.6):
     dependencies:
@@ -30327,8 +30600,7 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
-  node-addon-api@7.1.1:
-    optional: true
+  node-addon-api@7.1.1: {}
 
   node-domexception@1.0.0: {}
 
@@ -30731,6 +31003,8 @@ snapshots:
       playwright-core: 1.58.2
     optionalDependencies:
       fsevents: 2.3.2
+
+  po-parser@2.1.1: {}
 
   points-on-curve@0.2.0: {}
 
@@ -32357,14 +32631,16 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  terser-webpack-plugin@5.3.14(webpack@5.101.3):
+  terser-webpack-plugin@5.3.14(@swc/core@1.15.40(@swc/helpers@0.5.17))(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       serialize-javascript: 7.0.3
       terser: 5.44.0
-      webpack: 5.101.3
+      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))
+    optionalDependencies:
+      "@swc/core": 1.15.40(@swc/helpers@0.5.17)
 
   terser@5.44.0:
     dependencies:
@@ -32468,7 +32744,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-loader@9.5.7(typescript@5.8.3)(webpack@5.101.3):
+  ts-loader@9.5.7(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.21.0
@@ -32476,9 +32752,9 @@ snapshots:
       semver: 7.7.4
       source-map: 0.7.6
       typescript: 5.8.3
-      webpack: 5.101.3
+      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))
 
-  ts-node@10.9.2(@types/node@22.18.1)(typescript@5.8.3):
+  ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@22.18.1)(typescript@5.8.3):
     dependencies:
       "@cspotcode/source-map-support": 0.8.1
       "@tsconfig/node10": 1.0.11
@@ -32495,8 +32771,10 @@ snapshots:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      "@swc/core": 1.15.40(@swc/helpers@0.5.17)
 
-  ts-node@10.9.2(@types/node@22.18.8)(typescript@5.8.3):
+  ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@22.18.8)(typescript@5.8.3):
     dependencies:
       "@cspotcode/source-map-support": 0.8.1
       "@tsconfig/node10": 1.0.11
@@ -32513,8 +32791,10 @@ snapshots:
       typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      "@swc/core": 1.15.40(@swc/helpers@0.5.17)
 
-  ts-node@10.9.2(@types/node@24.6.2)(typescript@5.9.2):
+  ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@24.6.2)(typescript@5.9.2):
     dependencies:
       "@cspotcode/source-map-support": 0.8.1
       "@tsconfig/node10": 1.0.11
@@ -32531,12 +32811,14 @@ snapshots:
       typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+    optionalDependencies:
+      "@swc/core": 1.15.40(@swc/helpers@0.5.17)
 
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.22.3)(typescript@5.8.3)(yaml@2.8.1):
+  tsup@8.5.1(@swc/core@1.15.40(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.15)(tsx@4.22.3)(typescript@5.8.3)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.2)
       cac: 6.7.14
@@ -32556,6 +32838,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
+      "@swc/core": 1.15.40(@swc/helpers@0.5.17)
       postcss: 8.5.15
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -32839,10 +33122,12 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.1.12
 
-  use-intl@3.26.5(react@19.2.6):
+  use-intl@4.13.0(react@19.2.6):
     dependencies:
-      "@formatjs/fast-memoize": 2.2.7
-      intl-messageformat: 10.7.16
+      "@formatjs/fast-memoize": 3.1.5
+      "@schummar/icu-type-parser": 1.21.5
+      icu-minify: 4.13.0
+      intl-messageformat: 11.2.7
       react: 19.2.6
 
   use-isomorphic-layout-effect@1.2.1(@types/react@19.1.12)(react@19.2.6):
@@ -33255,7 +33540,7 @@ snapshots:
 
   webpack-virtual-modules@0.5.0: {}
 
-  webpack@5.101.3:
+  webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)):
     dependencies:
       "@types/eslint-scope": 3.7.7
       "@types/estree": 1.0.8
@@ -33279,7 +33564,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.3.14(webpack@5.101.3)
+      terser-webpack-plugin: 5.3.14(@swc/core@1.15.40(@swc/helpers@0.5.17))(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,7 @@ packages:
 
 catalog:
   next: 15.5.18
-  next-intl: 3.26.5
+  next-intl: 4.13.0
   react: 19.2.6
   react-dom: 19.2.6
 


### PR DESCRIPTION
## Summary
- keep public canonical metadata, hreflang, sitemaps, robots, and structured data on `https://solana.com` across apps
- preserve preview/runtime URL behavior by separating public canonical URLs from deployment `siteUrl` values
- fix proxied docs/i18n redirect host handling so language changes do not bounce to Vercel app roots
- add explicit templates canonical metadata

## Testing
- `pnpm --filter @workspace/i18n test`
- `pnpm --filter solana-com-breakpoint test`
- `pnpm --filter solana-com-media test`
- `pnpm --filter solana-templates check-types`
- `pnpm --filter solana-com-accelerate check-types`
- `pnpm --filter solana-com exec tsc --noEmit`
- `pnpm --filter solana-docs lint`
- Prettier check and `git diff --check`