### PR TITLE
Fix media news post validation crashes

### DIFF
--- a/apps/media/app/[locale]/news/[...urlSegments]/page.tsx
+++ b/apps/media/app/[locale]/news/[...urlSegments]/page.tsx
@@ -18,7 +18,6 @@ import rehypeSlug from "rehype-slug";
 import { newsPostMetadata } from "@/lib/metadata";
 import { fetchPublishedPostBySlug } from "@/lib/post-data";
 import { extractHeadings } from "@/lib/extract-headings";
-import { isPublishedPost } from "@/lib/keystatic/post-status";
 import { formatPublishedAt } from "@/lib/keystatic/publishing";
 import type { Metadata } from "next";
 
@@ -239,8 +238,8 @@ export async function generateStaticParams() {
     const publishedSlugs: string[] = [];
 
     for (const slug of slugs) {
-      const post = await reader.collections.posts.read(slug);
-      if (isPublishedPost(post)) {
+      const post = await fetchPublishedPostBySlug(slug);
+      if (post) {
         publishedSlugs.push(slug);
       }
     }

--- a/apps/media/content/posts/build-onchain-perps.mdx
+++ b/apps/media/content/posts/build-onchain-perps.mdx
@@ -5,6 +5,7 @@ heroImage: /uploads/posts/build-onchain-perps/heroImage.webp
 description: >-
   Solana Foundation supports teams building onchain perps, other derivatives,
   and the applications around them.
+author: solana-foundation
 publishedAt: 2026-06-01T17:00:00.000Z
 categories:
   - category: defi

--- a/apps/media/content/posts/chiliz-sports-industry-on-solana.mdx
+++ b/apps/media/content/posts/chiliz-sports-industry-on-solana.mdx
@@ -6,6 +6,7 @@ description: >-
   Fantasy, prediction markets, sports betting, and licensed Fan Tokens from
   Chiliz are now live on one network, in front of one of the largest crypto
   audiences anywhere.
+author: solana-foundation
 publishedAt: 2026-05-27T10:00:00.000Z
 categories:
   - category: consumer

--- a/apps/media/content/posts/quantum-readiness.mdx
+++ b/apps/media/content/posts/quantum-readiness.mdx
@@ -5,6 +5,7 @@ heroImage: /uploads/posts/quantum-readiness/heroImage.webp
 description: >-
   Where Solana’s quantum readiness stands and the path forward, with independent
   research from Firedancer and Anza
+author: solana-foundation
 publishedAt: 2026-04-27T13:50:00.000Z
 categories:
   - category: developers

--- a/apps/media/content/posts/solana-developer-platform.mdx
+++ b/apps/media/content/posts/solana-developer-platform.mdx
@@ -5,6 +5,7 @@ heroImage: /uploads/posts/solana-developer-platform/heroImage.webp
 description: |
   Solana Foundation launches Solana Developer Platform,
   a unified API platform for institutions and enterprises building on Solana.
+author: solana-foundation
 publishedAt: 2026-03-24T12:50:00.000Z
 categories:
   - category: developers

--- a/apps/media/content/posts/solana-ecosystem-security.mdx
+++ b/apps/media/content/posts/solana-ecosystem-security.mdx
@@ -3,6 +3,7 @@ title: Raising the Bar on Solana Ecosystem Security
 status: published
 heroImage: /uploads/posts/solana-ecosystem-security/hero.webp
 description: Introducing STRIDE and Solana Incident Response Network
+author: solana-foundation
 publishedAt: 2026-04-06T19:30:00.000Z
 categories:
   - category: defi

--- a/apps/media/lib/google-news-sitemap.ts
+++ b/apps/media/lib/google-news-sitemap.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { reader } from "@/lib/reader";
-import { isPublishedPost } from "@/lib/keystatic/post-status";
+import { fetchPublishedPostBySlug } from "@/lib/post-data";
 import { parsePublishedAt } from "@/lib/keystatic/publishing";
 
 const BASE_URL = "https://solana.com";
@@ -35,8 +35,8 @@ async function getPublishedPosts(now: Date): Promise<RecentPublishedPost[]> {
   const posts: RecentPublishedPost[] = [];
 
   for (const slug of allSlugs) {
-    const post = await reader.collections.posts.read(slug);
-    if (!isPublishedPost(post, now)) {
+    const post = await fetchPublishedPostBySlug(slug, now);
+    if (!post) {
       continue;
     }
 

--- a/apps/media/lib/keystatic/post-data.ts
+++ b/apps/media/lib/keystatic/post-data.ts
@@ -20,8 +20,23 @@ export interface LatestPostsResponse {
   };
 }
 
+type PostEntry = Awaited<ReturnType<typeof reader.collections.posts.read>>;
+
 function dedupeStrings(values: string[]): string[] {
   return Array.from(new Set(values));
+}
+
+export async function readPostBySlug(
+  slug: string,
+  context?: string,
+): Promise<PostEntry | null> {
+  try {
+    return await reader.collections.posts.read(slug);
+  } catch (error) {
+    const suffix = context ? ` in ${context}` : "";
+    console.error(`Failed to read post "${slug}"${suffix}:`, error);
+    return null;
+  }
 }
 
 /**
@@ -29,7 +44,7 @@ function dedupeStrings(values: string[]): string[] {
  */
 async function transformPost(
   slug: string,
-  post: Awaited<ReturnType<typeof reader.collections.posts.read>>,
+  post: PostEntry,
 ): Promise<PostItem | null> {
   if (!post) return null;
 
@@ -166,7 +181,7 @@ export const fetchLatestPosts = async (
     const postsWithDates: Array<{
       slug: string;
       date: Date | null;
-      post: Awaited<ReturnType<typeof reader.collections.posts.read>>;
+      post: PostEntry;
     }> = [];
 
     for (const slug of allSlugs) {
@@ -303,9 +318,9 @@ export interface FeaturedPostResponse {
   post: PostItem | null;
 }
 
-export async function fetchPublishedPostBySlug(slug: string) {
-  const post = await reader.collections.posts.read(slug);
-  return isPublishedPost(post) ? post : null;
+export async function fetchPublishedPostBySlug(slug: string, now?: Date) {
+  const post = await readPostBySlug(slug, "fetchPublishedPostBySlug");
+  return isPublishedPost(post, now) ? post : null;
 }
 
 /**
@@ -319,7 +334,7 @@ export const fetchFeaturedPost = async (): Promise<FeaturedPostResponse> => {
     const featuredCandidates: Array<{
       slug: string;
       date: Date | null;
-      post: Awaited<ReturnType<typeof reader.collections.posts.read>>;
+      post: PostEntry;
     }> = [];
 
     for (const slug of allSlugs) {

--- a/apps/media/lib/news-rss.ts
+++ b/apps/media/lib/news-rss.ts
@@ -2,7 +2,7 @@ import { Feed } from "feed";
 import { NextResponse } from "next/server";
 import { reader } from "@/lib/reader";
 import { contentDocumentToPlainText } from "@/lib/content-renderer";
-import { isPublishedPost } from "@/lib/keystatic/post-status";
+import { fetchPublishedPostBySlug } from "@/lib/post-data";
 import { parsePublishedAt } from "@/lib/keystatic/publishing";
 import faviconPng from "@solana-com/ui-chrome/assets/favicon.png";
 
@@ -41,8 +41,8 @@ async function buildNewsFeed(feedUrl: string) {
   }> = [];
 
   for (const slug of allSlugs) {
-    const post = await reader.collections.posts.read(slug);
-    if (isPublishedPost(post)) {
+    const post = await fetchPublishedPostBySlug(slug);
+    if (post) {
       postsWithDates.push({
         slug,
         date: parsePublishedAt(post.publishedAt),

--- a/apps/media/lib/post-data.ts
+++ b/apps/media/lib/post-data.ts
@@ -3,6 +3,7 @@ export {
   fetchLatestPosts,
   fetchFeaturedPost,
   fetchPublishedPostBySlug,
+  readPostBySlug,
   type LatestPostsParams,
   type LatestPostsResponse,
   type FeaturedPostResponse,


### PR DESCRIPTION
## Summary
- backfill missing `author` frontmatter on published media posts so Keystatic validation succeeds
- guard post reads used by news article static params, RSS, and Google News sitemap so one malformed post does not break the whole route/feed
- preserve `publishedAt` as the release gate for listings, article metadata, RSS, and Google News sitemap generation

## Validation
- `pnpm --filter solana-com-media typecheck`
- `pnpm --filter solana-com-media test`
- `pnpm --filter solana-com-media build`
- built server smoke checks returned 200 for `/news`, `/news/rss.xml`, `/en/news/rss.xml`, `/en/news/feed`, `/news/google-news.xml`, and the reported failing articles
- RSS outputs rendered valid XML with 20 items and 20 `pubDate` entries; first RSS pubDate was `Mon, 01 Jun 2026 17:00:00 GMT`
- Google News sitemap rendered 275 URLs and kept the first `news:publication_date` as `2026-06-01T17:00:00.000Z`
