### PR TITLE
feat(news): add category routes

### DIFF
--- a/apps/media/app/[locale]/news/[...urlSegments]/page.tsx
+++ b/apps/media/app/[locale]/news/[...urlSegments]/page.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { notFound } from "next/navigation";
 import Image from "next/image";
 import { reader } from "@/lib/reader";
@@ -15,11 +14,23 @@ import { SocialShare } from "@/components/ui/social-share";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
 import rehypeSlug from "rehype-slug";
-import { newsPostMetadata } from "@/lib/metadata";
-import { fetchPublishedPostBySlug } from "@/lib/post-data";
+import {
+  categoryListingMetadata,
+  newsListingMetadata,
+  newsPostMetadata,
+} from "@/lib/metadata";
+import { fetchLatestPosts, fetchPublishedPostBySlug } from "@/lib/post-data";
+import { fetchCategoryByPath } from "@/lib/category-data";
 import { extractHeadings } from "@/lib/extract-headings";
 import { formatPublishedAt } from "@/lib/keystatic/publishing";
 import type { Metadata } from "next";
+import PostsClientPage from "../client-page";
+import {
+  CASE_STUDIES_FILTER_LABEL,
+  CASE_STUDIES_FILTER_SLUG,
+  newsFilterToSlug,
+} from "@/lib/news-filters";
+import { fetchNewsFilterOptions } from "@/lib/news-filter-options";
 
 export const revalidate = 300;
 export const dynamicParams = true;
