### PR TITLE
docs: fix incorrect flags, fields, and program ID in Kora docs

### DIFF
--- a/apps/docs/content/docs/en/tools/kora/getting-started/quick-start.mdx
+++ b/apps/docs/content/docs/en/tools/kora/getting-started/quick-start.mdx
@@ -14,7 +14,7 @@ SOL, enabling better UX for applications where users may not hold SOL.
 Kora RPC validates client requests based on a configuration (`kora.toml`) that
 defines allowable programs, wallets, tokens, etc. Once validated, the Kora
 server will sign the transaction and send it to the network (or return a
-serialized siged transaction to the client).
+serialized signed transaction to the client).
 
 ```
 ┌─────────────────┐    ┌─────────────────┐    ┌─────────────────┐
@@ -75,7 +75,7 @@ The demo contains three main components:
   airdrops SOL, initializes test token)
 - `quick-start.ts` - Quick start demonstration script showing establishing a
   Kora connection and making a simple call to the Kora RPC server
-- `full-demo.ts` - Full demo script demonstration multiple Kora RPC methods
+- `full-demo.ts` - Full demo script demonstrating multiple Kora RPC methods
 
 **Server Directory (`server/`)**
 
@@ -142,7 +142,7 @@ more information on the signers configuration, see the
 
 ## Test Server
 
-Open three terminals and run the following commands:
+Open five terminals and run the following commands:
 
 ### Terminal 1: Start Local Test Validator
 
@@ -171,10 +171,10 @@ your .env and update the `allowed_tokens` and `allowed_spl_paid_tokens` in
 
 ```toml
 allowed_tokens = [
-    "YOUR_USDC_LOCAL_PUBLICK_KEY"    # Update this based on the USDC_LOCAL_KEY public key comment in your .env
+    "YOUR_USDC_LOCAL_PUBLIC_KEY"    # Update this based on the USDC_LOCAL_KEY public key comment in your .env
 ]
 allowed_spl_paid_tokens = [
-    "YOUR_USDC_LOCAL_PUBLICK_KEY"    # Update this based on the USDC_LOCAL_KEY public key comment in your .env
+    "YOUR_USDC_LOCAL_PUBLIC_KEY"    # Update this based on the USDC_LOCAL_KEY public key comment in your .env
 ]
 ```
 
@@ -245,7 +245,7 @@ Kora Config: {
       'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
       'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
       'AddressLookupTab1e1111111111111111111111111',
-      'ComputeBudget11111111111111111111111111111111'
+      'ComputeBudget111111111111111111111111111111'
     ],
     allowed_tokens: [
       'usdCAEFbouFGxdkbHCRtMTcN7DJHd3aCmP9vqjLgmAp'

--- a/apps/docs/content/docs/en/tools/kora/guides/x402.mdx
+++ b/apps/docs/content/docs/en/tools/kora/guides/x402.mdx
@@ -466,8 +466,8 @@ This endpoint:
 
 This endpoint:
 
-- Receives the the x402 payment payload after the payment has been verified by
-  the `/verify` endpoint
+- Receives the x402 payment payload after the payment has been verified by the
+  `/verify` endpoint
 - Uses Kora's `signAndSendTransaction` to sign and broadcast the transaction
 - Returns the transaction signature as proof of settlement
 
@@ -517,7 +517,7 @@ for more information.
 
 ### The Client Application
 
-The client (`client/src/index.ts`) demonstrates automatic how x402 works by
+The client (`client/src/index.ts`) demonstrates how x402 works automatically by
 sending a request with a standard `fetch` call and then retrying the request
 with the payment wrapper:
 

--- a/apps/docs/content/docs/en/tools/kora/json-rpc-api/get-config.mdx
+++ b/apps/docs/content/docs/en/tools/kora/json-rpc-api/get-config.mdx
@@ -40,7 +40,7 @@ curl -X POST http://localhost:8080 \
 
 ```typescript
 const config = await client.getConfig();
