### PR TITLE
docs: expand keychain awareness across docs, cookbook & enterprise

### DIFF
--- a/apps/docs/content/cookbook/wallets/create-keypair.mdx
+++ b/apps/docs/content/cookbook/wallets/create-keypair.mdx
@@ -12,6 +12,13 @@ a keypair or wallet. If you are
 need to create one yourself. However, if you are not using a wallet, you will
 need to generate a keypair to sign your transactions.
 
+<Callout type="warn">
+  A keypair created this way holds a raw private key. Never embed one in
+  client-side code or commit it to source control. For backend services in
+  production, use a key-management backend instead — see [Signing in
+  Production](/docs/core/transactions/signing-in-production).
+</Callout>
+
 ### Extractable keypair
 
 <CodeTabs storage="cookbook" flags="r">

--- a/apps/docs/content/cookbook/wallets/meta.json
+++ b/apps/docs/content/cookbook/wallets/meta.json
@@ -10,6 +10,7 @@
     "restore-from-mnemonic",
     "generate-vanity-address",
     "sign-message",
+    "sign-with-keychain",
     "connect-wallet-react"
   ]
 }

--- a/apps/docs/content/cookbook/wallets/restore-keypair.mdx
+++ b/apps/docs/content/cookbook/wallets/restore-keypair.mdx
@@ -6,6 +6,13 @@ description: "Learn how to restore keypairs from a secret key on Solana."
 If you have an existing secret key, you can restore your Keypair from it. This
 allows you to access your wallet and sign transactions in your dApp.
 
+<Callout type="warn">
+  Handle secret keys with care: never embed them in client-side code or commit
+  them to source control. For backend services in production, use a
+  key-management backend instead of a raw secret key — see [Signing in
+  Production](/docs/core/transactions/signing-in-production).
+</Callout>
+
 ## From Bytes
 
 <CodeTabs storage="cookbook" flags="r">

--- a/apps/docs/content/cookbook/wallets/sign-with-keychain.mdx
+++ b/apps/docs/content/cookbook/wallets/sign-with-keychain.mdx
@@ -1,0 +1,62 @@
+---
+title: How to Sign with a Keychain Backend
+description:
+  "Sign Solana transactions through a key-management backend using
+  @solana/keychain, so you can swap signing providers without changing code."
+---
+
+[Keychain](/docs/tools/keychain) provides one `SolanaSigner` interface across
+many key-management backends — in-memory keys, cloud KMS/HSM, and managed wallet
+services. Write your signing code once, then switch backends through
+configuration.
+
+The example below signs a transfer with an in-memory signer. The same code works
+with any backend; only the signer's construction changes.
+
+<CodeTabs storage="cookbook" flags="r">
+
+```ts !! title="Kit" file=packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.ts#region=sign
+
+```
+
+</CodeTabs>
+
+<Callout type="warn">
+  The in-memory signer holds a raw private key — use it for development and
+  tests. In production, use a managed backend so keys stay in dedicated
+  infrastructure. See [Choosing a
+  backend](/docs/tools/keychain/choosing-a-backend).
+</Callout>
+
+## Use a production backend
+
+To sign with a production backend, install its package (or the umbrella
+`@solana/keychain`) and construct the signer through the unified factory. The
+signing code stays the same.
+
+```ts title="AWS KMS"
+import { createKeychainSigner } from "@solana/keychain";
+
+const signer = await createKeychainSigner({
+  backend: "aws-kms",
+  keyId: "alias/my-solana-key",
+  publicKey: "base58_public_key"
+});
+```
+
+```ts title="HashiCorp Vault"
+import { createKeychainSigner } from "@solana/keychain";
+
+const signer = await createKeychainSigner({
+  backend: "vault",
+  vaultAddr: "https://vault.example.com:8200",
+  vaultToken: "hvs.xxxxx",
+  keyName: "my-solana-key",
+  publicKey: "base58_public_key"
+});
+```
+
+See the [TypeScript guide](/docs/tools/keychain/getting-started/typescript) for
+every backend's configuration, or
+[Choosing a backend](/docs/tools/keychain/choosing-a-backend) to compare custody
+models.

--- a/apps/docs/content/cookbook/wallets/sign-with-keychain.mdx
+++ b/apps/docs/content/cookbook/wallets/sign-with-keychain.mdx
@@ -10,8 +10,8 @@ many key-management backends — in-memory keys, cloud KMS/HSM, and managed wall
 services. Write your signing code once, then switch backends through
 configuration.
 
-The example below signs a transfer with an in-memory signer. The same code works
-with any backend; only the signer's construction changes.
+The example below signs and sends a transfer with an in-memory signer. The same
+code works with any backend; only the signer's construction changes.
 
 <CodeTabs storage="cookbook" flags="r">
 

--- a/apps/docs/content/docs/en/clients/official/javascript.mdx
+++ b/apps/docs/content/docs/en/clients/official/javascript.mdx
@@ -49,13 +49,13 @@ transactions, and subscriptions in one store.
 
 For kit-compatible backend signing across multiple key management backends:
 