@@ -31,6 +42,11 @@ export default async function PostPage({
 }) {
   const resolvedParams = await params;
   const slug = resolvedParams.urlSegments.join("/");
+
+  const filterPage = await renderFilterPage(resolvedParams.urlSegments);
+  if (filterPage) {
+    return filterPage;
+  }
 
   const post = await fetchPublishedPostBySlug(slug);
 
@@ -232,6 +248,66 @@ export default async function PostPage({
   );
 }
 
+async function renderFilterPage(urlSegments: string[]) {
+  if (urlSegments.length !== 1) {
+    return null;
+  }
+
+  const filterSlug = urlSegments[0];
+  if (!filterSlug) {
+    return null;
+  }
+
+  if (filterSlug === CASE_STUDIES_FILTER_SLUG) {
+    const latestPosts = await fetchLatestPosts({
+      limit: 13,
+      tag: CASE_STUDIES_FILTER_SLUG,
+    });
+
+    if (latestPosts.posts.length === 0) {
+      return null;
+    }
+
+    const filterOptions = await fetchNewsFilterOptions();
+
+    return (
+      <PostsClientPage
+        featuredPost={latestPosts.posts[0] ?? null}
+        latestPosts={latestPosts.posts}
+        initialPageInfo={latestPosts.pageInfo}
+        initialFilter={CASE_STUDIES_FILTER_LABEL}
+        filterOptions={filterOptions}
+      />
+    );
+  }
+
+  const { category } = await fetchCategoryByPath(filterSlug);
+  if (!category) {
+    return null;
+  }
+
+  const latestPosts = await fetchLatestPosts({
+    limit: 13,
+    category: category.name,
+  });
+
+  if (latestPosts.posts.length === 0) {
+    return null;
+  }
+
+  const filterOptions = await fetchNewsFilterOptions();
+
+  return (
+    <PostsClientPage
+      featuredPost={latestPosts.posts[0] ?? null}
+      latestPosts={latestPosts.posts}
+      initialPageInfo={latestPosts.pageInfo}
+      initialFilter={category.name}
+      filterOptions={filterOptions}
+    />
+  );
+}
+
 export async function generateStaticParams() {
   try {
     const slugs = await reader.collections.posts.list();
@@ -244,7 +320,10 @@ export async function generateStaticParams() {
       }
     }
 
-    return publishedSlugs.map((slug) => ({
+    const filterSlugs = (await fetchNewsFilterOptions()).map(newsFilterToSlug);
+    const routeSlugs = [...publishedSlugs, ...filterSlugs];
+
+    return routeSlugs.map((slug) => ({
       urlSegments: slug.split("/"),
     }));
   } catch (error) {
@@ -260,5 +339,23 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const resolvedParams = await params;
   const slug = resolvedParams.urlSegments.join("/");
+
+  if (resolvedParams.urlSegments.length === 1) {
+    if (slug === CASE_STUDIES_FILTER_SLUG) {
+      const filterOptions = await fetchNewsFilterOptions();
+      if (filterOptions.includes(CASE_STUDIES_FILTER_LABEL)) {
+        return newsListingMetadata();
+      }
+    }
+
+    const category = (await fetchCategoryByPath(slug)).category;
+    if (category) {
+      const filterOptions = await fetchNewsFilterOptions();
+      if (filterOptions.includes(category.name)) {
+        return categoryListingMetadata(slug);
+      }
+    }
+  }
+
   return newsPostMetadata(slug);
 }

--- a/apps/media/app/[locale]/news/client-page.tsx
+++ b/apps/media/app/[locale]/news/client-page.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useCallback, useMemo, useEffect, useState } from "react";
+import { useCallback, useMemo, useEffect, useState } from "react";
 import Link from "next/link";
 import Image from "next/image";
 import ErrorBoundary from "@/components/error-boundary";
@@ -12,8 +12,10 @@ import { PostCard } from "@/components/post/post-card";
 import LoadMoreStatus from "@/components/ui/load-more-status";
 import uniqBy from "lodash/uniqBy";
 import {
+  CASE_STUDIES_FILTER_SLUG,
   filterPostsByNewsFilter,
-  getNewsFilterOptions,
+  isCaseStudiesFilter,
+  newsFilterToPath,
 } from "@/lib/news-filters";
 
 const DEFAULT_PAGE_INFO: PageInfo = {
@@ -27,13 +29,19 @@ interface PostsClientPageProps {
   featuredPost: PostItem | null;
   latestPosts: PostItem[];
   initialPageInfo?: PageInfo;
+  initialFilter?: string | null;
+  filterOptions: string[];
 }
 
 export default function PostsClientPage(props: PostsClientPageProps) {
-  const { featuredPost, latestPosts, initialPageInfo } = props;
-  const [selectedFilter, setSelectedFilter] = React.useState<string | null>(
-    null,
-  );
+  const {
+    featuredPost,
+    latestPosts,
+    initialPageInfo,
+    initialFilter,
+    filterOptions,
+  } = props;
+  const selectedFilter = initialFilter ?? null;
 
   const [posts, setPosts] = useState<(PostItem | null)[]>(latestPosts);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
@@ -42,7 +50,6 @@ export default function PostsClientPage(props: PostsClientPageProps) {
   );
   const [currentCursor, setCurrentCursor] = useState<string | null>(null);
 
-  // Load more posts via API
   const handleLoadMore = useCallback(async () => {
     if (!pageInfo?.hasNextPage || isLoadingMore) return;
 
@@ -52,6 +59,13 @@ export default function PostsClientPage(props: PostsClientPageProps) {
       const cursor = currentCursor || pageInfo.endCursor;
       const params = new URLSearchParams({ limit: "13" });
       if (cursor) params.set("cursor", cursor);
+      if (selectedFilter) {
+        if (isCaseStudiesFilter(selectedFilter)) {
+          params.set("tag", CASE_STUDIES_FILTER_SLUG);
+        } else {
+          params.set("category", selectedFilter);
+        }
+      }
 
       const res = await fetch(`/api/posts/latest?${params.toString()}`);
       if (!res.ok) throw new Error("Failed to fetch posts");
@@ -60,61 +74,44 @@ export default function PostsClientPage(props: PostsClientPageProps) {
       const newPosts = response.posts;
 
       if (newPosts.length > 0) {
-        // Append older posts to the end
         setPosts((prev) => uniqBy([...prev, ...newPosts], "id"));
 
-        // Update the cursor to the last (oldest) edge
         const lastEdge = newPosts[newPosts.length - 1];
         if (lastEdge?.cursor) {
           setCurrentCursor(lastEdge.cursor);
         }
       }
 
-      // Always update pageInfo to track pagination state
       setPageInfo(response.pageInfo ?? DEFAULT_PAGE_INFO);
     } catch (error) {
       console.error("Failed to load more posts:", error);
     } finally {
       setIsLoadingMore(false);
     }
-  }, [pageInfo.hasNextPage, pageInfo.endCursor, isLoadingMore, currentCursor]);
+  }, [
+    pageInfo.hasNextPage,
+    pageInfo.endCursor,
+    isLoadingMore,
+    currentCursor,
+    selectedFilter,
+  ]);
 
-  // Extract regular posts from postsData
   useEffect(() => {
-    // Remove featured post from latest posts if it exists
     setPosts(
       featuredPost
         ? latestPosts?.filter((post) => post?.id !== featuredPost?.id) || []
         : latestPosts || [],
     );
 
-    // Set the cursor from the last (oldest) post edge
     const lastPost = latestPosts[latestPosts.length - 1];
     if (lastPost?.cursor) {
       setCurrentCursor(lastPost.cursor);
     }
   }, [latestPosts, featuredPost]);
 
-  const filterOptions = useMemo(() => getNewsFilterOptions(posts), [posts]);
-
   const filteredPosts = useMemo(() => {
     return filterPostsByNewsFilter(posts, selectedFilter);
   }, [posts, selectedFilter]);
-
-  // const handleCopyLink = useCallback(() => {
-  //   if (
-  //     !featuredPost ||
-  //     typeof window === "undefined" ||
-  //     !navigator.clipboard
-  //   ) {
-  //     return;
-  //   }
-
-  //   const articleUrl = `${window.location.origin}${featuredPost.url}`;
-  //   navigator.clipboard.writeText(articleUrl).catch(() => {
-  //     /* no-op */
-  //   });
-  // }, [featuredPost]);
 
   return (
     <ErrorBoundary>
@@ -184,31 +181,34 @@ export default function PostsClientPage(props: PostsClientPageProps) {
             </div>
           )}
           <div className="px-4 md:px-6 lg:px-0">
-            {/* Filter Button Group */}
             {filterOptions.length > 0 && (
               <div className="flex flex-wrap items-center gap-3 max-w-6xl mx-auto w-full mb-6">
                 <span className="text-sm font-medium text-muted-foreground">
                   Filter by category:
                 </span>
                 <Button
+                  asChild
                   variant={selectedFilter === null ? "default" : "secondary"}
                   size="sm"
-                  onClick={() => setSelectedFilter(null)}
                   className="capitalize"
                 >
-                  All
+                  <Link href="/news" scroll={false}>
+                    All
+                  </Link>
                 </Button>
                 {filterOptions.map((category) => (
                   <Button
+                    asChild
                     key={category}
                     variant={
                       selectedFilter === category ? "default" : "secondary"
                     }
                     size="sm"
-                    onClick={() => setSelectedFilter(category)}
                     className="capitalize"
                   >
-                    {category}
+                    <Link href={newsFilterToPath(category)} scroll={false}>
+                      {category}
+                    </Link>
                   </Button>
                 ))}
               </div>
@@ -222,8 +222,7 @@ export default function PostsClientPage(props: PostsClientPageProps) {
               </div>
             )}
 
-            {/* Show message when no posts match the filter */}
-            {filteredPosts.length === 0 && selectedFilter && (
+            {filteredPosts.length === 0 && selectedFilter && !featuredPost && (
               <div className="text-center py-12 max-w-6xl mx-auto w-full">
                 <p className="text-muted-foreground">
                   No posts found for &quot;{selectedFilter}&quot;.
@@ -231,8 +230,7 @@ export default function PostsClientPage(props: PostsClientPageProps) {
               </div>
             )}
 
-            {/* Only show LoadMoreStatus when there are posts and no filter is active */}
-            {posts.length > 0 && !selectedFilter && (
+            {posts.length > 0 && (
               <LoadMoreStatus
                 isLoading={isLoadingMore}
                 hasMore={pageInfo.hasNextPage}

--- a/apps/media/app/[locale]/news/page.tsx
+++ b/apps/media/app/[locale]/news/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import PostsClientPage from "./client-page";
 import { fetchFeaturedPost, fetchLatestPosts } from "@/lib/post-data";
 import { newsListingMetadata } from "@/lib/metadata";
+import { fetchNewsFilterOptions } from "@/lib/news-filter-options";
 
 export const revalidate = 300;
 
@@ -16,12 +17,14 @@ export default async function PostsPage({
 }) {
   const featuredPost = await fetchFeaturedPost();
   const latestPosts = await fetchLatestPosts({ limit: 13 });
+  const filterOptions = await fetchNewsFilterOptions();
 
   return (
     <PostsClientPage
       featuredPost={featuredPost.post}
       latestPosts={latestPosts.posts}
       initialPageInfo={latestPosts.pageInfo}
+      filterOptions={filterOptions}
     />
   );
 }

--- a/apps/media/lib/news-filter-options.ts
+++ b/apps/media/lib/news-filter-options.ts
@@ -1,0 +1,34 @@
+import "server-only";
+
+import { fetchAllCategories } from "@/lib/category-data";
+import { fetchLatestPosts } from "@/lib/post-data";
+import {
+  CASE_STUDIES_FILTER_LABEL,
+  CASE_STUDIES_FILTER_SLUG,
+} from "@/lib/news-filters";
+
+export async function fetchNewsFilterOptions(): Promise<string[]> {
+  const categories = await fetchAllCategories();
+  const options: string[] = [];
+  const caseStudies = await fetchLatestPosts({
+    limit: 1,
+    tag: CASE_STUDIES_FILTER_SLUG,
+  });
+
+  if (caseStudies.posts.length > 0) {
+    options.push(CASE_STUDIES_FILTER_LABEL);
+  }
+
+  for (const category of categories) {
+    const latestPosts = await fetchLatestPosts({
+      limit: 1,
+      category: category.name,
+    });
+
+    if (latestPosts.posts.length > 0) {
+      options.push(category.name);
+    }
+  }
+
+  return options;
+}

--- a/apps/media/lib/news-filters.ts
+++ b/apps/media/lib/news-filters.ts
@@ -1,8 +1,12 @@
 import { PostItem } from "./post-types";
 
 export const CASE_STUDIES_FILTER_LABEL = "Case Studies";
+export const CASE_STUDIES_FILTER_SLUG = "case-studies";
 
-const CASE_STUDIES_TAG_VALUES = new Set(["case studies", "case-studies"]);
+const CASE_STUDIES_TAG_VALUES = new Set([
+  "case studies",
+  CASE_STUDIES_FILTER_SLUG,
+]);
 
 function isCaseStudiesTag(tag: string): boolean {
   return CASE_STUDIES_TAG_VALUES.has(tag.trim().toLowerCase());
@@ -44,4 +48,24 @@ export function filterPostsByNewsFilter(
       post?.tags?.some(isCaseStudiesTag)
     );
   });
+}
+
+export function newsFilterToPath(filter: string | null): string {
+  if (!filter) {
+    return "/news";
+  }
+
+  return `/news/${newsFilterToSlug(filter)}`;
+}
+
+export function newsFilterToSlug(filter: string): string {
+  return filter
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+export function isCaseStudiesFilter(filter: string | null): boolean {
+  return filter === CASE_STUDIES_FILTER_LABEL;
 }


### PR DESCRIPTION
### Problem

In preparation for a link to `/news/changelog/`, it would be cool if news article categories had their own routs e.g. 

`/news/defi` for Defi
`/news/developers` for Developers
`/news` is for all news

### Summary of Changes

Made a change so that the news category routes are implemented.

Ensuring the following:
- the scroll reset is set to false
- the hero page renders the most recent article for that category