### PR TITLE
chore: upgrade Vitest catalog

### DIFF
--- a/apps/breakpoint/package.json
+++ b/apps/breakpoint/package.json
@@ -41,7 +41,7 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^4.2.4",
     "typescript": "5.8.3",
-    "vitest": "^4.0.18"
+    "vitest": "catalog:"
   },
   "packageManager": "pnpm@10.15.1"
 }

--- a/apps/media/package.json
+++ b/apps/media/package.json
@@ -81,7 +81,7 @@
     "postcss-nesting": "^13.0.2",
     "sharp": "^0.33.5",
     "typescript": "5.8.3",
-    "vitest": "^4.0.18"
+    "vitest": "catalog:"
   },
   "packageManager": "pnpm@10.15.1"
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -95,7 +95,7 @@
     "ts-node": "^10.9.2",
     "tsx": "^4.21.1",
     "typescript": "5.8.3",
-    "vitest": "^4.0.18"
+    "vitest": "catalog:"
   },
   "scripts": {
     "build": "pnpm run generate:sitemap && NODE_OPTIONS='--max-old-space-size=8192' next build",

--- a/packages/docs-examples/package.json
+++ b/packages/docs-examples/package.json
@@ -32,7 +32,7 @@
   "devDependencies": {
     "@types/node": "^22.10.10",
     "typescript": "5.8.3",
-    "vitest": "^2.1.9"
+    "vitest": "catalog:"
   },
   "engines": {
     "node": ">=20"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -19,7 +19,7 @@
     "@types/react": "^19.0.14",
     "@types/react-dom": "^19.0.6",
     "typescript": "5.8.3",
-    "vitest": "^4.0.18"
+    "vitest": "catalog:"
   },
   "dependencies": {
     "next": "catalog:",

--- a/packages/ui-chrome/package.json
+++ b/packages/ui-chrome/package.json
@@ -39,7 +39,7 @@
     "@types/react": "^19.0.14",
     "@types/react-dom": "^19.0.6",
     "typescript": "5.8.3",
-    "vitest": "^4.0.18"
+    "vitest": "catalog:"
   },
   "peerDependencies": {
     "@workspace/i18n": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     react-dom:
       specifier: 19.2.6
       version: 19.2.6
+    vitest:
+      specifier: 4.1.8
+      version: 4.1.8
 
 overrides:
   "@babel/plugin-transform-modules-systemjs@>=7.12.0 <=7.29.3": 7.29.4
@@ -80,16 +83,16 @@ importers:
     dependencies:
       "@mdx-js/loader":
         specifier: ^3.1.1
-        version: 3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
+        version: 3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15))
       "@mdx-js/react":
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.1.12)(react@19.2.6)
       "@next/mdx":
         specifier: ^15.2.9
-        version: 15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))
+        version: 15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15)))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -195,7 +198,7 @@ importers:
     dependencies:
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -273,8 +276,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+        specifier: "catalog:"
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
 
   apps/docs:
     dependencies:
@@ -322,7 +325,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -367,7 +370,7 @@ importers:
         version: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fumadocs-mdx:
         specifier: ^12.0.3
-        version: 12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1))
+        version: 12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
       fumadocs-ui:
         specifier: 14.7.7
         version: 14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.3)(yaml@2.8.1))
