### PR TITLE
docs: quickstart update to Kit

### DIFF
--- a/apps/docs/content/docs/en/intro/quick-start/reading-from-network.mdx
+++ b/apps/docs/content/docs/en/intro/quick-start/reading-from-network.mdx
@@ -2,53 +2,62 @@
 title: Reading from Network
 description:
   Learn how to read data from the Solana blockchain network. This guide covers
-  fetching wallet accounts, program accounts, and token mint accounts using
-  JavaScript/TypeScript, with practical examples using the Solana web3.js
-  library.
+  fetching wallet accounts, program accounts, and token mint accounts with
+  JavaScript/TypeScript examples using Solana Kit.
 ---
 
-Read data from the Solana network by fetching different accounts. This section
-will help you understand the structure of Solana
-[accounts](/docs/core/accounts). Each Solana account has a unique
-[address](/docs/core/accounts#account-address) that is used to locate its
-corresponding onchain data. Accounts contain either
+Read data from the Solana network by fetching different accounts. This guide
+explains the structure of Solana [accounts](/docs/core/accounts). Each Solana
+account has a unique [address](/docs/core/accounts#account-address) that is used
+to locate the account's onchain data. Solana accounts contain either
 [state data or an executable program](/docs/core/accounts#types-of-accounts).
 
 ## Fetch a wallet account
 
 <WithMentions>
 
-A wallet is an account owned by the
-[System Program](/docs/core/programs#the-system-program). Wallets are primarily
-used to hold SOL and sign transactions. When SOL is sent to a new address for
-the first time, a system account is automatically created.
+A wallet account is an account owned by the
+[System Program](/docs/core/programs#the-system-program). Wallet accounts are
+primarily used to hold SOL and sign transactions. When SOL is sent to a new
+address for the first time, a system account is automatically created.
 
-The example below generates a [new keypair](mention:keypair),
-[requests SOL](mention:airdrop) to fund the new public key address, and
-[retrieves the account data](mention:info) for the newly funded wallet.
+The example below [creates RPC clients](mention:rpc), generates a
+[new signer](mention:keypair), [requests SOL](mention:airdrop) to fund the new
+address, and [retrieves the account data](mention:info) directly from the RPC
+client.
 
 <CodeTabs flags="r">
 
 ```ts !! title="Fetch account"
-import { Keypair, Connection, LAMPORTS_PER_SOL } from "@solana/web3.js";
+import {
+  airdropFactory,
+  createSolanaRpc,
+  createSolanaRpcSubscriptions,
+  generateKeyPairSigner,
+  lamports
+} from "@solana/kit";
+
+// !mention(1:2) rpc
+const rpc = createSolanaRpc("http://localhost:8899");
+const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
 
 // !mention keypair
-const keypair = Keypair.generate();
-console.log(`Public Key: ${keypair.publicKey}`);
-
-const connection = new Connection("http://localhost:8899", "confirmed");
+const signer = await generateKeyPairSigner();
+console.log(`Address: ${signer.address}`);
 
 // Funding an address with SOL automatically creates an account
-// !mention airdrop
-const signature = await connection.requestAirdrop(
-  keypair.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
+// !mention(1:6) airdrop
+const airdrop = airdropFactory({ rpc, rpcSubscriptions });
+await airdrop({
+  recipientAddress: signer.address,
+  lamports: lamports(1_000_000_000n),
+  commitment: "confirmed"
+});
 
 // !mention info
-const accountInfo = await connection.getAccountInfo(keypair.publicKey);
-console.log(JSON.stringify(accountInfo, null, 2));
+const accountInfo = await rpc.getAccountInfo(signer.address).send();
+
+console.log(accountInfo);
 ```
 
 </CodeTabs>
@@ -58,66 +67,80 @@ console.log(JSON.stringify(accountInfo, null, 2));
 
 ## !!steps
 
-When you fetch a wallet account, the response includes the fields shown in the
-example output on the right.
+When you fetch a wallet account with `getAccountInfo()`, Kit returns the RPC
+response shown in the example output on the right.
+
+The response has two top-level fields: `context` describes when the read
+happened, and `value` contains the account fields returned by the RPC method.
 
 <CodePlaceholder title="Example output" />
 
-```json !! title="Example output"
+```ts !! title="Example output"
 {
-  "data": {
-    "type": "Buffer",
-    "data": []
+  context: {
+    slot: 420602714n,
+    apiVersion: "3.1.6"
   },
-  "executable": false,
-  "lamports": 1000000000,
-  "owner": "11111111111111111111111111111111",
-  "rentEpoch": 0,
-  "space": 0
+  value: {
+    lamports: 1000000000n,
+    data: ["", "base64"],
+    owner: "11111111111111111111111111111111",
+    executable: false,
+    rentEpoch: 0n,
+    space: 0n
+  }
 }
 ```
 
 ## !!steps
 
-The `data` field contains the account's data stored as bytes. For wallet
-accounts, this field is empty (0 bytes).
+The `context` field shows the slot used to read the account and the RPC API
+version that served the response. A later read can return a different slot or
+API version.
 
 <CodePlaceholder title="Example output" />
 
-```json !! title="Example output"
+```ts !! title="Example output"
 {
   // !focus(1:4)
-  "data": {
-    "type": "Buffer",
-    "data": []
+  context: {
+    slot: 420602714n,
+    apiVersion: "3.1.6"
   },
-  "executable": false,
-  "lamports": 1000000000,
-  "owner": "11111111111111111111111111111111",
-  "rentEpoch": 0,
-  "space": 0
+  value: {
+    lamports: 1000000000n,
+    data: ["", "base64"],
+    owner: "11111111111111111111111111111111",
+    executable: false,
+    rentEpoch: 0n,
+    space: 0n
+  }
 }
 ```
 
 ## !!steps
 
-The `executable` field indicates whether the account's `data` field contains
-executable program code. For wallet accounts this field is `false`.
+The `value` field contains the account state returned by the RPC method. The
+following steps walk through the fields inside `value` in the order the fields
+appear.
 
 <CodePlaceholder title="Example output" />
 
-```json !! title="Example output"
+```ts !! title="Example output"
 {
-  "data": {
-    "type": "Buffer",
-    "data": []
+  context: {
+    slot: 420602714n,
+    apiVersion: "3.1.6"
   },
-  // !focus
-  "executable": false,
-  "lamports": 1000000000,
-  "owner": "11111111111111111111111111111111",
-  "rentEpoch": 0,
-  "space": 0
+  // !focus(1:8)
+  value: {
+    lamports: 1000000000n,
+    data: ["", "base64"],
+    owner: "11111111111111111111111111111111",
+    executable: false,
+    rentEpoch: 0n,
+    space: 0n
+  }
 }
 ```
 
@@ -128,18 +151,48 @@ The `lamports` field contains the account's SOL balance, in
 
 <CodePlaceholder title="Example output" />
 
-```json !! title="Example output"
+```ts !! title="Example output"
 {
-  "data": {
-    "type": "Buffer",
-    "data": []
+  context: {
+    slot: 420602714n,
+    apiVersion: "3.1.6"
   },
-  "executable": false,
-  // !focus
-  "lamports": 1000000000,
-  "owner": "11111111111111111111111111111111",
-  "rentEpoch": 0,
-  "space": 0
+  value: {
+    // !focus
+    lamports: 1000000000n,
+    data: ["", "base64"],
+    owner: "11111111111111111111111111111111",
+    executable: false,
+    rentEpoch: 0n,
+    space: 0n
+  }
+}
+```
+
+## !!steps
+
+The `data` field contains the account's data stored as bytes. RPC returns
+account data as a tuple: the encoded data string, followed by the encoding. For
+wallet accounts, the encoded data string is empty because the account stores 0
+bytes of data.
+
+<CodePlaceholder title="Example output" />
+
+```ts !! title="Example output"
+{
+  context: {
+    slot: 420602714n,
+    apiVersion: "3.1.6"
+  },
+  value: {
+    lamports: 1000000000n,
+    // !focus
+    data: ["", "base64"],
+    owner: "11111111111111111111111111111111",
+    executable: false,
+    rentEpoch: 0n,
+    space: 0n
+  }
 }
 ```
 
@@ -151,66 +204,100 @@ owner is always the System Program, with the address
 
 <CodePlaceholder title="Example output" />
 
-```json !! title="Example output"
+```ts !! title="Example output"
 {
-  "data": {
-    "type": "Buffer",
-    "data": []
+  context: {
+    slot: 420602714n,
+    apiVersion: "3.1.6"
   },
-  "executable": false,
-  "lamports": 1000000000,
-  // !focus
-  "owner": "11111111111111111111111111111111",
-  "rentEpoch": 0,
-  "space": 0
+  value: {
+    lamports: 1000000000n,
+    data: ["", "base64"],
+    // !focus
+    owner: "11111111111111111111111111111111",
+    executable: false,
+    rentEpoch: 0n,
+    space: 0n
+  }
 }
 ```
 
 ## !!steps
 
-The `rentEpoch` field is a legacy field from a deprecated rent mechanism. (This
-field is included for backward compatibility.)
+The `executable` field indicates whether the account can be invoked as a
+program. For wallet accounts, the `executable` field is `false`.
 
 <CodePlaceholder title="Example output" />
 
-```json !! title="Example output"
+```ts !! title="Example output"
 {
-  "data": {
-    "type": "Buffer",
-    "data": []
+  context: {
+    slot: 420602714n,
+    apiVersion: "3.1.6"
   },
-  "executable": false,
-  "lamports": 1000000000,
-  "owner": "11111111111111111111111111111111",
-  // !focus
-  "rentEpoch": 0,
-  "space": 0
+  value: {
+    lamports: 1000000000n,
+    data: ["", "base64"],
+    owner: "11111111111111111111111111111111",
+    // !focus
+    executable: false,
+    rentEpoch: 0n,
+    space: 0n
+  }
 }
 ```
 
 ## !!steps
 
-The `space` field shows the number of bytes contained in the `data` field. This
-is not a field in the [Account type](/docs/core/accounts#account-structure)
-itself, but is included in the response.
-
-In this example, the `space` field is 0 because the `data` field contains 0
-bytes of data.
+The `rentEpoch` field is a legacy field from a deprecated rent mechanism. The
+field is still returned for backward compatibility.
 
 <CodePlaceholder title="Example output" />
 
-```json !! title="Example output"
+```ts !! title="Example output"
 {
-  "data": {
-    "type": "Buffer",
-    "data": []
+  context: {
+    slot: 420602714n,
+    apiVersion: "3.1.6"
   },
-  "executable": false,
-  "lamports": 1000000000,
-  "owner": "11111111111111111111111111111111",
-  "rentEpoch": 0,
-  // !focus
-  "space": 0
+  value: {
+    lamports: 1000000000n,
+    data: ["", "base64"],
+    owner: "11111111111111111111111111111111",
+    executable: false,
+    // !focus
+    rentEpoch: 0n,
+    space: 0n
+  }
+}
+```
+
+## !!steps
+
+The `space` field shows the number of bytes contained in the `data` field.
+Account-fetching APIs include the `space` value to save you from counting the
+bytes yourself.
+
+For the wallet account example, the `space` field is 0 because the `data` field
+contains 0 bytes of data.
+
+<CodePlaceholder title="Example output" />
+
+```ts !! title="Example output"
+{
+  context: {
+    slot: 420602714n,
+    apiVersion: "3.1.6"
+  },
+  value: {
+    lamports: 1000000000n,
+    data: ["", "base64"],
+    owner: "11111111111111111111111111111111",
+    executable: false,
+    rentEpoch: 0n,
+    // !focus
+    space: 0n
+  }
 }
 ```
 
@@ -219,42 +306,34 @@ bytes of data.
 ## Fetch the Token Program
 
 The example below fetches the Token Program to demonstrate the difference
-between wallet and program accounts. The program account stores the compiled
+between wallet and program accounts. The Token Program's address is the onchain
+Program account. For upgradeable programs, the Program account stores loader
+metadata and points to a separate ProgramData account that stores the deployed
 bytecode for the Token Program's
 [source code](https://github.com/solana-program/token/tree/main/program). You
-can view this program account on the
+can view the Program account on the
 [Solana Explorer](https://explorer.solana.com/address/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA).
 
 <CodeTabs flags="r">
 
 ```ts !! title="Fetch program account"
-import { Connection, PublicKey } from "@solana/web3.js";
+import { address, createSolanaRpc } from "@solana/kit";
 
-const connection = new Connection(
-  "https://api.mainnet.solana.com",
-  "confirmed"
-);
-// !mark(1:2)
-const address = new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
-const accountInfo = await connection.getAccountInfo(address);
+const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 
-// !collapse(1:17) collapsed
-console.log(
-  JSON.stringify(
-    accountInfo,
-    (key, value) => {
-      if (key === "data" && value && value.length > 1) {
-        return [
-          value[0],
-          "...truncated, total bytes: " + value.length + "...",
-          value[value.length - 1]
-        ];
-      }
-      return value;
-    },
-    2
-  )
+// !mark(1:3)
+const tokenProgramAddress = address(
+  "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
 );
+
+// !mark(1:5)
+const accountInfo = await rpc
+  .getAccountInfo(tokenProgramAddress, {
+    encoding: "base64"
+  })
+  .send();
+
+console.log(accountInfo);
 ```
 
 </CodeTabs>
@@ -265,87 +344,190 @@ console.log(
 
 The Token Program is an executable program account. Programs have the same
 underlying fields as all [accounts](/docs/core/accounts#account-structure), but
-with key differences.
+with key differences. Your `slot` and `apiVersion` may differ from the Token
+Program output shown here.
+
+The Token Program example uses `base64` encoding to return the Program account's
+raw bytes without asking RPC to interpret the bytes. The Program account data is
+short because the fetched account is the upgradeable Program account, not the
+separate ProgramData account that stores the compiled bytecode.
+
+The following steps walk through the fields inside `value` in the order the
+fields appear.
 
 <CodePlaceholder title="Token program account" />
 
-```json !! title="Token program account"
+```ts !! title="Token program account"
 {
-  "data": {
-    "type": "Buffer",
-    "data": [127, "...truncated, total bytes: 134080...", 0]
+  context: {
+    apiVersion: "3.1.14",
+    slot: 420601581n
   },
-  "executable": true,
-  "lamports": 4522329612,
-  "owner": "BPFLoader2111111111111111111111111111111111",
-  "rentEpoch": 18446744073709552000,
-  "space": 134080
+  value: {
+    data: ["AgAAACfxkLHTr5i4znFMROjK3/n4/EXLjl+sQgLv+BENl903", "base64"],
+    executable: true,
+    lamports: 2191440n,
+    owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+    rentEpoch: 18446744073709551615n,
+    space: 36n
+  }
+}
+```
+
+## !!steps
+
+The `data` field stores the BPF Upgradeable Loader's Program account state. The
+first tuple item contains the full account data encoded as base64. The second
+tuple item identifies the encoding. Here, the 36 bytes are the loader-state
+discriminator plus the ProgramData account address.
+
+For upgradeable programs, the Program account state points to the separate
+ProgramData account that stores the program's executable code.
+
+<CodePlaceholder title="Token program account" />
+
+```ts !! title="Token program account"
+{
+  context: {
+    apiVersion: "3.1.14",
+    slot: 420601581n
+  },
+  value: {
+    // !focus
+    data: ["AgAAACfxkLHTr5i4znFMROjK3/n4/EXLjl+sQgLv+BENl903", "base64"],
+    executable: true,
+    lamports: 2191440n,
+    owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+    rentEpoch: 18446744073709551615n,
+    space: 36n
+  }
 }
 ```
 
 ## !!steps
 
 The `executable` field is set to `true`, which indicates that the account's
-`data` field contains executable code.
+address can be invoked as a program.
 
 <CodePlaceholder title="Token program account" />
 
-```json !! title="Token program account"
+```ts !! title="Token program account"
 {
-  "data": {
-    "type": "Buffer",
-    "data": [127, "...truncated, total bytes: 134080...", 0]
+  context: {
+    apiVersion: "3.1.14",
+    slot: 420601581n
   },
-  // !focus
-  "executable": true,
-  "lamports": 4522329612,
-  "owner": "BPFLoader2111111111111111111111111111111111",
-  "rentEpoch": 18446744073709552000,
-  "space": 134080
+  value: {
+    data: ["AgAAACfxkLHTr5i4znFMROjK3/n4/EXLjl+sQgLv+BENl903", "base64"],
+    // !focus
+    executable: true,
+    lamports: 2191440n,
+    owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+    rentEpoch: 18446744073709551615n,
+    space: 36n
+  }
 }
 ```
 
 ## !!steps
 
-The `data` field stores the program's executable code.
+The `lamports` field contains the SOL balance held by the Program account.
+Program accounts need enough lamports to remain rent-exempt.
 
 <CodePlaceholder title="Token program account" />
 
-```json !! title="Token program account"
+```ts !! title="Token program account"
 {
-  // !focus(1:4)
-  "data": {
-    "type": "Buffer",
-    "data": [127, "...truncated, total bytes: 134080...", 0]
+  context: {
+    apiVersion: "3.1.14",
+    slot: 420601581n
   },
-  "executable": true,
-  "lamports": 4522329612,
-  "owner": "BPFLoader2111111111111111111111111111111111",
-  "rentEpoch": 18446744073709552000,
-  "space": 134080
+  value: {
+    data: ["AgAAACfxkLHTr5i4znFMROjK3/n4/EXLjl+sQgLv+BENl903", "base64"],
+    executable: true,
+    // !focus
+    lamports: 2191440n,
+    owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+    rentEpoch: 18446744073709551615n,
+    space: 36n
+  }
 }
 ```
 
 ## !!steps
 
-Every program account is owned by its
-[loader program](/docs/core/programs#loader-programs). In this example, the
-`owner` is the BPFLoader2 program.
+Every program account is owned by a
+[loader program](/docs/core/programs#loader-programs). For the Token Program
+account, the `owner` is the BPF Upgradeable Loader.
 
 <CodePlaceholder title="Token program account" />
 
-```json !! title="Token program account"
+```ts !! title="Token program account"
 {
-  "data": {
-    "type": "Buffer",
-    "data": [127, "...truncated, total bytes: 134080...", 0]
+  context: {
+    apiVersion: "3.1.14",
+    slot: 420601581n
   },
-  "executable": true,
-  "lamports": 4522329612,
-  // !focus
-  "owner": "BPFLoader2111111111111111111111111111111111",
-  "rentEpoch": 18446744073709552000,
-  "space": 134080
+  value: {
+    data: ["AgAAACfxkLHTr5i4znFMROjK3/n4/EXLjl+sQgLv+BENl903", "base64"],
+    executable: true,
+    lamports: 2191440n,
+    // !focus
+    owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+    rentEpoch: 18446744073709551615n,
+    space: 36n
+  }
+}
+```
+
+## !!steps
+
+The `rentEpoch` field is a legacy field from a deprecated rent mechanism. The
+field is still returned for backward compatibility.
+
+<CodePlaceholder title="Token program account" />
+
+```ts !! title="Token program account"
+{
+  context: {
+    apiVersion: "3.1.14",
+    slot: 420601581n
+  },
+  value: {
+    data: ["AgAAACfxkLHTr5i4znFMROjK3/n4/EXLjl+sQgLv+BENl903", "base64"],
+    executable: true,
+    lamports: 2191440n,
+    owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+    // !focus
+    rentEpoch: 18446744073709551615n,
+    space: 36n
+  }
+}
+```
+
+## !!steps
+
+The `space` field shows the full size of the Program account's data in bytes.
+The `space` value is only `36` bytes because the Program account stores loader
+metadata and a 32-byte pointer to ProgramData, not the full compiled program.
+
+<CodePlaceholder title="Token program account" />
+
+```ts !! title="Token program account"
+{
+  context: {
+    apiVersion: "3.1.14",
+    slot: 420601581n
+  },
+  value: {
+    data: ["AgAAACfxkLHTr5i4znFMROjK3/n4/EXLjl+sQgLv+BENl903", "base64"],
+    executable: true,
+    lamports: 2191440n,
+    owner: "BPFLoaderUpgradeab1e11111111111111111111111",
+    rentEpoch: 18446744073709551615n,
+    // !focus
+    space: 36n
+  }
 }
 ```
 
@@ -356,44 +538,32 @@ Every program account is owned by its
 A
 [mint account](https://github.com/solana-program/token/blob/program%40v8.0.0/program/src/state.rs#L16-L30)
 is an account owned by the Token Program that stores global metadata for a
-specific token. This includes the total supply, number of decimals, and the
-accounts that are authorized to mint or freeze tokens. The mint account's
-address uniquely identifies a token on the Solana network.
+specific token. The mint account stores the token's total supply, number of
+decimals, mint authority, and freeze authority. The mint account's address
+uniquely identifies a token on the Solana network.
 
 The example below fetches the USD Coin Mint account to demonstrate how a
-program's state is stored in a separate account.
+program's state is stored in a separate account. Exact balances and supply
+values may differ depending on the slot your RPC node reads from.
 
 <CodeTabs flags="r">
 
-```ts !! title="Fetch program account"
-import { Connection, PublicKey } from "@solana/web3.js";
+```ts !! title="Fetch mint account"
+import { address, createSolanaRpc } from "@solana/kit";
 
-const connection = new Connection(
-  "https://api.mainnet.solana.com",
-  "confirmed"
-);
+const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 
-// !mark(1:2)
-const address = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
-const accountInfo = await connection.getAccountInfo(address);
+// !mark
+const mintAddress = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
 
-// !collapse(1:17) collapsed
-console.log(
-  JSON.stringify(
-    accountInfo,
-    (key, value) => {
-      if (key === "data" && value && value.length > 1) {
-        return [
-          value[0],
-          "...truncated, total bytes: " + value.length + "...",
-          value[value.length - 1]
-        ];
-      }
-      return value;
-    },
-    2
-  )
-);
+// !mark(1:5)
+const accountInfo = await rpc
+  .getAccountInfo(mintAddress, {
+    encoding: "base64"
+  })
+  .send();
+
+console.log(accountInfo);
 ```
 
 </CodeTabs>
@@ -402,55 +572,43 @@ console.log(
 
 ## !!steps
 
-Mint accounts store state, not executable code. They are owned by the Token
-Program, which includes instructions defining how to create and update mint
-accounts.
+Mint accounts store state, not executable code. Mint accounts are owned by the
+Token Program, which includes instructions defining how to create and update
+mint accounts.
+
+The mint account example uses `base64` encoding so the raw account data is
+returned as an encoded string. The mint account is small enough to log directly.
+
+The following steps walk through the fields inside `value` in the order the
+fields appear.
 
 <CodePlaceholder title="Mint account" />
 
-```json !! title="Mint account"
+```ts !! title="Mint account"
 {
-  "data": {
-    "type": "Buffer",
-    "data": [1, "...truncated, total bytes: 82...", 103]
+  context: {
+    slot: 325000000n,
+    apiVersion: "3.1.14"
   },
-  "executable": false,
-  "lamports": 407438077149,
-  "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-  "rentEpoch": 18446744073709552000,
-  "space": 82
+  value: {
+    data: [
+      "AQAAAJj+huiNm+Lqi8HMpIeLKYjCQPUrhCS/tA7Rot3LXhmbbq9O2SvsHwAGAQEAAABicKqKWcWUBbRShshncubNEm6bil06OFNtN/e0FOi2Zw==",
+      "base64"
+    ],
+    executable: false,
+    lamports: 407438077149n,
+    owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    rentEpoch: 18446744073709551615n,
+    space: 82n
+  }
 }
 ```
 
 ## !!steps
 
-The mint account's `data` field stores state, not executable code, so the
-`executable` field is `false`.
-
-The Token Program defines the `Mint` data type, which is stored in the `data`
-field.
-
-<CodePlaceholder title="Mint account" />
-
-```json !! title="Mint account"
-{
-  "data": {
-    "type": "Buffer",
-    "data": [1, "...truncated, total bytes: 82...", 103]
-  },
-  // !focus
-  "executable": false,
-  "lamports": 407438077149,
-  "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-  "rentEpoch": 18446744073709552000,
-  "space": 82
-}
-```
-
-## !!steps
-
-The `data` field contains the serialized `Mint` account state, such as the mint
-authority, total supply, number of decimals.
+The `data` field contains the serialized `Mint` account state. The first tuple
+item contains the full 82-byte account data encoded as base64. The second tuple
+item identifies the encoding.
 
 To read from a Mint account, you must deserialize the `data` field into the
 `Mint` data type, which is shown in the
@@ -458,41 +616,164 @@ To read from a Mint account, you must deserialize the `data` field into the
 
 <CodePlaceholder title="Mint account" />
 
-```json !! title="Mint account"
+```ts !! title="Mint account"
 {
-  // !focus(1:4)
-  "data": {
-    "type": "Buffer",
-    "data": [1, "...truncated, total bytes: 82...", 103]
+  context: {
+    slot: 325000000n,
+    apiVersion: "3.1.14"
   },
-  "executable": false,
-  "lamports": 407438077149,
-  "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-  "rentEpoch": 18446744073709552000,
-  "space": 82
+  value: {
+    // !focus(1:4)
+    data: [
+      "AQAAAJj+huiNm+Lqi8HMpIeLKYjCQPUrhCS/tA7Rot3LXhmbbq9O2SvsHwAGAQEAAABicKqKWcWUBbRShshncubNEm6bil06OFNtN/e0FOi2Zw==",
+      "base64"
+    ],
+    executable: false,
+    lamports: 407438077149n,
+    owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    rentEpoch: 18446744073709551615n,
+    space: 82n
+  }
+}
+```
+
+## !!steps
+
+The `executable` field indicates whether the account can be invoked as a
+program. Mint accounts store state, so the `executable` field is `false`.
+
+<CodePlaceholder title="Mint account" />
+
+```ts !! title="Mint account"
+{
+  context: {
+    slot: 325000000n,
+    apiVersion: "3.1.14"
+  },
+  value: {
+    data: [
+      "AQAAAJj+huiNm+Lqi8HMpIeLKYjCQPUrhCS/tA7Rot3LXhmbbq9O2SvsHwAGAQEAAABicKqKWcWUBbRShshncubNEm6bil06OFNtN/e0FOi2Zw==",
+      "base64"
+    ],
+    // !focus
+    executable: false,
+    lamports: 407438077149n,
+    owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    rentEpoch: 18446744073709551615n,
+    space: 82n
+  }
+}
+```
+
+## !!steps
+
+The `lamports` field contains the SOL balance held by the mint account. The
+lamports value is the mint account's rent-exempt balance, not the token supply.
+
+<CodePlaceholder title="Mint account" />
+
+```ts !! title="Mint account"
+{
+  context: {
+    slot: 325000000n,
+    apiVersion: "3.1.14"
+  },
+  value: {
+    data: [
+      "AQAAAJj+huiNm+Lqi8HMpIeLKYjCQPUrhCS/tA7Rot3LXhmbbq9O2SvsHwAGAQEAAABicKqKWcWUBbRShshncubNEm6bil06OFNtN/e0FOi2Zw==",
+      "base64"
+    ],
+    executable: false,
+    // !focus
+    lamports: 407438077149n,
+    owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    rentEpoch: 18446744073709551615n,
+    space: 82n
+  }
 }
 ```
 
 ## !!steps
 
 The mint account is owned by the
-[Token Program](/docs/references/terminology#token-program). This means that its
-`data` field can only be modified by the Token Program' instructions.
+[Token Program](/docs/references/terminology#token-program). The mint account's
+`data` field can only be modified by the Token Program's instructions.
 
-<CodePlaceholder title="Mint Account" />
+<CodePlaceholder title="Mint account" />
 
-```json !! title="Mint Account"
+```ts !! title="Mint account"
 {
-  "data": {
-    "type": "Buffer",
-    "data": [1, "...truncated, total bytes: 82...", 103]
+  context: {
+    slot: 325000000n,
+    apiVersion: "3.1.14"
   },
-  "executable": false,
-  "lamports": 407438077149,
-  // !focus
-  "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-  "rentEpoch": 18446744073709552000,
-  "space": 82
+  value: {
+    data: [
+      "AQAAAJj+huiNm+Lqi8HMpIeLKYjCQPUrhCS/tA7Rot3LXhmbbq9O2SvsHwAGAQEAAABicKqKWcWUBbRShshncubNEm6bil06OFNtN/e0FOi2Zw==",
+      "base64"
+    ],
+    executable: false,
+    lamports: 407438077149n,
+    // !focus
+    owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    rentEpoch: 18446744073709551615n,
+    space: 82n
+  }
+}
+```
+
+## !!steps
+
+The `rentEpoch` field is a legacy field from a deprecated rent mechanism. The
+field is still returned for backward compatibility.
+
+<CodePlaceholder title="Mint account" />
+
+```ts !! title="Mint account"
+{
+  context: {
+    slot: 325000000n,
+    apiVersion: "3.1.14"
+  },
+  value: {
+    data: [
+      "AQAAAJj+huiNm+Lqi8HMpIeLKYjCQPUrhCS/tA7Rot3LXhmbbq9O2SvsHwAGAQEAAABicKqKWcWUBbRShshncubNEm6bil06OFNtN/e0FOi2Zw==",
+      "base64"
+    ],
+    executable: false,
+    lamports: 407438077149n,
+    owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    // !focus
+    rentEpoch: 18446744073709551615n,
+    space: 82n
+  }
+}
+```
+
+## !!steps
+
+The `space` field shows that the mint account contains 82 bytes of data.
+
+<CodePlaceholder title="Mint account" />
+
+```ts !! title="Mint account"
+{
+  context: {
+    slot: 325000000n,
+    apiVersion: "3.1.14"
+  },
+  value: {
+    data: [
+      "AQAAAJj+huiNm+Lqi8HMpIeLKYjCQPUrhCS/tA7Rot3LXhmbbq9O2SvsHwAGAQEAAABicKqKWcWUBbRShshncubNEm6bil06OFNtN/e0FOi2Zw==",
+      "base64"
+    ],
+    executable: false,
+    lamports: 407438077149n,
+    owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    rentEpoch: 18446744073709551615n,
+    // !focus
+    space: 82n
+  }
 }
 ```
 
@@ -501,53 +782,34 @@ The mint account is owned by the
 ## Deserialize mint account
 
 Before the raw bytes in an account's `data` field can be interpreted
-meaningfully they must be deserialized. The appropriate data type is defined by
-the program that owns the account. Most Solana programs provide client libraries
-with helper functions that abstract away the deserialization process. These
-functions convert the raw account bytes into structured data types, making it
-easier to work with the account data.
+meaningfully, the raw bytes must be deserialized. The program that owns the
+account defines the appropriate data type. Most Solana programs provide client
+libraries with helper functions that abstract away the deserialization process.
+Helper functions convert raw account bytes into structured data types, making
+account data easier to work with.
 
 <WithMentions>
 
-For example, the _shell`@solana/spl-token`_ library includes the
-[_ts`getMint()`_](mention:one) function to help deserialize a mint account's
-`data` field into the
+For example, the _shell`@solana-program/token`_ library includes the
+[_ts`fetchMint()`_](mention:one) function to fetch a mint account and
+deserialize the mint account's `data` field into the
 [Mint](https://github.com/solana-program/token/blob/program%40v8.0.0/program/src/state.rs#L16-L30)
-data type defined by the Token Program.
+data type defined by the Token Program. Optional authorities are returned as Kit
+`Option` values.
 
 <CodeTabs flags="r">
 
 ```ts !! title="Deserialize mint account data"
-import { PublicKey, Connection } from "@solana/web3.js";
-import { getMint } from "@solana/spl-token";
+import { address, createSolanaRpc } from "@solana/kit";
+import { fetchMint } from "@solana-program/token";
 
-const connection = new Connection(
-  "https://api.mainnet.solana.com",
-  "confirmed"
-);
+const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 
-const address = new PublicKey("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
+const mintAddress = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
 // !mention one
-const mintData = await getMint(connection, address, "confirmed");
+const mint = await fetchMint(rpc, mintAddress);
 
-// !collapse(1:17) collapsed
-console.log(
-  JSON.stringify(
-    mintData,
-    (key, value) => {
-      // Convert BigInt to String
-      if (typeof value === "bigint") {
-        return value.toString();
-      }
-      // Handle Buffer objects
-      if (Buffer.isBuffer(value)) {
-        return `<Buffer ${value.toString("hex")}>`;
-      }
-      return value;
-    },
-    2
-  )
-);
+console.log(mint);
 ```
 
 </CodeTabs>
@@ -576,21 +838,27 @@ pub struct Mint {
 
 ## !!steps
 
-The _ts`getMint()`_ function deserializes a mint account's `data` field into the
-Mint account type.
+The _ts`fetchMint()`_ function fetches a mint account and deserializes the mint
+account's `data` field into the Mint account type.
 
-```json title="Mint account"
+```ts title="Mint account"
 {
-  // !focus(1:4)
-  "data": {
-    "type": "Buffer",
-    "data": [1, "...truncated, total bytes: 82...", 103]
+  context: {
+    slot: 325000000n,
+    apiVersion: "3.1.14"
   },
-  "executable": false,
-  "lamports": 407438077149,
-  "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-  "rentEpoch": 18446744073709552000,
-  "space": 82
+  value: {
+    // !focus(1:4)
+    data: [
+      "AQAAAJj+huiNm+Lqi8HMpIeLKYjCQPUrhCS/tA7Rot3LXhmbbq9O2SvsHwAGAQEAAABicKqKWcWUBbRShshncubNEm6bil06OFNtN/e0FOi2Zw==",
+      "base64"
+    ],
+    executable: false,
+    lamports: 407438077149n,
+    owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    rentEpoch: 18446744073709551615n,
+    space: 82n
+  }
 }
 ```
 
@@ -598,20 +866,28 @@ You can view the fully deserialized
 [mint account](https://explorer.solana.com/address/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v?cluster=mainnet-beta)
 data on the Solana Explorer.
 
-<CodePlaceholder title="Deserialized mint data" />
+<CodePlaceholder title="Decoded mint account" />
 
-```json !! title="Deserialized mint data"
+```ts !! title="Decoded mint account"
 {
-  "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  "mintAuthority": "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG",
-  "supply": "8985397351591790",
-  "decimals": 6,
-  "isInitialized": true,
-  "freezeAuthority": "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar",
-  "tlvData": {
-    "type": "Buffer",
-    "data": []
-  }
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
 }
 ```
 
@@ -619,68 +895,125 @@ data on the Solana Explorer.
 
 The `address` field contains the mint account's address.
 
-<CodePlaceholder title="Deserialized mint data" />
+<CodePlaceholder title="Decoded mint account" />
 
-```json !! title="Deserialized mint data"
+```ts !! title="Decoded mint account"
 {
   // !focus
-  "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  "mintAuthority": "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG",
-  "supply": "8985397351591790",
-  "decimals": 6,
-  "isInitialized": true,
-  "freezeAuthority": "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar",
-  "tlvData": {
-    "type": "Buffer",
-    "data": []
-  }
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
 }
 ```
 
 ## !!steps
 
-The `mintAuthority` field shows the only account that can create new units of
-the token.
+The `data` field contains the deserialized `Mint` account state. The nested
+fields in `data` come from the Token Program's `Mint` account type.
 
-<CodePlaceholder title="Deserialized mint data" />
+<CodePlaceholder title="Decoded mint account" />
 
-```json !! title="Deserialized mint data"
+```ts !! title="Decoded mint account"
 {
-  "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  // !focus
-  "mintAuthority": "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG",
-  "supply": "8985397351591790",
-  "decimals": 6,
-  "isInitialized": true,
-  "freezeAuthority": "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar",
-  "tlvData": {
-    "type": "Buffer",
-    "data": []
-  }
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  // !focus(1:13)
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
 }
 ```
 
 ## !!steps
 
-The `supply` field shows the total number of tokens that have been minted. This
-value is measured in the smallest unit of the token. To get the total supply in
-standard units, adjust the value of the `supply` field by the `decimals`.
+The `data.mintAuthority` field shows the only account that can create new units
+of the token. Since the mint authority is optional, Kit returns the mint
+authority as an `Option`.
 
-<CodePlaceholder title="Deserialized mint data" />
+<CodePlaceholder title="Decoded mint account" />
 
-```json !! title="Deserialized mint data"
+```ts !! title="Decoded mint account"
 {
-  "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  "mintAuthority": "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG",
-  // !focus
-  "supply": "8985397351591790",
-  "decimals": 6,
-  "isInitialized": true,
-  "freezeAuthority": "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar",
-  "tlvData": {
-    "type": "Buffer",
-    "data": []
-  }
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    // !focus(1:4)
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
+}
+```
+
+## !!steps
+
+The `supply` field shows the total number of tokens that have been minted. The
+supply value is measured in the smallest unit of the token. To get the total
+supply in standard units, adjust the value of the `supply` field by the
+`decimals`.
+
+<CodePlaceholder title="Decoded mint account" />
+
+```ts !! title="Decoded mint account"
+{
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    // !focus
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
 }
 ```
 
@@ -688,92 +1021,288 @@ standard units, adjust the value of the `supply` field by the `decimals`.
 
 The `decimals` field shows the number of decimal places for the token.
 
-<CodePlaceholder title="Deserialized mint data" />
+<CodePlaceholder title="Decoded mint account" />
 
-```json !! title="Deserialized mint data"
+```ts !! title="Decoded mint account"
 {
-  "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  "mintAuthority": "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG",
-  "supply": "8985397351591790",
-  // !focus
-  "decimals": 6,
-  "isInitialized": true,
-  "freezeAuthority": "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar",
-  "tlvData": {
-    "type": "Buffer",
-    "data": []
-  }
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    // !focus
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
 }
 ```
 
 ## !!steps
 
 The `isInitialized` field indicates whether the mint account has been
-initialized. This field is a security check used in the Token Program.
+initialized. The `isInitialized` field is a security check used in the Token
+Program.
 
-<CodePlaceholder title="Deserialized mint data" />
+<CodePlaceholder title="Decoded mint account" />
 
-```json !! title="Deserialized mint data"
+```ts !! title="Decoded mint account"
 {
-  "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  "mintAuthority": "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG",
-  "supply": "8985397351591790",
-  "decimals": 6,
-  // !focus
-  "isInitialized": true,
-  "freezeAuthority": "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar",
-  "tlvData": {
-    "type": "Buffer",
-    "data": []
-  }
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    // !focus
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
 }
 ```
 
 ## !!steps
 
-The `freezeAuthority` field shows the account with authority to freeze token
-accounts. A frozen token account cannot transfer or burn the token it contains.
+The `data.freezeAuthority` field shows the account with authority to freeze
+token accounts. A frozen token account cannot transfer or burn the token balance
+inside the frozen token account.
 
-<CodePlaceholder title="Deserialized mint data" />
+<CodePlaceholder title="Decoded mint account" />
 
-```json !! title="Deserialized mint data"
+```ts !! title="Decoded mint account"
 {
-  "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  "mintAuthority": "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG",
-  "supply": "8985397351591790",
-  "decimals": 6,
-  "isInitialized": true,
-  // !focus
-  "freezeAuthority": "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar",
-  "tlvData": {
-    "type": "Buffer",
-    "data": []
-  }
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    // !focus(1:4)
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
 }
 ```
 
 ## !!steps
 
-The `tlvData` field contains extra data for Token Extensions and requires
-further deserialization. This field is only relevant to accounts created by the
-[Token Extension Program](/docs/tokens/extensions) (Token2022).
+The `executable` field keeps the same meaning after deserialization. The USDC
+mint account stores token state, so the USDC mint account cannot be invoked as a
+program.
 
-<CodePlaceholder title="Deserialized mint data" />
+<CodePlaceholder title="Decoded mint account" />
 
-```json !! title="Deserialized mint data"
+```ts !! title="Decoded mint account"
 {
-  "address": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-  "mintAuthority": "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG",
-  "supply": "8985397351591790",
-  "decimals": 6,
-  "isInitialized": true,
-  "freezeAuthority": "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar",
-  // !focus(1:4)
-  "tlvData": {
-    "type": "Buffer",
-    "data": []
-  }
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  // !focus
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
+}
+```
+
+## !!steps
+
+The `lamports` field contains the SOL balance held by the mint account. The
+lamports value is the mint account's rent-exempt balance, not the token supply.
+
+<CodePlaceholder title="Decoded mint account" />
+
+```ts !! title="Decoded mint account"
+{
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  // !focus
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
+}
+```
+
+## !!steps
+
+The `programAddress` field shows the program that owns the decoded mint account.
+For USDC, the owning program is the Token Program.
+
+<CodePlaceholder title="Decoded mint account" />
+
+```ts !! title="Decoded mint account"
+{
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  // !focus
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
+}
+```
+
+## !!steps
+
+The `space` field shows the size of the original mint account data in bytes. The
+Token Program's base `Mint` account is 82 bytes.
+
+<CodePlaceholder title="Decoded mint account" />
+
+```ts !! title="Decoded mint account"
+{
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  // !focus
+  space: 82n
 }
 ```
 
 </ScrollyCoding>
+
+### Serialized vs deserialized output
+
+Both examples read the same USDC mint account. The raw RPC fetch returns
+serialized bytes in the `data` field. To read the mint account's contents,
+decode the serialized bytes as the account type defined by the owning program.
+For a mint account, the Token Program defines the `Mint` type shown on the
+right.
+
+<SideBySide>
+
+### !left
+
+Before decoding, the [`data`](mention:serialized-data) field contains serialized
+account bytes.
+
+```ts title="Serialized mint account" -w
+{
+  context: {
+    slot: 325000000n,
+    apiVersion: "3.1.14"
+  },
+  value: {
+    // !mark(1:4)
+    // !mention(1:4) serialized-data
+    data: [
+      "AQAAAJj+huiNm+Lqi8HMpIeLKYjCQPUrhCS/tA7Rot3LXhmbbq9O2SvsHwAGAQEAAABicKqKWcWUBbRShshncubNEm6bil06OFNtN/e0FOi2Zw==",
+      "base64"
+    ],
+    executable: false,
+    lamports: 407438077149n,
+    owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    rentEpoch: 18446744073709551615n,
+    space: 82n
+  }
+}
+```
+
+### !right
+
+After decoding the serialized bytes as a `Mint`, the
+[`data`](mention:decoded-data) field contains named account fields.
+
+```ts title="Deserialized mint account" -w
+{
+  address: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+  // !mark(1:13)
+  // !mention(1:13) decoded-data
+  data: {
+    mintAuthority: {
+      __option: "Some",
+      value: "BJE5MMbqXjVwjAF7oxwPYXnTXDyspzZyt4vwenNw5ruG"
+    },
+    supply: 8985397351591790n,
+    decimals: 6,
+    isInitialized: true,
+    freezeAuthority: {
+      __option: "Some",
+      value: "7dGbd2QZcCKcTndnHcTL8q7SMVXAkp688NTQYwrRCrar"
+    }
+  },
+  executable: false,
+  lamports: 407438077149n,
+  programAddress: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  space: 82n
+}
+```
+
+</SideBySide>

--- a/apps/docs/content/docs/en/intro/quick-start/reading-from-network.mdx
+++ b/apps/docs/content/docs/en/intro/quick-start/reading-from-network.mdx
@@ -21,41 +21,39 @@ A wallet account is an account owned by the
 primarily used to hold SOL and sign transactions. When SOL is sent to a new
 address for the first time, a system account is automatically created.
 
-The example below [creates RPC clients](mention:rpc), generates a
+The example below [creates a Kit client](mention:client), generates a
 [new signer](mention:keypair), [requests SOL](mention:airdrop) to fund the new
-address, and [retrieves the account data](mention:info) directly from the RPC
-client.
+address, and [retrieves the account data](mention:info) from the client's RPC
+API.
 
 <CodeTabs flags="r">
 
 ```ts !! title="Fetch account"
-import {
-  airdropFactory,
-  createSolanaRpc,
-  createSolanaRpcSubscriptions,
-  generateKeyPairSigner,
-  lamports
-} from "@solana/kit";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer } from "@solana/kit-plugin-signer";
 
-// !mention(1:2) rpc
-const rpc = createSolanaRpc("http://localhost:8899");
-const rpcSubscriptions = createSolanaRpcSubscriptions("ws://localhost:8900");
+// !mention(1:9) client
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop());
 
 // !mention keypair
 const signer = await generateKeyPairSigner();
 console.log(`Address: ${signer.address}`);
 
 // Funding an address with SOL automatically creates an account
-// !mention(1:6) airdrop
-const airdrop = airdropFactory({ rpc, rpcSubscriptions });
-await airdrop({
-  recipientAddress: signer.address,
-  lamports: lamports(1_000_000_000n),
-  commitment: "confirmed"
-});
+// !mention(1:4) airdrop
+await client.airdrop(signer.address, lamports(1_000_000_000n));
 
 // !mention info
-const accountInfo = await rpc.getAccountInfo(signer.address).send();
+const accountInfo = await client.rpc.getAccountInfo(signer.address).send();
 
 console.log(accountInfo);
 ```
@@ -317,9 +315,17 @@ can view the Program account on the
 <CodeTabs flags="r">
 
 ```ts !! title="Fetch program account"
-import { address, createSolanaRpc } from "@solana/kit";
+import { address, createClient } from "@solana/kit";
+import { solanaRpc } from "@solana/kit-plugin-rpc";
+import { generatedPayer } from "@solana/kit-plugin-signer";
 
-const rpc = createSolanaRpc("https://api.mainnet.solana.com");
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "https://api.mainnet.solana.com"
+    })
+  );
 
 // !mark(1:3)
 const tokenProgramAddress = address(
@@ -327,7 +333,7 @@ const tokenProgramAddress = address(
 );
 
 // !mark(1:5)
-const accountInfo = await rpc
+const accountInfo = await client.rpc
   .getAccountInfo(tokenProgramAddress, {
     encoding: "base64"
   })
@@ -549,15 +555,23 @@ values may differ depending on the slot your RPC node reads from.
 <CodeTabs flags="r">
 
 ```ts !! title="Fetch mint account"
-import { address, createSolanaRpc } from "@solana/kit";
+import { address, createClient } from "@solana/kit";
+import { solanaRpc } from "@solana/kit-plugin-rpc";
+import { generatedPayer } from "@solana/kit-plugin-signer";
 
-const rpc = createSolanaRpc("https://api.mainnet.solana.com");
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "https://api.mainnet.solana.com"
+    })
+  );
 
 // !mark
 const mintAddress = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
 
 // !mark(1:5)
-const accountInfo = await rpc
+const accountInfo = await client.rpc
   .getAccountInfo(mintAddress, {
     encoding: "base64"
   })
@@ -800,14 +814,22 @@ data type defined by the Token Program. Optional authorities are returned as Kit
 <CodeTabs flags="r">
 
 ```ts !! title="Deserialize mint account data"
-import { address, createSolanaRpc } from "@solana/kit";
+import { address, createClient } from "@solana/kit";
+import { solanaRpc } from "@solana/kit-plugin-rpc";
+import { generatedPayer } from "@solana/kit-plugin-signer";
 import { fetchMint } from "@solana-program/token";
 
-const rpc = createSolanaRpc("https://api.mainnet.solana.com");
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "https://api.mainnet.solana.com"
+    })
+  );
 
 const mintAddress = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
 // !mention one
-const mint = await fetchMint(rpc, mintAddress);
+const mint = await fetchMint(client.rpc, mintAddress);
 
 console.log(mint);
 ```

--- a/apps/docs/content/docs/en/intro/quick-start/reading-from-network.mdx
+++ b/apps/docs/content/docs/en/intro/quick-start/reading-from-network.mdx
@@ -17,9 +17,10 @@ to locate the account's onchain data. Solana accounts contain either
 <WithMentions>
 
 A wallet account is an account owned by the
-[System Program](/docs/core/programs#the-system-program). Wallet accounts are
-primarily used to hold SOL and sign transactions. When SOL is sent to a new
-address for the first time, a system account is automatically created.
+[System Program](/docs/core/programs/builtin-programs#the-system-program).
+Wallet accounts are primarily used to hold SOL and sign transactions. When SOL
+is sent to a new address for the first time, a system account is automatically
+created.
 
 The example below [creates a Kit client](mention:client), generates a
 [new signer](mention:keypair), [requests SOL](mention:airdrop) to fund the new
@@ -49,7 +50,7 @@ const signer = await generateKeyPairSigner();
 console.log(`Address: ${signer.address}`);
 
 // Funding an address with SOL automatically creates an account
-// !mention(1:4) airdrop
+// !mention airdrop
 await client.airdrop(signer.address, lamports(1_000_000_000n));
 
 // !mention info
@@ -144,8 +145,8 @@ appear.
 
 ## !!steps
 
-The `lamports` field contains the account's SOL balance, in
-[lamports](/docs/references/terminology#lamport).
+The `lamports` field contains the account's SOL balance, measured in
+[lamports](/docs/references/terminology#lamport), the smallest unit of SOL.
 
 <CodePlaceholder title="Example output" />
 
@@ -222,8 +223,10 @@ owner is always the System Program, with the address
 
 ## !!steps
 
-The `executable` field indicates whether the account can be invoked as a
-program. For wallet accounts, the `executable` field is `false`.
+The `executable` field tells you whether the account's address is callable.
+`true` means the address represents a program that can process instructions.
+`false` means the account stores state, such as a wallet balance or account
+data, and is not called as a program. Wallet accounts use `false`.
 
 <CodePlaceholder title="Example output" />
 
@@ -272,9 +275,9 @@ field is still returned for backward compatibility.
 
 ## !!steps
 
-The `space` field shows the number of bytes contained in the `data` field.
-Account-fetching APIs include the `space` value to save you from counting the
-bytes yourself.
+The `space` field shows the number of bytes contained in the `data` field. The
+`space` field is returned with the account-fetching response, but it is not part
+of the account's data type.
 
 For the wallet account example, the `space` field is 0 because the `data` field
 contains 0 bytes of data.
@@ -304,18 +307,24 @@ contains 0 bytes of data.
 ## Fetch the Token Program
 
 The example below fetches the Token Program to demonstrate the difference
-between wallet and program accounts. The Token Program's address is the onchain
-Program account. For upgradeable programs, the Program account stores loader
-metadata and points to a separate ProgramData account that stores the deployed
-bytecode for the Token Program's
-[source code](https://github.com/solana-program/token/tree/main/program). You
-can view the Program account on the
+between wallet and program accounts. The Token Program defines instructions for
+working with tokens, such as creating and transferring tokens. Programs are
+invoked to process instructions. Program state, such as token data and balances,
+are stored in separate accounts owned by the program.
+
+The Token Program's address is the onchain Program account. For simplicity, you
+can think of the program address as the program, because that is the address
+used to invoke it. For upgradeable programs, the Program account stores metadata
+and points to a separate ProgramData account that stores the deployed executable
+code. You can view the Token Program
+[source code](https://github.com/solana-program/token/tree/main/program) and the
+Program account on the
 [Solana Explorer](https://explorer.solana.com/address/TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA).
 
 <CodeTabs flags="r">
 
 ```ts !! title="Fetch program account"
-import { address, createClient } from "@solana/kit";
+import { address, createClient, fetchJsonParsedAccount } from "@solana/kit";
 import { solanaRpc } from "@solana/kit-plugin-rpc";
 import { generatedPayer } from "@solana/kit-plugin-signer";
 
@@ -340,6 +349,14 @@ const accountInfo = await client.rpc
   .send();
 
 console.log(accountInfo);
+
+// !mark(1:4)
+const parsedAccount = await fetchJsonParsedAccount(
+  client.rpc,
+  tokenProgramAddress
+);
+
+console.log(parsedAccount);
 ```
 
 </CodeTabs>
@@ -350,13 +367,10 @@ console.log(accountInfo);
 
 The Token Program is an executable program account. Programs have the same
 underlying fields as all [accounts](/docs/core/accounts#account-structure), but
-with key differences. Your `slot` and `apiVersion` may differ from the Token
-Program output shown here.
+with key differences.
 
 The Token Program example uses `base64` encoding to return the Program account's
-raw bytes without asking RPC to interpret the bytes. The Program account data is
-short because the fetched account is the upgradeable Program account, not the
-separate ProgramData account that stores the compiled bytecode.
+raw data.
 
 The following steps walk through the fields inside `value` in the order the
 fields appear.
@@ -384,8 +398,8 @@ fields appear.
 
 The `data` field stores the BPF Upgradeable Loader's Program account state. The
 first tuple item contains the full account data encoded as base64. The second
-tuple item identifies the encoding. Here, the 36 bytes are the loader-state
-discriminator plus the ProgramData account address.
+tuple item identifies the encoding. Here, the 36 bytes include metadata and the
+ProgramData account address.
 
 For upgradeable programs, the Program account state points to the separate
 ProgramData account that stores the program's executable code.
@@ -463,8 +477,8 @@ Program accounts need enough lamports to remain rent-exempt.
 ## !!steps
 
 Every program account is owned by a
-[loader program](/docs/core/programs#loader-programs). For the Token Program
-account, the `owner` is the BPF Upgradeable Loader.
+[loader program](/docs/core/programs/program-deployment#loader-programs). For
+the Token Program account, the `owner` is the BPF Upgradeable Loader.
 
 <CodePlaceholder title="Token program account" />
 
@@ -515,7 +529,8 @@ field is still returned for backward compatibility.
 
 The `space` field shows the full size of the Program account's data in bytes.
 The `space` value is only `36` bytes because the Program account stores loader
-metadata and a 32-byte pointer to ProgramData, not the full compiled program.
+metadata and the address of the ProgramData account, not the full compiled
+program.
 
 <CodePlaceholder title="Token program account" />
 
@@ -537,16 +552,40 @@ metadata and a 32-byte pointer to ProgramData, not the full compiled program.
 }
 ```
 
+## !!steps
+
+The previous response returned the Program account's `data` field as a base64
+tuple. The parsed response deserializes those bytes into named fields on the
+`data` object. The `programData` field contains the address of the ProgramData
+account that stores the executable program code.
+
+<CodePlaceholder title="Parsed Token program account" />
+
+```ts !! title="Parsed Token program account"
+{
+  executable: true,
+  lamports: 43712780n,
+  programAddress: "BPFLoaderUpgradeab1e11111111111111111111111",
+  space: 36n,
+  address: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+  // !focus(1:4)
+  data: {
+    programData: "3gvYRKWyXRR9xKWe1ZjPhLY5ZJRN7KDB4rFZFGoJfFk2",
+    parsedAccountMeta: { program: "bpf-upgradeable-loader", type: "program" }
+  },
+  exists: true
+}
+```
+
 </ScrollyCoding>
 
 ## Fetch a mint account
 
-A
-[mint account](https://github.com/solana-program/token/blob/program%40v8.0.0/program/src/state.rs#L16-L30)
-is an account owned by the Token Program that stores global metadata for a
-specific token. The mint account stores the token's total supply, number of
-decimals, mint authority, and freeze authority. The mint account's address
-uniquely identifies a token on the Solana network.
+A [mint account](/docs/tokens/basics/create-mint) is an account owned by the
+Token Program that stores global metadata for a specific token. The mint account
+stores the token's total supply, number of decimals, mint authority, and freeze
+authority. The mint account's address uniquely identifies a token on the Solana
+network.
 
 The example below fetches the USD Coin Mint account to demonstrate how a
 program's state is stored in a separate account. Exact balances and supply
@@ -589,9 +628,6 @@ console.log(accountInfo);
 Mint accounts store state, not executable code. Mint accounts are owned by the
 Token Program, which includes instructions defining how to create and update
 mint accounts.
-
-The mint account example uses `base64` encoding so the raw account data is
-returned as an encoded string. The mint account is small enough to log directly.
 
 The following steps walk through the fields inside `value` in the order the
 fields appear.
@@ -795,12 +831,11 @@ The `space` field shows that the mint account contains 82 bytes of data.
 
 ## Deserialize mint account
 
-Before the raw bytes in an account's `data` field can be interpreted
-meaningfully, the raw bytes must be deserialized. The program that owns the
-account defines the appropriate data type. Most Solana programs provide client
-libraries with helper functions that abstract away the deserialization process.
-Helper functions convert raw account bytes into structured data types, making
-account data easier to work with.
+Account data is stored in the `data` field in a serialized format. To read that
+data as fields like `supply` or `decimals`, deserialize the `data` field into
+the account type defined by the owning program. Most Solana programs provide
+client libraries with helper functions for this step. These helpers return
+structured account data, making the result easier to work with.
 
 <WithMentions>
 
@@ -808,8 +843,7 @@ For example, the _shell`@solana-program/token`_ library includes the
 [_ts`fetchMint()`_](mention:one) function to fetch a mint account and
 deserialize the mint account's `data` field into the
 [Mint](https://github.com/solana-program/token/blob/program%40v8.0.0/program/src/state.rs#L16-L30)
-data type defined by the Token Program. Optional authorities are returned as Kit
-`Option` values.
+data type defined by the Token Program.
 
 <CodeTabs flags="r">
 
@@ -977,8 +1011,7 @@ fields in `data` come from the Token Program's `Mint` account type.
 ## !!steps
 
 The `data.mintAuthority` field shows the only account that can create new units
-of the token. Since the mint authority is optional, Kit returns the mint
-authority as an `Option`.
+of the token.
 
 <CodePlaceholder title="Decoded mint account" />
 
@@ -1104,8 +1137,9 @@ Program.
 ## !!steps
 
 The `data.freezeAuthority` field shows the account with authority to freeze
-token accounts. A frozen token account cannot transfer or burn the token balance
-inside the frozen token account.
+token accounts. A [token account](/docs/tokens/basics/create-token-account) is a
+separate account that stores units of a token for an owner. When frozen, a token
+account cannot transfer or burn its token balance.
 
 <CodePlaceholder title="Decoded mint account" />
 
@@ -1135,9 +1169,8 @@ inside the frozen token account.
 
 ## !!steps
 
-The `executable` field keeps the same meaning after deserialization. The USDC
-mint account stores token state, so the USDC mint account cannot be invoked as a
-program.
+The `executable` field is false. The USDC mint account stores token state, so
+the USDC mint account cannot be invoked as a program.
 
 <CodePlaceholder title="Decoded mint account" />
 
@@ -1198,8 +1231,9 @@ lamports value is the mint account's rent-exempt balance, not the token supply.
 
 ## !!steps
 
-The `programAddress` field shows the program that owns the decoded mint account.
-For USDC, the owning program is the Token Program.
+The `programAddress` field shows the program that owns the mint account. For
+USDC, the owning program is the Token Program. Only the program that owns an
+account can modify its `data` field through the program's deployed instructions.
 
 <CodePlaceholder title="Decoded mint account" />
 
@@ -1262,18 +1296,17 @@ Token Program's base `Mint` account is 82 bytes.
 
 ### Serialized vs deserialized output
 
-Both examples read the same USDC mint account. The raw RPC fetch returns
-serialized bytes in the `data` field. To read the mint account's contents,
-decode the serialized bytes as the account type defined by the owning program.
-For a mint account, the Token Program defines the `Mint` type shown on the
-right.
+Both examples read the same USDC mint account. The first response leaves the
+`data` field serialized. To read the mint account's contents, decode that data
+as the account type defined by the owning program. For a mint account, the Token
+Program defines the `Mint` type shown on the right.
 
 <SideBySide>
 
 ### !left
 
 Before decoding, the [`data`](mention:serialized-data) field contains serialized
-account bytes.
+account data.
 
 ```ts title="Serialized mint account" -w
 {
@@ -1299,8 +1332,8 @@ account bytes.
 
 ### !right
 
-After decoding the serialized bytes as a `Mint`, the
-[`data`](mention:decoded-data) field contains named account fields.
+After decoding the data as a `Mint`, the [`data`](mention:decoded-data) field
+contains named account fields.
 
 ```ts title="Deserialized mint account" -w
 {

--- a/apps/docs/content/docs/en/intro/quick-start/writing-to-network.mdx
+++ b/apps/docs/content/docs/en/intro/quick-start/writing-to-network.mdx
@@ -1,118 +1,113 @@
 ---
 title: Writing to the Network
 description:
-  Learn how to interact with the Solana network by sending transactions and
-  instructions. Follow step-by-step examples to transfer SOL tokens and create
-  new tokens using the System Program and Token Extensions Program.
+  Learn how to write data to the Solana network by sending transactions and
+  instructions. Follow step-by-step examples to transfer SOL and create a token
+  mint using Solana Kit.
 ---
 
-In the previous section, you learned how to read data from the Solana network.
-Now you'll learn how to write data to it. Writing to the Solana network involves
-sending transactions that contain one or more instruction.
+In the previous section, you learned how to
+[read data from the Solana network](/docs/intro/quick-start/reading-from-network)
+with a Kit client and RPC requests. Writing data to the Solana network requires
+a [transaction](/docs/core/transactions). A transaction contains one or more
+[instructions](/docs/core/instructions), and each instruction invokes a program.
 
-Programs define the business logic for what each
-[instruction](/docs/core/instructions) does. When you submit a
-[transaction](/docs/core/transactions), the Solana runtime executes each
-instruction in sequence and atomically. The examples in this section show how to
-build and send transactions to invoke Solana programs, they include:
+Programs define the business logic for each instruction. When you send a
+transaction, the Solana runtime executes the transaction's instructions in
+order. The transaction is atomic: either every instruction succeeds, or every
+instruction fails.
 
-1. Transferring SOL between accounts
-2. Creating a new token
+The examples in this section show how to:
+
+1. Transfer SOL between accounts
+2. Create a new token mint
 
 ## Transfer SOL
 
-The example below transfers SOL between two accounts. Each account has an owner
-program, which is the only program that can deduct the account's SOL balance.
-
-All wallet accounts are owned by the System Program. To transfer SOL, you must
-invoke the System Program's
+The example below transfers SOL from one account to another. Wallet accounts are
+owned by the [System Program](/docs/core/programs#the-system-program). To deduct
+SOL from a wallet account, the transaction must invoke the System Program's
 [transfer](https://github.com/anza-xyz/agave/blob/v2.1.11/programs/system/src/system_processor.rs#L183-L213)
-instruction.
+instruction, and the source account must sign the transaction.
 
 <WithNotes>
 
 <CodeTabs flags="r">
 
 ```ts !! title="Transfer SOL"
-import {
-  LAMPORTS_PER_SOL,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  Keypair,
-  Connection
-} from "@solana/web3.js";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getTransferSolInstruction } from "@solana-program/system";
 
-// !tooltip[/connection/] connection
-const connection = new Connection("http://localhost:8899", "confirmed");
+// !tooltip[/createClient/] client
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
-// !tooltip[/sender/] sender
-const sender = new Keypair();
 // !tooltip[/receiver/] receiver
-const receiver = new Keypair();
+const receiver = await generateKeyPairSigner();
 
-// !tooltip[/requestAirdrop/] airdrop
-const signature = await connection.requestAirdrop(
-  sender.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
-
-// !tooltip[/transferInstruction/] instruction
-const transferInstruction = SystemProgram.transfer({
-  fromPubkey: sender.publicKey,
-  toPubkey: receiver.publicKey,
-  lamports: 0.01 * LAMPORTS_PER_SOL
+// !tooltip[/transferInstruction/] transferInstruction
+const transferInstruction = getTransferSolInstruction({
+  source: client.payer,
+  destination: receiver.address,
+  amount: lamports(10_000_000n)
 });
 
-// !tooltip[/transaction/] transaction
-const transaction = new Transaction().add(transferInstruction);
+// !tooltip[/sendTransaction/] sendTransaction
+const result = await client.sendTransaction([transferInstruction]);
 
-// !tooltip[/sendAndConfirmTransaction/] sendAndConfirmTransaction
-const transactionSignature = await sendAndConfirmTransaction(
-  connection,
-  transaction,
-  [sender]
-);
+console.log("Transaction Signature:", result.context.signature);
 
-console.log("Transaction Signature:", `${transactionSignature}`);
+// !tooltip[/balances/] balances
+const { value: senderBalance } = await client.rpc
+  .getBalance(client.payer.address)
+  .send();
+const { value: receiverBalance } = await client.rpc
+  .getBalance(receiver.address)
+  .send();
 
-const senderBalance = await connection.getBalance(sender.publicKey);
-const receiverBalance = await connection.getBalance(receiver.publicKey);
-
-console.log("Sender Balance:", `${senderBalance}`);
-console.log("Receiver Balance:", `${receiverBalance}`);
+console.log("Sender Balance:", senderBalance);
+console.log("Receiver Balance:", receiverBalance);
 ```
 
 </CodeTabs>
 
-### !connection
+### !client
 
-Create a connection to the a Solana cluster.
-
-### !sender
-
-Generate a new keypair to use as the `sender`.
+Create a Kit client for the local validator. `generatedPayer()` adds a payer
+signer, `solanaRpc()` adds RPC and transaction-sending capabilities,
+`rpcAirdrop()` adds `client.airdrop`, and `airdropPayer()` funds the payer with
+test SOL.
 
 ### !receiver
 
-Generate a new keypair to use as the `receiver`.
+Generate a signer for the account receiving SOL. The receiver does not need to
+sign this transfer. If the receiver address does not already have an account,
+receiving SOL creates a system account at that address.
 
-### !airdrop
+### !transferInstruction
 
-Request an airdrop of SOL to fund the `sender`.
+Build the System Program instruction that transfers lamports from the client
+payer to the receiver.
 
-### !instruction
+### !sendTransaction
 
-Build instruction to invoke the System Program's transfer instruction.
+Send the instruction as a transaction. The Kit client fetches a recent
+blockhash, sets the fee payer, signs with the required signers, sends the
+transaction, and waits for confirmation.
 
-### !transaction
+### !balances
 
-Create new transaction and add the transfer instruction.
-
-### !sendAndConfirmTransaction
-
-Send the transaction.
+Fetch the sender and receiver balances after the transaction is confirmed.
 
 </WithNotes>
 
@@ -120,400 +115,343 @@ Send the transaction.
 
 ## !!steps
 
-Create a `Connection` to handle sending transactions and fetching account data.
+Create a Kit client for the local test validator. This is the same plugin-client
+syntax used in the token docs. The signer plugin is installed before the RPC
+plugin so the RPC plugin can use the payer when planning transactions.
 
-In this example, we're connecting to the local test validator which runs on
-`localhost:8899`.
-
-```ts title="Connection"
-const connection = new Connection("http://localhost:8899", "confirmed");
+```ts title="Client setup"
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 ```
 
 ```ts !! title="Transfer SOL"
-import {
-  LAMPORTS_PER_SOL,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  Keypair,
-  Connection
-} from "@solana/web3.js";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getTransferSolInstruction } from "@solana-program/system";
+
+// !focus(1:10)
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+```
+
+## !!steps
+
+Generate a signer for the receiver. The sender is `client.payer`, which was
+created by `generatedPayer()` and funded by `airdropPayer()`.
+
+```ts title="Receiver signer"
+const receiver = await generateKeyPairSigner();
+```
+
+```ts !! title="Transfer SOL"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getTransferSolInstruction } from "@solana-program/system";
+
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
 // !focus
-const connection = new Connection("http://localhost:8899", "confirmed");
-```
-
-## !!steps
-
-Generate new [keypairs](/docs/core/accounts#public-key) to use as the sender and
-receiver accounts.
-
-```ts title="Generate keypairs"
-const sender = new Keypair();
-const receiver = new Keypair();
-```
-
-```ts !! title="Transfer SOL"
-import {
-  LAMPORTS_PER_SOL,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  Keypair,
-  Connection
-} from "@solana/web3.js";
-
-const connection = new Connection("http://localhost:8899", "confirmed");
-
-// !focus(1:2)
-const sender = new Keypair();
-const receiver = new Keypair();
-```
-
-## !!steps
-
-Add SOL to the sender account. On networks other than mainnet, you can use the
-`requestAirdrop` method to get SOL for testing.
-
-```ts title="Airdrop"
-const signature = await connection.requestAirdrop(
-  sender.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
-```
-
-```ts !! title="Transfer SOL"
-import {
-  LAMPORTS_PER_SOL,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  Keypair,
-  Connection
-} from "@solana/web3.js";
-
-const connection = new Connection("http://localhost:8899", "confirmed");
-
-const sender = new Keypair();
-const receiver = new Keypair();
-
-// !focus(1:5)
-const signature = await connection.requestAirdrop(
-  sender.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
+const receiver = await generateKeyPairSigner();
 ```
 
 ## !!steps
 
 <WithMentions>
 
-The `SystemProgram.transfer()` method creates an instruction that transfers SOL
-from the [`fromPubkey`](mention:from) account to the [`toPubkey`](mention:to)
-account for the specified number of [`lamports`](mention:lamports).
+The `getTransferSolInstruction()` helper creates a System Program instruction.
+The instruction transfers SOL from the [`source`](mention:source) signer to the
+[`destination`](mention:destination) address for the specified
+[`amount`](mention:amount) of lamports.
 
 ```ts title="Transfer instruction"
-const transferInstruction = SystemProgram.transfer({
-  // !mention from
-  fromPubkey: sender.publicKey,
-  // !mention to
-  toPubkey: receiver.publicKey,
-  // !mention lamports
-  lamports: 0.01 * LAMPORTS_PER_SOL
+const transferInstruction = getTransferSolInstruction({
+  // !mention source
+  source: client.payer,
+  // !mention destination
+  destination: receiver.address,
+  // !mention amount
+  amount: lamports(10_000_000n)
 });
 ```
 
 </WithMentions>
 
 ```ts !! title="Transfer SOL"
-import {
-  LAMPORTS_PER_SOL,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  Keypair,
-  Connection
-} from "@solana/web3.js";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getTransferSolInstruction } from "@solana-program/system";
 
-const connection = new Connection("http://localhost:8899", "confirmed");
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
-const sender = new Keypair();
-const receiver = new Keypair();
-
-const signature = await connection.requestAirdrop(
-  sender.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
+const receiver = await generateKeyPairSigner();
 
 // !focus(1:5)
-const transferInstruction = SystemProgram.transfer({
-  fromPubkey: sender.publicKey,
-  toPubkey: receiver.publicKey,
-  lamports: 0.01 * LAMPORTS_PER_SOL
+const transferInstruction = getTransferSolInstruction({
+  source: client.payer,
+  destination: receiver.address,
+  amount: lamports(10_000_000n)
 });
 ```
 
 ## !!steps
 
-Create a transaction and add the instruction to the transaction. In this
-example, we're creating a transaction with a single instruction. However, you
-can add multiple instructions to a transaction.
-
-```ts title="Transaction"
-const transaction = new Transaction().add(transferInstruction);
-```
-
-```ts !! title="Transfer SOL"
-import {
-  LAMPORTS_PER_SOL,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  Keypair,
-  Connection
-} from "@solana/web3.js";
-
-const connection = new Connection("http://localhost:8899", "confirmed");
-
-const sender = new Keypair();
-const receiver = new Keypair();
-
-const signature = await connection.requestAirdrop(
-  sender.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
-
-const transferInstruction = SystemProgram.transfer({
-  fromPubkey: sender.publicKey,
-  toPubkey: receiver.publicKey,
-  lamports: 0.01 * LAMPORTS_PER_SOL
-});
-
-// !focus
-const transaction = new Transaction().add(transferInstruction);
-```
-
-## !!steps
-
-<WithMentions>
-
-Sign and send the [transaction](mention:transaction) to the network. The
-[sender](mention:sender) keypair is required in the signers array to authorize
-the transfer of SOL from their account.
+Call `client.sendTransaction()` with an array of instructions. The Kit client
+turns the instructions into one transaction, signs with the signers attached to
+the instructions, sends the transaction, and waits for confirmation.
 
 ```ts title="Send transaction"
-const transactionSignature = await sendAndConfirmTransaction(
-  connection,
-  // !mention transaction
-  transaction,
-  // !mention sender
-  [sender]
-);
+const result = await client.sendTransaction([transferInstruction]);
+
+console.log("Transaction Signature:", result.context.signature);
 ```
 
-</WithMentions>
-
-The transaction signature is a unique identifier that can be used to look up the
-transaction on Solana Explorer.
-
 ```ts !! title="Transfer SOL"
-import {
-  LAMPORTS_PER_SOL,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  Keypair,
-  Connection
-} from "@solana/web3.js";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getTransferSolInstruction } from "@solana-program/system";
 
-const connection = new Connection("http://localhost:8899", "confirmed");
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
-const sender = new Keypair();
-const receiver = new Keypair();
+const receiver = await generateKeyPairSigner();
 
-const signature = await connection.requestAirdrop(
-  sender.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
-
-const transferInstruction = SystemProgram.transfer({
-  fromPubkey: sender.publicKey,
-  toPubkey: receiver.publicKey,
-  lamports: 0.01 * LAMPORTS_PER_SOL
+const transferInstruction = getTransferSolInstruction({
+  source: client.payer,
+  destination: receiver.address,
+  amount: lamports(10_000_000n)
 });
 
-const transaction = new Transaction().add(transferInstruction);
+// !focus(1:3)
+const result = await client.sendTransaction([transferInstruction]);
+
+console.log("Transaction Signature:", result.context.signature);
+```
+
+## !!steps
+
+After the transaction is confirmed, fetch both balances using `client.rpc`. This
+read uses the same RPC pattern from the
+[reading guide](/docs/intro/quick-start/reading-from-network).
+
+```ts title="Fetch balances"
+const { value: senderBalance } = await client.rpc
+  .getBalance(client.payer.address)
+  .send();
+const { value: receiverBalance } = await client.rpc
+  .getBalance(receiver.address)
+  .send();
+```
+
+```ts !! title="Transfer SOL"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getTransferSolInstruction } from "@solana-program/system";
+
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
+const receiver = await generateKeyPairSigner();
+
+const transferInstruction = getTransferSolInstruction({
+  source: client.payer,
+  destination: receiver.address,
+  amount: lamports(10_000_000n)
+});
+
+const result = await client.sendTransaction([transferInstruction]);
+
+console.log("Transaction Signature:", result.context.signature);
 
 // !focus(1:6)
-const transactionSignature = await sendAndConfirmTransaction(
-  connection,
-  transaction,
-  [sender]
-);
+const { value: senderBalance } = await client.rpc
+  .getBalance(client.payer.address)
+  .send();
+const { value: receiverBalance } = await client.rpc
+  .getBalance(receiver.address)
+  .send();
 
-console.log("Transaction Signature:", `${transactionSignature}`);
+console.log("Sender Balance:", senderBalance);
+console.log("Receiver Balance:", receiverBalance);
 ```
 
 </ScrollyCoding>
 
 ## Create a token
 
-The example below creates a new token on Solana using the Token Extensions
-Program. This requires two instructions:
+The example below creates a new token mint using the
+[Token Extensions Program](/docs/tokens/extensions). A mint account is the
+account that defines a token's global settings, such as decimals, supply, mint
+authority, and freeze authority.
 
-1. Invoke the System Program to create a new account.
-2. Invoke the Token Extensions Program to initialize that account as a Mint.
+Creating a mint account requires two instructions:
+
+1. Invoke the System Program to create a new account owned by the Token
+   Extensions Program.
+2. Invoke the Token Extensions Program to initialize that account as a mint.
 
 <WithNotes>
 
 <CodeTabs flags="r">
 
 ```ts !! title="Create mint account"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getCreateAccountInstruction } from "@solana-program/system";
 import {
-  Connection,
-  Keypair,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  LAMPORTS_PER_SOL
-} from "@solana/web3.js";
-import {
-  MINT_SIZE,
-  TOKEN_2022_PROGRAM_ID,
-  createInitializeMint2Instruction,
-  getMinimumBalanceForRentExemptMint,
-  getMint
-} from "@solana/spl-token";
+  fetchMint,
+  getInitializeMintInstruction,
+  getMintSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
 
-const connection = new Connection("http://localhost:8899", "confirmed");
+// !tooltip[/createClient/] client
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
-// !tooltip[/wallet/] wallet
-const wallet = new Keypair();
-// Fund the wallet with SOL
-const signature = await connection.requestAirdrop(
-  wallet.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
-
-// Generate keypair to use as address of mint account
 // !tooltip[/mint/] mint
-const mint = new Keypair();
+const mint = await generateKeyPairSigner();
 
-// Calculate lamports required for rent exemption
-// !tooltip[/rentExemptionLamports/] rentExemptionLamports
-const rentExemptionLamports =
-  await getMinimumBalanceForRentExemptMint(connection);
+// !tooltip[/space/] space
+const space = BigInt(getMintSize());
 
-// Instruction to create new account with space for new mint account
+// !tooltip[/rent/] rent
+const rent = await client.rpc.getMinimumBalanceForRentExemption(space).send();
+
 // !tooltip[/createAccountInstruction/] createAccountInstruction
-const createAccountInstruction = SystemProgram.createAccount({
-  fromPubkey: wallet.publicKey,
-  newAccountPubkey: mint.publicKey,
-  space: MINT_SIZE,
-  lamports: rentExemptionLamports,
-  programId: TOKEN_2022_PROGRAM_ID
+const createAccountInstruction = getCreateAccountInstruction({
+  payer: client.payer,
+  newAccount: mint,
+  space,
+  lamports: rent,
+  programAddress: TOKEN_2022_PROGRAM_ADDRESS
 });
 
-// Instruction to initialize mint account
 // !tooltip[/initializeMintInstruction/] initializeMintInstruction
-const initializeMintInstruction = createInitializeMint2Instruction(
-  mint.publicKey,
-  2, // decimals
-  wallet.publicKey, // mint authority
-  wallet.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
-);
+const initializeMintInstruction = getInitializeMintInstruction({
+  mint: mint.address,
+  decimals: 2,
+  mintAuthority: client.payer.address,
+  freezeAuthority: client.payer.address,
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
 
-// Build transaction with instructions to create new account and initialize mint account
-// !tooltip[/transaction/] transaction
-const transaction = new Transaction().add(
+// !tooltip[/sendTransaction/] sendTransaction
+const result = await client.sendTransaction([
   createAccountInstruction,
   initializeMintInstruction
-);
+]);
 
-// !tooltip[/sendAndConfirmTransaction/] sendAndConfirmTransaction
-const transactionSignature = await sendAndConfirmTransaction(
-  connection,
-  transaction,
-  [
-    wallet, // payer
-    mint // mint address keypair
-  ]
-);
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", result.context.signature);
 
-console.log("Transaction Signature:", `${transactionSignature}`);
-
-const mintData = await getMint(
-  connection,
-  mint.publicKey,
-  "confirmed",
-  TOKEN_2022_PROGRAM_ID
-);
-// !collapse(1:17) collapsed
-console.log(
-  "Mint Account:",
-  JSON.stringify(
-    mintData,
-    (key, value) => {
-      // Convert BigInt to String
-      if (typeof value === "bigint") {
-        return value.toString();
-      }
-      // Handle Buffer objects
-      if (Buffer.isBuffer(value)) {
-        return `<Buffer ${value.toString("hex")}>`;
-      }
-      return value;
-    },
-    2
-  )
-);
+// !tooltip[/mintAccount/] mintAccount
+const mintAccount = await fetchMint(client.rpc, mint.address);
+console.log("Mint Account:", mintAccount);
 ```
 
 </CodeTabs>
 
-### !wallet
+### !client
 
-Generate a new keypair to use as the wallet.
+Create and fund a Kit client for the local validator. The funded payer pays
+account rent and transaction fees.
 
 ### !mint
 
-Generate a new keypair to use as the address of the Mint account to create.
+Generate a signer for the mint account. The mint signer authorizes the use of
+the new account address.
 
-### !rentLamports
+### !space
 
-Calculate the lamports required for a Mint account.
+Calculate the number of bytes required for a mint account with no extensions.
 
-### !rentExemptionLamports
+### !rent
 
-Calculate the lamports required for rent exemption
+Calculate the lamports required to make the mint account rent-exempt.
 
 ### !createAccountInstruction
 
-Build instruction to create a new account with space for the Mint account type
-and owned by the Token Extensions Program.
+Build the System Program instruction that creates the mint account and assigns
+the account to the Token Extensions Program.
 
 ### !initializeMintInstruction
 
-Build instruction to initialize the data of the new account as a Mint account
-type.
+Build the Token Extensions Program instruction that writes the initial mint data
+into the new account.
 
-### !transaction
+### !sendTransaction
 
-Create new transaction and add both instructions.
+Send both instructions as one transaction. Instruction order matters: the
+account must be created before the account can be initialized.
 
-The order of instructions matters here. The `createAccountInstruction` must come
-before the `initializeMintInstruction`.
+### !mintAccount
 
-### !sendAndConfirmTransaction
-
-Send the transaction.
+Fetch the mint account after confirmation. The helper reads the account and
+deserializes the mint account's data field into the Mint type.
 
 </WithNotes>
 
@@ -521,209 +459,159 @@ Send the transaction.
 
 ## !!steps
 
-Creating a token requires using both the `@solana/web3.js` and
-`@solana/spl-token` libraries. The code in the example below will:
+Create and fund a Kit client, then generate the mint signer. The client payer
+funds account creation and pays the transaction fee. The mint signer becomes the
+address of the new mint account.
 
-<WithMentions>
+```ts title="Client and mint setup"
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
-- [Create a connection](mention:connection)
-- [Generate a keypair](mention:wallet) to pay for the transaction
-- [Request an airdrop](mention:airdrop) to fund the keypair
-
-```ts title="Connection & wallet setup"
-// !mention connection
-const connection = new Connection("http://localhost:8899", "confirmed");
-
-// !mention wallet
-const wallet = new Keypair();
-// !mention(1:4) airdrop
-const signature = await connection.requestAirdrop(
-  wallet.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
+const mint = await generateKeyPairSigner();
 ```
 
-</WithMentions>
-
 ```ts !! title="Create mint account"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getCreateAccountInstruction } from "@solana-program/system";
 import {
-  Connection,
-  Keypair,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  LAMPORTS_PER_SOL
-} from "@solana/web3.js";
-import {
-  MINT_SIZE,
-  TOKEN_2022_PROGRAM_ID,
-  createInitializeMint2Instruction,
-  getMinimumBalanceForRentExemptMint,
-  getMint
-} from "@solana/spl-token";
+  fetchMint,
+  getInitializeMintInstruction,
+  getMintSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
 
-// !focus(1:8)
-const connection = new Connection("http://localhost:8899", "confirmed");
+// !focus(1:12)
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
-const wallet = new Keypair();
-const signature = await connection.requestAirdrop(
-  wallet.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
+const mint = await generateKeyPairSigner();
 ```
 
 ## !!steps
 
-Generate a keypair for the mint account. The public key will be used as the mint
-account's address.
+Calculate the mint account size, then ask RPC for the rent-exempt balance for
+that size. The mint account must hold at least this many lamports when the
+account is created.
 
-```ts title="Mint keypair"
-const mint = new Keypair();
+```ts title="Mint account size and rent"
+const space = BigInt(getMintSize());
+
+const rent = await client.rpc.getMinimumBalanceForRentExemption(space).send();
 ```
 
 ```ts !! title="Create mint account"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getCreateAccountInstruction } from "@solana-program/system";
 import {
-  Connection,
-  Keypair,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  LAMPORTS_PER_SOL
-} from "@solana/web3.js";
-import {
-  MINT_SIZE,
-  TOKEN_2022_PROGRAM_ID,
-  createInitializeMint2Instruction,
-  getMinimumBalanceForRentExemptMint,
-  getMint
-} from "@solana/spl-token";
+  fetchMint,
+  getInitializeMintInstruction,
+  getMintSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
 
-const connection = new Connection("http://localhost:8899", "confirmed");
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
-const wallet = new Keypair();
-const signature = await connection.requestAirdrop(
-  wallet.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
+const mint = await generateKeyPairSigner();
 
-// !focus
-const mint = new Keypair();
-```
+// !focus(1:3)
+const space = BigInt(getMintSize());
 
-## !!steps
-
-Calculate the minimum lamports required for a mint account. The
-`getMinimumBalanceForRentExemptMint` function calculates how many lamport must
-be allocated for the data on a mint account.
-
-```ts title="Rent exemption"
-const rentExemptionLamports =
-  await getMinimumBalanceForRentExemptMint(connection);
-```
-
-```ts !! title="Create mint account"
-import {
-  Connection,
-  Keypair,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  LAMPORTS_PER_SOL
-} from "@solana/web3.js";
-import {
-  MINT_SIZE,
-  TOKEN_2022_PROGRAM_ID,
-  createInitializeMint2Instruction,
-  getMinimumBalanceForRentExemptMint,
-  getMint
-} from "@solana/spl-token";
-
-const connection = new Connection("http://localhost:8899", "confirmed");
-
-const wallet = new Keypair();
-const signature = await connection.requestAirdrop(
-  wallet.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
-
-const mint = new Keypair();
-
-// !focus(1:2)
-const rentExemptionLamports =
-  await getMinimumBalanceForRentExemptMint(connection);
+const rent = await client.rpc.getMinimumBalanceForRentExemption(space).send();
 ```
 
 ## !!steps
 
 <WithMentions>
 
-The first instruction invokes the System Program's `createAccount` instruction
-to:
-
-1. Allocate the [number of bytes](mention:space) needed to store the mint data.
-2. [Transfer lamports](mention:lamports) from the wallet to fund the new
-   account.
-3. [Assign ownership](mention:programId) of the account to the
-   [Token Extensions program](/docs/tokens/extensions).
+The first instruction invokes the System Program. The instruction uses the
+[`payer`](mention:payer) to fund a [`newAccount`](mention:new-account),
+allocates the mint account [`space`](mention:space), transfers the rent-exempt
+[`lamports`](mention:lamports), and assigns ownership to the
+[`programAddress`](mention:program-address).
 
 ```ts title="Create account instruction"
-const createAccountInstruction = SystemProgram.createAccount({
-  // !mention(1:2) lamports
-  fromPubkey: wallet.publicKey,
-  newAccountPubkey: mint.publicKey,
+// !mark(1:12)
+const createAccountInstruction = getCreateAccountInstruction({
+  // !mention payer
+  payer: client.payer,
+  // !mention new-account
+  newAccount: mint,
   // !mention space
-  space: MINT_SIZE,
+  space,
   // !mention lamports
-  lamports: rentExemptionLamports,
-  // !mention programId
-  programId: TOKEN_2022_PROGRAM_ID
+  lamports: rent,
+  // !mention program-address
+  programAddress: TOKEN_2022_PROGRAM_ADDRESS
 });
 ```
 
 </WithMentions>
 
 ```ts !! title="Create mint account"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getCreateAccountInstruction } from "@solana-program/system";
 import {
-  Connection,
-  Keypair,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  LAMPORTS_PER_SOL
-} from "@solana/web3.js";
-import {
-  MINT_SIZE,
-  TOKEN_2022_PROGRAM_ID,
-  createInitializeMint2Instruction,
-  getMinimumBalanceForRentExemptMint,
-  getMint
-} from "@solana/spl-token";
+  fetchMint,
+  getInitializeMintInstruction,
+  getMintSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
 
-const connection = new Connection("http://localhost:8899", "confirmed");
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
-const wallet = new Keypair();
-const signature = await connection.requestAirdrop(
-  wallet.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
+const mint = await generateKeyPairSigner();
 
-const mint = new Keypair();
+const space = BigInt(getMintSize());
 
-const rentExemptionLamports =
-  await getMinimumBalanceForRentExemptMint(connection);
+const rent = await client.rpc.getMinimumBalanceForRentExemption(space).send();
 
 // !focus(1:7)
-const createAccountInstruction = SystemProgram.createAccount({
-  fromPubkey: wallet.publicKey,
-  newAccountPubkey: mint.publicKey,
-  space: MINT_SIZE,
-  lamports: rentExemptionLamports,
-  programId: TOKEN_2022_PROGRAM_ID
+const createAccountInstruction = getCreateAccountInstruction({
+  payer: client.payer,
+  newAccount: mint,
+  space,
+  lamports: rent,
+  programAddress: TOKEN_2022_PROGRAM_ADDRESS
 });
 ```
 
@@ -731,241 +619,214 @@ const createAccountInstruction = SystemProgram.createAccount({
 
 <WithMentions>
 
-The second instruction invokes the
-[Token Extensions Program](mention:programId)'s
-`createInitializeMint2Instruction` instruction to initialize the mint account
-with the following data:
-
-- [2 decimals](mention:decimals)
-- [Wallet](mention:authority) as both mint authority and freeze authority
+The second instruction invokes the Token Extensions Program. The instruction
+initializes the [`mint`](mention:mint-account) address with a
+[`decimals`](mention:decimals) value, a
+[`mintAuthority`](mention:mint-authority), a
+[`freezeAuthority`](mention:freeze-authority), and the
+[`tokenProgram`](mention:token-program) that owns the mint account.
 
 ```ts title="Initialize mint instruction"
-const initializeMintInstruction = createInitializeMint2Instruction(
-  mint.publicKey,
+// !mark(1:12)
+const initializeMintInstruction = getInitializeMintInstruction({
+  // !mention mint-account
+  mint: mint.address,
   // !mention decimals
-  2,
-  // !mention authority
-  wallet.publicKey,
-  // !mention authority
-  wallet.publicKey,
-  // !mention programId
-  TOKEN_2022_PROGRAM_ID
-);
+  decimals: 2,
+  // !mention mint-authority
+  mintAuthority: client.payer.address,
+  // !mention freeze-authority
+  freezeAuthority: client.payer.address,
+  // !mention token-program
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
 ```
 
 </WithMentions>
 
 ```ts !! title="Create mint account"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getCreateAccountInstruction } from "@solana-program/system";
 import {
-  Connection,
-  Keypair,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  LAMPORTS_PER_SOL
-} from "@solana/web3.js";
-import {
-  MINT_SIZE,
-  TOKEN_2022_PROGRAM_ID,
-  createInitializeMint2Instruction,
-  getMinimumBalanceForRentExemptMint,
-  getMint
-} from "@solana/spl-token";
+  fetchMint,
+  getInitializeMintInstruction,
+  getMintSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
 
-const connection = new Connection("http://localhost:8899", "confirmed");
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
 
-const wallet = new Keypair();
-const signature = await connection.requestAirdrop(
-  wallet.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
+const mint = await generateKeyPairSigner();
 
-const mint = new Keypair();
+const space = BigInt(getMintSize());
 
-const rentExemptionLamports =
-  await getMinimumBalanceForRentExemptMint(connection);
+const rent = await client.rpc.getMinimumBalanceForRentExemption(space).send();
 
-const createAccountInstruction = SystemProgram.createAccount({
-  fromPubkey: wallet.publicKey,
-  newAccountPubkey: mint.publicKey,
-  space: MINT_SIZE,
-  lamports: rentExemptionLamports,
-  programId: TOKEN_2022_PROGRAM_ID
+const createAccountInstruction = getCreateAccountInstruction({
+  payer: client.payer,
+  newAccount: mint,
+  space,
+  lamports: rent,
+  programAddress: TOKEN_2022_PROGRAM_ADDRESS
 });
 
-// !focus(1:6)
-const initializeMintInstruction = createInitializeMint2Instruction(
-  mint.publicKey,
-  2, // decimals
-  wallet.publicKey, // mint authority
-  wallet.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
-);
+// !focus(1:7)
+const initializeMintInstruction = getInitializeMintInstruction({
+  mint: mint.address,
+  decimals: 2,
+  mintAuthority: client.payer.address,
+  freezeAuthority: client.payer.address,
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
 ```
 
 ## !!steps
 
-Add both instructions to a single transaction. This ensures that account
-creation and initialization happen atomically. (Either both instructions
-succeed, or neither does.)
-
-This approach is common when building complex Solana transactions, as it
-guarantees that all instructions execute together.
-
-```ts title="Transaction"
-const transaction = new Transaction().add(
-  createAccountInstruction,
-  initializeMintInstruction
-);
-```
-
-```ts !! title="Create mint account"
-import {
-  Connection,
-  Keypair,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  LAMPORTS_PER_SOL
-} from "@solana/web3.js";
-import {
-  MINT_SIZE,
-  TOKEN_2022_PROGRAM_ID,
-  createInitializeMint2Instruction,
-  getMinimumBalanceForRentExemptMint,
-  getMint
-} from "@solana/spl-token";
-
-const connection = new Connection("http://localhost:8899", "confirmed");
-
-const wallet = new Keypair();
-const signature = await connection.requestAirdrop(
-  wallet.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
-
-const mint = new Keypair();
-
-const rentExemptionLamports =
-  await getMinimumBalanceForRentExemptMint(connection);
-
-const createAccountInstruction = SystemProgram.createAccount({
-  fromPubkey: wallet.publicKey,
-  newAccountPubkey: mint.publicKey,
-  space: MINT_SIZE,
-  lamports: rentExemptionLamports,
-  programId: TOKEN_2022_PROGRAM_ID
-});
-
-const initializeMintInstruction = createInitializeMint2Instruction(
-  mint.publicKey,
-  2, // decimals
-  wallet.publicKey, // mint authority
-  wallet.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
-);
-
-// !focus(1:4)
-const transaction = new Transaction().add(
-  createAccountInstruction,
-  initializeMintInstruction
-);
-```
-
-## !!steps
-
-<WithMentions>
-
-Sign and send the transaction. Two signatures are required:
-
-- The [wallet](mention:wallet) account signs as the payer for
-  [transaction fees](/docs/core/fees) and account creation
-- The [mint](mention:mint) account signs to authorize the use of its address for
-  the new account
+Send both instructions in one transaction. The create account instruction must
+come before the initialize mint instruction because the mint account must exist
+before the Token Extensions Program can write mint data to the account.
 
 ```ts title="Send transaction"
-const transactionSignature = await sendAndConfirmTransaction(
-  connection,
-  transaction,
-  [
-    // !mention wallet
-    wallet,
-    // !mention mint
-    mint
-  ]
-);
-```
-
-The transaction signature returned can be used to inspect the transaction on
-Solana Explorer.
-
-</WithMentions>
-
-```ts !! title="Create mint account"
-import {
-  Connection,
-  Keypair,
-  SystemProgram,
-  Transaction,
-  sendAndConfirmTransaction,
-  LAMPORTS_PER_SOL
-} from "@solana/web3.js";
-import {
-  MINT_SIZE,
-  TOKEN_2022_PROGRAM_ID,
-  createInitializeMint2Instruction,
-  getMinimumBalanceForRentExemptMint,
-  getMint
-} from "@solana/spl-token";
-
-const connection = new Connection("http://localhost:8899", "confirmed");
-
-const wallet = new Keypair();
-const signature = await connection.requestAirdrop(
-  wallet.publicKey,
-  LAMPORTS_PER_SOL
-);
-await connection.confirmTransaction(signature, "confirmed");
-
-const mint = new Keypair();
-
-const rentExemptionLamports =
-  await getMinimumBalanceForRentExemptMint(connection);
-
-const createAccountInstruction = SystemProgram.createAccount({
-  fromPubkey: wallet.publicKey,
-  newAccountPubkey: mint.publicKey,
-  space: MINT_SIZE,
-  lamports: rentExemptionLamports,
-  programId: TOKEN_2022_PROGRAM_ID
-});
-
-const initializeMintInstruction = createInitializeMint2Instruction(
-  mint.publicKey,
-  2, // decimals
-  wallet.publicKey, // mint authority
-  wallet.publicKey, // freeze authority
-  TOKEN_2022_PROGRAM_ID
-);
-
-const transaction = new Transaction().add(
+const result = await client.sendTransaction([
   createAccountInstruction,
   initializeMintInstruction
-);
+]);
+```
 
-// !focus(1:9)
-const transactionSignature = await sendAndConfirmTransaction(
-  connection,
-  transaction,
-  [
-    wallet, // payer
-    mint // mint address keypair
-  ]
-);
+```ts !! title="Create mint account"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getCreateAccountInstruction } from "@solana-program/system";
+import {
+  fetchMint,
+  getInitializeMintInstruction,
+  getMintSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
 
-console.log("Transaction Signature:", `${transactionSignature}`);
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
+const mint = await generateKeyPairSigner();
+
+const space = BigInt(getMintSize());
+
+const rent = await client.rpc.getMinimumBalanceForRentExemption(space).send();
+
+const createAccountInstruction = getCreateAccountInstruction({
+  payer: client.payer,
+  newAccount: mint,
+  space,
+  lamports: rent,
+  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+const initializeMintInstruction = getInitializeMintInstruction({
+  mint: mint.address,
+  decimals: 2,
+  mintAuthority: client.payer.address,
+  freezeAuthority: client.payer.address,
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+// !focus(1:4)
+const result = await client.sendTransaction([
+  createAccountInstruction,
+  initializeMintInstruction
+]);
+
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", result.context.signature);
+```
+
+## !!steps
+
+After the transaction is confirmed, fetch the mint account. This final read uses
+the same account-reading concept from the previous guide: fetch the account at
+an address, then inspect the deserialized account data returned by the program
+helper.
+
+```ts title="Fetch mint account"
+const mintAccount = await fetchMint(client.rpc, mint.address);
+console.log("Mint Account:", mintAccount);
+```
+
+```ts !! title="Create mint account"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
+import { generatedPayer, airdropPayer } from "@solana/kit-plugin-signer";
+import { getCreateAccountInstruction } from "@solana-program/system";
+import {
+  fetchMint,
+  getInitializeMintInstruction,
+  getMintSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const client = await createClient()
+  .use(generatedPayer())
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900"
+    })
+  )
+  .use(rpcAirdrop())
+  .use(airdropPayer(lamports(1_000_000_000n)));
+
+const mint = await generateKeyPairSigner();
+
+const space = BigInt(getMintSize());
+
+const rent = await client.rpc.getMinimumBalanceForRentExemption(space).send();
+
+const createAccountInstruction = getCreateAccountInstruction({
+  payer: client.payer,
+  newAccount: mint,
+  space,
+  lamports: rent,
+  programAddress: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+const initializeMintInstruction = getInitializeMintInstruction({
+  mint: mint.address,
+  decimals: 2,
+  mintAuthority: client.payer.address,
+  freezeAuthority: client.payer.address,
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+const result = await client.sendTransaction([
+  createAccountInstruction,
+  initializeMintInstruction
+]);
+
+console.log("Mint Address:", mint.address);
+console.log("Transaction Signature:", result.context.signature);
+
+// !focus(1:2)
+const mintAccount = await fetchMint(client.rpc, mint.address);
+console.log("Mint Account:", mintAccount);
 ```
 
 </ScrollyCoding>

--- a/apps/docs/content/docs/en/intro/quick-start/writing-to-network.mdx
+++ b/apps/docs/content/docs/en/intro/quick-start/writing-to-network.mdx
@@ -8,14 +8,14 @@ description:
 
 In the previous section, you learned how to
 [read data from the Solana network](/docs/intro/quick-start/reading-from-network)
-with a Kit client and RPC requests. Writing data to the Solana network requires
-a [transaction](/docs/core/transactions). A transaction contains one or more
+by fetching accounts. Writing data to the Solana network requires a
+[transaction](/docs/core/transactions). A transaction contains one or more
 [instructions](/docs/core/instructions), and each instruction invokes a program.
 
 Programs define the business logic for each instruction. When you send a
 transaction, the Solana runtime executes the transaction's instructions in
-order. The transaction is atomic: either every instruction succeeds, or every
-instruction fails.
+order. Transactions are atomic. Either every instruction in the transaction
+succeeds, or the entire transaction fails.
 
 The examples in this section show how to:
 
@@ -24,11 +24,14 @@ The examples in this section show how to:
 
 ## Transfer SOL
 
-The example below transfers SOL from one account to another. Wallet accounts are
-owned by the [System Program](/docs/core/programs#the-system-program). To deduct
-SOL from a wallet account, the transaction must invoke the System Program's
+The example below transfers SOL from one account to another. Only the program
+designated as an account's owner can modify the account's data or deduct
+lamports from its balance. Wallet accounts are owned by the
+[System Program](/docs/core/programs#the-system-program), so transferring SOL
+between wallet accounts requires an instruction that invokes the System
+Program's
 [transfer](https://github.com/anza-xyz/agave/blob/v2.1.11/programs/system/src/system_processor.rs#L183-L213)
-instruction, and the source account must sign the transaction.
+instruction. The source account must also sign the transaction.
 
 <WithNotes>
 
@@ -115,9 +118,9 @@ Fetch the sender and receiver balances after the transaction is confirmed.
 
 ## !!steps
 
-Create a Kit client for the local test validator. This is the same plugin-client
-syntax used in the token docs. The signer plugin is installed before the RPC
-plugin so the RPC plugin can use the payer when planning transactions.
+Create a Kit client for the local test validator. This snippet adds a payer
+signer, connects to the local RPC endpoint, enables airdrops, and funds the
+payer with test SOL for the transfer.
 
 ```ts title="Client setup"
 const client = await createClient()
@@ -275,9 +278,7 @@ console.log("Transaction Signature:", result.context.signature);
 
 ## !!steps
 
-After the transaction is confirmed, fetch both balances using `client.rpc`. This
-read uses the same RPC pattern from the
-[reading guide](/docs/intro/quick-start/reading-from-network).
+After the transaction is confirmed, fetch both balances using `client.rpc`.
 
 ```ts title="Fetch balances"
 const { value: senderBalance } = await client.rpc
@@ -422,8 +423,8 @@ account rent and transaction fees.
 
 ### !mint
 
-Generate a signer for the mint account. The mint signer authorizes the use of
-the new account address.
+Generate a signer to use as the address of the new mint account. The signer
+authorizes creation of that account.
 
 ### !space
 
@@ -459,9 +460,9 @@ deserializes the mint account's data field into the Mint type.
 
 ## !!steps
 
-Create and fund a Kit client, then generate the mint signer. The client payer
-funds account creation and pays the transaction fee. The mint signer becomes the
-address of the new mint account.
+Create and fund a Kit client, then generate a signer to use as the address of
+the new mint account. The client payer funds account creation and pays the
+transaction fee.
 
 ```ts title="Client and mint setup"
 const client = await createClient()
@@ -507,9 +508,9 @@ const mint = await generateKeyPairSigner();
 
 ## !!steps
 
-Calculate the mint account size, then ask RPC for the rent-exempt balance for
-that size. The mint account must hold at least this many lamports when the
-account is created.
+Calculate the mint account size in bytes, then make an RPC request to calculate
+the lamports required to store that data in the account. This required balance
+is referred to as rent.
 
 ```ts title="Mint account size and rent"
 const space = BigInt(getMintSize());
@@ -559,7 +560,6 @@ allocates the mint account [`space`](mention:space), transfers the rent-exempt
 [`programAddress`](mention:program-address).
 
 ```ts title="Create account instruction"
-// !mark(1:12)
 const createAccountInstruction = getCreateAccountInstruction({
   // !mention payer
   payer: client.payer,
@@ -623,11 +623,10 @@ The second instruction invokes the Token Extensions Program. The instruction
 initializes the [`mint`](mention:mint-account) address with a
 [`decimals`](mention:decimals) value, a
 [`mintAuthority`](mention:mint-authority), a
-[`freezeAuthority`](mention:freeze-authority), and the
+[`freezeAuthority`](mention:freeze-authority), and specifies the
 [`tokenProgram`](mention:token-program) that owns the mint account.
 
 ```ts title="Initialize mint instruction"
-// !mark(1:12)
 const initializeMintInstruction = getInitializeMintInstruction({
   // !mention mint-account
   mint: mint.address,
@@ -761,10 +760,7 @@ console.log("Transaction Signature:", result.context.signature);
 
 ## !!steps
 
-After the transaction is confirmed, fetch the mint account. This final read uses
-the same account-reading concept from the previous guide: fetch the account at
-an address, then inspect the deserialized account data returned by the program
-helper.
+After the transaction is confirmed, fetch the mint account.
 
 ```ts title="Fetch mint account"
 const mintAccount = await fetchMint(client.rpc, mint.address);


### PR DESCRIPTION
### Problem

Quickstart section using `solana/web3.js` for examples

### Summary of Changes

Update quickstart to use Kit for Typescript examples

Fixes #

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
