### PR TITLE
fix(docs): hide sidebar on mobile landscape

### DIFF
--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -126,6 +126,39 @@
   max-width: 250px;
 }
 
+/*
+ * Mobile devices in landscape can cross Fumadocs' md breakpoint by width
+ * while still having very limited vertical space. Keep the docs in the
+ * mobile drawer layout for those viewports instead of pinning the sidebar.
+ */
+@media (orientation: landscape) and (max-height: 500px) and (pointer: coarse) {
+  .fumadocs #nd-sidebar {
+    position: fixed !important;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 30;
+    max-width: none;
+    background: hsl(var(--fd-background) / 0.8);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+    font-size: 15px;
+  }
+
+  .fumadocs #nd-sidebar[data-open="false"] {
+    visibility: hidden !important;
+    pointer-events: none;
+  }
+
+  .fumadocs #nd-sidebar[data-open="true"] {
+    visibility: visible !important;
+  }
+
+  .fumadocs #fd-sidebar-toggle {
+    display: block !important;
+  }
+}
+
 .fumadocs #nd-sidebar [data-radix-scroll-area-viewport] {
   mask-image: none !important;
   padding-left: 0rem !important;


### PR DESCRIPTION
## Summary

Fixes #194.

Mobile devices in landscape can cross Fumadocs' `md` breakpoint by width while still having limited vertical space. This keeps the docs sidebar in drawer mode for coarse-pointer landscape viewports with short height instead of pinning the desktop sidebar.

## Changes

- Add a scoped media query for mobile landscape viewports.
- Keep the sidebar fixed/drawer-like in that mode.
- Hide the closed drawer from visibility and pointer events.
- Keep the sidebar toggle visible so users can open the drawer.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm --filter solana-docs lint`
- `pnpm --filter solana-docs build`
- Playwright viewport checks:
  - 844x390 mobile landscape: sidebar closed hidden, toggle visible
  - 932x430 mobile landscape: sidebar closed hidden, toggle visible
  - 844x390 mobile landscape open: drawer visible, nav links usable
  - 1280x800 desktop: sidebar unchanged/sticky
  - 820x1180 tablet portrait: sidebar unchanged/sticky