-console.log("Fee payer:", config.fee_payer);
+console.log("Fee payers:", config.fee_payers);
 console.log(
   "Validation config:",
   JSON.stringify(config.validation_config, null, 2)

--- a/apps/docs/content/docs/en/tools/kora/operators/configuration.mdx
+++ b/apps/docs/content/docs/en/tools/kora/operators/configuration.mdx
@@ -239,7 +239,7 @@ allowed_programs = [
     "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",   # Token-2022 Program
     "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",  # Associated Token Program
     "AddressLookupTab1e1111111111111111111111111",   # Address Lookup Table Program
-    "ComputeBudget11111111111111111111111111111111", # Compute Budget Program
+    "ComputeBudget111111111111111111111111111111", # Compute Budget Program
 ]
 allowed_tokens = [
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",  # USDC (mainnet)
@@ -670,7 +670,7 @@ allowed_programs = [
     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",   # SPL Token
     "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",  # Associated Token
     "AddressLookupTab1e1111111111111111111111111",   # Address Lookup Table
-    "ComputeBudget11111111111111111111111111111111", # Compute Budget
+    "ComputeBudget111111111111111111111111111111", # Compute Budget
     "MyProgram111111111111111111111111111111111",
     # Add your specific program IDs here
 ]

--- a/apps/docs/content/docs/en/tools/kora/operators/signers.mdx
+++ b/apps/docs/content/docs/en/tools/kora/operators/signers.mdx
@@ -26,9 +26,9 @@ transaction fees. If compromised, an attacker could:
 
 ## Signer Configuration
 
-The Kora RPC CLI requires a `signer.toml` to be specified via the
-`--signers-config` flag. The `singer.toml` file allows you to configure the
-signer(s) and signer configuration for your node. `signer.toml` has two
+The Kora RPC CLI requires a `signers.toml` to be specified via the
+`--signers-config` flag. The `signers.toml` file allows you to configure the
+signer(s) and signer configuration for your node. `signers.toml` has two
 sections:
 
 1. `[signer_pool]` - Configuration for the signer pool
@@ -63,9 +63,9 @@ configure multiple signers for improved reliability and performance.
 
 ### Example
 
-Here's an example `signers.toml` file to defines a round-robin signer pool with
-three signers (_note: we'll cover the different signer types/configurations in
-the next section_):
+Here's an example `signers.toml` file that defines a round-robin signer pool
+with three signers (_note: we'll cover the different signer types/configurations
+in the next section_):
 
 ```toml
 [signer_pool]
@@ -352,7 +352,7 @@ Let's fetch them from Privy:
 From your dashboard, select the application you want to use for Kora (or click
 "+ New app" if you don't have one).
 
-Select "Retrieve API Keys" anc click "+ New Secret":
+Select "Retrieve API Keys" and click "+ New Secret":
 
 ![Privy Wallets](/assets/docs/tools/kora/signers/privy-app.jpg)
 
@@ -421,10 +421,10 @@ wallet_id_env = "PRIVY_WALLET_ID"
 ## No Signer
 
 If no signer is configured, Kora will throw an error. If you want to run Kora
-without a signer, you run it with the `--no-signer` flag:
+without a signer, you run it with the `--no-load-signer` flag:
 
 ```bash
-kora --config path/to/kora.toml rpc start --no-signer
+kora --config path/to/kora.toml rpc start --no-load-signer
 ```
 
 Note that this will limit your node to only processing requests that do not
@@ -459,7 +459,7 @@ require a signer.
 Add detailed logging to diagnose issues:
 
 ```bash
-RUST_LOG=debug kora rpc --with-turnkey-signer
+RUST_LOG=debug kora --config path/to/kora.toml rpc start --signers-config path/to/signers.toml
 ```
 
 ## Security & Best Practices
@@ -480,19 +480,19 @@ operations:
 
 ```typescript
 // Fetch the signers by calling getPayerSigner
-const { signer, payment_destination } = await client.getPayerSigner();
-console.log(signer, payment_destination);
+const { signer_address, payment_address } = await client.getPayerSigner();
+console.log(signer_address, payment_address);
 
 // Estimate with specific signer
 const estimate = await client.estimateTransactionFee({
   transaction: tx,
-  signer_key: signer // Public key of preferred signer (one of the signers in the signer pool)
+  signer_key: signer_address // Public key of preferred signer (one of the signers in the signer pool)
 });
 
 // Sign with same signer
 const signed = await client.signTransaction({
   transaction: tx,
-  signer_key: signer // Same signer for consistency
+  signer_key: signer_address // Same signer for consistency
 });
 ```
 


### PR DESCRIPTION
Went through the Kora docs and found a handful of small mistakes. They're all minor so I grouped them into one PR.

**signers.mdx**

- The "No Signer" section says to run with `--no-signer`, but the flag is `--no-load-signer` (the same file uses it correctly in a few other places).
- The verbose logging snippet runs `kora rpc --with-turnkey-signer`, which isn't a real command/flag. Switched it to the normal start command with `RUST_LOG=debug`.
- The `getPayerSigner` example destructures `{ signer, payment_destination }`, but the response is `{ signer_address, payment_address }` (`GetPayerSignerResponse` in the TS SDK). Updated the destructure and the `signer_key` usages to match.
- `signer.toml`/`singer.toml` -> `signers.toml`, plus two typos (`anc click`, "file to defines").

**configuration.mdx and quick-start.mdx**

- The Compute Budget program ID had two extra `1`s. Fixed to `ComputeBudget111111111111111111111111111111`. The x402 guide already uses the correct one.

**get-config.mdx**

- The TS example reads `config.fee_payer`; the field is `fee_payers`, which matches the JSON response shown just above it.

**quick-start.mdx**

- "Open three terminals" but the section lists five (Terminal 1-5). Also fixed `siged`, `PUBLICK`, and `demonstration`.

**x402.mdx**

- Two grammar fixes ("the the", and a reordered sentence).

Ran prettier on the changed files.
