### PR TITLE
docs: update verified builds docs for deprecated --remote flow

### DIFF
--- a/apps/docs/content/docs/en/programs/verified-builds.mdx
+++ b/apps/docs/content/docs/en/programs/verified-builds.mdx
@@ -575,7 +575,8 @@ branch. You can also define a certain commit in case you want to continue
 working on the repository by using the `commit-hash` parameter:
 `--commit-hash 5b82b86f02afbde330dff3e1847bed2d42069f4e`
 
-Finally, submit a remote verification job against the OtterSec API:
+When prompted, answer yes to upload your verification PDA onchain. Then submit a
+remote verification job against the OtterSec API:
 
 ```bash
 solana-verify remote submit-job --program-id FWEYpBAf9WsemQiNbAewhyESfR38GBBHLrCaU3MpEKWv --uploader <your-upgrade-authority>

--- a/apps/docs/content/docs/en/programs/verified-builds.mdx
+++ b/apps/docs/content/docs/en/programs/verified-builds.mdx
@@ -309,46 +309,27 @@ If you want to lock the verification to a certain release, you can append the
 
 ### Verify against public API
 
-Finally you can also directly verify the program against anyone that is running
-the verify API::
-
-```bash
-solana-verify verify-from-repo --remote -um --program-id PhoeNiXZ8ByJGLkxNfZRnkUfjvmuYqLR89jjFHGqdXY https://github.com/Ellipsis-Labs/phoenix-v1
-```
-
-> It is recommended to use a payed RPC Url because otherwise you may run into
-> rate limits of the free RPCs. So instead of `-um` you should use
-> `--url yourRpcUrl` for a more reliable verification.
-
-The `--remote` flag sends a build request to the OtterSec API, which triggers a
-remote build of your program. Once the build is complete, the system verifies
-that the onchain hash of your program matches the hash of the generated build
-artifact from your repository.
-
-The default is the
-[OtterSec API](https://github.com/otter-sec/solana-verified-programs-api).
-
-Make sure to pick yes when you are asked to upload the verification data
-onchain. This is used by the API to verify that you uploaded the verification
-data.
-
-You can also trigger a remote job manually by using:
+After you upload your verification PDA onchain with `verify-from-repo`, submit a
+remote verification job to the
+[OtterSec API](https://github.com/otter-sec/solana-verified-programs-api):
 
 ```bash
 solana-verify remote submit-job --program-id <program-id> --uploader <address>
 ```
 
-Where the uploader is the address that has the authority to write to the PDA.
-That should be program authority in most cases. If your program is controlled by
-a multisig please continue in the
+The `--uploader` is the address that uploaded the verification PDA, usually your
+program's upgrade authority. If your program is controlled by a multisig,
+continue in the
 [multisig verification](#how-to-verify-your-program-when-its-controlled-by-a-multisig-like-squads)
 part of this guide below.
 
-This will submit a job to the OtterSec API and you can then verify the job
-status with:
+> The legacy `--remote` flag on `verify-from-repo` has been deprecated. Upload
+> your PDA first, then run `remote submit-job`.
+
+This submits a job to the OtterSec API. You can check the job status with:
 
 ```bash
-solana-verify remote get-job-status --job-id <job-id>
+solana-verify remote get-job --job-id <job-id>
 ```
 
 Once the verification has completed successfully, which may take awhile, you
@@ -594,16 +575,11 @@ branch. You can also define a certain commit in case you want to continue
 working on the repository by using the `commit-hash` parameter:
 `--commit-hash 5b82b86f02afbde330dff3e1847bed2d42069f4e`
 
-Finally you can also directly verify the program against the OtterSec API:
+Finally, submit a remote verification job against the OtterSec API:
 
 ```bash
-solana-verify verify-from-repo https://github.com/solana-developers/verified-program --url YOUR-RPC-URL --remote --program-id FWEYpBAf9WsemQiNbAewhyESfR38GBBHLrCaU3MpEKWv --mount-path waffle --library-name waffle --commit-hash 5b82b86f02afbde330dff3e1847bed2d42069f4e
+solana-verify remote submit-job --program-id FWEYpBAf9WsemQiNbAewhyESfR38GBBHLrCaU3MpEKWv --uploader <your-upgrade-authority>
 ```
-
-The `--remote` command sends a build request to the OtterSec API, which triggers
-a remote build of your program. Once the build is complete, the system verifies
-that the onchain hash of your program matches the hash of the generated build
-artifact from your repository.
 
 ## Popular programs that are already verified
 


### PR DESCRIPTION
### Problem
Verified builds docs still showed `verify-from-repo --remote`, but that flag is deprecated in the latest solana-verify CLI.
### Summary of Changes
- Updated the remote verification flow to use remote submit-job after uploading the on-chain PDA.
- Replaced outdated `--remote` examples and corrected the job status command to remote get-job.
