### PR TITLE
Remove generated quotes from media blockquotes

### DIFF
--- a/apps/media/styles.css
+++ b/apps/media/styles.css
@@ -300,6 +300,13 @@
     line-height: 1.8 !important;
   }
 
+  .prose blockquote p:first-of-type::before,
+  .prose-dark blockquote p:first-of-type::before,
+  .prose blockquote p:last-of-type::after,
+  .prose-dark blockquote p:last-of-type::after {
+    content: none !important;
+  }
+
   .prose > ul,
   .prose-dark > ul,
   .prose > ol,


### PR DESCRIPTION
## Summary
- Disable Tailwind Typography's generated opening and closing quote pseudo-elements for media article blockquotes
- Preserve existing blockquote border, spacing, italic, and muted text styling

## Testing
- pnpm --filter solana-com-media lint
- Playwright computed-style check on /news/only-possible-on-solana-drip confirmed blockquote ::before and ::after content are both none