@@ -515,7 +518,7 @@ importers:
         version: 1.2.4(@types/react@19.1.12)(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -680,8 +683,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+        specifier: "catalog:"
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
 
   apps/templates:
     dependencies:
@@ -823,7 +826,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -1031,7 +1034,7 @@ importers:
         version: 3.4.19(tsx@4.22.3)(yaml@2.8.1)
       ts-loader:
         specifier: ^9.5.7
-        version: 9.5.7(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
+        version: 9.5.7(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@22.18.1)(typescript@5.8.3)
@@ -1042,8 +1045,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+        specifier: "catalog:"
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
 
   packages/config-eslint:
     devDependencies:
@@ -1147,8 +1150,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^2.1.9
-        version: 2.1.9(@types/node@22.19.19)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)
+        specifier: "catalog:"
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
 
   packages/ecosystem-data:
     devDependencies:
@@ -1227,8 +1230,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+        specifier: "catalog:"
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
 
   packages/sentry:
     devDependencies:
@@ -1377,8 +1380,8 @@ importers:
         specifier: 5.8.3
         version: 5.8.3
       vitest:
-        specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+        specifier: "catalog:"
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
 
 packages:
   "@0no-co/graphql.web@1.2.0":
@@ -2377,6 +2380,13 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@babel/runtime@7.29.7":
+    resolution:
+      {
+        integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==,
+      }
+    engines: { node: ">=6.9.0" }
+
   "@babel/template@7.27.2":
     resolution:
       {
@@ -2979,15 +2989,6 @@ packages:
         integrity: sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg==,
       }
 
-  "@esbuild/aix-ppc64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==,
-      }
-    engines: { node: ">=12" }
-    cpu: [ppc64]
-    os: [aix]
-
   "@esbuild/aix-ppc64@0.25.10":
     resolution:
       {
@@ -3006,6 +3007,15 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  "@esbuild/aix-ppc64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [aix]
+
   "@esbuild/aix-ppc64@0.28.0":
     resolution:
       {
@@ -3014,15 +3024,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [ppc64]
     os: [aix]
-
-  "@esbuild/android-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [android]
 
   "@esbuild/android-arm64@0.25.10":
     resolution:
@@ -3042,6 +3043,15 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  "@esbuild/android-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [android]
+
   "@esbuild/android-arm64@0.28.0":
     resolution:
       {
@@ -3049,15 +3059,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [android]
-
-  "@esbuild/android-arm@0.21.5":
-    resolution:
-      {
-        integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm]
     os: [android]
 
   "@esbuild/android-arm@0.25.10":
@@ -3078,6 +3079,15 @@ packages:
     cpu: [arm]
     os: [android]
 
+  "@esbuild/android-arm@0.27.7":
+    resolution:
+      {
+        integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [android]
+
   "@esbuild/android-arm@0.28.0":
     resolution:
       {
@@ -3085,15 +3095,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm]
-    os: [android]
-
-  "@esbuild/android-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [android]
 
   "@esbuild/android-x64@0.25.10":
@@ -3114,6 +3115,15 @@ packages:
     cpu: [x64]
     os: [android]
 
+  "@esbuild/android-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [android]
+
   "@esbuild/android-x64@0.28.0":
     resolution:
       {
@@ -3122,15 +3132,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [x64]
     os: [android]
-
-  "@esbuild/darwin-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [darwin]
 
   "@esbuild/darwin-arm64@0.25.10":
     resolution:
@@ -3150,6 +3151,15 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  "@esbuild/darwin-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [darwin]
+
   "@esbuild/darwin-arm64@0.28.0":
     resolution:
       {
@@ -3157,15 +3167,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [darwin]
-
-  "@esbuild/darwin-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [darwin]
 
   "@esbuild/darwin-x64@0.25.10":
@@ -3186,6 +3187,15 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  "@esbuild/darwin-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [darwin]
+
   "@esbuild/darwin-x64@0.28.0":
     resolution:
       {
@@ -3194,15 +3204,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [x64]
     os: [darwin]
-
-  "@esbuild/freebsd-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [freebsd]
 
   "@esbuild/freebsd-arm64@0.25.10":
     resolution:
@@ -3222,6 +3223,15 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  "@esbuild/freebsd-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [freebsd]
+
   "@esbuild/freebsd-arm64@0.28.0":
     resolution:
       {
@@ -3229,15 +3239,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [freebsd]
-
-  "@esbuild/freebsd-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [freebsd]
 
   "@esbuild/freebsd-x64@0.25.10":
@@ -3258,6 +3259,15 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  "@esbuild/freebsd-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [freebsd]
+
   "@esbuild/freebsd-x64@0.28.0":
     resolution:
       {
@@ -3266,15 +3276,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [x64]
     os: [freebsd]
-
-  "@esbuild/linux-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [linux]
 
   "@esbuild/linux-arm64@0.25.10":
     resolution:
@@ -3294,6 +3295,15 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  "@esbuild/linux-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [linux]
+
   "@esbuild/linux-arm64@0.28.0":
     resolution:
       {
@@ -3301,15 +3311,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [linux]
-
-  "@esbuild/linux-arm@0.21.5":
-    resolution:
-      {
-        integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm]
     os: [linux]
 
   "@esbuild/linux-arm@0.25.10":
@@ -3330,6 +3331,15 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  "@esbuild/linux-arm@0.27.7":
+    resolution:
+      {
+        integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm]
+    os: [linux]
+
   "@esbuild/linux-arm@0.28.0":
     resolution:
       {
@@ -3337,15 +3347,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm]
-    os: [linux]
-
-  "@esbuild/linux-ia32@0.21.5":
-    resolution:
-      {
-        integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [ia32]
     os: [linux]
 
   "@esbuild/linux-ia32@0.25.10":
@@ -3366,6 +3367,15 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  "@esbuild/linux-ia32@0.27.7":
+    resolution:
+      {
+        integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [linux]
+
   "@esbuild/linux-ia32@0.28.0":
     resolution:
       {
@@ -3373,15 +3383,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
-    os: [linux]
-
-  "@esbuild/linux-loong64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [loong64]
     os: [linux]
 
   "@esbuild/linux-loong64@0.25.10":
@@ -3402,6 +3403,15 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  "@esbuild/linux-loong64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==,
+      }
+    engines: { node: ">=18" }
+    cpu: [loong64]
+    os: [linux]
+
   "@esbuild/linux-loong64@0.28.0":
     resolution:
       {
@@ -3409,15 +3419,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [loong64]
-    os: [linux]
-
-  "@esbuild/linux-mips64el@0.21.5":
-    resolution:
-      {
-        integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [mips64el]
     os: [linux]
 
   "@esbuild/linux-mips64el@0.25.10":
@@ -3438,6 +3439,15 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  "@esbuild/linux-mips64el@0.27.7":
+    resolution:
+      {
+        integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [mips64el]
+    os: [linux]
+
   "@esbuild/linux-mips64el@0.28.0":
     resolution:
       {
@@ -3445,15 +3455,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [mips64el]
-    os: [linux]
-
-  "@esbuild/linux-ppc64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==,
-      }
-    engines: { node: ">=12" }
-    cpu: [ppc64]
     os: [linux]
 
   "@esbuild/linux-ppc64@0.25.10":
@@ -3474,6 +3475,15 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  "@esbuild/linux-ppc64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ppc64]
+    os: [linux]
+
   "@esbuild/linux-ppc64@0.28.0":
     resolution:
       {
@@ -3481,15 +3491,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ppc64]
-    os: [linux]
-
-  "@esbuild/linux-riscv64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==,
-      }
-    engines: { node: ">=12" }
-    cpu: [riscv64]
     os: [linux]
 
   "@esbuild/linux-riscv64@0.25.10":
@@ -3510,6 +3511,15 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  "@esbuild/linux-riscv64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [riscv64]
+    os: [linux]
+
   "@esbuild/linux-riscv64@0.28.0":
     resolution:
       {
@@ -3517,15 +3527,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [riscv64]
-    os: [linux]
-
-  "@esbuild/linux-s390x@0.21.5":
-    resolution:
-      {
-        integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==,
-      }
-    engines: { node: ">=12" }
-    cpu: [s390x]
     os: [linux]
 
   "@esbuild/linux-s390x@0.25.10":
@@ -3546,6 +3547,15 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  "@esbuild/linux-s390x@0.27.7":
+    resolution:
+      {
+        integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [s390x]
+    os: [linux]
+
   "@esbuild/linux-s390x@0.28.0":
     resolution:
       {
@@ -3553,15 +3563,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [s390x]
-    os: [linux]
-
-  "@esbuild/linux-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [linux]
 
   "@esbuild/linux-x64@0.25.10":
@@ -3577,6 +3578,15 @@ packages:
     resolution:
       {
         integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [linux]
+
+  "@esbuild/linux-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -3609,6 +3619,15 @@ packages:
     cpu: [arm64]
     os: [netbsd]
 
+  "@esbuild/netbsd-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [netbsd]
+
   "@esbuild/netbsd-arm64@0.28.0":
     resolution:
       {
@@ -3616,15 +3635,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [netbsd]
-
-  "@esbuild/netbsd-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [netbsd]
 
   "@esbuild/netbsd-x64@0.25.10":
@@ -3640,6 +3650,15 @@ packages:
     resolution:
       {
         integrity: sha512-HwGDZ0VLVBY3Y+Nw0JexZy9o/nUAWq9MlV7cahpaXKW6TOzfVno3y3/M8Ga8u8Yr7GldLOov27xiCnqRZf0tCA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [netbsd]
+
+  "@esbuild/netbsd-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -3672,6 +3691,15 @@ packages:
     cpu: [arm64]
     os: [openbsd]
 
+  "@esbuild/openbsd-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openbsd]
+
   "@esbuild/openbsd-arm64@0.28.0":
     resolution:
       {
@@ -3679,15 +3707,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [openbsd]
-
-  "@esbuild/openbsd-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [openbsd]
 
   "@esbuild/openbsd-x64@0.25.10":
@@ -3703,6 +3722,15 @@ packages:
     resolution:
       {
         integrity: sha512-/it7w9Nb7+0KFIzjalNJVR5bOzA9Vay+yIPLVHfIQYG/j+j9VTH84aNB8ExGKPU4AzfaEvN9/V4HV+F+vo8OEg==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [openbsd]
+
+  "@esbuild/openbsd-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -3735,6 +3763,15 @@ packages:
     cpu: [arm64]
     os: [openharmony]
 
+  "@esbuild/openharmony-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [openharmony]
+
   "@esbuild/openharmony-arm64@0.28.0":
     resolution:
       {
@@ -3743,15 +3780,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [arm64]
     os: [openharmony]
-
-  "@esbuild/sunos-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
-    os: [sunos]
 
   "@esbuild/sunos-x64@0.25.10":
     resolution:
@@ -3771,6 +3799,15 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  "@esbuild/sunos-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [sunos]
+
   "@esbuild/sunos-x64@0.28.0":
     resolution:
       {
@@ -3779,15 +3816,6 @@ packages:
     engines: { node: ">=18" }
     cpu: [x64]
     os: [sunos]
-
-  "@esbuild/win32-arm64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==,
-      }
-    engines: { node: ">=12" }
-    cpu: [arm64]
-    os: [win32]
 
   "@esbuild/win32-arm64@0.25.10":
     resolution:
@@ -3807,6 +3835,15 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  "@esbuild/win32-arm64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==,
+      }
+    engines: { node: ">=18" }
+    cpu: [arm64]
+    os: [win32]
+
   "@esbuild/win32-arm64@0.28.0":
     resolution:
       {
@@ -3814,15 +3851,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [arm64]
-    os: [win32]
-
-  "@esbuild/win32-ia32@0.21.5":
-    resolution:
-      {
-        integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==,
-      }
-    engines: { node: ">=12" }
-    cpu: [ia32]
     os: [win32]
 
   "@esbuild/win32-ia32@0.25.10":
@@ -3843,6 +3871,15 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  "@esbuild/win32-ia32@0.27.7":
+    resolution:
+      {
+        integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==,
+      }
+    engines: { node: ">=18" }
+    cpu: [ia32]
+    os: [win32]
+
   "@esbuild/win32-ia32@0.28.0":
     resolution:
       {
@@ -3850,15 +3887,6 @@ packages:
       }
     engines: { node: ">=18" }
     cpu: [ia32]
-    os: [win32]
-
-  "@esbuild/win32-x64@0.21.5":
-    resolution:
-      {
-        integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==,
-      }
-    engines: { node: ">=12" }
-    cpu: [x64]
     os: [win32]
 
   "@esbuild/win32-x64@0.25.10":
@@ -3874,6 +3902,15 @@ packages:
     resolution:
       {
         integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==,
+      }
+    engines: { node: ">=18" }
+    cpu: [x64]
+    os: [win32]
+
+  "@esbuild/win32-x64@0.27.7":
+    resolution:
+      {
+        integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==,
       }
     engines: { node: ">=18" }
     cpu: [x64]
@@ -8637,6 +8674,12 @@ packages:
         integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==,
       }
 
+  "@standard-schema/spec@1.1.0":
+    resolution:
+      {
+        integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==,
+      }
+
   "@svgr/babel-plugin-add-jsx-attribute@8.0.0":
     resolution:
       {
@@ -9463,6 +9506,12 @@ packages:
         integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
       }
 
+  "@types/estree@1.0.9":
+    resolution:
+      {
+        integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==,
+      }
+
   "@types/geojson@7946.0.16":
     resolution:
       {
@@ -9883,36 +9932,16 @@ packages:
         integrity: sha512-4YjXj8rL9UVX444vaKuSmXgZD0ABOEgQNd6BR75vACaeAcuwU8powNyKDoAM9JIPfVhx7/zHCum5z+7lx2Mp9g==,
       }
 
-  "@vitest/expect@2.1.9":
+  "@vitest/expect@4.1.8":
     resolution:
       {
-        integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==,
+        integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==,
       }
 
-  "@vitest/expect@4.0.18":
+  "@vitest/mocker@4.1.8":
     resolution:
       {
-        integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==,
-      }
-
-  "@vitest/mocker@2.1.9":
-    resolution:
-      {
-        integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==,
-      }
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
-  "@vitest/mocker@4.0.18":
-    resolution:
-      {
-        integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==,
+        integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==,
       }
     peerDependencies:
       msw: ^2.4.9
@@ -9923,64 +9952,34 @@ packages:
       vite:
         optional: true
 
-  "@vitest/pretty-format@2.1.9":
+  "@vitest/pretty-format@4.1.8":
     resolution:
       {
-        integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==,
+        integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==,
       }
 
-  "@vitest/pretty-format@4.0.18":
+  "@vitest/runner@4.1.8":
     resolution:
       {
-        integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==,
+        integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==,
       }
 
-  "@vitest/runner@2.1.9":
+  "@vitest/snapshot@4.1.8":
     resolution:
       {
-        integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==,
+        integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==,
       }
 
-  "@vitest/runner@4.0.18":
+  "@vitest/spy@4.1.8":
     resolution:
       {
-        integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==,
+        integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==,
       }
 
-  "@vitest/snapshot@2.1.9":
+  "@vitest/utils@4.1.8":
     resolution:
       {
-        integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==,
-      }
-
-  "@vitest/snapshot@4.0.18":
-    resolution:
-      {
-        integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==,
-      }
-
-  "@vitest/spy@2.1.9":
-    resolution:
-      {
-        integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==,
-      }
-
-  "@vitest/spy@4.0.18":
-    resolution:
-      {
-        integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==,
-      }
-
-  "@vitest/utils@2.1.9":
-    resolution:
-      {
-        integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==,
-      }
-
-  "@vitest/utils@4.0.18":
-    resolution:
-      {
-        integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==,
+        integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==,
       }
 
   "@webassemblyjs/ast@1.14.1":
@@ -10238,6 +10237,14 @@ packages:
     engines: { node: ">=0.4.0" }
     hasBin: true
 
+  acorn@8.16.0:
+    resolution:
+      {
+        integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==,
+      }
+    engines: { node: ">=0.4.0" }
+    hasBin: true
+
   agent-base@6.0.2:
     resolution:
       {
@@ -10304,10 +10311,10 @@ packages:
         integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==,
       }
 
-  ajv@8.17.1:
+  ajv@8.20.0:
     resolution:
       {
-        integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==,
+        integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
       }
 
   altcha-lib@1.3.0:
@@ -10875,13 +10882,6 @@ packages:
         integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==,
       }
 
-  chai@5.3.3:
-    resolution:
-      {
-        integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==,
-      }
-    engines: { node: ">=18" }
-
   chai@6.2.2:
     resolution:
       {
@@ -10958,13 +10958,6 @@ packages:
       {
         integrity: sha512-bNFETTG/pM5ryzQ9Ad0lJOTa6HWD/YsScAR3EnCPZRPlQh77JocYktSHOUHelyhm8IARL+o4c4F1bP5KVOjiRA==,
       }
-
-  check-error@2.1.3:
-    resolution:
-      {
-        integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==,
-      }
-    engines: { node: ">= 16" }
 
   cheerio-select@2.1.0:
     resolution:
@@ -11955,13 +11948,6 @@ packages:
         integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==,
       }
 
-  deep-eql@5.0.2:
-    resolution:
-      {
-        integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==,
-      }
-    engines: { node: ">=6" }
-
   deep-extend@0.6.0:
     resolution:
       {
@@ -12297,6 +12283,13 @@ packages:
       }
     engines: { node: ">=10.13.0" }
 
+  enhanced-resolve@5.22.2:
+    resolution:
+      {
+        integrity: sha512-0rxICaFZ7NQho/sHely2bvOPRP0Eu2B0NZ9zM54YvRvWMn7jfz3DmnOZDR9LlXDdDcqntAVc6Hfy4gr/tdH/Ag==,
+      }
+    engines: { node: ">=10.13.0" }
+
   enquire.js@2.1.6:
     resolution:
       {
@@ -12382,6 +12375,12 @@ packages:
         integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==,
       }
 
+  es-module-lexer@2.1.0:
+    resolution:
+      {
+        integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==,
+      }
+
   es-object-atoms@1.1.1:
     resolution:
       {
@@ -12434,14 +12433,6 @@ packages:
         integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==,
       }
 
-  esbuild@0.21.5:
-    resolution:
-      {
-        integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==,
-      }
-    engines: { node: ">=12" }
-    hasBin: true
-
   esbuild@0.25.10:
     resolution:
       {
@@ -12454,6 +12445,14 @@ packages:
     resolution:
       {
         integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==,
+      }
+    engines: { node: ">=18" }
+    hasBin: true
+
+  esbuild@0.27.7:
+    resolution:
+      {
+        integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==,
       }
     engines: { node: ">=18" }
     hasBin: true
@@ -14751,10 +14750,10 @@ packages:
       }
     engines: { node: ^12.20.0 || ^14.13.1 || >=16.0.0 }
 
-  loader-runner@4.3.0:
+  loader-runner@4.3.2:
     resolution:
       {
-        integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==,
+        integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==,
       }
     engines: { node: ">=6.11.5" }
 
@@ -14850,12 +14849,6 @@ packages:
         integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==,
       }
     hasBin: true
-
-  loupe@3.2.1:
-    resolution:
-      {
-        integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==,
-      }
 
   lower-case-first@1.0.2:
     resolution:
@@ -16245,24 +16238,11 @@ packages:
       }
     engines: { node: ">=8" }
 
-  pathe@1.1.2:
-    resolution:
-      {
-        integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==,
-      }
-
   pathe@2.0.3:
     resolution:
       {
         integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==,
       }
-
-  pathval@2.0.1:
-    resolution:
-      {
-        integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==,
-      }
-    engines: { node: ">= 14.16" }
 
   pg-int8@1.0.1:
     resolution:
@@ -17798,13 +17778,6 @@ packages:
         integrity: sha512-ENl7cYHaK/Ktwk5OTD+aDbQ3uC8IByu/6Bkg+HDv8Mm+XnBnppVNalcfJTNsp1ibstKh030/JKQQWglDvtKwEQ==,
       }
 
-  serialize-javascript@7.0.3:
-    resolution:
-      {
-        integrity: sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==,
-      }
-    engines: { node: ">=20.0.0" }
-
   server-only@0.0.1:
     resolution:
       {
@@ -18131,10 +18104,10 @@ packages:
       }
     engines: { node: ">=6" }
 
-  std-env@3.10.0:
+  std-env@4.1.0:
     resolution:
       {
-        integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==,
+        integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==,
       }
 
   stop-iteration-iterator@1.1.0:
@@ -18574,29 +18547,56 @@ packages:
       }
     engines: { node: ">=18" }
 
-  terser-webpack-plugin@5.3.14:
+  terser-webpack-plugin@5.6.1:
     resolution:
       {
-        integrity: sha512-vkZjpUjb6OMS7dhV+tILUW6BhpDR7P2L/aQSAv+Uwk+m8KATX9EccViHTJR2qDtACKPIYndLGCyl3FMo+r2LMw==,
+        integrity: sha512-201R5j+sJpK8nFWwKVyNfZot8FaJbLZDq5evriVzbV1wDtSXDjRUDRfJzHpAaxFDMEhsZL1QkeqM61wgsS3KaQ==,
       }
     engines: { node: ">= 10.13.0" }
     peerDependencies:
+      "@minify-html/node": "*"
       "@swc/core": "*"
+      "@swc/css": "*"
+      "@swc/html": "*"
+      clean-css: "*"
+      cssnano: "*"
+      csso: "*"
       esbuild: "*"
+      html-minifier-terser: "*"
+      lightningcss: "*"
+      postcss: "*"
       uglify-js: "*"
       webpack: ^5.1.0
     peerDependenciesMeta:
+      "@minify-html/node":
+        optional: true
       "@swc/core":
         optional: true
+      "@swc/css":
+        optional: true
+      "@swc/html":
+        optional: true
+      clean-css:
+        optional: true
+      cssnano:
+        optional: true
+      csso:
+        optional: true
       esbuild:
+        optional: true
+      html-minifier-terser:
+        optional: true
+      lightningcss:
+        optional: true
+      postcss:
         optional: true
       uglify-js:
         optional: true
 
-  terser@5.44.0:
+  terser@5.48.0:
     resolution:
       {
-        integrity: sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==,
+        integrity: sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==,
       }
     engines: { node: ">=10" }
     hasBin: true
@@ -18688,10 +18688,24 @@ packages:
       }
     engines: { node: ">=18" }
 
+  tinyexec@1.2.4:
+    resolution:
+      {
+        integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
+      }
+    engines: { node: ">=18" }
+
   tinyglobby@0.2.15:
     resolution:
       {
         integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==,
+      }
+    engines: { node: ">=12.0.0" }
+
+  tinyglobby@0.2.17:
+    resolution:
+      {
+        integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==,
       }
     engines: { node: ">=12.0.0" }
 
@@ -18701,31 +18715,10 @@ packages:
         integrity: sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw==,
       }
 
-  tinypool@1.1.1:
+  tinyrainbow@3.1.0:
     resolution:
       {
-        integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
-
-  tinyrainbow@1.2.0:
-    resolution:
-      {
-        integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==,
-      }
-    engines: { node: ">=14.0.0" }
-
-  tinyrainbow@3.0.3:
-    resolution:
-      {
-        integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==,
-      }
-    engines: { node: ">=14.0.0" }
-
-  tinyspy@3.0.2:
-    resolution:
-      {
-        integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==,
+        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
       }
     engines: { node: ">=14.0.0" }
 
@@ -19485,48 +19478,6 @@ packages:
         integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==,
       }
 
-  vite-node@2.1.9:
-    resolution:
-      {
-        integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
-    hasBin: true
-
-  vite@5.4.21:
-    resolution:
-      {
-        integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
-    hasBin: true
-    peerDependencies:
-      "@types/node": ^18.0.0 || >=20.0.0
-      less: "*"
-      lightningcss: ^1.21.0
-      sass: "*"
-      sass-embedded: "*"
-      stylus: "*"
-      sugarss: "*"
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      "@types/node":
-        optional: true
-      less:
-        optional: true
-      lightningcss:
-        optional: true
-      sass:
-        optional: true
-      sass-embedded:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-
   vite@7.3.2:
     resolution:
       {
@@ -19570,38 +19521,10 @@ packages:
       yaml:
         optional: true
 
-  vitest@2.1.9:
+  vitest@4.1.8:
     resolution:
       {
-        integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==,
-      }
-    engines: { node: ^18.0.0 || >=20.0.0 }
-    hasBin: true
-    peerDependencies:
-      "@edge-runtime/vm": "*"
-      "@types/node": ^18.0.0 || >=20.0.0
-      "@vitest/browser": 2.1.9
-      "@vitest/ui": 2.1.9
-      happy-dom: "*"
-      jsdom: "*"
-    peerDependenciesMeta:
-      "@edge-runtime/vm":
-        optional: true
-      "@types/node":
-        optional: true
-      "@vitest/browser":
-        optional: true
-      "@vitest/ui":
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-
-  vitest@4.0.18:
-    resolution:
-      {
-        integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==,
+        integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==,
       }
     engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
@@ -19609,12 +19532,15 @@ packages:
       "@edge-runtime/vm": "*"
       "@opentelemetry/api": ^1.9.0
       "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-      "@vitest/browser-playwright": 4.0.18
-      "@vitest/browser-preview": 4.0.18
-      "@vitest/browser-webdriverio": 4.0.18
-      "@vitest/ui": 4.0.18
+      "@vitest/browser-playwright": 4.1.8
+      "@vitest/browser-preview": 4.1.8
+      "@vitest/browser-webdriverio": 4.1.8
+      "@vitest/coverage-istanbul": 4.1.8
+      "@vitest/coverage-v8": 4.1.8
+      "@vitest/ui": 4.1.8
       happy-dom: "*"
       jsdom: "*"
+      vite: 7.3.2
     peerDependenciesMeta:
       "@edge-runtime/vm":
         optional: true
@@ -19627,6 +19553,10 @@ packages:
       "@vitest/browser-preview":
         optional: true
       "@vitest/browser-webdriverio":
+        optional: true
+      "@vitest/coverage-istanbul":
+        optional: true
+      "@vitest/coverage-v8":
         optional: true
       "@vitest/ui":
         optional: true
@@ -19692,10 +19622,10 @@ packages:
         integrity: sha512-9YlCL/ynK3CTlrSRrDxZvUauLzAswPCrsaCgilqFevUYpeEW0/3ScEjaa3kbW/T0ghhkEr7mv+fpjqn1Y1YuTA==,
       }
 
-  watchpack@2.4.4:
+  watchpack@2.5.1:
     resolution:
       {
-        integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==,
+        integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==,
       }
     engines: { node: ">=10.13.0" }
 
@@ -19756,6 +19686,13 @@ packages:
     resolution:
       {
         integrity: sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==,
+      }
+    engines: { node: ">=10.13.0" }
+
+  webpack-sources@3.5.0:
+    resolution:
+      {
+        integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==,
       }
     engines: { node: ">=10.13.0" }
 
@@ -20935,6 +20872,9 @@ snapshots:
 
   "@babel/runtime@7.28.4": {}
 
+  "@babel/runtime@7.29.7":
+    optional: true
+
   "@babel/template@7.27.2":
     dependencies:
       "@babel/code-frame": 7.27.1
@@ -21365,19 +21305,16 @@ snapshots:
 
   "@emotion/weak-memoize@0.4.0": {}
 
-  "@esbuild/aix-ppc64@0.21.5":
-    optional: true
-
   "@esbuild/aix-ppc64@0.25.10":
     optional: true
 
   "@esbuild/aix-ppc64@0.27.2":
     optional: true
 
-  "@esbuild/aix-ppc64@0.28.0":
+  "@esbuild/aix-ppc64@0.27.7":
     optional: true
 
-  "@esbuild/android-arm64@0.21.5":
+  "@esbuild/aix-ppc64@0.28.0":
     optional: true
 
   "@esbuild/android-arm64@0.25.10":
@@ -21386,10 +21323,10 @@ snapshots:
   "@esbuild/android-arm64@0.27.2":
     optional: true
 
-  "@esbuild/android-arm64@0.28.0":
+  "@esbuild/android-arm64@0.27.7":
     optional: true
 
-  "@esbuild/android-arm@0.21.5":
+  "@esbuild/android-arm64@0.28.0":
     optional: true
 
   "@esbuild/android-arm@0.25.10":
@@ -21398,10 +21335,10 @@ snapshots:
   "@esbuild/android-arm@0.27.2":
     optional: true
 
-  "@esbuild/android-arm@0.28.0":
+  "@esbuild/android-arm@0.27.7":
     optional: true
 
-  "@esbuild/android-x64@0.21.5":
+  "@esbuild/android-arm@0.28.0":
     optional: true
 
   "@esbuild/android-x64@0.25.10":
@@ -21410,10 +21347,10 @@ snapshots:
   "@esbuild/android-x64@0.27.2":
     optional: true
 
-  "@esbuild/android-x64@0.28.0":
+  "@esbuild/android-x64@0.27.7":
     optional: true
 
-  "@esbuild/darwin-arm64@0.21.5":
+  "@esbuild/android-x64@0.28.0":
     optional: true
 
   "@esbuild/darwin-arm64@0.25.10":
@@ -21422,10 +21359,10 @@ snapshots:
   "@esbuild/darwin-arm64@0.27.2":
     optional: true
 
-  "@esbuild/darwin-arm64@0.28.0":
+  "@esbuild/darwin-arm64@0.27.7":
     optional: true
 
-  "@esbuild/darwin-x64@0.21.5":
+  "@esbuild/darwin-arm64@0.28.0":
     optional: true
 
   "@esbuild/darwin-x64@0.25.10":
@@ -21434,10 +21371,10 @@ snapshots:
   "@esbuild/darwin-x64@0.27.2":
     optional: true
 
-  "@esbuild/darwin-x64@0.28.0":
+  "@esbuild/darwin-x64@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.21.5":
+  "@esbuild/darwin-x64@0.28.0":
     optional: true
 
   "@esbuild/freebsd-arm64@0.25.10":
@@ -21446,10 +21383,10 @@ snapshots:
   "@esbuild/freebsd-arm64@0.27.2":
     optional: true
 
-  "@esbuild/freebsd-arm64@0.28.0":
+  "@esbuild/freebsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/freebsd-x64@0.21.5":
+  "@esbuild/freebsd-arm64@0.28.0":
     optional: true
 
   "@esbuild/freebsd-x64@0.25.10":
@@ -21458,10 +21395,10 @@ snapshots:
   "@esbuild/freebsd-x64@0.27.2":
     optional: true
 
-  "@esbuild/freebsd-x64@0.28.0":
+  "@esbuild/freebsd-x64@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm64@0.21.5":
+  "@esbuild/freebsd-x64@0.28.0":
     optional: true
 
   "@esbuild/linux-arm64@0.25.10":
@@ -21470,10 +21407,10 @@ snapshots:
   "@esbuild/linux-arm64@0.27.2":
     optional: true
 
-  "@esbuild/linux-arm64@0.28.0":
+  "@esbuild/linux-arm64@0.27.7":
     optional: true
 
-  "@esbuild/linux-arm@0.21.5":
+  "@esbuild/linux-arm64@0.28.0":
     optional: true
 
   "@esbuild/linux-arm@0.25.10":
@@ -21482,10 +21419,10 @@ snapshots:
   "@esbuild/linux-arm@0.27.2":
     optional: true
 
-  "@esbuild/linux-arm@0.28.0":
+  "@esbuild/linux-arm@0.27.7":
     optional: true
 
-  "@esbuild/linux-ia32@0.21.5":
+  "@esbuild/linux-arm@0.28.0":
     optional: true
 
   "@esbuild/linux-ia32@0.25.10":
@@ -21494,10 +21431,10 @@ snapshots:
   "@esbuild/linux-ia32@0.27.2":
     optional: true
 
-  "@esbuild/linux-ia32@0.28.0":
+  "@esbuild/linux-ia32@0.27.7":
     optional: true
 
-  "@esbuild/linux-loong64@0.21.5":
+  "@esbuild/linux-ia32@0.28.0":
     optional: true
 
   "@esbuild/linux-loong64@0.25.10":
@@ -21506,10 +21443,10 @@ snapshots:
   "@esbuild/linux-loong64@0.27.2":
     optional: true
 
-  "@esbuild/linux-loong64@0.28.0":
+  "@esbuild/linux-loong64@0.27.7":
     optional: true
 
-  "@esbuild/linux-mips64el@0.21.5":
+  "@esbuild/linux-loong64@0.28.0":
     optional: true
 
   "@esbuild/linux-mips64el@0.25.10":
@@ -21518,10 +21455,10 @@ snapshots:
   "@esbuild/linux-mips64el@0.27.2":
     optional: true
 
-  "@esbuild/linux-mips64el@0.28.0":
+  "@esbuild/linux-mips64el@0.27.7":
     optional: true
 
-  "@esbuild/linux-ppc64@0.21.5":
+  "@esbuild/linux-mips64el@0.28.0":
     optional: true
 
   "@esbuild/linux-ppc64@0.25.10":
@@ -21530,10 +21467,10 @@ snapshots:
   "@esbuild/linux-ppc64@0.27.2":
     optional: true
 
-  "@esbuild/linux-ppc64@0.28.0":
+  "@esbuild/linux-ppc64@0.27.7":
     optional: true
 
-  "@esbuild/linux-riscv64@0.21.5":
+  "@esbuild/linux-ppc64@0.28.0":
     optional: true
 
   "@esbuild/linux-riscv64@0.25.10":
@@ -21542,10 +21479,10 @@ snapshots:
   "@esbuild/linux-riscv64@0.27.2":
     optional: true
 
-  "@esbuild/linux-riscv64@0.28.0":
+  "@esbuild/linux-riscv64@0.27.7":
     optional: true
 
-  "@esbuild/linux-s390x@0.21.5":
+  "@esbuild/linux-riscv64@0.28.0":
     optional: true
 
   "@esbuild/linux-s390x@0.25.10":
@@ -21554,16 +21491,19 @@ snapshots:
   "@esbuild/linux-s390x@0.27.2":
     optional: true
 
-  "@esbuild/linux-s390x@0.28.0":
+  "@esbuild/linux-s390x@0.27.7":
     optional: true
 
-  "@esbuild/linux-x64@0.21.5":
+  "@esbuild/linux-s390x@0.28.0":
     optional: true
 
   "@esbuild/linux-x64@0.25.10":
     optional: true
 
   "@esbuild/linux-x64@0.27.2":
+    optional: true
+
+  "@esbuild/linux-x64@0.27.7":
     optional: true
 
   "@esbuild/linux-x64@0.28.0":
@@ -21575,16 +21515,19 @@ snapshots:
   "@esbuild/netbsd-arm64@0.27.2":
     optional: true
 
-  "@esbuild/netbsd-arm64@0.28.0":
+  "@esbuild/netbsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/netbsd-x64@0.21.5":
+  "@esbuild/netbsd-arm64@0.28.0":
     optional: true
 
   "@esbuild/netbsd-x64@0.25.10":
     optional: true
 
   "@esbuild/netbsd-x64@0.27.2":
+    optional: true
+
+  "@esbuild/netbsd-x64@0.27.7":
     optional: true
 
   "@esbuild/netbsd-x64@0.28.0":
@@ -21596,16 +21539,19 @@ snapshots:
   "@esbuild/openbsd-arm64@0.27.2":
     optional: true
 
-  "@esbuild/openbsd-arm64@0.28.0":
+  "@esbuild/openbsd-arm64@0.27.7":
     optional: true
 
-  "@esbuild/openbsd-x64@0.21.5":
+  "@esbuild/openbsd-arm64@0.28.0":
     optional: true
 
   "@esbuild/openbsd-x64@0.25.10":
     optional: true
 
   "@esbuild/openbsd-x64@0.27.2":
+    optional: true
+
+  "@esbuild/openbsd-x64@0.27.7":
     optional: true
 
   "@esbuild/openbsd-x64@0.28.0":
@@ -21617,10 +21563,10 @@ snapshots:
   "@esbuild/openharmony-arm64@0.27.2":
     optional: true
 
-  "@esbuild/openharmony-arm64@0.28.0":
+  "@esbuild/openharmony-arm64@0.27.7":
     optional: true
 
-  "@esbuild/sunos-x64@0.21.5":
+  "@esbuild/openharmony-arm64@0.28.0":
     optional: true
 
   "@esbuild/sunos-x64@0.25.10":
@@ -21629,10 +21575,10 @@ snapshots:
   "@esbuild/sunos-x64@0.27.2":
     optional: true
 
-  "@esbuild/sunos-x64@0.28.0":
+  "@esbuild/sunos-x64@0.27.7":
     optional: true
 
-  "@esbuild/win32-arm64@0.21.5":
+  "@esbuild/sunos-x64@0.28.0":
     optional: true
 
   "@esbuild/win32-arm64@0.25.10":
@@ -21641,10 +21587,10 @@ snapshots:
   "@esbuild/win32-arm64@0.27.2":
     optional: true
 
-  "@esbuild/win32-arm64@0.28.0":
+  "@esbuild/win32-arm64@0.27.7":
     optional: true
 
-  "@esbuild/win32-ia32@0.21.5":
+  "@esbuild/win32-arm64@0.28.0":
     optional: true
 
   "@esbuild/win32-ia32@0.25.10":
@@ -21653,16 +21599,19 @@ snapshots:
   "@esbuild/win32-ia32@0.27.2":
     optional: true
 
-  "@esbuild/win32-ia32@0.28.0":
+  "@esbuild/win32-ia32@0.27.7":
     optional: true
 
-  "@esbuild/win32-x64@0.21.5":
+  "@esbuild/win32-ia32@0.28.0":
     optional: true
 
   "@esbuild/win32-x64@0.25.10":
     optional: true
 
   "@esbuild/win32-x64@0.27.2":
+    optional: true
+
+  "@esbuild/win32-x64@0.27.7":
     optional: true
 
   "@esbuild/win32-x64@0.28.0":
@@ -22378,12 +22327,12 @@ snapshots:
       "@types/react": 19.1.12
       react: 19.2.6
 
-  "@mdx-js/loader@3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))":
+  "@mdx-js/loader@3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15))":
     dependencies:
       "@mdx-js/mdx": 3.1.1
       source-map: 0.7.6
     optionalDependencies:
-      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))
+      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15)
     transitivePeerDependencies:
       - supports-color
 
@@ -22450,11 +22399,11 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  "@next/mdx@15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))":
+  "@next/mdx@15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15)))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))":
     dependencies:
       source-map: 0.7.6
     optionalDependencies:
-      "@mdx-js/loader": 3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
+      "@mdx-js/loader": 3.1.1(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15))
       "@mdx-js/react": 3.1.1(@types/react@19.1.12)(react@19.2.6)
 
   "@next/swc-darwin-arm64@15.5.18":
@@ -24888,7 +24837,7 @@ snapshots:
 
   "@sentry/core@10.11.0": {}
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -24900,7 +24849,34 @@ snapshots:
       "@sentry/opentelemetry": 10.11.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)
       "@sentry/react": 10.11.0(react@19.2.6)
       "@sentry/vercel-edge": 10.11.0
-      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
+      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15))
+      chalk: 3.0.0
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      resolve: 1.22.8
+      rollup: 4.59.0
+      stacktrace-parser: 0.1.11
+    transitivePeerDependencies:
+      - "@opentelemetry/context-async-hooks"
+      - "@opentelemetry/core"
+      - "@opentelemetry/sdk-trace-base"
+      - encoding
+      - react
+      - supports-color
+      - webpack
+
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))":
+    dependencies:
+      "@opentelemetry/api": 1.9.0
+      "@opentelemetry/semantic-conventions": 1.37.0
+      "@rollup/plugin-commonjs": 28.0.1(rollup@4.59.0)
+      "@sentry-internal/browser-utils": 10.11.0
+      "@sentry/bundler-plugin-core": 4.3.0
+      "@sentry/core": 10.11.0
+      "@sentry/node": 10.11.0
+      "@sentry/opentelemetry": 10.11.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)
+      "@sentry/react": 10.11.0(react@19.2.6)
+      "@sentry/vercel-edge": 10.11.0
+      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       chalk: 3.0.0
       next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
@@ -24990,12 +24966,22 @@ snapshots:
       "@opentelemetry/resources": 2.1.0(@opentelemetry/api@1.9.0)
       "@sentry/core": 10.11.0
 
-  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))":
+  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))":
     dependencies:
       "@sentry/bundler-plugin-core": 4.3.0
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))
+      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15))":
+    dependencies:
+      "@sentry/bundler-plugin-core": 4.3.0
+      unplugin: 1.0.1
+      uuid: 9.0.1
+      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -25750,6 +25736,8 @@ snapshots:
 
   "@standard-schema/spec@1.0.0": {}
 
