### PR TITLE
docs: warn against sending funds to incorrect addresses

### DIFF
--- a/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
+++ b/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
@@ -310,15 +310,15 @@ instruction and updates the lamport balance of both accounts.
 ![SOL transfer process diagram](/assets/docs/core/transactions/sol-transfer-process.svg)
 
 <Callout type="warn" title="Verify the recipient before sending SOL">
-  A System Program transfer adds lamports to **any** account. There is no
-  protocol-level check that the recipient can move the SOL back out. Lamports
-  can only be moved out by the account's owning program, so sending SOL to a
-  [token mint](/docs/tokens/basics/create-mint), a program, or a
-  [PDA](/docs/core/pda) you don't control **risks permanent loss of funds** —
-  only an authority specified by the owning program can return them. SOL sent to
-  a
-  [token account](/docs/tokens/basics/create-token-account) is recoverable only
-  by that account's owner, never by the sender.
+
+A System Program transfer adds lamports to **any** account. There is no
+protocol-level check that the recipient can move the SOL back out. Lamports can
+only be moved out by the account's owning program, so sending SOL to a
+[token mint](/docs/tokens/basics/create-mint), a program, or a
+[PDA](/docs/core/pda) you don't control **risks permanent loss of funds** — only
+an authority specified by the owning program can return them. SOL sent to a
+[token account](/docs/tokens/basics/create-token-account) is recoverable only by
+that account's owner, never by the sender.
 
 SPL **token** transfers are partly self-protecting: the Token Program rejects a
 transfer whose accounts don't match the expected mint. Native **SOL** transfers

--- a/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
+++ b/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
@@ -309,6 +309,25 @@ instruction and updates the lamport balance of both accounts.
 
 ![SOL transfer process diagram](/assets/docs/core/transactions/sol-transfer-process.svg)
 