-| Package          | Description                                                                                              | GitHub                                                         |
-| ---------------- | -------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| @solana/keychain | Unified signing: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, CDP, Para, Dfns, Crossmint | [Source](https://github.com/solana-foundation/solana-keychain) |
+| Package          | Description                                                                                                               | GitHub                                                         |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| @solana/keychain | Unified signing: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, CDP, Para, Dfns, Crossmint, Openfort, Utila | [Source](https://github.com/solana-foundation/solana-keychain) |
 
-See the
-[Adding Signers guide](https://github.com/solana-foundation/solana-keychain/blob/main/docs/ADDING_SIGNERS.md)
-to integrate additional key management services.
+See the [Keychain documentation](/docs/tools/keychain) and
+[Choosing a backend](/docs/tools/keychain/choosing-a-backend) for setup and
+custody-model guidance.
 
 ## Solana Web3.js
 

--- a/apps/docs/content/docs/en/clients/official/rust.mdx
+++ b/apps/docs/content/docs/en/clients/official/rust.mdx
@@ -93,10 +93,11 @@ Pinocchio includes program-specific crates for interacting with Solana programs:
 
 For production backend signing across multiple key management backends:
 
-| Crate           | Description                                                                                              | Docs                                              | GitHub                                                         |
-| --------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------- |
-| solana-keychain | Unified signing: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, CDP, Para, Dfns, Crossmint | [Crate](https://crates.io/crates/solana-keychain) | [Source](https://github.com/solana-foundation/solana-keychain) |
+| Crate           | Description                                                                                                               | Docs                                              | GitHub                                                         |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- | -------------------------------------------------------------- |
+| solana-keychain | Unified signing: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, CDP, Para, Dfns, Crossmint, Openfort, Utila | [Crate](https://crates.io/crates/solana-keychain) | [Source](https://github.com/solana-foundation/solana-keychain) |
 
 Use feature flags to include only the backends you need. See the
-[Adding Signers guide](https://github.com/solana-foundation/solana-keychain/blob/main/docs/ADDING_SIGNERS.md)
-to integrate additional key management services.
+[Keychain documentation](/docs/tools/keychain) and
+[Choosing a backend](/docs/tools/keychain/choosing-a-backend) for setup and
+custody-model guidance.

--- a/apps/docs/content/docs/en/core/transactions/meta.json
+++ b/apps/docs/content/docs/en/core/transactions/meta.json
@@ -2,6 +2,7 @@
   "title": "Transactions",
   "pages": [
     "transaction-structure",
+    "signing-in-production",
     "versioned-transactions",
     "transaction-pipeline",
     "durable-nonces"

--- a/apps/docs/content/docs/en/core/transactions/signing-in-production.mdx
+++ b/apps/docs/content/docs/en/core/transactions/signing-in-production.mdx
@@ -1,0 +1,70 @@
+---
+title: Signing in Production
+description:
+  Where signing keys live in a production Solana application, and how to choose
+  between local keys, browser wallets, cloud KMS/HSM, and managed signing
+  backends.
+type: conceptual
+prerequisites:
+  - /docs/core/transactions/transaction-structure
+related:
+  - /docs/tools/keychain
+  - /docs/payments/production-readiness
+---
+
+A transaction only executes if it carries a valid
+[signature](/docs/core/transactions/transaction-structure#signatures) from every
+required signer. During local development you usually hold that key as a
+[`Keypair`](/developers/cookbook/wallets/create-keypair) and sign directly. In
+production the important question is different: **where does the private key
+live, and who is allowed to authorize a signature with it?**
+
+<Callout type="warn">
+  Never embed private keys in client-side code, bundle them into a frontend, or
+  commit them to source control. Anyone who obtains a key gains full control of
+  that account's funds.
+</Callout>
+
+## Signing approaches
+
+| Approach                  | Where the key lives                                     | Who signs                                          | Best for                                                      |
+| ------------------------- | ------------------------------------------------------- | -------------------------------------------------- | ------------------------------------------------------------- |
+| **Local keypair**         | A file or environment variable on the machine           | Your code, directly                                | Local development, tests, CI                                  |
+| **Browser wallet**        | The end user's wallet (e.g. Phantom, Solflare)          | The end user, per transaction                      | Frontend dApps where users sign their own transactions        |
+| **Cloud KMS / HSM**       | A hardware-backed key service (AWS KMS, GCP KMS, Vault) | Your backend requests a signature from the service | Backend services, treasury operations, regulated environments |
+| **Managed / MPC wallets** | Split or custodied across a provider's infrastructure   | The provider co-signs according to your policy     | Embedded wallets, approval workflows, institutional custody   |
+
+The local keypair is the only approach that puts raw key material inside your
+application. Every production approach keeps the key in dedicated infrastructure
+and asks that infrastructure to sign on your behalf.
+
+## Backend signing
+
+When a server needs to sign — paying fees, sending program transactions, or
+operating a treasury — use a dedicated key-management backend rather than a raw
+keypair. The Solana Foundation maintains [Keychain](/docs/tools/keychain), a
+unified signing library (Rust and TypeScript) that exposes one `SolanaSigner`
+interface across every backend in the table above: Memory, HashiCorp Vault, AWS
+KMS, GCP KMS, Fireblocks, Privy, Turnkey, CDP, Crossmint, Dfns, Para, Openfort,
+and Utila.
+
+Because the interface is identical across backends, you can develop locally with
+an in-memory key and switch to a production backend through configuration,
+without rewriting application code. Keychain is compatible with
+[`@solana/kit`](/docs/clients/official/javascript) and the
+[Rust SDK](/docs/clients/official/rust).
+
+<Cards>
+  <Card title="Keychain" href="/docs/tools/keychain">
+    Unified signing across local keys, KMS, HSM, and managed wallet backends.
+  </Card>
+  <Card
+    title="Choosing a backend"
+    href="/docs/tools/keychain/choosing-a-backend"
+  >
+    Compare custody models and pick the right signing backend for your app.
+  </Card>
+</Cards>
+
+For the full production checklist — key management, RPC security, and monitoring
+— see [Production Readiness](/docs/payments/production-readiness).

--- a/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
+++ b/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
@@ -65,6 +65,11 @@ values. Each `Signature` is a 64-byte Ed25519 signature of the serialized
 required for every [signer account](#account-addresses) referenced by the
 transaction's instructions.
 
+Each signature is produced by a private key. Where that key lives — a local
+keypair, a cloud HSM or KMS, or a managed wallet service — is a production
+design decision. See
+[Signing in Production](/docs/core/transactions/signing-in-production).
+
 The first signature in the array belongs to the **fee payer**, the account that
 pays the transaction
 [base fee and prioritization fee](/docs/core/fees/fee-structure#base-fee). This

--- a/apps/docs/content/docs/en/frontend/client.mdx
+++ b/apps/docs/content/docs/en/frontend/client.mdx
@@ -100,6 +100,13 @@ Use `prepareAndSend` for a pre-built flow (simulation plus logging) or call
 `sign` / `toWire` to collect signatures manually before relaying the wire format
 yourself.
 
+<Callout type="info">
+  Running headless — in an API route, worker, or script with no browser wallet?
+  Sign with a backend key-management service instead of a raw keypair. See
+  [Keychain](/docs/tools/keychain) and [Signing in
+  Production](/docs/core/transactions/signing-in-production).
+</Callout>
+
 ## Common patterns for Solana devs
 
 - **Headless state machines**: Run the client inside API routes, scripts, or

--- a/apps/docs/content/docs/en/intro/quick-start/writing-to-network.mdx
+++ b/apps/docs/content/docs/en/intro/quick-start/writing-to-network.mdx
@@ -826,3 +826,10 @@ console.log("Mint Account:", mintAccount);
 ```
 
 </ScrollyCoding>
+
+<Callout type="info">
+  These examples use `generatedPayer()` to create a throwaway keypair for local
+  testing. Production applications should never hold raw private keys in code —
+  delegate signing to a key-management backend. See [Signing in
+  Production](/docs/core/transactions/signing-in-production).
+</Callout>

--- a/apps/docs/content/docs/en/payments/production-readiness.mdx
+++ b/apps/docs/content/docs/en/payments/production-readiness.mdx
@@ -408,19 +408,17 @@ for complete implementation.
 
 ### Signing Infrastructure
 
-For production backend signing, consider using
-[solana-keychain](https://github.com/solana-foundation/solana-keychain)—a
-unified signing library that abstracts multiple key management backends through
-a single interface: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS,
-CDP, Para, Dfns, Crossmint. This allows you to develop locally with in-memory
-keys, then swap to production-grade backends without changing application code.
+For production backend signing, use [Keychain](/docs/tools/keychain)—a unified
+signing library that abstracts multiple key management backends through a single
+interface: Memory, Vault, Privy, Turnkey, AWS KMS, Fireblocks, GCP KMS, CDP,
+Para, Dfns, Crossmint, Openfort, and Utila. This lets you develop locally with
+in-memory keys, then swap to production-grade backends without changing
+application code.
 
-Available for both [Rust](https://crates.io/crates/solana-keychain) and
+Not sure which backend fits? See
+[Choosing a backend](/docs/tools/keychain/choosing-a-backend). Keychain is
+available for both [Rust](https://crates.io/crates/solana-keychain) and
 [TypeScript](https://www.npmjs.com/package/@solana/keychain).
-
-Check out the
-[Adding Signers guide](https://github.com/solana-foundation/solana-keychain/blob/main/docs/ADDING_SIGNERS.md)
-to integrate additional key management services.
 
 ### RPC Security
 

--- a/apps/docs/content/docs/en/tools/keychain/choosing-a-backend.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/choosing-a-backend.mdx
@@ -1,0 +1,96 @@
+---
+title: Choosing a backend
+description:
+  Compare Keychain's signing backends by custody model — local keys, self-hosted
+  and cloud key management, and managed or MPC wallets — and pick the right one
+  for your application.
+related:
+  - /docs/core/transactions/signing-in-production
+  - /docs/tools/keychain/production-best-practices
+---
+
+Keychain exposes one `SolanaSigner` interface across every backend, so the
+choice is operational, not architectural — you can change it later through
+configuration. For server-side signing, the decision comes down to two
+questions: **where does the private key live, and who is allowed to authorize a
+signature with it?**
+
+<Callout type="info">
+  This guide covers backend (server-side) signing. When your end users sign
+  their own transactions in a browser, use a wallet through the Wallet Standard
+  instead — see [Signing in
+  Production](/docs/core/transactions/signing-in-production).
+</Callout>
+
+## Custody models
+
+- **Self-custody (in-process)** — your application holds the raw private key.
+  Convenient for development, but unsuitable for production. Backend:
+  **Memory**.
+- **Self-hosted key management** — you operate the key infrastructure; the key
+  stays inside it and signs on request. Backend: **HashiCorp Vault**.
+- **Cloud KMS / HSM** — a cloud provider stores the key in hardware-backed
+  infrastructure; the key never leaves the service and your IAM policy controls
+  who can sign. Backends: **AWS KMS**, **GCP KMS**.
+- **MPC & institutional custody** — the key is split or custodied across a
+  provider, which co-signs according to your policy (approvals, limits).
+  Backends: **Fireblocks**, **Dfns**, **Para**, **Utila**.
+- **Embedded & managed wallets** — a provider manages wallets on your behalf,
+  often to onboard end users. Backends: **Privy**, **Turnkey**, **CDP**,
+  **Crossmint**, **Openfort**.
+
+## Backend comparison
+
+| Backend         | Custody model                | Best for                                   | Notes                                                |
+| --------------- | ---------------------------- | ------------------------------------------ | ---------------------------------------------------- |
+| Memory          | Self-custody (in-process)    | Local development, tests, CI               | Raw key in process — do not use in production        |
+| HashiCorp Vault | Self-hosted key management   | Teams running their own key infrastructure | Transit engine; you operate and audit it             |
+| AWS KMS         | Cloud KMS / HSM              | Backends running on AWS                    | Key never leaves KMS; IAM controls signing           |
+| GCP KMS         | Cloud KMS / HSM              | Backends running on GCP                    | Key never leaves KMS; IAM controls signing           |
+| Fireblocks      | MPC / institutional custody  | Treasuries, exchanges, regulated custody   | Policy engine and approval workflows                 |
+| Dfns            | MPC wallet infrastructure    | Programmatic wallets with policy controls  | Ed25519 signing                                      |
+| Para            | MPC wallets                  | Apps that want MPC-backed wallets          | API key + wallet ID                                  |
+| Utila           | MPC custody + co-signer      | Existing Utila-managed Solana wallets      | `signMessage` unsupported; you broadcast the tx      |
+| Privy           | Embedded wallets             | Consumer apps onboarding users to wallets  | App-managed embedded wallets                         |
+| Turnkey         | Non-custodial key management | Programmatic, policy-gated signing         | Non-custodial key management                         |
+| CDP             | Managed wallet (Coinbase)    | Apps on the Coinbase Developer Platform    | `signMessage` accepts UTF-8 payloads only            |
+| Crossmint       | Managed wallets              | Marketplaces and managed-wallet apps       | `smart` and `mpc` wallets; `signMessage` unsupported |
+| Openfort        | Embedded backend wallets     | Server-side wallets                        | TEE-stored keys                                      |
+
+## Decision guide
+
+- **Prototyping or running tests** → Memory.
+- **Already on AWS or GCP** → that cloud's KMS (AWS KMS / GCP KMS).
+- **Running your own, multi-cloud, or on-prem infrastructure** → HashiCorp
+  Vault.
+- **Need institutional custody, multi-party approvals, or compliance controls**
+  → an MPC / custody backend (Fireblocks, Dfns, Utila).
+- **Onboarding end users to embedded wallets** → a managed wallet backend
+  (Privy, Turnkey, CDP, Crossmint, Openfort).
+
+## Enterprise scenarios
+
+- **Treasury operations** — separate an operational "hot" signer from a "cold"
+  treasury signer. Back the treasury with MPC custody or a cloud HSM and require
+  approval policies before high-value signatures.
+- **Approval workflows** — MPC and custody backends (e.g. Fireblocks) enforce
+  multi-party approval before a signature is produced.
+- **Compliance and audit** — cloud KMS (AWS/GCP) and Vault emit signing audit
+  logs; institutional custodians add policy enforcement and reporting.
+- **Regulated environments** — keep key material in an HSM, KMS, or
+  institutional custodian so raw keys never touch your application.
+
+See [Production best practices](/docs/tools/keychain/production-best-practices)
+for operating these backends safely.
+
+<Cards>
+  <Card title="Rust guide" href="/docs/tools/keychain/getting-started/rust">
+    Configure each backend in Rust.
+  </Card>
+  <Card
+    title="TypeScript guide"
+    href="/docs/tools/keychain/getting-started/typescript"
+  >
+    Configure each backend in TypeScript.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/en/tools/keychain/choosing-a-backend.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/choosing-a-backend.mdx
@@ -32,9 +32,9 @@ The flow below maps those constraints to a backend.
 ```mermaid title="Choosing a Keychain backend"
 flowchart TD
     Start{Signing for your own app,<br/>or provisioning wallets<br/>for end users?}
-    Start -->|End users| Managed[Embedded / managed wallets<br/>Privy · Turnkey · CDP<br/>Crossmint · Openfort · Para]
+    Start -->|End users| Managed[Embedded / managed wallets<br/>Privy · Turnkey · CDP<br/>Crossmint · Openfort]
     Start -->|Your own app| Q2{Need multi-party approval,<br/>institutional custody,<br/>or regulatory controls?}
-    Q2 -->|Yes| MPC[MPC / institutional custody<br/>Fireblocks · Dfns · Utila]
+    Q2 -->|Yes| MPC[MPC / institutional custody<br/>Fireblocks · Dfns · Para · Utila]
     Q2 -->|No| Q3{Hold the key yourself,<br/>or let a provider hold it?}
     Q3 -->|Provider holds it| Q4{Which cloud do you<br/>already run on?}
     Q4 -->|AWS| AWS[AWS KMS]
@@ -58,7 +58,7 @@ flowchart TD
 
 If you provision wallets that **end users** own and operate (consumer apps,
 onboarding flows), use an **embedded / managed wallet** backend — Privy,
-Turnkey, CDP, Crossmint, Openfort, or Para. These manage per-user wallets and
+Turnkey, CDP, Crossmint, or Openfort. These manage per-user wallets and
 authentication on your behalf.
 
 If you're signing as **your own application** — a fee payer, a treasury, backend
@@ -72,8 +72,8 @@ automation — continue below.
 
 If signatures must clear an approval policy, spending limit, or compliance
 workflow before they're produced — or you need a regulated custodian holding the
-keys — use an **MPC / institutional custody** backend: Fireblocks, Dfns, or
-Utila. These split or custody the key and co-sign according to your policy.
+keys — use an **MPC / institutional custody** backend: Fireblocks, Dfns, Para,
+or Utila. These split or custody the key and co-sign according to your policy.
 
 If you only need a key that signs on request, continue below.
 

--- a/apps/docs/content/docs/en/tools/keychain/choosing-a-backend.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/choosing-a-backend.mdx
@@ -1,9 +1,9 @@
 ---
 title: Choosing a backend
 description:
-  Compare Keychain's signing backends by custody model — local keys, self-hosted
-  and cloud key management, and managed or MPC wallets — and pick the right one
-  for your application.
+  Pick a Keychain signing backend from your requirements — custody, existing
+  infrastructure, approval controls, and whether you sign for your own app or
+  provision wallets for end users.
 related:
   - /docs/core/transactions/signing-in-production
   - /docs/tools/keychain/production-best-practices
@@ -11,9 +11,14 @@ related:
 
 Keychain exposes one `SolanaSigner` interface across every backend, so the
 choice is operational, not architectural — you can change it later through
-configuration. For server-side signing, the decision comes down to two
-questions: **where does the private key live, and who is allowed to authorize a
-signature with it?**
+configuration. Because of that, **start from your requirements, not from a
+product.** Two questions decide most of it: _where does the private key live,
+and who is allowed to authorize a signature with it?_
+
+There is no single best backend. Each one is a better fit for a particular set
+of constraints — the cloud you already run on, whether you want to operate key
+infrastructure, and what custody and approval controls you're required to have.
+The flow below maps those constraints to a backend.
 
 <Callout type="info">
   This guide covers backend (server-side) signing. When your end users sign
@@ -22,7 +27,80 @@ signature with it?**
   Production](/docs/core/transactions/signing-in-production).
 </Callout>
 
+## Decision flow
+
+```mermaid title="Choosing a Keychain backend"
+flowchart TD
+    Start{Signing for your own app,<br/>or provisioning wallets<br/>for end users?}
+    Start -->|End users| Managed[Embedded / managed wallets<br/>Privy · Turnkey · CDP<br/>Crossmint · Openfort · Para]
+    Start -->|Your own app| Q2{Need multi-party approval,<br/>institutional custody,<br/>or regulatory controls?}
+    Q2 -->|Yes| MPC[MPC / institutional custody<br/>Fireblocks · Dfns · Utila]
+    Q2 -->|No| Q3{Hold the key yourself,<br/>or let a provider hold it?}
+    Q3 -->|Provider holds it| Q4{Which cloud do you<br/>already run on?}
+    Q4 -->|AWS| AWS[AWS KMS]
+    Q4 -->|GCP| GCP[GCP KMS]
+    Q3 -->|Run it myself /<br/>multi-cloud / on-prem| Vault[HashiCorp Vault]
+```
+
+<Callout type="info">
+  Local development and tests don't need any of this — use the **Memory**
+  backend for prototyping, then switch to one of the production backends above
+  through configuration.
+</Callout>
+
+## Walk the questions
+
+<Steps>
+
+<Step>
+
+### Are you signing for your own application, or for your end users?
+
+If you provision wallets that **end users** own and operate (consumer apps,
+onboarding flows), use an **embedded / managed wallet** backend — Privy,
+Turnkey, CDP, Crossmint, Openfort, or Para. These manage per-user wallets and
+authentication on your behalf.
+
+If you're signing as **your own application** — a fee payer, a treasury, backend
+automation — continue below.
+
+</Step>
+
+<Step>
+
+### Do you need multi-party approval, institutional custody, or regulatory controls?
+
+If signatures must clear an approval policy, spending limit, or compliance
+workflow before they're produced — or you need a regulated custodian holding the
+keys — use an **MPC / institutional custody** backend: Fireblocks, Dfns, or
+Utila. These split or custody the key and co-sign according to your policy.
+
+If you only need a key that signs on request, continue below.
+
+</Step>
+
+<Step>
+
+### Do you want to hold the key yourself, or let a provider hold it?
+
+If a cloud provider should hold the key in hardware-backed infrastructure and
+your IAM policy controls who can sign, use that cloud's KMS:
+
+- **Running on AWS** → AWS KMS
+- **Running on GCP** → GCP KMS
+
+If you want to operate the key infrastructure yourself — or you're multi-cloud
+or on-prem — use **HashiCorp Vault**. You run and audit it; the key stays inside
+the Transit engine and signs on request.
+
+</Step>
+
+</Steps>
+
 ## Custody models
+
+The backends group into five custody models. The flow above lands you in one of
+them.
 
 - **Self-custody (in-process)** — your application holds the raw private key.
   Convenient for development, but unsuitable for production. Backend:
@@ -57,18 +135,11 @@ signature with it?**
 | Crossmint       | Managed wallets              | Marketplaces and managed-wallet apps       | `smart` and `mpc` wallets; `signMessage` unsupported |
 | Openfort        | Embedded backend wallets     | Server-side wallets                        | TEE-stored keys                                      |
 
-## Decision guide
-
-- **Prototyping or running tests** → Memory.
-- **Already on AWS or GCP** → that cloud's KMS (AWS KMS / GCP KMS).
-- **Running your own, multi-cloud, or on-prem infrastructure** → HashiCorp
-  Vault.
-- **Need institutional custody, multi-party approvals, or compliance controls**
-  → an MPC / custody backend (Fireblocks, Dfns, Utila).
-- **Onboarding end users to embedded wallets** → a managed wallet backend
-  (Privy, Turnkey, CDP, Crossmint, Openfort).
-
 ## Enterprise scenarios
+
+A single application often needs more than one of these at once. Because the
+interface is identical, you can run a different backend per role without
+changing call sites.
 
 - **Treasury operations** — separate an operational "hot" signer from a "cold"
   treasury signer. Back the treasury with MPC custody or a cloud HSM and require

--- a/apps/docs/content/docs/en/tools/keychain/getting-started/rust.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/getting-started/rust.mdx
@@ -35,6 +35,7 @@ solana-keychain = { version = "1.2", features = ["all"] }
 | `dfns`       | Dfns wallet infrastructure      |
 | `openfort`   | Openfort embedded wallets       |
 | `para`       | Para MPC wallets                |
+| `utila`      | Utila MPC custody               |
 | `all`        | Enable all backends             |
 
 ## Basic Usage

--- a/apps/docs/content/docs/en/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/getting-started/typescript.mdx
@@ -25,6 +25,7 @@ pnpm add @solana/keychain-crossmint   # Crossmint
 pnpm add @solana/keychain-dfns        # Dfns
 pnpm add @solana/keychain-openfort    # Openfort
 pnpm add @solana/keychain-para        # Para
+pnpm add @solana/keychain-utila       # Utila
 ```
 
 ## Basic Usage

--- a/apps/docs/content/docs/en/tools/keychain/index.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/index.mdx
@@ -4,40 +4,49 @@ description: Unified Solana signing across multiple key management backends
 ---
 
 **Solana Keychain provides a unified interface for signing Solana transactions
-across multiple key management backends.** Use it to integrate enterprise-grade
-signing into your backend services.
+across multiple key management backends.** Develop locally with an in-memory
+key, then switch to enterprise key management, cloud HSMs, or managed wallet
+services in production — without rewriting your signing code.
 
 ### Why Keychain?
 
 - **Single Interface**: One `SolanaSigner` trait works across all backends
-- **Swap Backends**: Change key management providers without rewriting code
+- **Swap Backends**: Change key management providers through configuration, not
+  code
 - **Zero-Cost Abstraction**: Feature flags include only what you need
+- **Audited**: Security-reviewed by [Accretion](https://accretion.xyz)
 
 ### Architecture
 
-- **Languages**: Rust + TypeScript
+- **Languages**: Rust + TypeScript, at full parity
 - **Trait**: Unified `SolanaSigner` interface
 - **Backends**: Memory, Vault, AWS KMS, GCP KMS, Privy, Turnkey, Fireblocks,
-  CDP, Crossmint, Dfns, Openfort, Para
+  CDP, Crossmint, Dfns, Openfort, Para, Utila
 - **Compatibility**: `@solana/kit` and `@solana/signers` compatible (TypeScript)
   | `solana-sdk` and `solana-sdk-v3` compatible (Rust)
 
 ### Supported Backends
 
-| Backend         | Use Case                    | Rust | TypeScript |
-| --------------- | --------------------------- | ---- | ---------- |
-| Memory          | Development, testing        | ✓    | ✓          |
-| HashiCorp Vault | Self-hosted HSM             | ✓    | ✓          |
-| AWS KMS         | Cloud-native (AWS)          | ✓    | ✓          |
-| GCP KMS         | Cloud-native (GCP)          | ✓    | ✓          |
-| Privy           | Embedded wallets            | ✓    | ✓          |
-| Turnkey         | Non-custodial               | ✓    | ✓          |
-| Fireblocks      | Institutional MPC           | ✓    | ✓          |
-| CDP             | Coinbase Developer Platform | ✓    | ✓          |
-| Crossmint       | Crossmint managed wallets   | ✓    | ✓          |
-| Dfns            | Dfns wallet infrastructure  | ✓    | ✓          |
-| Openfort        | Openfort embedded wallets   | ✓    | ✓          |
-| Para            | Para MPC wallets            | ✓    | ✓          |
+Backends span local development, self-hosted and cloud key management, and
+managed or MPC wallet services. See
+[Choosing a backend](/docs/tools/keychain/choosing-a-backend) to compare custody
+models and pick the right one.
+
+| Backend         | Use Case                     | Rust | TypeScript |
+| --------------- | ---------------------------- | ---- | ---------- |
+| Memory          | Development, testing         | ✓    | ✓          |
+| HashiCorp Vault | Self-hosted key management   | ✓    | ✓          |
+| AWS KMS         | Cloud-native (AWS)           | ✓    | ✓          |
+| GCP KMS         | Cloud-native (GCP)           | ✓    | ✓          |
+| Privy           | Embedded wallets             | ✓    | ✓          |
+| Turnkey         | Non-custodial key management | ✓    | ✓          |
+| Fireblocks      | Institutional custody        | ✓    | ✓          |
+| CDP             | Coinbase Developer Platform  | ✓    | ✓          |
+| Crossmint       | Crossmint managed wallets    | ✓    | ✓          |
+| Dfns            | Dfns wallet infrastructure   | ✓    | ✓          |
+| Openfort        | Openfort backend wallets     | ✓    | ✓          |
+| Para            | Para MPC wallets             | ✓    | ✓          |
+| Utila           | Utila MPC custody            | ✓    | ✓          |
 
 ## Quick Start
 
@@ -64,7 +73,7 @@ let signature = signer.sign_transaction(&mut tx).await?;
 
 - [Rust Guide](/docs/tools/keychain/getting-started/rust) - Full installation
   and backend configuration
-- [Crates.io](https://crates.io/crates/solana-keychain/1.2.0) - Rust crate
+- [Crates.io](https://crates.io/crates/solana-keychain) - Rust crate
 
 ### TypeScript
 
@@ -98,22 +107,44 @@ const signedTx = await signTransactionWithSigners(
 
 - [TypeScript Guide](/docs/tools/keychain/getting-started/typescript) -
   `@solana/keychain` packages
-- [npm Package](https://www.npmjs.com/package/@solana/keychain/v/1.2.0) - npm
-  package
+- [npm Package](https://www.npmjs.com/package/@solana/keychain) - npm package
 
-## Other Resources
+## Next steps
 
-- [Adding Custom Signers](https://github.com/solana-foundation/solana-keychain/blob/main/docs/ADDING_SIGNERS.md) -
-  Integrate new backends
-- [GitHub Releases](https://github.com/solana-foundation/solana-keychain/releases) -
-  Release history
+<Cards>
+  <Card title="Rust guide" href="/docs/tools/keychain/getting-started/rust">
+    Install the crate and configure each backend.
+  </Card>
+  <Card
+    title="TypeScript guide"
+    href="/docs/tools/keychain/getting-started/typescript"
+  >
+    Install the packages and configure each backend.
+  </Card>
+  <Card
+    title="Choosing a backend"
+    href="/docs/tools/keychain/choosing-a-backend"
+  >
+    Compare custody models and pick the right signing backend.
+  </Card>
+  <Card
+    title="Production best practices"
+    href="/docs/tools/keychain/production-best-practices"
+  >
+    Operate signing safely: hot/cold separation, rotation, monitoring.
+  </Card>
+  <Card
+    title="Adding custom signers"
+    href="/docs/tools/keychain/adding-signers"
+  >
+    Integrate a new key management backend.
+  </Card>
+</Cards>
 
 ## Source
 
-[GitHub Repository](https://github.com/solana-foundation/solana-keychain)
+- [GitHub Repository](https://github.com/solana-foundation/solana-keychain)
+- [Release history](https://github.com/solana-foundation/solana-keychain/releases)
 
-Built and maintained by the [Solana Foundation](https://solana.org).
-
-Licensed under MIT. See
-[LICENSE](https://github.com/solana-foundation/solana-keychain/blob/main/LICENSE)
-for details.
+Built and maintained by the [Solana Foundation](https://solana.org). Licensed
+under MIT.

--- a/apps/docs/content/docs/en/tools/keychain/meta.json
+++ b/apps/docs/content/docs/en/tools/keychain/meta.json
@@ -1,4 +1,9 @@
 {
   "title": "Keychain",
-  "pages": ["getting-started", "adding-signers"]
+  "pages": [
+    "getting-started",
+    "choosing-a-backend",
+    "production-best-practices",
+    "adding-signers"
+  ]
 }

--- a/apps/docs/content/docs/en/tools/keychain/production-best-practices.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/production-best-practices.mdx
@@ -1,0 +1,60 @@
+---
+title: Production best practices
+description:
+  Operate Keychain signing backends safely in production — separation of duties,
+  key rotation, least-privilege access, availability, transport security,
+  monitoring, and audit.
+related:
+  - /docs/tools/keychain/choosing-a-backend
+  - /docs/payments/production-readiness
+---
+
+Keychain abstracts the signing backend, but operating a signer in production is
+still your responsibility. These practices apply across backends; see
+[Choosing a backend](/docs/tools/keychain/choosing-a-backend) for selecting one.
+
+## Separate hot and cold signers
+
+Use a low-balance operational ("hot") signer for frequent, automated
+transactions, and a separate high-value ("cold") signer for treasury movements.
+Back the cold signer with MPC custody or a cloud HSM and require approval
+policies before it signs. Because the interface is identical, each role can use
+a different backend without changing call sites.
+
+## Rotate keys deliberately
+
+On Solana the signing key _is_ the account address, so rotating a key produces a
+new address. Plan rotation as a migration: provision a new key, reassign the
+relevant authorities (or move funds) to the new address, then retire the old
+one. Use distinct keys per environment so devnet keys are never reused on
+mainnet.
+
+## Grant least-privilege access
+
+Scope each backend's credentials to the minimum needed to sign. For AWS KMS,
+that is `kms:Sign` and `kms:DescribeKey` on the specific key; prefer IAM roles
+over static credentials. Apply the same principle to Vault policies and managed
+wallet API keys.
+
+## Plan for availability
+
+Remote backends depend on a network service. Call `isAvailable()` before relying
+on a signer, apply retries with backoff on transient failures, and define a
+fallback path for outages. Keychain enforces HTTPS for remote backends and
+applies a default request timeout.
+
+## Protect secrets and transport
+
+- All remote backends communicate over HTTPS; non-HTTPS endpoints are rejected.
+- Supply API keys, tokens, and credentials from a secret manager or environment
+  variables — never hard-code them or commit them to source control.
+- Keychain sanitizes error responses to avoid leaking secrets into logs; keep
+  your own logging free of raw credentials and key material.
+
+## Monitor and audit signing
+
+Track signing success rate, latency, and failure counts, and alert on spikes —
+see the metrics in
+[Production Readiness](/docs/payments/production-readiness#monitoring). Enable
+provider-side audit logs (KMS, Vault, or custodian) and reconcile them against
+the transactions your application submits.

--- a/apps/web/public/llms-en.txt
+++ b/apps/web/public/llms-en.txt
@@ -13,6 +13,7 @@ This documentation provides comprehensive guides, references, and tutorials for 
 
 - [Accounts](https://solana.com/docs/core/accounts): How Solana stores data in accounts
 - [Transactions](https://solana.com/docs/core/transactions): The fundamental building blocks for interacting with Solana
+- [Signing in Production](https://solana.com/docs/core/transactions/signing-in-production): Where signing keys live in production and how to choose a backend
 - [Programs](https://solana.com/docs/core/programs): Smart contracts on Solana
 - [Program Derived Addresses](https://solana.com/docs/core/pda): Deterministic addresses for program-controlled accounts
 - [Cross Program Invocation](https://solana.com/docs/core/cpi): How programs invoke other programs
@@ -68,6 +69,7 @@ This documentation provides comprehensive guides, references, and tutorials for 
 - [Tools](https://solana.com/docs/tools): Developer tool documentation
 - [Kora](https://solana.com/docs/tools/kora): Solana signing infrastructure
 - [Keychain](https://solana.com/docs/tools/keychain): Unified Solana signing across key management backends
+- [Choosing a Signing Backend](https://solana.com/docs/tools/keychain/choosing-a-backend): Compare custody models and pick a Keychain backend
 - [Commerce Kit](https://solana.com/docs/tools/commerce-kit): Commerce primitives for Solana payment experiences
 - [Solana Pay](https://solana.com/docs/tools/solana-pay): Standard protocol for decentralized payments on Solana
 - [Attestations](https://solana.com/docs/tools/attestations): Verifiable claims and credentials on Solana

--- a/apps/web/public/llms.txt
+++ b/apps/web/public/llms.txt
@@ -13,6 +13,7 @@ This documentation provides comprehensive guides, references, and tutorials for 
 
 - [Accounts](https://solana.com/docs/core/accounts): How Solana stores data in accounts
 - [Transactions](https://solana.com/docs/core/transactions): The fundamental building blocks for interacting with Solana
+- [Signing in Production](https://solana.com/docs/core/transactions/signing-in-production): Where signing keys live in production and how to choose a backend
 - [Programs](https://solana.com/docs/core/programs): Smart contracts on Solana
 - [Program Derived Addresses](https://solana.com/docs/core/pda): Deterministic addresses for program-controlled accounts
 - [Cross Program Invocation](https://solana.com/docs/core/cpi): How programs invoke other programs
@@ -68,6 +69,7 @@ This documentation provides comprehensive guides, references, and tutorials for 
 - [Tools](https://solana.com/docs/tools): Developer tool documentation
 - [Kora](https://solana.com/docs/tools/kora): Solana signing infrastructure
 - [Keychain](https://solana.com/docs/tools/keychain): Unified Solana signing across key management backends
+- [Choosing a Signing Backend](https://solana.com/docs/tools/keychain/choosing-a-backend): Compare custody models and pick a Keychain backend
 - [Commerce Kit](https://solana.com/docs/tools/commerce-kit): Commerce primitives for Solana payment experiences
 - [Solana Pay](https://solana.com/docs/tools/solana-pay): Standard protocol for decentralized payments on Solana
 - [Attestations](https://solana.com/docs/tools/attestations): Verifiable claims and credentials on Solana

--- a/apps/web/src/data/solutions/enterprise.ts
+++ b/apps/web/src/data/solutions/enterprise.ts
@@ -38,7 +38,7 @@ export const FAQ_ITEMS = [
   },
   {
     key: "custody",
-    link: null,
+    link: "/docs/tools/keychain",
   },
   {
     key: "compliance",
@@ -63,6 +63,11 @@ export const RESOURCES = [
   {
     key: "token-extensions",
     href: "/docs/tokens/extensions",
+    external: false,
+  },
+  {
+    key: "keychain",
+    href: "/docs/tools/keychain",
     external: false,
   },
   {

--- a/llmtxt-generator.py
+++ b/llmtxt-generator.py
@@ -24,6 +24,7 @@ CURATED_SECTIONS = {
     "Core Concepts": [
         ("Accounts", "docs/core/accounts", "How Solana stores data in accounts"),
         ("Transactions", "docs/core/transactions", "The fundamental building blocks for interacting with Solana"),
+        ("Signing in Production", "docs/core/transactions/signing-in-production", "Where signing keys live in production and how to choose a backend"),
         ("Programs", "docs/core/programs", "Smart contracts on Solana"),
         ("Program Derived Addresses", "docs/core/pda", "Deterministic addresses for program-controlled accounts"),
         ("Cross Program Invocation", "docs/core/cpi", "How programs invoke other programs"),
@@ -71,6 +72,7 @@ CURATED_SECTIONS = {
         ("Tools", "docs/tools", "Developer tool documentation"),
         ("Kora", "docs/tools/kora", "Solana signing infrastructure"),
         ("Keychain", "docs/tools/keychain", "Unified Solana signing across key management backends"),
+        ("Choosing a Signing Backend", "docs/tools/keychain/choosing-a-backend", "Compare custody models and pick a Keychain backend"),
         ("Commerce Kit", "docs/tools/commerce-kit", "Commerce primitives for Solana payment experiences"),
         ("Solana Pay", "docs/tools/solana-pay", "Standard protocol for decentralized payments on Solana"),
         ("Attestations", "docs/tools/attestations", "Verifiable claims and credentials on Solana"),

--- a/packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.test.ts
+++ b/packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.test.ts
@@ -1,0 +1,7 @@
+import { describe, it, expect } from "vitest";
+
+describe("cookbook/wallets/sign-with-keychain/kit", () => {
+  it("signs a transaction with a Keychain memory signer", async () => {
+    await expect(import("./kit")).resolves.toBeDefined();
+  });
+});

--- a/packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.test.ts
+++ b/packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from "vitest";
+import { describe, it } from "vitest";
+import { expectExampleLogsSignature } from "../../../test/assert-signature";
 
 describe("cookbook/wallets/sign-with-keychain/kit", () => {
-  it("signs a transaction with a Keychain memory signer", async () => {
-    await expect(import("./kit")).resolves.toBeDefined();
+  it("signs and sends a transfer with a Keychain memory signer", async () => {
+    await expectExampleLogsSignature(() => import("./kit"));
   });
 });

--- a/packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.ts
+++ b/packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.ts
@@ -1,15 +1,14 @@
 // #region sign
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { createKeychainSigner } from "@solana/keychain";
+import { createMemorySigner } from "@solana/keychain-memory";
 import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
 import { airdropSigner, signer } from "@solana/kit-plugin-signer";
 import { getTransferSolInstruction } from "@solana-program/system";
 
-// One factory, one config shape for every backend. Swap `backend: "memory"`
-// for "aws-kms", "vault", "turnkey", ... and the rest of this file is
-// identical — each backend returns the same `SolanaSigner` interface.
-const keychainSigner = await createKeychainSigner({
-  backend: "memory",
+// Every Keychain backend returns the same `SolanaSigner`. Swap this in-memory
+// signer for `createAwsKmsSigner`, `createVaultSigner`, ... and the rest of
+// this file is identical.
+const keychainSigner = await createMemorySigner({
   privateKey: crypto.getRandomValues(new Uint8Array(32)),
 });
 

--- a/packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.ts
+++ b/packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.ts
@@ -1,47 +1,38 @@
 // #region sign
-import { createMemorySignerFromBytes } from "@solana/keychain-memory";
-import {
-  appendTransactionMessageInstruction,
-  createSolanaRpc,
-  createTransactionMessage,
-  generateKeyPairSigner,
-  getSignatureFromTransaction,
-  lamports,
-  pipe,
-  setTransactionMessageFeePayerSigner,
-  setTransactionMessageLifetimeUsingBlockhash,
-  signTransactionMessageWithSigners,
-} from "@solana/kit";
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { createKeychainSigner } from "@solana/keychain";
+import { rpcAirdrop, solanaRpc } from "@solana/kit-plugin-rpc";
+import { airdropSigner, signer } from "@solana/kit-plugin-signer";
 import { getTransferSolInstruction } from "@solana-program/system";
 
-// Create a Keychain signer. Swap `createMemorySignerFromBytes` for any backend
-// (AWS KMS, Vault, Fireblocks, Turnkey, ...) and the signing code below is the
-// same — every backend returns the same `SolanaSigner` interface.
-const signer = await createMemorySignerFromBytes(
-  crypto.getRandomValues(new Uint8Array(32)),
-);
+// One factory, one config shape for every backend. Swap `backend: "memory"`
+// for "aws-kms", "vault", "turnkey", ... and the rest of this file is
+// identical — each backend returns the same `SolanaSigner` interface.
+const keychainSigner = await createKeychainSigner({
+  backend: "memory",
+  privateKey: crypto.getRandomValues(new Uint8Array(32)),
+});
 
 const recipient = await generateKeyPairSigner();
 
-const rpc = createSolanaRpc("http://localhost:8899");
-const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+const client = await createClient()
+  .use(signer(keychainSigner))
+  .use(
+    solanaRpc({
+      rpcUrl: "http://localhost:8899",
+      rpcSubscriptionsUrl: "ws://localhost:8900",
+    }),
+  )
+  .use(rpcAirdrop())
+  .use(airdropSigner(lamports(1_000_000_000n)));
 
-const transactionMessage = pipe(
-  createTransactionMessage({ version: 0 }),
-  (m) => setTransactionMessageFeePayerSigner(signer, m),
-  (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
-  (m) =>
-    appendTransactionMessageInstruction(
-      getTransferSolInstruction({
-        source: signer,
-        destination: recipient.address,
-        amount: lamports(10_000_000n),
-      }),
-      m,
-    ),
-);
+const { context } = await client.sendTransaction([
+  getTransferSolInstruction({
+    source: keychainSigner,
+    destination: recipient.address,
+    amount: lamports(10_000_000n),
+  }),
+]);
 
-const signedTransaction =
-  await signTransactionMessageWithSigners(transactionMessage);
-console.log("Signature:", getSignatureFromTransaction(signedTransaction));
+console.log("Signature:", context.signature);
 // #endregion sign

--- a/packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.ts
+++ b/packages/docs-examples/cookbook/wallets/sign-with-keychain/kit.ts
@@ -1,0 +1,47 @@
+// #region sign
+import { createMemorySignerFromBytes } from "@solana/keychain-memory";
+import {
+  appendTransactionMessageInstruction,
+  createSolanaRpc,
+  createTransactionMessage,
+  generateKeyPairSigner,
+  getSignatureFromTransaction,
+  lamports,
+  pipe,
+  setTransactionMessageFeePayerSigner,
+  setTransactionMessageLifetimeUsingBlockhash,
+  signTransactionMessageWithSigners,
+} from "@solana/kit";
+import { getTransferSolInstruction } from "@solana-program/system";
+
+// Create a Keychain signer. Swap `createMemorySignerFromBytes` for any backend
+// (AWS KMS, Vault, Fireblocks, Turnkey, ...) and the signing code below is the
+// same — every backend returns the same `SolanaSigner` interface.
+const signer = await createMemorySignerFromBytes(
+  crypto.getRandomValues(new Uint8Array(32)),
+);
+
+const recipient = await generateKeyPairSigner();
+
+const rpc = createSolanaRpc("http://localhost:8899");
+const { value: latestBlockhash } = await rpc.getLatestBlockhash().send();
+
+const transactionMessage = pipe(
+  createTransactionMessage({ version: 0 }),
+  (m) => setTransactionMessageFeePayerSigner(signer, m),
+  (m) => setTransactionMessageLifetimeUsingBlockhash(latestBlockhash, m),
+  (m) =>
+    appendTransactionMessageInstruction(
+      getTransferSolInstruction({
+        source: signer,
+        destination: recipient.address,
+        amount: lamports(10_000_000n),
+      }),
+      m,
+    ),
+);
+
+const signedTransaction =
+  await signTransactionMessageWithSigners(transactionMessage);
+console.log("Signature:", getSignatureFromTransaction(signedTransaction));
+// #endregion sign

--- a/packages/docs-examples/package.json
+++ b/packages/docs-examples/package.json
@@ -16,6 +16,7 @@
     "@solana-program/system": "^0.12.0",
     "@solana-program/token": "^0.13.0",
     "@solana-program/token-2022": "^0.9.0",
+    "@solana/keychain-memory": "^1.3.0",
     "@solana/kit": "^6.8.0",
     "@solana/kit-plugin-rpc": "^0.11.1",
     "@solana/kit-plugin-signer": "^0.10.0",

--- a/packages/docs-examples/package.json
+++ b/packages/docs-examples/package.json
@@ -16,7 +16,7 @@
     "@solana-program/system": "^0.12.0",
     "@solana-program/token": "^0.13.0",
     "@solana-program/token-2022": "^0.9.0",
-    "@solana/keychain-memory": "^1.3.0",
+    "@solana/keychain": "^1.3.0",
     "@solana/kit": "^6.8.0",
     "@solana/kit-plugin-rpc": "^0.11.1",
     "@solana/kit-plugin-signer": "^0.10.0",

--- a/packages/docs-examples/package.json
+++ b/packages/docs-examples/package.json
@@ -16,7 +16,7 @@
     "@solana-program/system": "^0.12.0",
     "@solana-program/token": "^0.13.0",
     "@solana-program/token-2022": "^0.9.0",
-    "@solana/keychain": "^1.3.0",
+    "@solana/keychain-memory": "^1.3.0",
     "@solana/kit": "^6.8.0",
     "@solana/kit-plugin-rpc": "^0.11.1",
     "@solana/kit-plugin-signer": "^0.10.0",

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -4012,7 +4012,7 @@
         },
         "custody": {
           "question": "What custody solutions are available?",
-          "answer": "Major institutional custody providers supporting Solana include: Fireblocks, Anchorage, BitGo, Coinbase, Copper, Crypto Finance, and Gemini. These providers offer insurance coverage, regulatory compliance (SOC2, qualified custodian status), institutional SLAs, and integration with trading/settlement systems."
+          "answer": "Major institutional custody providers supporting Solana include: Fireblocks, Anchorage, BitGo, Coinbase, Copper, Crypto Finance, and Gemini. These providers offer insurance coverage, regulatory compliance (SOC2, qualified custodian status), institutional SLAs, and integration with trading/settlement systems. For application-level signing, Solana Keychain provides one interface across many of these backends — including Fireblocks, cloud KMS (AWS and GCP), HashiCorp Vault, and managed wallet services — so you can switch providers without changing code."
         },
         "compliance": {
           "question": "What compliance features are available?",
@@ -4035,6 +4035,10 @@
         "token-extensions": {
           "title": "Token Extensions",
           "description": "Deep dive into compliance and programmability features."
+        },
+        "keychain": {
+          "title": "Keychain — Secure Signing",
+          "description": "Unified signing across KMS, HSM, and institutional custody backends."
         },
         "grants": {
           "title": "Grants Program",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1106,6 +1106,9 @@ importers:
       "@solana-program/token-2022":
         specifier: ^0.9.0
         version: 0.9.0(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-memory":
+        specifier: ^1.3.0
+        version: 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
       "@solana/kit":
         specifier: ^6.8.0
         version: 6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6)
@@ -8257,6 +8260,31 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  "@solana/keychain-core@1.3.0":
+    resolution:
+      {
+        integrity: sha512-iIH3GRQdNPiLZVDU7MxiDzIQ8Fd8GKw4LxaeuifBjqWHFbAlOFSjgvvtNix1VFHy1quvCFSJZt+/0l0MRX0aoQ==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-core": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-memory@1.3.0":
+    resolution:
+      {
+        integrity: sha512-HSsYvUmwEbq2kOHcTKyos1Jf6VRjsojfUp25FCvkZX1ve+R+gQ9AQ3kkQBbGvK4jNhPQOOT4P+qPFIWFN+zBYA==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
 
   "@solana/keys@6.9.0":
     resolution:
@@ -25296,6 +25324,26 @@ snapshots:
       "@solana/errors": 6.9.0(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
+
+  "@solana/keychain-core@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-core": 6.9.0(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+
+  "@solana/keychain-memory@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - "@solana/codecs-core"
 
   "@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)":
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1106,7 +1106,7 @@ importers:
       "@solana-program/token-2022":
         specifier: ^0.9.0
         version: 0.9.0(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain":
+      "@solana/keychain-memory":
         specifier: ^1.3.0
         version: 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
       "@solana/kit":
@@ -1475,157 +1475,6 @@ packages:
       {
         integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==,
       }
-
-  "@aws-crypto/crc32@5.2.0":
-    resolution:
-      {
-        integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==,
-      }
-    engines: { node: ">=16.0.0" }
-
-  "@aws-crypto/sha256-browser@5.2.0":
-    resolution:
-      {
-        integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==,
-      }
-
-  "@aws-crypto/sha256-js@5.2.0":
-    resolution:
-      {
-        integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==,
-      }
-    engines: { node: ">=16.0.0" }
-
-  "@aws-crypto/supports-web-crypto@5.2.0":
-    resolution:
-      {
-        integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==,
-      }
-
-  "@aws-crypto/util@5.2.0":
-    resolution:
-      {
-        integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==,
-      }
-
-  "@aws-sdk/client-kms@3.1070.0":
-    resolution:
-      {
-        integrity: sha512-ELJH11w1IU0V5kqQ/eg2iu4HqaXOJQ/3nC8I7y93+mZW39osINlOHFKgYQNizwZA5KoSxSgVYmLPnnF/i0oKmw==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/core@3.974.21":
-    resolution:
-      {
-        integrity: sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/credential-provider-env@3.972.47":
-    resolution:
-      {
-        integrity: sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/credential-provider-http@3.972.49":
-    resolution:
-      {
-        integrity: sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/credential-provider-ini@3.972.54":
-    resolution:
-      {
-        integrity: sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/credential-provider-login@3.972.53":
-    resolution:
-      {
-        integrity: sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/credential-provider-node@3.972.56":
-    resolution:
-      {
-        integrity: sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/credential-provider-process@3.972.47":
-    resolution:
-      {
-        integrity: sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/credential-provider-sso@3.972.53":
-    resolution:
-      {
-        integrity: sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/credential-provider-web-identity@3.972.53":
-    resolution:
-      {
-        integrity: sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/nested-clients@3.997.21":
-    resolution:
-      {
-        integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/signature-v4-multi-region@3.996.35":
-    resolution:
-      {
-        integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/token-providers@3.1069.0":
-    resolution:
-      {
-        integrity: sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/types@3.973.13":
-    resolution:
-      {
-        integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/util-locate-window@3.965.8":
-    resolution:
-      {
-        integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws-sdk/xml-builder@3.972.30":
-    resolution:
-      {
-        integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==,
-      }
-    engines: { node: ">=20.0.0" }
-
-  "@aws/lambda-invoke-store@0.2.4":
-    resolution:
-      {
-        integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==,
-      }
-    engines: { node: ">=18.0.0" }
 
   "@babel/code-frame@7.27.1":
     resolution:
@@ -5038,13 +4887,6 @@ packages:
       }
     engines: { node: ^14.21.3 || >=16 }
 
-  "@noble/curves@2.2.0":
-    resolution:
-      {
-        integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==,
-      }
-    engines: { node: ">= 20.19.0" }
-
   "@noble/ed25519@1.7.5":
     resolution:
       {
@@ -5063,19 +4905,6 @@ packages:
         integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==,
       }
     engines: { node: ^14.21.3 || >=16 }
-
-  "@noble/hashes@2.2.0":
-    resolution:
-      {
-        integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==,
-      }
-    engines: { node: ">= 20.19.0" }
-
-  "@nodable/entities@2.2.0":
-    resolution:
-      {
-        integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==,
-      }
 
   "@nodelib/fs.scandir@2.1.5":
     resolution:
@@ -8117,69 +7946,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  "@smithy/core@3.25.0":
-    resolution:
-      {
-        integrity: sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A==,
-      }
-    engines: { node: ">=18.0.0" }
-
-  "@smithy/credential-provider-imds@4.4.0":
-    resolution:
-      {
-        integrity: sha512-pPQmNdEvMJttv9z2kdYxoui83p/nr32zjMf0aMfmzmGmFEgKXUfy0vXiNg0fx4R5XLQzmJBLM9Wg0guEq2/q8A==,
-      }
-    engines: { node: ">=18.0.0" }
-
-  "@smithy/fetch-http-handler@5.5.0":
-    resolution:
-      {
-        integrity: sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA==,
-      }
-    engines: { node: ">=18.0.0" }
-
-  "@smithy/is-array-buffer@2.2.0":
-    resolution:
-      {
-        integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==,
-      }
-    engines: { node: ">=14.0.0" }
-
-  "@smithy/node-http-handler@4.8.0":
-    resolution:
-      {
-        integrity: sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg==,
-      }
-    engines: { node: ">=18.0.0" }
-
-  "@smithy/signature-v4@5.5.0":
-    resolution:
-      {
-        integrity: sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg==,
-      }
-    engines: { node: ">=18.0.0" }
-
-  "@smithy/types@4.15.0":
-    resolution:
-      {
-        integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==,
-      }
-    engines: { node: ">=18.0.0" }
-
-  "@smithy/util-buffer-from@2.2.0":
-    resolution:
-      {
-        integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==,
-      }
-    engines: { node: ">=14.0.0" }
-
-  "@smithy/util-utf8@2.3.0":
-    resolution:
-      {
-        integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==,
-      }
-    engines: { node: ">=14.0.0" }
-
   "@solana-foundation/solana-lib@2.41.0":
     resolution:
       {
@@ -8495,30 +8261,6 @@ packages:
       typescript:
         optional: true
 
-  "@solana/keychain-aws-kms@1.3.0":
-    resolution:
-      {
-        integrity: sha512-8AEluPCptebRumZ7j/kZVpnqFWY7Ot4Uf5zg0Cyj2ywlD1W5e79BVwYd/Abo5s0rKKt7/du7bKIWO2Opxmtsvg==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain-cdp@1.3.0":
-    resolution:
-      {
-        integrity: sha512-OupkRqt+hBOotdKh47wSAnMLch84fS5WsZ2T9pn7oUPPpU6yL/0uBjpA6Ck3W6/XcCA30W7ZOG+YkdQmEWzuow==,
-      }
-    engines: { node: ">=19" }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
   "@solana/keychain-core@1.3.0":
     resolution:
       {
@@ -8532,53 +8274,6 @@ packages:
       "@solana/signers": ">=6.0.1"
       "@solana/transactions": ">=6.0.1"
 
-  "@solana/keychain-crossmint@1.3.0":
-    resolution:
-      {
-        integrity: sha512-yqIZNov32A6Xzu9CP5e1oXJjfoZvpx8yxMs9YuAWBthiEEZmcn3Vpc+scm0+hPvG9I2nnsDx8znvBO5x5Klrlg==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain-dfns@1.3.0":
-    resolution:
-      {
-        integrity: sha512-5ba2PnodtUwgjTq847qD5oRzqemGSxlhbzTlJQjQT8k9zo46JlBzphFCOCRDUeQlIddsuKrSZoxv40dgt58FTQ==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain-fireblocks@1.3.0":
-    resolution:
-      {
-        integrity: sha512-OhmmS6Dl+T4oPLMjGYlYU4ktO11U6AFxTTRsTmXXkAIPiFjmkdHikAGC9IntzWx8EaUgkOnIZoD6HojQZlqcXg==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain-gcp-kms@1.3.0":
-    resolution:
-      {
-        integrity: sha512-pN4gwD3kSmNLaFd4VA5eU/+1XoyB3agTr6cIb8blH1Haw06JqYwgSQLP3fVTc628vsN4YBF9uyzXV+Ye9Wub/g==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
   "@solana/keychain-memory@1.3.0":
     resolution:
       {
@@ -8586,95 +8281,6 @@ packages:
       }
     peerDependencies:
       "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain-openfort@1.3.0":
-    resolution:
-      {
-        integrity: sha512-46NYBokdI9caJe+EN41m9B0l80y8CXvxX/U8VidIhyToV/5JbGmFJyHUXUNKX9jJpowTnkFd8Po7mZi9rlC3Ug==,
-      }
-    engines: { node: ">=19" }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain-para@1.3.0":
-    resolution:
-      {
-        integrity: sha512-pp6KcIqxUHY5O4AynLedc+GMe8JUzBJU6tzIQy1soBYZURtyld4mWjkQ9xAotbYpLXg0aJnKaQIW5xGQFfGO/w==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain-privy@1.3.0":
-    resolution:
-      {
-        integrity: sha512-NhmQ9m6iSi3Rn3ZGuCLJYwXKe3KXJtXDa07GSQScwovPHgr+X3pHRRNqvcrots7YvBsSuCPQlBzJPhCNkpurIQ==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-core": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain-turnkey@1.3.0":
-    resolution:
-      {
-        integrity: sha512-HyyYgjXSggbc3CujccNtpLa/cfVkoYYYlF9YE1Ty41JUEFUEmM48SO9bxpvYQtayLcwrB1WVKK7WryjMgcuBgg==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-core": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain-utila@1.3.0":
-    resolution:
-      {
-        integrity: sha512-saZuRoFyCukgbrYqvzGTdt3/bZANDwUrUobjdp4V/QjnsUrU4cvcIVs9rb0ck/yZQVY+q8WzR0fHz5RfKodD7w==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain-vault@1.3.0":
-    resolution:
-      {
-        integrity: sha512-8AdMQ8iZX1fGalG57EmbUljFZ49fEO+QyGboO/rMb081uJG0OidrOPnG2zrRiTU621eR+Pkp297iL3Vt5w8iQQ==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-core": ">=6.0.1"
-      "@solana/codecs-strings": ">=6.0.1"
-      "@solana/keys": ">=6.0.1"
-      "@solana/signers": ">=6.0.1"
-      "@solana/transactions": ">=6.0.1"
-
-  "@solana/keychain@1.3.0":
-    resolution:
-      {
-        integrity: sha512-zkxeNyyZxnYtgEwXWzaZrrdTMv7dnPz4pN5IhYsmVUyYWou8+e77l9NnLQOdhbXlOBYaya7m1JS4WMDNT1HATg==,
-      }
-    peerDependencies:
-      "@solana/addresses": ">=6.0.1"
-      "@solana/codecs-core": ">=6.0.1"
       "@solana/codecs-strings": ">=6.0.1"
       "@solana/keys": ">=6.0.1"
       "@solana/signers": ">=6.0.1"
@@ -10820,12 +10426,6 @@ packages:
       }
     engines: { node: ">= 8" }
 
-  anynum@1.0.0:
-    resolution:
-      {
-        integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==,
-      }
-
   arg@4.1.3:
     resolution:
       {
@@ -11128,12 +10728,6 @@ packages:
     resolution:
       {
         integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==,
-      }
-
-  bowser@2.14.1:
-    resolution:
-      {
-        integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==,
       }
 
   brace-expansion@1.1.12:
@@ -13296,19 +12890,6 @@ packages:
         integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
       }
 
-  fast-xml-builder@1.2.0:
-    resolution:
-      {
-        integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==,
-      }
-
-  fast-xml-parser@5.7.3:
-    resolution:
-      {
-        integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==,
-      }
-    hasBin: true
-
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution:
       {
@@ -13626,26 +13207,12 @@ packages:
       }
     engines: { node: ">=14" }
 
-  gaxios@7.1.5:
-    resolution:
-      {
-        integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==,
-      }
-    engines: { node: ">=18" }
-
   gcp-metadata@6.1.1:
     resolution:
       {
         integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==,
       }
     engines: { node: ">=14" }
-
-  gcp-metadata@8.1.2:
-    resolution:
-      {
-        integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==,
-      }
-    engines: { node: ">=18" }
 
   gensync@1.0.0-beta.2:
     resolution:
@@ -13799,13 +13366,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  google-auth-library@10.7.0:
-    resolution:
-      {
-        integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==,
-      }
-    engines: { node: ">=18" }
-
   google-auth-library@9.15.1:
     resolution:
       {
@@ -13817,13 +13377,6 @@ packages:
     resolution:
       {
         integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==,
-      }
-    engines: { node: ">=14" }
-
-  google-logging-utils@1.1.3:
-    resolution:
-      {
-        integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==,
       }
     engines: { node: ">=14" }
 
@@ -14816,12 +14369,6 @@ packages:
         integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
       }
     hasBin: true
-
-  jose@6.2.3:
-    resolution:
-      {
-        integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==,
-      }
 
   joycon@3.1.1:
     resolution:
@@ -16677,13 +16224,6 @@ packages:
         integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
       }
     engines: { node: ">=8" }
-
-  path-expression-matcher@1.5.0:
-    resolution:
-      {
-        integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==,
-      }
-    engines: { node: ">=14.0.0" }
 
   path-is-absolute@1.0.1:
     resolution:
@@ -18766,12 +18306,6 @@ packages:
       }
     engines: { node: ">=8" }
 
-  strnum@2.4.0:
-    resolution:
-      {
-        integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==,
-      }
-
   style-to-js@1.1.17:
     resolution:
       {
@@ -20403,13 +19937,6 @@ packages:
       }
     engines: { node: ">=18" }
 
-  xml-naming@0.1.0:
-    resolution:
-      {
-        integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==,
-      }
-    engines: { node: ">=16.0.0" }
-
   xml2js@0.5.0:
     resolution:
       {
@@ -20617,192 +20144,6 @@ snapshots:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
       lru-cache: 10.4.3
-
-  "@aws-crypto/crc32@5.2.0":
-    dependencies:
-      "@aws-crypto/util": 5.2.0
-      "@aws-sdk/types": 3.973.13
-      tslib: 2.8.1
-
-  "@aws-crypto/sha256-browser@5.2.0":
-    dependencies:
-      "@aws-crypto/sha256-js": 5.2.0
-      "@aws-crypto/supports-web-crypto": 5.2.0
-      "@aws-crypto/util": 5.2.0
-      "@aws-sdk/types": 3.973.13
-      "@aws-sdk/util-locate-window": 3.965.8
-      "@smithy/util-utf8": 2.3.0
-      tslib: 2.8.1
-
-  "@aws-crypto/sha256-js@5.2.0":
-    dependencies:
-      "@aws-crypto/util": 5.2.0
-      "@aws-sdk/types": 3.973.13
-      tslib: 2.8.1
-
-  "@aws-crypto/supports-web-crypto@5.2.0":
-    dependencies:
-      tslib: 2.8.1
-
-  "@aws-crypto/util@5.2.0":
-    dependencies:
-      "@aws-sdk/types": 3.973.13
-      "@smithy/util-utf8": 2.3.0
-      tslib: 2.8.1
-
-  "@aws-sdk/client-kms@3.1070.0":
-    dependencies:
-      "@aws-crypto/sha256-browser": 5.2.0
-      "@aws-crypto/sha256-js": 5.2.0
-      "@aws-sdk/core": 3.974.21
-      "@aws-sdk/credential-provider-node": 3.972.56
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/fetch-http-handler": 5.5.0
-      "@smithy/node-http-handler": 4.8.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/core@3.974.21":
-    dependencies:
-      "@aws-sdk/types": 3.973.13
-      "@aws-sdk/xml-builder": 3.972.30
-      "@aws/lambda-invoke-store": 0.2.4
-      "@smithy/core": 3.25.0
-      "@smithy/signature-v4": 5.5.0
-      "@smithy/types": 4.15.0
-      bowser: 2.14.1
-      tslib: 2.8.1
-
-  "@aws-sdk/credential-provider-env@3.972.47":
-    dependencies:
-      "@aws-sdk/core": 3.974.21
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/credential-provider-http@3.972.49":
-    dependencies:
-      "@aws-sdk/core": 3.974.21
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/fetch-http-handler": 5.5.0
-      "@smithy/node-http-handler": 4.8.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/credential-provider-ini@3.972.54":
-    dependencies:
-      "@aws-sdk/core": 3.974.21
-      "@aws-sdk/credential-provider-env": 3.972.47
-      "@aws-sdk/credential-provider-http": 3.972.49
-      "@aws-sdk/credential-provider-login": 3.972.53
-      "@aws-sdk/credential-provider-process": 3.972.47
-      "@aws-sdk/credential-provider-sso": 3.972.53
-      "@aws-sdk/credential-provider-web-identity": 3.972.53
-      "@aws-sdk/nested-clients": 3.997.21
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/credential-provider-imds": 4.4.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/credential-provider-login@3.972.53":
-    dependencies:
-      "@aws-sdk/core": 3.974.21
-      "@aws-sdk/nested-clients": 3.997.21
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/credential-provider-node@3.972.56":
-    dependencies:
-      "@aws-sdk/credential-provider-env": 3.972.47
-      "@aws-sdk/credential-provider-http": 3.972.49
-      "@aws-sdk/credential-provider-ini": 3.972.54
-      "@aws-sdk/credential-provider-process": 3.972.47
-      "@aws-sdk/credential-provider-sso": 3.972.53
-      "@aws-sdk/credential-provider-web-identity": 3.972.53
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/credential-provider-imds": 4.4.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/credential-provider-process@3.972.47":
-    dependencies:
-      "@aws-sdk/core": 3.974.21
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/credential-provider-sso@3.972.53":
-    dependencies:
-      "@aws-sdk/core": 3.974.21
-      "@aws-sdk/nested-clients": 3.997.21
-      "@aws-sdk/token-providers": 3.1069.0
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/credential-provider-web-identity@3.972.53":
-    dependencies:
-      "@aws-sdk/core": 3.974.21
-      "@aws-sdk/nested-clients": 3.997.21
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/nested-clients@3.997.21":
-    dependencies:
-      "@aws-crypto/sha256-browser": 5.2.0
-      "@aws-crypto/sha256-js": 5.2.0
-      "@aws-sdk/core": 3.974.21
-      "@aws-sdk/signature-v4-multi-region": 3.996.35
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/fetch-http-handler": 5.5.0
-      "@smithy/node-http-handler": 4.8.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/signature-v4-multi-region@3.996.35":
-    dependencies:
-      "@aws-sdk/types": 3.973.13
-      "@smithy/signature-v4": 5.5.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/token-providers@3.1069.0":
-    dependencies:
-      "@aws-sdk/core": 3.974.21
-      "@aws-sdk/nested-clients": 3.997.21
-      "@aws-sdk/types": 3.973.13
-      "@smithy/core": 3.25.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/types@3.973.13":
-    dependencies:
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@aws-sdk/util-locate-window@3.965.8":
-    dependencies:
-      tslib: 2.8.1
-
-  "@aws-sdk/xml-builder@3.972.30":
-    dependencies:
-      "@smithy/types": 4.15.0
-      fast-xml-parser: 5.7.3
-      tslib: 2.8.1
-
-  "@aws/lambda-invoke-store@0.2.4": {}
 
   "@babel/code-frame@7.27.1":
     dependencies:
@@ -23121,19 +22462,11 @@ snapshots:
     dependencies:
       "@noble/hashes": 1.8.0
 
-  "@noble/curves@2.2.0":
-    dependencies:
-      "@noble/hashes": 2.2.0
-
   "@noble/ed25519@1.7.5": {}
 
   "@noble/hashes@1.1.5": {}
 
   "@noble/hashes@1.8.0": {}
-
-  "@noble/hashes@2.2.0": {}
-
-  "@nodable/entities@2.2.0": {}
 
   "@nodelib/fs.scandir@2.1.5":
     dependencies:
@@ -25752,54 +25085,6 @@ snapshots:
     dependencies:
       escape-string-regexp: 5.0.0
 
-  "@smithy/core@3.25.0":
-    dependencies:
-      "@aws-crypto/crc32": 5.2.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@smithy/credential-provider-imds@4.4.0":
-    dependencies:
-      "@smithy/core": 3.25.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@smithy/fetch-http-handler@5.5.0":
-    dependencies:
-      "@smithy/core": 3.25.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@smithy/is-array-buffer@2.2.0":
-    dependencies:
-      tslib: 2.8.1
-
-  "@smithy/node-http-handler@4.8.0":
-    dependencies:
-      "@smithy/core": 3.25.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@smithy/signature-v4@5.5.0":
-    dependencies:
-      "@smithy/core": 3.25.0
-      "@smithy/types": 4.15.0
-      tslib: 2.8.1
-
-  "@smithy/types@4.15.0":
-    dependencies:
-      tslib: 2.8.1
-
-  "@smithy/util-buffer-from@2.2.0":
-    dependencies:
-      "@smithy/is-array-buffer": 2.2.0
-      tslib: 2.8.1
-
-  "@smithy/util-utf8@2.3.0":
-    dependencies:
-      "@smithy/util-buffer-from": 2.2.0
-      tslib: 2.8.1
-
   "@solana-foundation/solana-lib@2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@radix-ui/react-tooltip": 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -26040,29 +25325,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  "@solana/keychain-aws-kms@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@aws-sdk/client-kms": 3.1070.0
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - "@solana/codecs-core"
-      - "@solana/codecs-strings"
-
-  "@solana/keychain-cdp@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - "@solana/codecs-core"
-
   "@solana/keychain-core@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
     dependencies:
       "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -26071,53 +25333,6 @@ snapshots:
       "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-
-  "@solana/keychain-crossmint@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - "@solana/codecs-core"
-
-  "@solana/keychain-dfns@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - "@solana/codecs-core"
-
-  "@solana/keychain-fireblocks@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      jose: 6.2.3
-    transitivePeerDependencies:
-      - "@solana/codecs-core"
-
-  "@solana/keychain-gcp-kms@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      google-auth-library: 10.7.0
-    transitivePeerDependencies:
-      - "@solana/codecs-core"
-      - "@solana/codecs-strings"
-      - supports-color
 
   "@solana/keychain-memory@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
     dependencies:
@@ -26129,96 +25344,6 @@ snapshots:
       "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
     transitivePeerDependencies:
       - "@solana/codecs-core"
-
-  "@solana/keychain-openfort@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - "@solana/codecs-core"
-
-  "@solana/keychain-para@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - "@solana/codecs-core"
-
-  "@solana/keychain-privy@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-core": 6.9.0(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-
-  "@solana/keychain-turnkey@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@noble/curves": 2.2.0
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-core": 6.9.0(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-
-  "@solana/keychain-utila@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      jose: 6.2.3
-    transitivePeerDependencies:
-      - "@solana/codecs-core"
-
-  "@solana/keychain-vault@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-core": 6.9.0(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-
-  "@solana/keychain@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
-    dependencies:
-      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/codecs-core": 6.9.0(typescript@5.8.3)
-      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/keychain-aws-kms": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-cdp": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-crossmint": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-dfns": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-fireblocks": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-gcp-kms": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-memory": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-openfort": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-para": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-privy": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-turnkey": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-utila": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-vault": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
-    transitivePeerDependencies:
-      - supports-color
 
   "@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)":
     dependencies:
@@ -27786,8 +26911,6 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
-  anynum@1.0.0: {}
-
   arg@4.1.3: {}
 
   arg@5.0.2: {}
@@ -27984,8 +27107,6 @@ snapshots:
       bn.js: 5.2.3
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
-
-  bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -29452,18 +28573,6 @@ snapshots:
 
   fast-uri@3.1.2: {}
 
-  fast-xml-builder@1.2.0:
-    dependencies:
-      path-expression-matcher: 1.5.0
-      xml-naming: 0.1.0
-
-  fast-xml-parser@5.7.3:
-    dependencies:
-      "@nodable/entities": 2.2.0
-      fast-xml-builder: 1.2.0
-      path-expression-matcher: 1.5.0
-      strnum: 2.4.0
-
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
   fastq@1.19.1:
@@ -29689,14 +28798,6 @@ snapshots:
       - encoding
       - supports-color
 
-  gaxios@7.1.5:
-    dependencies:
-      extend: 3.0.2
-      https-proxy-agent: 7.0.6
-      node-fetch: 3.3.2
-    transitivePeerDependencies:
-      - supports-color
-
   gcp-metadata@6.1.1:
     dependencies:
       gaxios: 6.7.1
@@ -29704,14 +28805,6 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
-      - supports-color
-
-  gcp-metadata@8.1.2:
-    dependencies:
-      gaxios: 7.1.5
-      google-logging-utils: 1.1.3
-      json-bigint: 1.0.0
-    transitivePeerDependencies:
       - supports-color
 
   gensync@1.0.0-beta.2: {}
@@ -29813,17 +28906,6 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
-  google-auth-library@10.7.0:
-    dependencies:
-      base64-js: 1.5.1
-      ecdsa-sig-formatter: 1.0.11
-      gaxios: 7.1.5
-      gcp-metadata: 8.1.2
-      google-logging-utils: 1.1.3
-      jws: 4.0.1
-    transitivePeerDependencies:
-      - supports-color
-
   google-auth-library@9.15.1:
     dependencies:
       base64-js: 1.5.1
@@ -29837,8 +28919,6 @@ snapshots:
       - supports-color
 
   google-logging-utils@0.0.2: {}
-
-  google-logging-utils@1.1.3: {}
 
   googleapis-common@7.2.0:
     dependencies:
@@ -30488,8 +29568,6 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.6.1: {}
-
-  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 
@@ -31856,8 +30934,6 @@ snapshots:
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
-
-  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -33377,10 +32453,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.4.0:
-    dependencies:
-      anynum: 1.0.0
-
   style-to-js@1.1.17:
     dependencies:
       style-to-object: 1.0.9
@@ -34583,8 +33655,6 @@ snapshots:
       sax: 1.4.1
 
   xml-name-validator@5.0.0: {}
-
-  xml-naming@0.1.0: {}
 
   xml2js@0.5.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,7 +77,7 @@ importers:
         version: 3.8.3
       turbo:
         specifier: latest
-        version: 2.9.15
+        version: 2.9.18
 
   apps/accelerate:
     dependencies:
@@ -131,7 +131,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -225,7 +225,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -388,7 +388,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-seo:
         specifier: ^6.6.0
         version: 6.8.0(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -569,7 +569,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -723,7 +723,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       nuqs:
         specifier: ^2.4.3
         version: 2.7.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6)
@@ -898,7 +898,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -1046,7 +1046,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: "catalog:"
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jsdom@26.1.0(bufferutil@4.1.0))(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
 
   packages/config-eslint:
     devDependencies:
@@ -1073,7 +1073,7 @@ importers:
         version: 5.2.0(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-turbo:
         specifier: ^2.8.21
-        version: 2.9.15(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.15)
+        version: 2.9.15(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.18)
       globals:
         specifier: ^15.15.0
         version: 15.15.0
@@ -1106,7 +1106,7 @@ importers:
       "@solana-program/token-2022":
         specifier: ^0.9.0
         version: 0.9.0(@solana/kit@6.9.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)(utf-8-validate@6.0.6))(@solana/sysvars@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
-      "@solana/keychain-memory":
+      "@solana/keychain":
         specifier: ^1.3.0
         version: 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
       "@solana/kit":
@@ -1206,7 +1206,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -1234,7 +1234,7 @@ importers:
         version: 5.8.3
       vitest:
         specifier: "catalog:"
-        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jsdom@26.1.0(bufferutil@4.1.0))(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
 
   packages/sentry:
     devDependencies:
@@ -1350,7 +1350,7 @@ importers:
         version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -1475,6 +1475,157 @@ packages:
       {
         integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==,
       }
+
+  "@aws-crypto/crc32@5.2.0":
+    resolution:
+      {
+        integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==,
+      }
+    engines: { node: ">=16.0.0" }
+
+  "@aws-crypto/sha256-browser@5.2.0":
+    resolution:
+      {
+        integrity: sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==,
+      }
+
+  "@aws-crypto/sha256-js@5.2.0":
+    resolution:
+      {
+        integrity: sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==,
+      }
+    engines: { node: ">=16.0.0" }
+
+  "@aws-crypto/supports-web-crypto@5.2.0":
+    resolution:
+      {
+        integrity: sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==,
+      }
+
+  "@aws-crypto/util@5.2.0":
+    resolution:
+      {
+        integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==,
+      }
+
+  "@aws-sdk/client-kms@3.1070.0":
+    resolution:
+      {
+        integrity: sha512-ELJH11w1IU0V5kqQ/eg2iu4HqaXOJQ/3nC8I7y93+mZW39osINlOHFKgYQNizwZA5KoSxSgVYmLPnnF/i0oKmw==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/core@3.974.21":
+    resolution:
+      {
+        integrity: sha512-P5JAHvn4dTi96UsAGS67LVOqqpUNNRhnfFXqzCYtdBIGZtqBue4CXvRr9YenOO7PALj/Pn8uuyw53FBCiCYw8w==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/credential-provider-env@3.972.47":
+    resolution:
+      {
+        integrity: sha512-3YoPwJczcc+MtX2xxXaYaOOWO6xKUJr1ZIIDIFuninr51BYONVVcF/CP8K2xfVRC/PztJjqKWxNGFH7BWQAw1Q==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/credential-provider-http@3.972.49":
+    resolution:
+      {
+        integrity: sha512-2UtGUPy+x3lqyceHrtC1uEuVxBZbDalPF6KAFqBwYgm4edWdBrZKNnCqzDs7KynWUvEC6mrR+ojRk+ZgQz9C2w==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/credential-provider-ini@3.972.54":
+    resolution:
+      {
+        integrity: sha512-Hx4gO4YRjFwitf3MVl3cDwYe1aryJthC4txVl9b+JAURovA50M2ywf9r8j1E/Q6SCTPT4qQpjOAbKYIC9CG+Vw==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/credential-provider-login@3.972.53":
+    resolution:
+      {
+        integrity: sha512-+71sluhkgPqdhbbD3UDwUpj24GCkng9HQx6z7qoBFb8dwkF4ktpOcVKDeHpgg8PvBgLYwAnUYLTEGRC/PniCiQ==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/credential-provider-node@3.972.56":
+    resolution:
+      {
+        integrity: sha512-iI+4o0dvQQ4NHel4FMDiFy5q2gaU/ryLK3niOsoPccAt9WLFRkV4XTYPWRr9XvmBUqEzXG73S4p/8gm0Lu/W3A==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/credential-provider-process@3.972.47":
+    resolution:
+      {
+        integrity: sha512-tAizPm9IFo/PHn06c+LQJlzfY2AGOlyF0CUljFejrU6LcZBjnk8pmbZK3/xoIDdnIzjEdbClfvY3mXfr818ZEg==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/credential-provider-sso@3.972.53":
+    resolution:
+      {
+        integrity: sha512-pUXE3fu4tfEDV8BksIgf4dXvuIH10FhwHMl/wu8rBD5T1sMpryQWFVitH3kdPS90wlgrGYJQ/meQTSPacyZfeg==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/credential-provider-web-identity@3.972.53":
+    resolution:
+      {
+        integrity: sha512-JmMGlhVvSj8uSG9CpeDkJAXT35H89tc6v84iMgEIE75q4yp1MKVVKvopv6Gg28HJIR7hMNkojRF8H2m5W44wyg==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/nested-clients@3.997.21":
+    resolution:
+      {
+        integrity: sha512-eC7Vl7Qom/BGhZjG9GEqPwdQ/fk45hg1t5LP4EUxG5d1fdshLbaxCiwh/tszUzDX/4mW40mu2QsbeJJRPBbqUw==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/signature-v4-multi-region@3.996.35":
+    resolution:
+      {
+        integrity: sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/token-providers@3.1069.0":
+    resolution:
+      {
+        integrity: sha512-ks4X+kngC3PA5howV7Qu1TgG4bfC4jPykKdvw3nmBSXR9yZxRJouBholFSNQ5kY3L+Fgwyw+LCjzQmNi+KR91g==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/types@3.973.13":
+    resolution:
+      {
+        integrity: sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/util-locate-window@3.965.8":
+    resolution:
+      {
+        integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws-sdk/xml-builder@3.972.30":
+    resolution:
+      {
+        integrity: sha512-StElZPEoBquWwNqw1AcfpzEyZqJvFxouG+mpDNYlcH6ZOrqd2CuIryv+8LV8gNHZUOyKyJF3Dq9vxaXEmDR9TQ==,
+      }
+    engines: { node: ">=20.0.0" }
+
+  "@aws/lambda-invoke-store@0.2.4":
+    resolution:
+      {
+        integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==,
+      }
+    engines: { node: ">=18.0.0" }
 
   "@babel/code-frame@7.27.1":
     resolution:
@@ -4887,6 +5038,13 @@ packages:
       }
     engines: { node: ^14.21.3 || >=16 }
 
+  "@noble/curves@2.2.0":
+    resolution:
+      {
+        integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==,
+      }
+    engines: { node: ">= 20.19.0" }
+
   "@noble/ed25519@1.7.5":
     resolution:
       {
@@ -4905,6 +5063,19 @@ packages:
         integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==,
       }
     engines: { node: ^14.21.3 || >=16 }
+
+  "@noble/hashes@2.2.0":
+    resolution:
+      {
+        integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==,
+      }
+    engines: { node: ">= 20.19.0" }
+
+  "@nodable/entities@2.2.0":
+    resolution:
+      {
+        integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==,
+      }
 
   "@nodelib/fs.scandir@2.1.5":
     resolution:
@@ -7946,6 +8117,69 @@ packages:
       }
     engines: { node: ">=12" }
 
+  "@smithy/core@3.25.0":
+    resolution:
+      {
+        integrity: sha512-TTD6el7tvKyafkXBf7XO3jLOE+qVxOTrLjp/fEGiV3BMfUHK/LfdYlQO9YgZvzxC7kqA3H/IhJXNqQgnbgjb7A==,
+      }
+    engines: { node: ">=18.0.0" }
+
+  "@smithy/credential-provider-imds@4.4.0":
+    resolution:
+      {
+        integrity: sha512-pPQmNdEvMJttv9z2kdYxoui83p/nr32zjMf0aMfmzmGmFEgKXUfy0vXiNg0fx4R5XLQzmJBLM9Wg0guEq2/q8A==,
+      }
+    engines: { node: ">=18.0.0" }
+
+  "@smithy/fetch-http-handler@5.5.0":
+    resolution:
+      {
+        integrity: sha512-OG8kBYAgX7lf32+xLzgirvuLffn1KNoszaSiButt45i2cRa5irk8LQXLYQ5Smij1SBTN4KMNcBsRwRrLPfIGyA==,
+      }
+    engines: { node: ">=18.0.0" }
+
+  "@smithy/is-array-buffer@2.2.0":
+    resolution:
+      {
+        integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==,
+      }
+    engines: { node: ">=14.0.0" }
+
+  "@smithy/node-http-handler@4.8.0":
+    resolution:
+      {
+        integrity: sha512-Mq7TNt/VhlEWiYRLQGpzUWeUxh899UGpjKh7Ru0WVIDIjnE+cTRAn0NYlFQ6bWfsQnKnpCbWJj86HzmcG0qEdg==,
+      }
+    engines: { node: ">=18.0.0" }
+
+  "@smithy/signature-v4@5.5.0":
+    resolution:
+      {
+        integrity: sha512-vW6UdK7e7gV2wU/tXRsPq4pMQMusb8VymdVOyIFNA1FtyRmEClRFkYDtYI8UcO/HM0wK3qqjvvQs3HOlbgMbdg==,
+      }
+    engines: { node: ">=18.0.0" }
+
+  "@smithy/types@4.15.0":
+    resolution:
+      {
+        integrity: sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==,
+      }
+    engines: { node: ">=18.0.0" }
+
+  "@smithy/util-buffer-from@2.2.0":
+    resolution:
+      {
+        integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==,
+      }
+    engines: { node: ">=14.0.0" }
+
+  "@smithy/util-utf8@2.3.0":
+    resolution:
+      {
+        integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==,
+      }
+    engines: { node: ">=14.0.0" }
+
   "@solana-foundation/solana-lib@2.41.0":
     resolution:
       {
@@ -8261,6 +8495,30 @@ packages:
       typescript:
         optional: true
 
+  "@solana/keychain-aws-kms@1.3.0":
+    resolution:
+      {
+        integrity: sha512-8AEluPCptebRumZ7j/kZVpnqFWY7Ot4Uf5zg0Cyj2ywlD1W5e79BVwYd/Abo5s0rKKt7/du7bKIWO2Opxmtsvg==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-cdp@1.3.0":
+    resolution:
+      {
+        integrity: sha512-OupkRqt+hBOotdKh47wSAnMLch84fS5WsZ2T9pn7oUPPpU6yL/0uBjpA6Ck3W6/XcCA30W7ZOG+YkdQmEWzuow==,
+      }
+    engines: { node: ">=19" }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
   "@solana/keychain-core@1.3.0":
     resolution:
       {
@@ -8274,6 +8532,53 @@ packages:
       "@solana/signers": ">=6.0.1"
       "@solana/transactions": ">=6.0.1"
 
+  "@solana/keychain-crossmint@1.3.0":
+    resolution:
+      {
+        integrity: sha512-yqIZNov32A6Xzu9CP5e1oXJjfoZvpx8yxMs9YuAWBthiEEZmcn3Vpc+scm0+hPvG9I2nnsDx8znvBO5x5Klrlg==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-dfns@1.3.0":
+    resolution:
+      {
+        integrity: sha512-5ba2PnodtUwgjTq847qD5oRzqemGSxlhbzTlJQjQT8k9zo46JlBzphFCOCRDUeQlIddsuKrSZoxv40dgt58FTQ==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-fireblocks@1.3.0":
+    resolution:
+      {
+        integrity: sha512-OhmmS6Dl+T4oPLMjGYlYU4ktO11U6AFxTTRsTmXXkAIPiFjmkdHikAGC9IntzWx8EaUgkOnIZoD6HojQZlqcXg==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-gcp-kms@1.3.0":
+    resolution:
+      {
+        integrity: sha512-pN4gwD3kSmNLaFd4VA5eU/+1XoyB3agTr6cIb8blH1Haw06JqYwgSQLP3fVTc628vsN4YBF9uyzXV+Ye9Wub/g==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
   "@solana/keychain-memory@1.3.0":
     resolution:
       {
@@ -8281,6 +8586,95 @@ packages:
       }
     peerDependencies:
       "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-openfort@1.3.0":
+    resolution:
+      {
+        integrity: sha512-46NYBokdI9caJe+EN41m9B0l80y8CXvxX/U8VidIhyToV/5JbGmFJyHUXUNKX9jJpowTnkFd8Po7mZi9rlC3Ug==,
+      }
+    engines: { node: ">=19" }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-para@1.3.0":
+    resolution:
+      {
+        integrity: sha512-pp6KcIqxUHY5O4AynLedc+GMe8JUzBJU6tzIQy1soBYZURtyld4mWjkQ9xAotbYpLXg0aJnKaQIW5xGQFfGO/w==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-privy@1.3.0":
+    resolution:
+      {
+        integrity: sha512-NhmQ9m6iSi3Rn3ZGuCLJYwXKe3KXJtXDa07GSQScwovPHgr+X3pHRRNqvcrots7YvBsSuCPQlBzJPhCNkpurIQ==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-core": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-turnkey@1.3.0":
+    resolution:
+      {
+        integrity: sha512-HyyYgjXSggbc3CujccNtpLa/cfVkoYYYlF9YE1Ty41JUEFUEmM48SO9bxpvYQtayLcwrB1WVKK7WryjMgcuBgg==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-core": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-utila@1.3.0":
+    resolution:
+      {
+        integrity: sha512-saZuRoFyCukgbrYqvzGTdt3/bZANDwUrUobjdp4V/QjnsUrU4cvcIVs9rb0ck/yZQVY+q8WzR0fHz5RfKodD7w==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain-vault@1.3.0":
+    resolution:
+      {
+        integrity: sha512-8AdMQ8iZX1fGalG57EmbUljFZ49fEO+QyGboO/rMb081uJG0OidrOPnG2zrRiTU621eR+Pkp297iL3Vt5w8iQQ==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-core": ">=6.0.1"
+      "@solana/codecs-strings": ">=6.0.1"
+      "@solana/keys": ">=6.0.1"
+      "@solana/signers": ">=6.0.1"
+      "@solana/transactions": ">=6.0.1"
+
+  "@solana/keychain@1.3.0":
+    resolution:
+      {
+        integrity: sha512-zkxeNyyZxnYtgEwXWzaZrrdTMv7dnPz4pN5IhYsmVUyYWou8+e77l9NnLQOdhbXlOBYaya7m1JS4WMDNT1HATg==,
+      }
+    peerDependencies:
+      "@solana/addresses": ">=6.0.1"
+      "@solana/codecs-core": ">=6.0.1"
       "@solana/codecs-strings": ">=6.0.1"
       "@solana/keys": ">=6.0.1"
       "@solana/signers": ">=6.0.1"
@@ -9213,18 +9607,18 @@ packages:
         integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==,
       }
 
-  "@turbo/darwin-64@2.9.15":
+  "@turbo/darwin-64@2.9.18":
     resolution:
       {
-        integrity: sha512-nnDo9R1Df+s2x6jxlERtbg7xRpuicf8p4J2krcnjeaMBt3q9V41pGXa4t9YM2Y4ozozsVJ+CH405CJUrWIQK4Q==,
+        integrity: sha512-9f27peFu16ur8c0v9nUFUEyBnbKuuFsUTjHFWfmwGfzySBXbHwzU44QhZon6Mznz0cHsIr3984NQj/bVrnGSRw==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@turbo/darwin-arm64@2.9.15":
+  "@turbo/darwin-arm64@2.9.18":
     resolution:
       {
-        integrity: sha512-fDSx56oqoFuS+yUQw7hqjQTkjrSLdMcplhuLC8HcSkWC6YrpwEmUUYsPYHPxy4ALvLxnmPQuk6XoSD8tdkjP+g==,
+        integrity: sha512-9A6TMRq/Ib+QnbhLlgkhOm+624wO4pzSQ/yQviQfWHOlFvaYxdnIAYmu2H6TS6y7kSVL0DvzNe04NbESTOzFVQ==,
       }
     cpu: [arm64]
     os: [darwin]
@@ -9236,34 +9630,34 @@ packages:
       }
     hasBin: true
 
-  "@turbo/linux-64@2.9.15":
+  "@turbo/linux-64@2.9.18":
     resolution:
       {
-        integrity: sha512-/bmxn+x/xE+oh0VzEXt/zf2zsORAYZPrL3db5/VrXzYt0Z4wxcvffwJBGlSfla2smfS1BLGBiyWldJlWDXJVXA==,
+        integrity: sha512-zCdIDtz69AnbYh913elJRRoF3QY5aa2HNnf+4rAkc7bQ+tWujiDkCNV7stazOUPggaDvhKIf2Z87qHftTeXSkw==,
       }
     cpu: [x64]
     os: [linux]
 
-  "@turbo/linux-arm64@2.9.15":
+  "@turbo/linux-arm64@2.9.18":
     resolution:
       {
-        integrity: sha512-cbOaDe1ijz5As+mimOOHgmRMolZZZO7miNBHHp5xdiYMm2Q/Dwu1JVLx/Kw4s7xjocG/oEoHrpHrxpEAIEfNiw==,
+        integrity: sha512-Va1kXI04naMgYwqv/5Dfa36dTDx8015U7oaQAjrXa45ua9OoFjSV4OmvkML4EmXvUclQHCiBRbY8bvd0jV7eAg==,
       }
     cpu: [arm64]
     os: [linux]
 
-  "@turbo/windows-64@2.9.15":
+  "@turbo/windows-64@2.9.18":
     resolution:
       {
-        integrity: sha512-/Fzm7afui7uK7dFBwrTXKuDhBBTiHk5I+hMVAPMR7cqQyDo2norCNUsN9PdNuYcmzYbhSOxzz498wQYvSAz29w==,
+        integrity: sha512-m0kDhZANxSNz9ck1ybogFscHabriAsp4eDFNrN/1H5WrgTF7b3VlcPZnhuO3v2+E2KnCbeAc+UUT10BZZHdDKw==,
       }
     cpu: [x64]
     os: [win32]
 
-  "@turbo/windows-arm64@2.9.15":
+  "@turbo/windows-arm64@2.9.18":
     resolution:
       {
-        integrity: sha512-fOHEsLcqVdFXLw2ApWv4gxwfHzkUnpo9rHGml+9+dyHj148m/Bc+556kEvb5+4u6prI1LMd8zEZE2HcO6Jn2VQ==,
+        integrity: sha512-nUdR8WqoomUys9iIQmG45TMiizJ+5BV8egSeLLZba/AWblyp3fVBcIH1kSE58OtK4g2YzbMJEth6Ttv9w5rqMA==,
       }
     cpu: [arm64]
     os: [win32]
@@ -10426,6 +10820,12 @@ packages:
       }
     engines: { node: ">= 8" }
 
+  anynum@1.0.0:
+    resolution:
+      {
+        integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==,
+      }
+
   arg@4.1.3:
     resolution:
       {
@@ -10728,6 +11128,12 @@ packages:
     resolution:
       {
         integrity: sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==,
+      }
+
+  bowser@2.14.1:
+    resolution:
+      {
+        integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==,
       }
 
   brace-expansion@1.1.12:
@@ -12890,6 +13296,19 @@ packages:
         integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
       }
 
+  fast-xml-builder@1.2.0:
+    resolution:
+      {
+        integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==,
+      }
+
+  fast-xml-parser@5.7.3:
+    resolution:
+      {
+        integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==,
+      }
+    hasBin: true
+
   fastestsmallesttextencoderdecoder@1.0.22:
     resolution:
       {
@@ -13207,12 +13626,26 @@ packages:
       }
     engines: { node: ">=14" }
 
+  gaxios@7.1.5:
+    resolution:
+      {
+        integrity: sha512-5FZy72Rh8LhtjmvDrKkI+lVhrsQrVKVsItxMoDm5mNQE+xR0WVIIs+jzPSJgBvKVsLi24fZhXJIsNI0bihDzFg==,
+      }
+    engines: { node: ">=18" }
+
   gcp-metadata@6.1.1:
     resolution:
       {
         integrity: sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==,
       }
     engines: { node: ">=14" }
+
+  gcp-metadata@8.1.2:
+    resolution:
+      {
+        integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==,
+      }
+    engines: { node: ">=18" }
 
   gensync@1.0.0-beta.2:
     resolution:
@@ -13366,6 +13799,13 @@ packages:
       }
     engines: { node: ">=8" }
 
+  google-auth-library@10.7.0:
+    resolution:
+      {
+        integrity: sha512-QpTAbNJ36TliZLx3TTtahR8HG0hN9RllL1e3FymOvQSIKK8JmgV58H924ub2wa2DsS3ANjjP1Aw1N+Ramc8hqQ==,
+      }
+    engines: { node: ">=18" }
+
   google-auth-library@9.15.1:
     resolution:
       {
@@ -13377,6 +13817,13 @@ packages:
     resolution:
       {
         integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==,
+      }
+    engines: { node: ">=14" }
+
+  google-logging-utils@1.1.3:
+    resolution:
+      {
+        integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==,
       }
     engines: { node: ">=14" }
 
@@ -14369,6 +14816,12 @@ packages:
         integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==,
       }
     hasBin: true
+
+  jose@6.2.3:
+    resolution:
+      {
+        integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==,
+      }
 
   joycon@3.1.1:
     resolution:
@@ -16224,6 +16677,13 @@ packages:
         integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
       }
     engines: { node: ">=8" }
+
+  path-expression-matcher@1.5.0:
+    resolution:
+      {
+        integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==,
+      }
+    engines: { node: ">=14.0.0" }
 
   path-is-absolute@1.0.1:
     resolution:
@@ -18306,6 +18766,12 @@ packages:
       }
     engines: { node: ">=8" }
 
+  strnum@2.4.0:
+    resolution:
+      {
+        integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==,
+      }
+
   style-to-js@1.1.17:
     resolution:
       {
@@ -18926,10 +19392,10 @@ packages:
     engines: { node: ">=18.0.0" }
     hasBin: true
 
-  turbo@2.9.15:
+  turbo@2.9.18:
     resolution:
       {
-        integrity: sha512-VpKvD9Z0Hu/xrGUAYX1wnhfpqv835wIwGqeKfulvBPTOcDap0E3nFwyzCAVV85fB1sBcBDEfTP+7FSW7GzwWSQ==,
+        integrity: sha512-bwabv6PupzeavybzEoArBAkwq5fnzwf8OFnRtpHwnviFWuwJPFxtyH+aVp36TmIqK3aYYgtTJ3J0m2ysxxSzQg==,
       }
     hasBin: true
 
@@ -19937,6 +20403,13 @@ packages:
       }
     engines: { node: ">=18" }
 
+  xml-naming@0.1.0:
+    resolution:
+      {
+        integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==,
+      }
+    engines: { node: ">=16.0.0" }
+
   xml2js@0.5.0:
     resolution:
       {
@@ -20144,6 +20617,192 @@ snapshots:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
       lru-cache: 10.4.3
+
+  "@aws-crypto/crc32@5.2.0":
+    dependencies:
+      "@aws-crypto/util": 5.2.0
+      "@aws-sdk/types": 3.973.13
+      tslib: 2.8.1
+
+  "@aws-crypto/sha256-browser@5.2.0":
+    dependencies:
+      "@aws-crypto/sha256-js": 5.2.0
+      "@aws-crypto/supports-web-crypto": 5.2.0
+      "@aws-crypto/util": 5.2.0
+      "@aws-sdk/types": 3.973.13
+      "@aws-sdk/util-locate-window": 3.965.8
+      "@smithy/util-utf8": 2.3.0
+      tslib: 2.8.1
+
+  "@aws-crypto/sha256-js@5.2.0":
+    dependencies:
+      "@aws-crypto/util": 5.2.0
+      "@aws-sdk/types": 3.973.13
+      tslib: 2.8.1
+
+  "@aws-crypto/supports-web-crypto@5.2.0":
+    dependencies:
+      tslib: 2.8.1
+
+  "@aws-crypto/util@5.2.0":
+    dependencies:
+      "@aws-sdk/types": 3.973.13
+      "@smithy/util-utf8": 2.3.0
+      tslib: 2.8.1
+
+  "@aws-sdk/client-kms@3.1070.0":
+    dependencies:
+      "@aws-crypto/sha256-browser": 5.2.0
+      "@aws-crypto/sha256-js": 5.2.0
+      "@aws-sdk/core": 3.974.21
+      "@aws-sdk/credential-provider-node": 3.972.56
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/fetch-http-handler": 5.5.0
+      "@smithy/node-http-handler": 4.8.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/core@3.974.21":
+    dependencies:
+      "@aws-sdk/types": 3.973.13
+      "@aws-sdk/xml-builder": 3.972.30
+      "@aws/lambda-invoke-store": 0.2.4
+      "@smithy/core": 3.25.0
+      "@smithy/signature-v4": 5.5.0
+      "@smithy/types": 4.15.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  "@aws-sdk/credential-provider-env@3.972.47":
+    dependencies:
+      "@aws-sdk/core": 3.974.21
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/credential-provider-http@3.972.49":
+    dependencies:
+      "@aws-sdk/core": 3.974.21
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/fetch-http-handler": 5.5.0
+      "@smithy/node-http-handler": 4.8.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/credential-provider-ini@3.972.54":
+    dependencies:
+      "@aws-sdk/core": 3.974.21
+      "@aws-sdk/credential-provider-env": 3.972.47
+      "@aws-sdk/credential-provider-http": 3.972.49
+      "@aws-sdk/credential-provider-login": 3.972.53
+      "@aws-sdk/credential-provider-process": 3.972.47
+      "@aws-sdk/credential-provider-sso": 3.972.53
+      "@aws-sdk/credential-provider-web-identity": 3.972.53
+      "@aws-sdk/nested-clients": 3.997.21
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/credential-provider-imds": 4.4.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/credential-provider-login@3.972.53":
+    dependencies:
+      "@aws-sdk/core": 3.974.21
+      "@aws-sdk/nested-clients": 3.997.21
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/credential-provider-node@3.972.56":
+    dependencies:
+      "@aws-sdk/credential-provider-env": 3.972.47
+      "@aws-sdk/credential-provider-http": 3.972.49
+      "@aws-sdk/credential-provider-ini": 3.972.54
+      "@aws-sdk/credential-provider-process": 3.972.47
+      "@aws-sdk/credential-provider-sso": 3.972.53
+      "@aws-sdk/credential-provider-web-identity": 3.972.53
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/credential-provider-imds": 4.4.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/credential-provider-process@3.972.47":
+    dependencies:
+      "@aws-sdk/core": 3.974.21
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/credential-provider-sso@3.972.53":
+    dependencies:
+      "@aws-sdk/core": 3.974.21
+      "@aws-sdk/nested-clients": 3.997.21
+      "@aws-sdk/token-providers": 3.1069.0
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/credential-provider-web-identity@3.972.53":
+    dependencies:
+      "@aws-sdk/core": 3.974.21
+      "@aws-sdk/nested-clients": 3.997.21
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/nested-clients@3.997.21":
+    dependencies:
+      "@aws-crypto/sha256-browser": 5.2.0
+      "@aws-crypto/sha256-js": 5.2.0
+      "@aws-sdk/core": 3.974.21
+      "@aws-sdk/signature-v4-multi-region": 3.996.35
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/fetch-http-handler": 5.5.0
+      "@smithy/node-http-handler": 4.8.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/signature-v4-multi-region@3.996.35":
+    dependencies:
+      "@aws-sdk/types": 3.973.13
+      "@smithy/signature-v4": 5.5.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/token-providers@3.1069.0":
+    dependencies:
+      "@aws-sdk/core": 3.974.21
+      "@aws-sdk/nested-clients": 3.997.21
+      "@aws-sdk/types": 3.973.13
+      "@smithy/core": 3.25.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/types@3.973.13":
+    dependencies:
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@aws-sdk/util-locate-window@3.965.8":
+    dependencies:
+      tslib: 2.8.1
+
+  "@aws-sdk/xml-builder@3.972.30":
+    dependencies:
+      "@smithy/types": 4.15.0
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
+  "@aws/lambda-invoke-store@0.2.4": {}
 
   "@babel/code-frame@7.27.1":
     dependencies:
@@ -22462,11 +23121,19 @@ snapshots:
     dependencies:
       "@noble/hashes": 1.8.0
 
+  "@noble/curves@2.2.0":
+    dependencies:
+      "@noble/hashes": 2.2.0
+
   "@noble/ed25519@1.7.5": {}
 
   "@noble/hashes@1.1.5": {}
 
   "@noble/hashes@1.8.0": {}
+
+  "@noble/hashes@2.2.0": {}
+
+  "@nodable/entities@2.2.0": {}
 
   "@nodelib/fs.scandir@2.1.5":
     dependencies:
@@ -25085,6 +25752,54 @@ snapshots:
     dependencies:
       escape-string-regexp: 5.0.0
 
+  "@smithy/core@3.25.0":
+    dependencies:
+      "@aws-crypto/crc32": 5.2.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@smithy/credential-provider-imds@4.4.0":
+    dependencies:
+      "@smithy/core": 3.25.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@smithy/fetch-http-handler@5.5.0":
+    dependencies:
+      "@smithy/core": 3.25.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@smithy/is-array-buffer@2.2.0":
+    dependencies:
+      tslib: 2.8.1
+
+  "@smithy/node-http-handler@4.8.0":
+    dependencies:
+      "@smithy/core": 3.25.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@smithy/signature-v4@5.5.0":
+    dependencies:
+      "@smithy/core": 3.25.0
+      "@smithy/types": 4.15.0
+      tslib: 2.8.1
+
+  "@smithy/types@4.15.0":
+    dependencies:
+      tslib: 2.8.1
+
+  "@smithy/util-buffer-from@2.2.0":
+    dependencies:
+      "@smithy/is-array-buffer": 2.2.0
+      tslib: 2.8.1
+
+  "@smithy/util-utf8@2.3.0":
+    dependencies:
+      "@smithy/util-buffer-from": 2.2.0
+      tslib: 2.8.1
+
   "@solana-foundation/solana-lib@2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@radix-ui/react-tooltip": 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -25325,6 +26040,29 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
+  "@solana/keychain-aws-kms@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@aws-sdk/client-kms": 3.1070.0
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - "@solana/codecs-core"
+      - "@solana/codecs-strings"
+
+  "@solana/keychain-cdp@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - "@solana/codecs-core"
+
   "@solana/keychain-core@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
     dependencies:
       "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -25333,6 +26071,53 @@ snapshots:
       "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
       "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+
+  "@solana/keychain-crossmint@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - "@solana/codecs-core"
+
+  "@solana/keychain-dfns@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - "@solana/codecs-core"
+
+  "@solana/keychain-fireblocks@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      jose: 6.2.3
+    transitivePeerDependencies:
+      - "@solana/codecs-core"
+
+  "@solana/keychain-gcp-kms@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      google-auth-library: 10.7.0
+    transitivePeerDependencies:
+      - "@solana/codecs-core"
+      - "@solana/codecs-strings"
+      - supports-color
 
   "@solana/keychain-memory@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
     dependencies:
@@ -25344,6 +26129,96 @@ snapshots:
       "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
     transitivePeerDependencies:
       - "@solana/codecs-core"
+
+  "@solana/keychain-openfort@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - "@solana/codecs-core"
+
+  "@solana/keychain-para@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - "@solana/codecs-core"
+
+  "@solana/keychain-privy@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-core": 6.9.0(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+
+  "@solana/keychain-turnkey@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@noble/curves": 2.2.0
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-core": 6.9.0(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+
+  "@solana/keychain-utila@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      jose: 6.2.3
+    transitivePeerDependencies:
+      - "@solana/codecs-core"
+
+  "@solana/keychain-vault@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-core": 6.9.0(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+
+  "@solana/keychain@1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))":
+    dependencies:
+      "@solana/addresses": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/codecs-core": 6.9.0(typescript@5.8.3)
+      "@solana/codecs-strings": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/keychain-aws-kms": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-cdp": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-core": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-crossmint": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-dfns": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-fireblocks": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-gcp-kms": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-memory": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-openfort": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-para": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-privy": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-turnkey": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-utila": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keychain-vault": 1.3.0(@solana/addresses@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/codecs-core@6.9.0(typescript@5.8.3))(@solana/codecs-strings@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/signers@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))(@solana/transactions@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3))
+      "@solana/keys": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/signers": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+      "@solana/transactions": 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
+    transitivePeerDependencies:
+      - supports-color
 
   "@solana/keys@6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)":
     dependencies:
@@ -26094,10 +26969,10 @@ snapshots:
 
   "@tsconfig/node16@1.0.4": {}
 
-  "@turbo/darwin-64@2.9.15":
+  "@turbo/darwin-64@2.9.18":
     optional: true
 
-  "@turbo/darwin-arm64@2.9.15":
+  "@turbo/darwin-arm64@2.9.18":
     optional: true
 
   "@turbo/gen@2.5.8(@swc/core@1.15.40(@swc/helpers@0.5.17))(@types/node@24.6.2)(typescript@5.9.2)":
@@ -26120,16 +26995,16 @@ snapshots:
       - supports-color
       - typescript
 
-  "@turbo/linux-64@2.9.15":
+  "@turbo/linux-64@2.9.18":
     optional: true
 
-  "@turbo/linux-arm64@2.9.15":
+  "@turbo/linux-arm64@2.9.18":
     optional: true
 
-  "@turbo/windows-64@2.9.15":
+  "@turbo/windows-64@2.9.18":
     optional: true
 
-  "@turbo/windows-arm64@2.9.15":
+  "@turbo/windows-arm64@2.9.18":
     optional: true
 
   "@turbo/workspaces@2.5.8(@types/node@24.6.2)":
@@ -26911,6 +27786,8 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.2
 
+  anynum@1.0.0: {}
+
   arg@4.1.3: {}
 
   arg@5.0.2: {}
@@ -27107,6 +27984,8 @@ snapshots:
       bn.js: 5.2.3
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.12:
     dependencies:
@@ -28371,11 +29250,11 @@ snapshots:
       string.prototype.matchall: 4.0.12
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-turbo@2.9.15(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.15):
+  eslint-plugin-turbo@2.9.15(eslint@9.39.4(jiti@2.6.1))(turbo@2.9.18):
     dependencies:
       dotenv: 16.0.3
       eslint: 9.39.4(jiti@2.6.1)
-      turbo: 2.9.15
+      turbo: 2.9.18
 
   eslint-scope@5.1.1:
     dependencies:
@@ -28572,6 +29451,18 @@ snapshots:
   fast-stable-stringify@1.0.0: {}
 
   fast-uri@3.1.2: {}
+
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      "@nodable/entities": 2.2.0
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.0
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
@@ -28798,6 +29689,14 @@ snapshots:
       - encoding
       - supports-color
 
+  gaxios@7.1.5:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
   gcp-metadata@6.1.1:
     dependencies:
       gaxios: 6.7.1
@@ -28805,6 +29704,14 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - encoding
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.5
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
       - supports-color
 
   gensync@1.0.0-beta.2: {}
@@ -28906,6 +29813,17 @@ snapshots:
       merge2: 1.4.1
       slash: 3.0.0
 
+  google-auth-library@10.7.0:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.5
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   google-auth-library@9.15.1:
     dependencies:
       base64-js: 1.5.1
@@ -28919,6 +29837,8 @@ snapshots:
       - supports-color
 
   google-logging-utils@0.0.2: {}
+
+  google-logging-utils@1.1.3: {}
 
   googleapis-common@7.2.0:
     dependencies:
@@ -29568,6 +30488,8 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.6.1: {}
+
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 
@@ -30521,7 +31443,7 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.0: {}
 
-  next-intl@4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
+  next-intl@4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
     dependencies:
       "@formatjs/intl-localematcher": 0.8.9
       "@parcel/watcher": 2.5.1
@@ -30934,6 +31856,8 @@ snapshots:
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
+
+  path-expression-matcher@1.5.0: {}
 
   path-is-absolute@1.0.1: {}
 
@@ -32453,6 +33377,10 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strnum@2.4.0:
+    dependencies:
+      anynum: 1.0.0
+
   style-to-js@1.1.17:
     dependencies:
       style-to-object: 1.0.9
@@ -32858,14 +33786,14 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  turbo@2.9.15:
+  turbo@2.9.18:
     optionalDependencies:
-      "@turbo/darwin-64": 2.9.15
-      "@turbo/darwin-arm64": 2.9.15
-      "@turbo/linux-64": 2.9.15
-      "@turbo/linux-arm64": 2.9.15
-      "@turbo/windows-64": 2.9.15
-      "@turbo/windows-arm64": 2.9.15
+      "@turbo/darwin-64": 2.9.18
+      "@turbo/darwin-arm64": 2.9.18
+      "@turbo/linux-64": 2.9.18
+      "@turbo/linux-arm64": 2.9.18
+      "@turbo/windows-64": 2.9.18
+      "@turbo/windows-arm64": 2.9.18
 
   tw-animate-css@1.4.0: {}
 
@@ -33293,7 +34221,7 @@ snapshots:
       tsx: 4.22.3
       yaml: 2.8.1
 
-  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)):
+  vitest@4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.1)(jsdom@26.1.0(bufferutil@4.1.0))(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1)):
     dependencies:
       "@vitest/expect": 4.1.8
       "@vitest/mocker": 4.1.8(vite@7.3.2(@types/node@22.18.1)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.3)(yaml@2.8.1))
@@ -33655,6 +34583,8 @@ snapshots:
       sax: 1.4.1
 
   xml-name-validator@5.0.0: {}
+
+  xml-naming@0.1.0: {}
 
   xml2js@0.5.0:
     dependencies:


### PR DESCRIPTION
Increase awareness and adoption of Solana Keychain as the production signing tool: add the missing "how to sign in production" guidance, surface keychain at high-traffic touchpoints, and sync stale backend lists to all 13 (adds Openfort + Utila).

## Changes

**Docs — core + awareness**
- New concept page: **Signing in Production** (`core/transactions`)
- New keychain pages: **Choosing a backend**, **Production best practices**
- Upgraded keychain overview — 13 backends, custody framing, sub-page cards
- Cross-linked keychain from quick-start, transaction structure, production-readiness, client SDKs (JS + Rust), frontend, and cookbook keypair recipes

**Cookbook + AI discoverability**
- New **Sign with Keychain** recipe + runnable in-memory example (`docs-examples`, type-checked)
- Surfaced the new signing pages in `llms.txt` (via the generator)

**Enterprise solutions page**
- Custody FAQ links to keychain and notes it in the answer
- Added a **Keychain** resource card

Closes TOO-508 TOO-521 TOO-522 TOO-523