### PR TITLE
Add Covenant to community skills (Infrastructure)

### DIFF
--- a/apps/web/src/data/skills/communitySkills.ts
+++ b/apps/web/src/data/skills/communitySkills.ts
@@ -277,6 +277,14 @@ export const COMMUNITY_SKILLS: CommunitySkill[] = [
     url: "https://github.com/sendaifun/skills/tree/72ef2aa814cca4662341bfcdc01cdc288e9bb502/skills/switchboard",
     category: INFRASTRUCTURE,
   },
+  {
+    slug: "covenant",
+    title: "Covenant",
+    description:
+      "Verifiable agent execution on Solana: signed capability gating, hash-chained audit, separately-keyed verifier refutation, and on-chain anchored Merkle witness. Devnet-first.",
+    url: "https://github.com/open-covenant/covenant-skill/tree/33683b38ad19f896d052764679ac266f2bed49a3/skill",
+    category: INFRASTRUCTURE,
+  },
 
   // ── Developer Tools ─────────────────────────────────────────────────
   {

--- a/apps/web/src/data/skills/communitySkills.ts
+++ b/apps/web/src/data/skills/communitySkills.ts
@@ -278,7 +278,7 @@ export const COMMUNITY_SKILLS: CommunitySkill[] = [
     category: INFRASTRUCTURE,
   },
   {
-    slug: "covenant",
+    slug: "covenant-skill",
     title: "Covenant",
     description:
       "Verifiable agent execution on Solana: signed capability gating, hash-chained audit, separately-keyed verifier refutation, and on-chain anchored Merkle witness. Devnet-first.",


### PR DESCRIPTION
Adds the **Covenant** Agent Skill to the community catalog under Infrastructure.

Covenant is a verifiable execution layer for autonomous agents on Solana. It turns two of the Agent Skill safety warnings — **W009** (never sign without approval) and **W011** (on-chain data is untrusted) — from prompt text into machine-enforced controls: signed capability gating, a hash-chained audit log with untrusted-input tagging, a separately-keyed verifier that refutes injection-steered runs, settlement receipts, and an on-chain anchored Merkle witness. Devnet-first.

Against the contribution checklist:
- **Repo:** https://github.com/open-covenant/covenant-skill — org-owned, branch-protected
- **URL** pinned to an immutable commit (`tree/33683b38…/skill`)
- **Security contact:** security@opencovenant.org (`SECURITY.md` present)
- **No secrets** requested; no remote bootstrap (no `curl | sh`, no postinstall)
- **Scope:** devnet-only; mainnet is a separate, gated milestone
