### PR TITLE
fix(web): update Access Protocol creator link

### DIFF
--- a/apps/web/builder/section-page/en/solutions-artists-creators.json
+++ b/apps/web/builder/section-page/en/solutions-artists-creators.json
@@ -455,7 +455,7 @@
                 "type": "gradient",
                 "callToAction": {
                   "hierarchy": "outline",
-                  "url": "https://hub.accessprotocol.co/creators",
+                  "url": "https://www.accessprotocol.co/en/creators",
                   "label": "Learn more"
                 },
                 "backgroundGradient": "green",

--- a/apps/web/src/data/solutions/artists-creators.ts
+++ b/apps/web/src/data/solutions/artists-creators.ts
@@ -25,7 +25,7 @@ export const CARDS_CREATE_URLS = [
 ];
 
 export const CARDS_EARN_URLS = [
-  "https://hub.accessprotocol.co/creators",
+  "https://www.accessprotocol.co/en/creators",
   "https://drip.haus/",
   "https://helio.co/nfts/",
   "https://tiplink.io/",


### PR DESCRIPTION
## Summary
- Updates the Access Protocol creator link on the Artists and Creators solution page
- Keeps the Builder.io section-page JSON in sync with the TypeScript data source

## Validation
- `curl -L -o /dev/null -s -w "%{http_code}" https://hub.accessprotocol.co/creators` -> `404`
- `curl -L -o /dev/null -s -w "%{http_code}" https://www.accessprotocol.co/en/creators` -> `200`
- `python3 -m json.tool apps/web/builder/section-page/en/solutions-artists-creators.json`
- `pnpm lint` -> passes; existing warnings only

Closes #940
