### PR TITLE
docs: correct Token-2022 supported extensions for subscriptions

### DIFF
--- a/apps/docs/content/docs/en/payments/subscriptions/overview.mdx
+++ b/apps/docs/content/docs/en/payments/subscriptions/overview.mdx
@@ -46,11 +46,10 @@ The program supports three authorization models:
 
 ## Supported Tokens
 
-The program supports tokens created with both SPL Token and Token-2022. For
-Token-2022 mints, it rejects extensions that would make scheduled or delegated
-transfers unsafe or unclear, including `ConfidentialTransfer`,
-`NonTransferable`, `PermanentDelegate`, `TransferHook`, `TransferFee`,
-`MintCloseAuthority`, and `Pausable`.
+The program supports tokens created with both SPL Token and Token-2022. The only
+Token-2022 extension it rejects is a configured `TransferHook` (where the hook
+`authority` or `program_id` is set). An inert `TransferHook` (both unset, and
+therefore permanently immutable) and all other extensions are allowed.
 
 ## On-Chain Events
 


### PR DESCRIPTION
## Summary
- The subscriptions overview claimed the program rejects 7 Token-2022 extensions (`ConfidentialTransfer`, `NonTransferable`, `PermanentDelegate`, `TransferHook`, `TransferFee`, `MintCloseAuthority`, `Pausable`). This is stale.
- Real behavior (`program/src/instructions/helpers/token.rs`, `validate_mint_extensions`): only a **configured** `TransferHook` is rejected. Inert hooks and all other extensions are allowed. The other 6 `MintHas*` error variants are dead code.
- Updated the English source to match the subscriptions program code and `README.md` on `origin/main`.

## Test Plan
- `grep -n -A4 "Supported Tokens" apps/docs/content/docs/en/payments/subscriptions/overview.mdx`
- Optional: `pnpm dev --filter solana-docs`, open `/docs/payments/subscriptions/overview#supported-tokens`.

## Notes
- Only the `en` source was edited. The 18 locale copies are generated by lingo.dev and will be regenerated by the translation pipeline.