### PR TITLE
docs: add Coin Railz to x402 Tooling table

### DIFF
--- a/apps/docs/content/docs/en/payments/agentic-payments.mdx
+++ b/apps/docs/content/docs/en/payments/agentic-payments.mdx
@@ -118,4 +118,4 @@ To learn more on x402, check out our guides:
 | [x402 GitHub](https://github.com/coinbase/x402)                 | Reference implementation             |
 | [ACK](https://github.com/agentcommercekit/ack)                  | Agent Commerce Kit                   |
 | [A2A x402](https://github.com/google-agentic-commerce/a2a-x402) | Google's agent-to-agent payments     |
-| [Coin Railz](https://coinrailz.com/)                            | 63 live x402 services — crypto analytics, NASA/ESA satellite data, IoT sensors, AI inference |
+| [Coin Railz](https://coinrailz.com/)                            | Multi-chain x402 service provider    |

--- a/apps/docs/content/docs/en/payments/agentic-payments.mdx
+++ b/apps/docs/content/docs/en/payments/agentic-payments.mdx
@@ -118,3 +118,4 @@ To learn more on x402, check out our guides:
 | [x402 GitHub](https://github.com/coinbase/x402)                 | Reference implementation             |
 | [ACK](https://github.com/agentcommercekit/ack)                  | Agent Commerce Kit                   |
 | [A2A x402](https://github.com/google-agentic-commerce/a2a-x402) | Google's agent-to-agent payments     |
+| [Coin Railz](https://coinrailz.com/)                            | 63 live x402 services — crypto analytics, NASA/ESA satellite data, IoT sensors, AI inference |


### PR DESCRIPTION
Adds Coin Railz (https://coinrailz.com/) to the x402 Tooling table. 63 live x402 services covering crypto analytics, NASA/ESA satellite data, IoT sensors, and AI inference. Supports EVM (Base) and Solana USDC.