+  "@standard-schema/spec@1.1.0": {}
+
   "@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.28.4)":
     dependencies:
       "@babel/core": 7.28.4
@@ -26257,11 +26245,11 @@ snapshots:
   "@types/eslint-scope@3.7.7":
     dependencies:
       "@types/eslint": 9.6.1
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
 
   "@types/eslint@9.6.1":
     dependencies:
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/json-schema": 7.0.15
 
   "@types/estree-jsx@1.0.5":
@@ -26269,6 +26257,8 @@ snapshots:
       "@types/estree": 1.0.8
 
   "@types/estree@1.0.8": {}
+
+  "@types/estree@1.0.9": {}
 
   "@types/geojson@7946.0.16": {}
 
@@ -26543,100 +26533,62 @@ snapshots:
     optionalDependencies:
       ajv: 6.14.0
 
-  "@vitest/expect@2.1.9":
+  "@vitest/expect@4.1.8":
     dependencies:
-      "@vitest/spy": 2.1.9
-      "@vitest/utils": 2.1.9
-      chai: 5.3.3
-      tinyrainbow: 1.2.0
-
-  "@vitest/expect@4.0.18":
-    dependencies:
-      "@standard-schema/spec": 1.0.0
+      "@standard-schema/spec": 1.1.0
       "@types/chai": 5.2.3