+<Callout type="warn" title="Verify the recipient before sending SOL">
+  A System Program transfer adds lamports to **any** account. There is no
+  protocol-level check that the recipient can move the SOL back out. Lamports
+  can only be moved out by the account's owning program, so sending SOL to a
+  [token mint](/docs/tokens/basics/create-mint), a program, or a
+  [PDA](/docs/core/pda) you don't control **risks permanent loss of funds** —
+  only an authority specified by the owning program can return them. SOL sent to
+  a
+  [token account](/docs/tokens/basics/create-token-account) is recoverable only
+  by that account's owner, never by the sender.
+
+SPL **token** transfers are partly self-protecting: the Token Program rejects a
+transfer whose accounts don't match the expected mint. Native **SOL** transfers
+have no such guard, so the sender must verify the recipient before signing. See
+[Verify Address](/docs/payments/send-payments/verify-address) for the full
+classification logic.
+
+</Callout>
+
 The example below shows the code relevant to the above diagrams. See the System
 Program's
 [`transfer` function](https://github.com/anza-xyz/agave/blob/v3.1.8/programs/system/src/system_processor.rs#L210).
@@ -784,6 +803,74 @@ but notice that each instruction contains the same required information.
 
 </CodeTabs>
 </WithMentions>
+
+### Verify the recipient before transferring
+
+Because a SOL transfer succeeds into any account, check the recipient before
+signing. Fetch the account and only send to a System Program wallet (or an
+unfunded
+[on-curve](/docs/payments/send-payments/verify-address#on-curve-addresses)
+address); reject mints, token accounts, programs, and PDAs you don't control.
+
+<CodeTabs flags="r">
+
+```ts !! title="Kit"
+import {
+  type Address,
+  createSolanaRpc,
+  fetchJsonParsedAccount,
+  isOffCurveAddress
+} from "@solana/kit";
+
+const rpc = createSolanaRpc("https://api.mainnet-beta.solana.com");
+
+const SYSTEM_PROGRAM = "11111111111111111111111111111111" as Address;
+
+/**
+ * Throws if `recipient` cannot safely receive native SOL.
+ *
+ * Only System Program wallets (or unfunded on-curve addresses) are safe. Any
+ * other account locks the lamports because no authority can debit them.
+ */
+async function assertSafeSolRecipient(recipient: Address): Promise<void> {
+  const account = await fetchJsonParsedAccount(rpc, recipient);
+
+  if (!account.exists) {
+    // Off-curve = a PDA with no account; reject conservatively.
+    if (isOffCurveAddress(recipient)) {
+      throw new Error(
+        "Recipient is a PDA with no account; SOL would be locked"
+      );
+    }
+    // On-curve = an unfunded wallet, safe to fund.
+    return;
+  }
+
+  if (account.programAddress !== SYSTEM_PROGRAM) {
+    throw new Error(
+      `Recipient is owned by ${account.programAddress}, not a wallet; SOL would be locked`
+    );
+  }
+}
+
+// A wallet: safe.
+await assertSafeSolRecipient(
+  "H8sMJSCQxfKiFTCfDR3DUMLPwcRbM61LGFJ8N4dK3WjS" as Address
+);
+
+// The USDC mint: rejected before any SOL leaves the sender.
+await assertSafeSolRecipient(
+  "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" as Address
+);
+```
+
+</CodeTabs>
+
+<Callout>
+  This snippet checks native SOL recipients. For the full classification that
+  also handles SPL token sends (token accounts, ATAs, Token-2022), see [Verify
+  Address](/docs/payments/send-payments/verify-address).
+</Callout>
 
 ## Fetching transaction details
 

--- a/apps/docs/content/docs/en/payments/production-readiness.mdx
+++ b/apps/docs/content/docs/en/payments/production-readiness.mdx
@@ -483,6 +483,20 @@ are:
 | Token Program      | `TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA` |
 | Token-2022 Program | `TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb` |
 
+Allowlisting the right addresses protects against spoofed tokens, but it does
+not protect against sending to the wrong _kind_ of account. A recipient address
+can be a wallet, a token account, a mint, or a program, and each requires
+different handling. Native SOL sent to anything other than a wallet leaves the
+sender's control — lost outright for a mint or program, recoverable only by the
+account owner for a token account — with no failed transaction to warn the user.
+
+<Callout type="warn" title="Validate recipients before sending">
+  Classify every recipient address before signing a transfer. See [Verify
+  Address](/docs/payments/send-payments/verify-address) for the full decision
+  tree and reference code that distinguishes wallets, token accounts, mints, and
+  programs.
+</Callout>
+
 ## Pre-Launch Checklist
 
 - [ ] Mainnet SOL acquired for fees and rent
@@ -494,6 +508,8 @@ are:
 - [ ] All common errors handled gracefully
 - [ ] Gasless configured (if applicable)
 - [ ] Mainnet token addresses verified (not devnet mints)
+- [ ] Recipient address validation before sending (wallet vs token account vs
+      mint vs program)
 - [ ] All keys backed up securely
 - [ ] Key management reviewed (no keys in frontend)
 - [ ] Transaction monitoring and alerting active

--- a/apps/docs/content/docs/en/payments/send-payments/verify-address.mdx
+++ b/apps/docs/content/docs/en/payments/send-payments/verify-address.mdx
@@ -5,9 +5,18 @@ description:
   fund loss.
 ---
 
-Sending tokens to the wrong address can result in permanent loss of funds.
-Address verification ensures you only send tokens to addresses that can properly
-receive and access them.
+Sending funds to the wrong address can result in permanent loss. Address
+verification ensures you only send to addresses that can properly receive and
+access the funds.
+
+Validation depends on what you send:
+
+- **SPL tokens** are partly self-protecting. The Token Program rejects a
+  transfer whose accounts don't match the expected mint, so a misdirected token
+  transfer fails without losing funds. Most of this page covers SPL token sends.
+- **Native SOL** has no such guard. A System Program transfer succeeds into any
+  account, so an incorrect recipient permanently locks the SOL. See
+  [Sending native SOL](#sending-native-sol).
 
 <Callout>
   See [How Payments Work on Solana](/docs/payments/how-payments-work) for core
@@ -89,6 +98,30 @@ mint address results in a failed transaction, but no funds are lost.
 Accounts owned by other programs require a policy decision. Some accounts (e.g.
 multisig wallets) may be valid token account owners, while others should be
 rejected.
+
+## Sending native SOL
+
+The classification above determines where SPL tokens can go. Native SOL is
+stricter: the only safe recipient is a **System Program wallet** (or an unfunded
+on-curve address that becomes one).
+
+A System Program transfer adds lamports to any account, including mints, token
+accounts, programs, and PDAs. Lamports can only be moved out by the account's
+owning program, so sending SOL to an incorrect recipient may result in funds
+being permanently lost.
+
+Unlike an SPL token transfer, the transaction does **not** fail when the
+recipient is an unexpected address.
+
+When sending native SOL, only an `IS_WALLET` result is acceptable.
+`IS_TOKEN_ACCOUNT` is **not**: a token account holds SPL tokens, and SOL sent
+there is outside the sender's control.
+
+<Callout type="warn">
+  This is a common way SOL is lost: a user pastes a token's mint address (or a
+  program address) into a SOL withdrawal. The transfer succeeds and the SOL is
+  unrecoverable. Always classify the recipient before signing a SOL transfer.
+</Callout>
 
 ## Verification Flow
 
@@ -191,6 +224,11 @@ The demo below uses three possible outcomes:
 | `IS_TOKEN_ACCOUNT` | Valid token account  | Send tokens directly to this address        |
 | `REJECT`           | Invalid address      | Do not send                                 |
 
+It then maps each result to per-asset acceptability with `canReceiveNativeSol`
+(wallets only) and `canReceiveSplToken` (wallets or token accounts). A token
+account returns `IS_TOKEN_ACCOUNT`, so it can receive SPL tokens but **not**
+native SOL — the distinction that prevents SOL from being locked.
+
 <CodeTabs flags="r">
 
 ```ts !! title="Demo"
@@ -287,6 +325,20 @@ export async function validateAddress(
   return { type: "REJECT", reason: "Unknown program owner" };
 }
 
+/**
+ * Native SOL is only safe to send to a wallet. Any other account locks it.
+ */
+function canReceiveNativeSol(result: ValidationResult): boolean {
+  return result.type === "IS_WALLET";
+}
+
+/**
+ * SPL tokens can go to a wallet (via its ATA) or directly to a token account.
+ */
+function canReceiveSplToken(result: ValidationResult): boolean {
+  return result.type === "IS_WALLET" || result.type === "IS_TOKEN_ACCOUNT";
+}
+
 // =============================================================================
 // Examples
 // =============================================================================
@@ -325,6 +377,12 @@ async function runExample(label: string, address: Address) {
 
   const result = await validateAddress(address);
   console.log("\nResult:", result);
+  console.log(
+    `Can receive SOL?   ${canReceiveNativeSol(result) ? "YES" : "NO"}`
+  );
+  console.log(
+    `Can receive token? ${canReceiveSplToken(result) ? "YES" : "NO"}`
+  );
 }
 
 console.log("\n" + "═".repeat(60));


### PR DESCRIPTION
Users can lose funds by sending **native SOL** to a token mint, program, or PDA. A System Program transfer succeeds into any account with no protocol-level guard — and unlike SPL token transfers (which fail on a mint/owner mismatch), the transaction does **not** fail, so the user gets no warning. The docs covered SPL-token address validation but never the native-SOL case. 
Target audience: wallets/CEX with "send" or "withdraw" functionality to warn or block users before sending a bad SOL transfer

## Changes

- **`core/transactions/transaction-structure.mdx`** — added a warning callout to the SOL transfer example plus a runnable `assertSafeSolRecipient` snippet that classifies the recipient before sending.
- **`payments/send-payments/verify-address.mdx`** — new "Sending native SOL" section (only `IS_WALLET` is acceptable for SOL); extended the demo with `canReceiveNativeSol` / `canReceiveSplToken` so a mint shows `Can receive SOL? NO`.
- **`payments/production-readiness.mdx`** — linked the recipient-validation guidance and added a pre-launch checklist item.

## Notes

- English only; other locales auto-regenerate.
- Kit snippets type-check clean against `@solana/kit@6.9.0`.

Closes DEV-715