### PR TITLE
fix: prevent docs navigation reloads

### DIFF
--- a/apps/docs/src/app/[locale]/layout.tsx
+++ b/apps/docs/src/app/[locale]/layout.tsx
@@ -10,6 +10,7 @@ import { config } from "@@/src/config";
 import { getBaseMetadata } from "@@/src/app/metadata";
 import { staticLocales } from "@workspace/i18n/config";
 import { getLangDir } from "rtl-detect";
+import { NextProvider } from "fumadocs-core/framework/next";
 import {
   Header,
   Footer,
@@ -43,17 +44,19 @@ export default async function RootLayout({ children, params }: Props) {
         </noscript>
         {/* End Google Tag Manager (noscript) */}
         <NextIntlClientProvider messages={messages} locale={locale}>
-          <PostHogProvider>
-            <ThemeProvider>
-              <GTMTrackingSnippet />
-              <SitewideTopAlert />
-              <CookieConsent />
-              <Header />
-              {children}
-              <Footer />
-              <PersistentPodcastPlayer />
-            </ThemeProvider>
-          </PostHogProvider>
+          <NextProvider>
+            <PostHogProvider>
+              <ThemeProvider>
+                <GTMTrackingSnippet />
+                <SitewideTopAlert />
+                <CookieConsent />
+                <Header />
+                {children}
+                <Footer />
+                <PersistentPodcastPlayer />
+              </ThemeProvider>
+            </PostHogProvider>
+          </NextProvider>
         </NextIntlClientProvider>
       </body>
     </html>

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -137,6 +137,12 @@
   padding-bottom: 0.4rem !important;
 }
 
+.fumadocs [role="tab"],
+.fumadocs [role="tab"] * {
+  /* Tab color transitions repaint the full docs layer in Chrome. */
+  transition: none !important;
+}
+
 .scrollbar-thin {
   scrollbar-width: thin;
   scrollbar-color: transparent transparent;


### PR DESCRIPTION
### Problem

Docs sidebar links were falling back to plain anchor navigation, causing full document reloads between docs pages. Docs tab color transitions also caused Chrome to repaint the full docs layer during tab switches, making the page look like it flashed.

### Summary of Changes

- Wrap the docs app with Fumadocs `NextProvider` so sidebar links use Next client routing.
- Disable docs tab transitions that repaint the full docs layer in Chrome.

Fixes #

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the browser).
- [x] Input from users or external services is validated before use; no `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit` passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependencies: none

Threat-model note for Critical changes: n/a