-      "@vitest/spy": 4.0.18
-      "@vitest/utils": 4.0.18
+      "@vitest/spy": 4.1.8
+      "@vitest/utils": 4.1.8
       chai: 6.2.2
-      tinyrainbow: 3.0.3
+      tinyrainbow: 3.1.0
 
-  "@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.19)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0))":
+  "@vitest/mocker@4.1.8(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))":
     dependencies:
-      "@vitest/spy": 2.1.9
+      "@vitest/spy": 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 5.4.21(@types/node@22.19.19)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)
+      vite: 7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)
 
-  "@vitest/mocker@4.0.18(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1))":
+  "@vitest/mocker@4.1.8(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))":
     dependencies:
-      "@vitest/spy": 4.0.18
+      "@vitest/spy": 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)
 
-  "@vitest/mocker@4.0.18(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1))":
+  "@vitest/mocker@4.1.8(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))":
     dependencies:
-      "@vitest/spy": 4.0.18
+      "@vitest/spy": 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)
 
-  "@vitest/mocker@4.0.18(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1))":
+  "@vitest/pretty-format@4.1.8":
     dependencies:
-      "@vitest/spy": 4.0.18
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+      tinyrainbow: 3.1.0
 
-  "@vitest/pretty-format@2.1.9":
+  "@vitest/runner@4.1.8":
     dependencies:
-      tinyrainbow: 1.2.0
-
-  "@vitest/pretty-format@4.0.18":
-    dependencies:
-      tinyrainbow: 3.0.3
-
-  "@vitest/runner@2.1.9":
-    dependencies:
-      "@vitest/utils": 2.1.9
-      pathe: 1.1.2
-
-  "@vitest/runner@4.0.18":
-    dependencies:
-      "@vitest/utils": 4.0.18
+      "@vitest/utils": 4.1.8
       pathe: 2.0.3
 
-  "@vitest/snapshot@2.1.9":
+  "@vitest/snapshot@4.1.8":
     dependencies:
-      "@vitest/pretty-format": 2.1.9
-      magic-string: 0.30.21
-      pathe: 1.1.2
-
-  "@vitest/snapshot@4.0.18":
-    dependencies:
-      "@vitest/pretty-format": 4.0.18
+      "@vitest/pretty-format": 4.1.8
+      "@vitest/utils": 4.1.8
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  "@vitest/spy@2.1.9":
-    dependencies:
-      tinyspy: 3.0.2
+  "@vitest/spy@4.1.8": {}
 
-  "@vitest/spy@4.0.18": {}
-
-  "@vitest/utils@2.1.9":
+  "@vitest/utils@4.1.8":
     dependencies:
-      "@vitest/pretty-format": 2.1.9
-      loupe: 3.2.1
-      tinyrainbow: 1.2.0
-
-  "@vitest/utils@4.0.18":
-    dependencies:
-      "@vitest/pretty-format": 4.0.18
-      tinyrainbow: 3.0.3
+      "@vitest/pretty-format": 4.1.8
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   "@webassemblyjs/ast@1.14.1":
     dependencies:
@@ -26808,9 +26760,9 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-import-phases@1.0.4(acorn@8.15.0):
+  acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
@@ -26821,6 +26773,8 @@ snapshots:
       acorn: 8.15.0
 
   acorn@8.15.0: {}
+
+  acorn@8.16.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -26851,13 +26805,13 @@ snapshots:
     optionalDependencies:
       react: 19.2.6
 
-  ajv-formats@2.1.1(ajv@8.17.1):
+  ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
 
-  ajv-keywords@5.1.0(ajv@8.17.1):
+  ajv-keywords@5.1.0(ajv@8.20.0):
     dependencies:
-      ajv: 8.17.1
+      ajv: 8.20.0
       fast-deep-equal: 3.1.3
 
   ajv@6.14.0:
@@ -26867,7 +26821,7 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ajv@8.17.1:
+  ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.2
@@ -27223,14 +27177,6 @@ snapshots:
 
   ccount@2.0.1: {}
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
-
   chai@6.2.2: {}
 
   chalk@2.4.2:
@@ -27283,8 +27229,6 @@ snapshots:
   chardet@0.7.0: {}
 
   chardet@2.1.0: {}
-
-  check-error@2.1.3: {}
 
   cheerio-select@2.1.0:
     dependencies:
@@ -27854,8 +27798,6 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  deep-eql@5.0.2: {}
-
   deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
@@ -28028,6 +27970,11 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.3
 
+  enhanced-resolve@5.22.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   enquire.js@2.1.6: {}
 
   entities@2.2.0: {}
@@ -28128,6 +28075,8 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -28168,32 +28117,6 @@ snapshots:
       acorn: 8.15.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
-
-  esbuild@0.21.5:
-    optionalDependencies:
-      "@esbuild/aix-ppc64": 0.21.5
-      "@esbuild/android-arm": 0.21.5
-      "@esbuild/android-arm64": 0.21.5
-      "@esbuild/android-x64": 0.21.5
-      "@esbuild/darwin-arm64": 0.21.5
-      "@esbuild/darwin-x64": 0.21.5
-      "@esbuild/freebsd-arm64": 0.21.5
-      "@esbuild/freebsd-x64": 0.21.5
-      "@esbuild/linux-arm": 0.21.5
-      "@esbuild/linux-arm64": 0.21.5
-      "@esbuild/linux-ia32": 0.21.5
-      "@esbuild/linux-loong64": 0.21.5
-      "@esbuild/linux-mips64el": 0.21.5
-      "@esbuild/linux-ppc64": 0.21.5
-      "@esbuild/linux-riscv64": 0.21.5
-      "@esbuild/linux-s390x": 0.21.5
-      "@esbuild/linux-x64": 0.21.5
-      "@esbuild/netbsd-x64": 0.21.5
-      "@esbuild/openbsd-x64": 0.21.5
-      "@esbuild/sunos-x64": 0.21.5
-      "@esbuild/win32-arm64": 0.21.5
-      "@esbuild/win32-ia32": 0.21.5
-      "@esbuild/win32-x64": 0.21.5
 
   esbuild@0.25.10:
     optionalDependencies:
@@ -28252,6 +28175,35 @@ snapshots:
       "@esbuild/win32-arm64": 0.27.2
       "@esbuild/win32-ia32": 0.27.2
       "@esbuild/win32-x64": 0.27.2
+
+  esbuild@0.27.7:
+    optionalDependencies:
+      "@esbuild/aix-ppc64": 0.27.7
+      "@esbuild/android-arm": 0.27.7
+      "@esbuild/android-arm64": 0.27.7
+      "@esbuild/android-x64": 0.27.7
+      "@esbuild/darwin-arm64": 0.27.7
+      "@esbuild/darwin-x64": 0.27.7
+      "@esbuild/freebsd-arm64": 0.27.7
+      "@esbuild/freebsd-x64": 0.27.7
+      "@esbuild/linux-arm": 0.27.7
+      "@esbuild/linux-arm64": 0.27.7
+      "@esbuild/linux-ia32": 0.27.7
+      "@esbuild/linux-loong64": 0.27.7
+      "@esbuild/linux-mips64el": 0.27.7
+      "@esbuild/linux-ppc64": 0.27.7
+      "@esbuild/linux-riscv64": 0.27.7
+      "@esbuild/linux-s390x": 0.27.7
+      "@esbuild/linux-x64": 0.27.7
+      "@esbuild/netbsd-arm64": 0.27.7
+      "@esbuild/netbsd-x64": 0.27.7
+      "@esbuild/openbsd-arm64": 0.27.7
+      "@esbuild/openbsd-x64": 0.27.7
+      "@esbuild/openharmony-arm64": 0.27.7
+      "@esbuild/sunos-x64": 0.27.7
+      "@esbuild/win32-arm64": 0.27.7
+      "@esbuild/win32-ia32": 0.27.7
+      "@esbuild/win32-x64": 0.27.7
 
   esbuild@0.28.0:
     optionalDependencies:
@@ -28719,7 +28671,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)):
+  fumadocs-mdx@12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)):
     dependencies:
       "@mdx-js/mdx": 3.1.1
       "@standard-schema/spec": 1.0.0
@@ -28742,7 +28694,7 @@ snapshots:
       "@fumadocs/mdx-remote": 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
-      vite: 7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+      vite: 7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -29137,7 +29089,7 @@ snapshots:
 
   history@5.3.0:
     dependencies:
-      "@babel/runtime": 7.28.4
+      "@babel/runtime": 7.29.7
     optional: true
 
   hoist-non-react-statics@3.3.2:
@@ -29811,7 +29763,7 @@ snapshots:
 
   load-tsconfig@0.2.5: {}
 
-  loader-runner@4.3.0: {}
+  loader-runner@4.3.2: {}
 
   local-pkg@1.1.2:
     dependencies:
@@ -29859,8 +29811,6 @@ snapshots:
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
-
-  loupe@3.2.1: {}
 
   lower-case-first@1.0.2:
     dependencies:
@@ -30952,11 +30902,7 @@ snapshots:
 
   path-type@4.0.0: {}
 
-  pathe@1.1.2: {}
-
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   pg-int8@1.0.1: {}
 
@@ -32050,9 +31996,9 @@ snapshots:
   schema-utils@4.3.3:
     dependencies:
       "@types/json-schema": 7.0.15
-      ajv: 8.17.1
-      ajv-formats: 2.1.1(ajv@8.17.1)
-      ajv-keywords: 5.1.0(ajv@8.17.1)
+      ajv: 8.20.0
+      ajv-formats: 2.1.1(ajv@8.20.0)
+      ajv-keywords: 5.1.0(ajv@8.20.0)
 
   scroll-into-view-if-needed@2.2.31:
     dependencies:
@@ -32081,8 +32027,6 @@ snapshots:
     dependencies:
       no-case: 2.3.2
       upper-case-first: 1.1.2
-
-  serialize-javascript@7.0.3: {}
 
   server-only@0.0.1: {}
 
@@ -32343,7 +32287,7 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
-  std-env@3.10.0: {}
+  std-env@4.1.0: {}
 
   stop-iteration-iterator@1.1.0:
     dependencies:
@@ -32631,21 +32575,33 @@ snapshots:
       minizlib: 3.1.0
       yallist: 5.0.0
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.15.40(@swc/helpers@0.5.17))(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))):
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      serialize-javascript: 7.0.3
-      terser: 5.44.0
-      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))
+      terser: 5.48.0
+      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       "@swc/core": 1.15.40(@swc/helpers@0.5.17)
+      lightningcss: 1.32.0
+      postcss: 8.5.15
 
-  terser@5.44.0:
+  terser-webpack-plugin@5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15)):
+    dependencies:
+      "@jridgewell/trace-mapping": 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.48.0
+      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15)
+    optionalDependencies:
+      "@swc/core": 1.15.40(@swc/helpers@0.5.17)
+      postcss: 8.5.15
+
+  terser@5.48.0:
     dependencies:
       "@jridgewell/source-map": 0.3.11
-      acorn: 8.15.0
+      acorn: 8.16.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -32681,7 +32637,14 @@ snapshots:
 
   tinyexec@1.0.2: {}
 
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -32691,13 +32654,7 @@ snapshots:
       "@types/tinycolor2": 1.4.6
       tinycolor2: 1.6.0
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@1.2.0: {}
-
-  tinyrainbow@3.0.3: {}
-
-  tinyspy@3.0.2: {}
+  tinyrainbow@3.1.0: {}
 
   title-case@2.1.1:
     dependencies:
