### PR TITLE
fix: stabilize Buzzsprout podcast RSS episode lookup

### DIFF
--- a/apps/media/__tests__/podcast-rss.test.ts
+++ b/apps/media/__tests__/podcast-rss.test.ts
@@ -44,4 +44,90 @@ describe("fetchEpisodeByIdFromRSS", () => {
     expect(byId?.title).toContain("Irina Chuchkina");
     expect(byId?.audioUrl).toContain("/2092514/episodes/19027082");
   });
+
+  it("parses the redesigned Buzzsprout episode markup", async () => {
+    const html = `<h2>1 episodes</h2><div id="episode_19255333" class="flex gap-4 py-5 md:py-8"><a class="w-12 h-12 flex" title="Play episode" href="/2617232/episodes/19255333-how-sofi-continues-to-reshape-banking-with-stablecoins?t=0"></a><a class="w-full no-underline" href="/2617232/episodes/19255333-how-sofi-continues-to-reshape-banking-with-stablecoins"><div class="show-notes flex justify-between"><div dir="auto"><h3 id="title_episode_19255333" class="text-base">How SoFI Continues to Reshape Banking with Stablecoins</h3><p id="description_episode_19255333" class="py-2 text-sm">Episode description</p><div class="flex"><time datetime="May 28, 2026" class="whitespace-nowrap">May 28, 2026</time><span >•</span> 24:08</div></div><img alt="Artwork" src="https://example.com/cover.jpg" /></div></a></div>`;
+
+    const fetchMock = vi.fn().mockImplementation(
+      async () =>
+        new Response(html, {
+          status: 200,
+          headers: {
+            "content-type": "text/html",
+          },
+        }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const episode = await fetchEpisodeByIdFromRSS(
+      "19255333",
+      "https://rss.buzzsprout.com/2617232.rss",
+      "mint-condition",
+    );
+
+    expect(episode?.id).toBe("19255333");
+    expect(episode?.slug).toBe(
+      "19255333-how-sofi-continues-to-reshape-banking-with-stablecoins",
+    );
+    expect(episode?.title).toBe(
+      "How SoFI Continues to Reshape Banking with Stablecoins",
+    );
+    expect(episode?.description).toBe("Episode description");
+    expect(episode?.duration).toBe(24 * 60 + 8);
+  });
+
+  it("falls back to the RSS feed when Buzzsprout scraping finds no episodes", async () => {
+    const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd">
+  <channel>
+    <title>Mint Condition</title>
+    <item>
+      <title>How SoFI Continues to Reshape Banking with Stablecoins</title>
+      <guid isPermaLink="false">Buzzsprout-19255333</guid>
+      <pubDate>Thu, 28 May 2026 12:00:00 +0000</pubDate>
+      <enclosure url="https://www.buzzsprout.com/2617232/episodes/19255333-how-sofi-continues-to-reshape-banking-with-stablecoins.mp3" length="17431539" type="audio/mpeg" />
+      <itunes:duration>1448</itunes:duration>
+      <description>Episode description</description>
+    </item>
+  </channel>
+</rss>`;
+
+    const fetchMock = vi.fn().mockImplementation(async (url: string) => {
+      if (url.includes("buzzsprout.com/2617232/episodes")) {
+        // Scrape returns markup the parser cannot understand
+        return new Response("<html><body>redesigned page</body></html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        });
+      }
+      return new Response(rssXml, {
+        status: 200,
+        headers: { "content-type": "application/rss+xml" },
+      });
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    // Look up by the same slug the Buzzsprout website scraper would produce,
+    // proving episode URLs stay stable when falling back to RSS
+    const episode = await fetchEpisodeByIdFromRSS(
+      "19255333-how-sofi-continues-to-reshape-banking-with-stablecoins",
+      "https://rss.buzzsprout.com/2617232.rss",
+      "mint-condition",
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://rss.buzzsprout.com/2617232.rss",
+      expect.any(Object),
+    );
+    expect(episode?.id).toBe("19255333");
+    expect(episode?.slug).toBe(
+      "19255333-how-sofi-continues-to-reshape-banking-with-stablecoins",
+    );
+    expect(episode?.title).toBe(
+      "How SoFI Continues to Reshape Banking with Stablecoins",
+    );
+    expect(episode?.audioUrl).toContain("/2617232/episodes/19255333");
+  });
 });

--- a/apps/media/lib/podcast-rss.ts
+++ b/apps/media/lib/podcast-rss.ts
@@ -148,6 +148,49 @@ function ensureUniqueEpisodeSlugs(
   });
 }
 
+/**
+ * Buzzsprout enclosure URLs embed the same `{id}-{slug}` path segment used by
+ * the Buzzsprout website (e.g. /2617232/episodes/19255333-some-title.mp3).
+ * Deriving the episode id and slug from it keeps RSS-sourced episode URLs
+ * identical to the ones produced by Buzzsprout website scraping.
+ */
+function extractBuzzsproutEpisodeRef(
+  enclosureUrl?: string,
+): { id: string; slug: string } | null {
+  if (!enclosureUrl) {
+    return null;
+  }
+
+  try {
+    const url = new URL(enclosureUrl);
+
+    if (!/(?:^|\.)buzzsprout\.com$/i.test(url.hostname)) {
+      return null;
+    }
+
+    const segment = url.pathname.match(
+      /\/episodes\/([^/?#]+?)(?:\.[a-z0-9]+)?$/i,
+    )?.[1];
+
+    if (!segment) {
+      return null;
+    }
+
+    const slug = slugifySegment(decodeURIComponent(segment));
+
+    if (!slug) {
+      return null;
+    }
+
+    return {
+      id: slug.match(/^(\d+)/)?.[1] ?? slug,
+      slug,
+    };
+  } catch {
+    return null;
+  }
+}
+
 function extractEpisodeThumbnail(item: {
   itunesImage?: { href?: string; $?: { href?: string } };
   itunes?: { image?: string };
@@ -296,11 +339,11 @@ function parseBuzzsproutEpisodesPage(
     const block = match[0] ?? "";
 
     const hrefMatch = block.match(
-      /<a class="w-full" href="(\/\d+\/episodes\/[^"]+)"/,
+      /<a class="w-full[^"]*" href="(\/\d+\/episodes\/[^"]+)"/,
     );
     const titleMatch = block.match(/<h3[^>]*>([\s\S]*?)<\/h3>/);
     const descriptionMatch = block.match(
-      /<div id="description_episode_[^"]+"[^>]*>([\s\S]*?)<\/div>/,
+      /<(?:div|p) id="description_episode_[^"]+"[^>]*>([\s\S]*?)<\/(?:div|p)>/,
     );
     const dateMatch = block.match(
       /<time datetime="([^"]+)" class="whitespace-nowrap">/,
@@ -407,7 +450,8 @@ export async function fetchEpisodesFromRSS(
         const duration = parseDuration(
           item.itunesDuration || item.itunes?.duration,
         );
-        const id = generateEpisodeId(item);
+        const buzzsproutRef = extractBuzzsproutEpisodeRef(item.enclosure?.url);
+        const id = buzzsproutRef?.id ?? generateEpisodeId(item);
         const publishedDate =
           item.pubDate || item.isoDate || new Date().toISOString();
         const linkSlug =
@@ -417,7 +461,10 @@ export async function fetchEpisodesFromRSS(
 
         return {
           id,
-          slug: linkSlug || buildEpisodeSlug(item.title, id, publishedDate),
+          slug:
+            linkSlug ||
+            buzzsproutRef?.slug ||
+            buildEpisodeSlug(item.title, id, publishedDate),
           recordingId: id,
           podcastSlug,
           title: item.title || "Untitled Episode",
@@ -476,7 +523,23 @@ export async function fetchEpisodesFromRSSCached(
 ): Promise<PodcastEpisode[]> {
   try {
     if (isBuzzsproutFeed(rssFeedUrl)) {
-      return await fetchEpisodesFromBuzzsprout(rssFeedUrl, podcastSlug);
+      // Buzzsprout website scraping gives stable episode slugs, but the page
+      // markup changes without notice — fall back to the RSS feed itself so
+      // episodes never silently disappear.
+      const scrapedEpisodes = await fetchEpisodesFromBuzzsprout(
+        rssFeedUrl,
+        podcastSlug,
+      ).catch((error) => {
+        console.error(
+          `❌ Failed to scrape Buzzsprout episodes for ${rssFeedUrl}:`,
+          error,
+        );
+        return [];
+      });
+
+      if (scrapedEpisodes.length > 0) {
+        return scrapedEpisodes;
+      }
     }
 
     const episodes = await fetchEpisodesFromRSS(rssFeedUrl, podcastSlug);

--- a/apps/media/lib/podcast-rss.ts
+++ b/apps/media/lib/podcast-rss.ts
@@ -540,6 +540,10 @@ export async function fetchEpisodesFromRSSCached(
       if (scrapedEpisodes.length > 0) {
         return scrapedEpisodes;
       }
+
+      console.warn(
+        `Buzzsprout scraping returned no episodes for ${rssFeedUrl}, falling back to RSS feed`,
+      );
     }
 
     const episodes = await fetchEpisodesFromRSS(rssFeedUrl, podcastSlug);


### PR DESCRIPTION
## Summary
- parse Buzzsprout episode ids and slugs from enclosure URLs when falling back to RSS
- tolerate updated Buzzsprout episode page markup
- fall back to RSS when Buzzsprout scraping returns no episodes

## Testing
- pnpm --filter solana-com-media test -- apps/media/__tests__/podcast-rss.test.ts