### PR TITLE
docs: clarify versioned message header prefix

### DIFF
--- a/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
+++ b/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
@@ -160,6 +160,15 @@ pub struct MessageHeader {
 
 </WithMentions>
 
+<Callout type="info" title="Legacy and versioned message prefixes">
+  In a legacy transaction message, the first message byte is
+  `num_required_signatures`, followed by the other two `MessageHeader` bytes. In
+  a versioned transaction message, the first byte is a version prefix instead;
+  the three-byte `MessageHeader` starts immediately after that prefix. See
+  [versioned transactions](/docs/core/transactions/versioned-transactions) for
+  the full v0 message layout.
+</Callout>
+
 ![Diagram showing the three parts of the message header](/assets/docs/core/transactions/message_header.png)
 
 ### Account addresses


### PR DESCRIPTION
## Summary
- Adds a callout clarifying how the first message byte differs for legacy and versioned transaction messages
- Points readers to the versioned transactions page for the full v0 layout

## Validation
- `pnpm --filter solana-docs lint`

Closes #359
