### PR TITLE
docs: add Faremeter to agentic payments x402 tooling

### DIFF
--- a/apps/docs/content/docs/en/payments/agentic-payments.mdx
+++ b/apps/docs/content/docs/en/payments/agentic-payments.mdx
@@ -110,11 +110,12 @@ To learn more on x402, check out our guides:
 
 ### x402 Tooling
 
-| SDK                                                             | Description                          |
-| --------------------------------------------------------------- | ------------------------------------ |
-| [Corbits](https://corbits.dev/)                                 | Solana-first x402 implementation     |
-| [MCPay.tech](https://mcpay.tech/)                               | Pay-per-request for MCP servers      |
-| [PayAI](https://payai.network/)                                 | x402 facilitator with Solana support |
-| [x402 GitHub](https://github.com/coinbase/x402)                 | Reference implementation             |
-| [ACK](https://github.com/agentcommercekit/ack)                  | Agent Commerce Kit                   |
-| [A2A x402](https://github.com/google-agentic-commerce/a2a-x402) | Google's agent-to-agent payments     |
+| SDK                                                             | Description                                    |
+| --------------------------------------------------------------- | ---------------------------------------------- |
+| [Faremeter](https://faremeter.xyz/)                             | Frictionless agentic payments for Solana & EVM |
+| [Corbits](https://corbits.dev/)                                 | Solana-first x402 implementation               |
+| [MCPay.tech](https://mcpay.tech/)                               | Pay-per-request for MCP servers                |
+| [PayAI](https://payai.network/)                                 | x402 facilitator with Solana support           |
+| [x402 GitHub](https://github.com/coinbase/x402)                 | Reference implementation                       |
+| [ACK](https://github.com/agentcommercekit/ack)                  | Agent Commerce Kit                             |
+| [A2A x402](https://github.com/google-agentic-commerce/a2a-x402) | Google's agent-to-agent payments               |


### PR DESCRIPTION
Add Faremeter (https://faremeter.xyz/) as the first entry in the x402 Tooling table on the Agentic Payments page.