@@ -32744,7 +32701,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-loader@9.5.7(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))):
+  ts-loader@9.5.7(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.21.0
@@ -32752,7 +32709,7 @@ snapshots:
       semver: 7.7.4
       source-map: 0.7.6
       typescript: 5.8.3
-      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))
+      webpack: 5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   ts-node@10.9.2(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@22.18.1)(typescript@5.8.3):
     dependencies:
@@ -33234,242 +33191,146 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@2.1.9(@types/node@22.19.19)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0):
+  vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1):
     dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 1.1.2
-      vite: 5.4.21(@types/node@22.19.19)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)
-    transitivePeerDependencies:
-      - "@types/node"
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vite@5.4.21(@types/node@22.19.19)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0):
-    dependencies:
-      esbuild: 0.21.5
-      postcss: 8.5.15
-      rollup: 4.59.0
-    optionalDependencies:
-      "@types/node": 22.19.19
-      fsevents: 2.3.3
-      lightningcss: 1.32.0
-      sass: 1.92.1
-      terser: 5.44.0
-
-  vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1):
-    dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15
       rollup: 4.59.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       "@types/node": 22.18.1
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
       sass: 1.92.1
-      terser: 5.44.0
+      terser: 5.48.0
       tsx: 4.22.3
       yaml: 2.8.1
 
-  vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1):
+  vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15
       rollup: 4.59.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       "@types/node": 22.18.8
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
       sass: 1.92.1
-      terser: 5.44.0
+      terser: 5.48.0
       tsx: 4.22.3
       yaml: 2.8.1
 
-  vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1):
+  vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1):
     dependencies:
-      esbuild: 0.27.2
+      esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.15
       rollup: 4.59.0
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.17
     optionalDependencies:
       "@types/node": 22.19.19
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
       sass: 1.92.1
-      terser: 5.44.0
+      terser: 5.48.0
       tsx: 4.22.3
       yaml: 2.8.1
 
-  vitest@2.1.9(@types/node@22.19.19)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)):
     dependencies:
-      "@vitest/expect": 2.1.9
-      "@vitest/mocker": 2.1.9(vite@5.4.21(@types/node@22.19.19)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0))
-      "@vitest/pretty-format": 2.1.9
-      "@vitest/runner": 2.1.9
-      "@vitest/snapshot": 2.1.9
-      "@vitest/spy": 2.1.9
-      "@vitest/utils": 2.1.9
-      chai: 5.3.3
-      debug: 4.4.3
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      pathe: 1.1.2
-      std-env: 3.10.0
-      tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinypool: 1.1.1
-      tinyrainbow: 1.2.0
-      vite: 5.4.21(@types/node@22.19.19)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)
-      vite-node: 2.1.9(@types/node@22.19.19)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      "@types/node": 22.19.19
-      jsdom: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-    transitivePeerDependencies:
-      - less
-      - lightningcss
-      - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1):
-    dependencies:
-      "@vitest/expect": 4.0.18
-      "@vitest/mocker": 4.0.18(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1))
-      "@vitest/pretty-format": 4.0.18
-      "@vitest/runner": 4.0.18
-      "@vitest/snapshot": 4.0.18
-      "@vitest/spy": 4.0.18
-      "@vitest/utils": 4.0.18
-      es-module-lexer: 1.7.0
+      "@vitest/expect": 4.1.8
+      "@vitest/mocker": 4.1.8(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
+      "@vitest/pretty-format": 4.1.8
+      "@vitest/runner": 4.1.8
+      "@vitest/snapshot": 4.1.8
+      "@vitest/spy": 4.1.8
+      "@vitest/utils": 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@opentelemetry/api": 1.9.0
       "@types/node": 22.18.1
       jsdom: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)):
     dependencies:
-      "@vitest/expect": 4.0.18
-      "@vitest/mocker": 4.0.18(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1))
-      "@vitest/pretty-format": 4.0.18
-      "@vitest/runner": 4.0.18
-      "@vitest/snapshot": 4.0.18
-      "@vitest/spy": 4.0.18
-      "@vitest/utils": 4.0.18
-      es-module-lexer: 1.7.0
+      "@vitest/expect": 4.1.8
+      "@vitest/mocker": 4.1.8(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
+      "@vitest/pretty-format": 4.1.8
+      "@vitest/runner": 4.1.8
+      "@vitest/snapshot": 4.1.8
+      "@vitest/spy": 4.1.8
+      "@vitest/utils": 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@opentelemetry/api": 1.9.0
       "@types/node": 22.18.8
       jsdom: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jiti@2.6.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.19.19)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)):
     dependencies:
-      "@vitest/expect": 4.0.18
-      "@vitest/mocker": 4.0.18(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1))
-      "@vitest/pretty-format": 4.0.18
-      "@vitest/runner": 4.0.18
-      "@vitest/snapshot": 4.0.18
-      "@vitest/spy": 4.0.18
-      "@vitest/utils": 4.0.18
-      es-module-lexer: 1.7.0
+      "@vitest/expect": 4.1.8
+      "@vitest/mocker": 4.1.8(vite@7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
+      "@vitest/pretty-format": 4.1.8
+      "@vitest/runner": 4.1.8
+      "@vitest/snapshot": 4.1.8
+      "@vitest/spy": 4.1.8
+      "@vitest/utils": 4.1.8
+      es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 1.0.2
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.0.3
-      vite: 7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.44.0)(tsx@4.22.3)(yaml@2.8.1)
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 7.3.2(@types/node@22.19.19)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       "@opentelemetry/api": 1.9.0
       "@types/node": 22.19.19
       jsdom: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - yaml
 
   vscode-jsonrpc@8.2.0: {}
 
@@ -33496,7 +33357,7 @@ snapshots:
 
   walk-up-path@3.0.1: {}
 
-  watchpack@2.4.4:
+  watchpack@2.5.1:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
@@ -33538,38 +33399,90 @@ snapshots:
 
   webpack-sources@3.3.3: {}
 
+  webpack-sources@3.5.0: {}
+
   webpack-virtual-modules@0.5.0: {}
 
-  webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)):
+  webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15):
     dependencies:
       "@types/eslint-scope": 3.7.7
-      "@types/estree": 1.0.8
+      "@types/estree": 1.0.9
       "@types/json-schema": 7.0.15
       "@webassemblyjs/ast": 1.14.1
       "@webassemblyjs/wasm-edit": 1.14.1
       "@webassemblyjs/wasm-parser": 1.14.1
-      acorn: 8.15.0
-      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.21.0
+      enhanced-resolve: 5.22.2
       es-module-lexer: 1.7.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
       json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
+      loader-runner: 4.3.2
       mime-types: 2.1.35
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.3.14(@swc/core@1.15.40(@swc/helpers@0.5.17))(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17)))
-      watchpack: 2.4.4
-      webpack-sources: 3.3.3
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
+      watchpack: 2.5.1
+      webpack-sources: 3.5.0
     transitivePeerDependencies:
+      - "@minify-html/node"
       - "@swc/core"
+      - "@swc/css"
+      - "@swc/html"
+      - clean-css
+      - cssnano
+      - csso
       - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15):
+    dependencies:
+      "@types/eslint-scope": 3.7.7
+      "@types/estree": 1.0.9
+      "@types/json-schema": 7.0.15
+      "@webassemblyjs/ast": 1.14.1
+      "@webassemblyjs/wasm-edit": 1.14.1
+      "@webassemblyjs/wasm-parser": 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.2
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.22.2
+      es-module-lexer: 1.7.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.2
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      terser-webpack-plugin: 5.6.1(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15)(webpack@5.101.3(@swc/core@1.15.40(@swc/helpers@0.5.17))(postcss@8.5.15))
+      watchpack: 2.5.1
+      webpack-sources: 3.5.0
+    transitivePeerDependencies:
+      - "@minify-html/node"
+      - "@swc/core"
+      - "@swc/css"
+      - "@swc/html"
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
       - uglify-js
 
   whatwg-encoding@3.1.1:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ catalog:
   next-intl: 4.13.0
   react: 19.2.6
   react-dom: 19.2.6
+  vitest: 4.1.8
 
 auditConfig:
   ignoreGhsas:


### PR DESCRIPTION
## Summary
- add Vitest to the pnpm catalog at 4.1.8
- switch direct workspace Vitest dev dependencies to `catalog:`
- refresh the pnpm lockfile for Vitest 4.1.8

## Test plan
- `pnpm test`
- `pnpm list vitest -r --depth 0`