### PR TITLE
Update privacy ecosystem projects

### DIFF
--- a/apps/web/src/app/[locale]/privacy/privacy-page.tsx
+++ b/apps/web/src/app/[locale]/privacy/privacy-page.tsx
@@ -48,16 +48,17 @@ interface PrivacyPageProps {
 }
 
 const PROJECT_PRIVACY_TYPES: Record<string, string> = {
+  arcane: "confidential",
   contra: "fullyPrivate",
   encrypt: "fullyPrivate",
+  heliusPrivacyProtocol: "fullyPrivate",
   privacyCash: "anonymous",
-  silentSwap: "anonymous",
   encifher: "confidential",
+  ligero: "confidential",
   magicBlock: "fullyPrivate",
   lightProtocol: "anonymous",
   arcium: "fullyPrivate",
   inco: "fullyPrivate",
-  zama: "fullyPrivate",
   confidentialTransfer: "confidential",
 };
 
@@ -69,16 +70,17 @@ const BADGE_FOR_TYPE: Record<string, { className: string; label: string }> = {
 };
 
 const PROJECT_META_TAGS: Record<string, string> = {
+  arcane: "FIN",
   arcium: "MPC",
   contra: "E2E",
   encifher: "DEFI",
   encrypt: "INFRA",
+  heliusPrivacyProtocol: "ZK",
   inco: "FHE",
+  ligero: "ZK",
   lightProtocol: "ZK",
   magicBlock: "GAME",
   privacyCash: "TX",
-  silentSwap: "SWAP",
-  zama: "FHE",
   confidentialTransfer: "CT-EXT",
 };
 
@@ -516,9 +518,11 @@ function Ticker() {
       <em>Encrypted&nbsp;Identity</em>
       <span className="pp-star">✦</span>
       Private&nbsp;DAO<span className="pp-star">✦</span>
-      <em>Zama&nbsp;FHE</em>
+      <em>Helius&nbsp;Privacy</em>
       <span className="pp-star">✦</span>
-      SilentSwap<span className="pp-star">✦</span>
+      Arcane<span className="pp-star">✦</span>
+      <em>Ligero&nbsp;ZK</em>
+      <span className="pp-star">✦</span>
     </span>
   );
 

--- a/apps/web/src/data/solutions/privacy.ts
+++ b/apps/web/src/data/solutions/privacy.ts
@@ -1,5 +1,9 @@
 export const ECOSYSTEM_PROJECTS = [
   {
+    key: "arcane",
+    href: "https://arcane.finance/",
+  },
+  {
     key: "arcium",
     href: "https://arcium.com",
   },
@@ -20,8 +24,16 @@ export const ECOSYSTEM_PROJECTS = [
     href: "https://encrypt.xyz",
   },
   {
+    key: "heliusPrivacyProtocol",
+    href: "https://x.com/HeliusPrivacy",
+  },
+  {
     key: "inco",
     href: "https://inco.org",
+  },
+  {
+    key: "ligero",
+    href: "https://ligero-inc.com/",
   },
   {
     key: "lightProtocol",
@@ -34,13 +46,5 @@ export const ECOSYSTEM_PROJECTS = [
   {
     key: "privacyCash",
     href: "https://privacy.cash",
-  },
-  {
-    key: "silentSwap",
-    href: "https://silentswap.com",
-  },
-  {
-    key: "zama",
-    href: "https://zama.ai",
   },
 ];

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -10275,156 +10275,158 @@
   },
   "privacy": {
     "title": "Privacy on Solana | Confidential Transactions & Zero-Knowledge Proofs",
-    "description": "Explore the spectrum of privacy on Solana, from pseudonymous transactions to fully private computation. Learn about Confidential Token Extensions, zero-knowledge proofs, and the ecosystem of privacy tools.",
+    "description": "Explore privacy on Solana, from public accounts to encrypted computation. Learn about Confidential Token Extensions, ZK proofs, and privacy projects.",
     "hero": {
       "title": "Privacy on Solana",
-      "subtitle": "From pseudonymous wallets to fully encrypted computation, Solana supports every level of privacy.",
+      "subtitle": "Solana supports several privacy models: public addresses, private amounts, unlinkable payments, and encrypted computation.",
       "supportingText": "Explore Privacy Tools"
     },
     "spectrum": {
       "title": "Privacy is a Spectrum",
-      "description": "Most discussions about privacy assume only two modes: public or private. But real systems are more nuanced. Privacy can be understood across two axes, identity visibility and data visibility, creating four distinct models."
+      "description": "Privacy is not a single switch. Identity and data visibility can be mixed, giving builders different tools for different products."
     },
     "modes": {
       "pseudonymity": {
         "title": "Pseudonymity",
-        "description": "Data is public, but identity is not. A pseudonymous system lets anyone inspect transactions, balances, and history, but none of it is linked to a real-world person unless the owner chooses to reveal themselves.",
+        "description": "Data is public, but identity is not. Anyone can inspect activity, while the wallet owner decides when to connect it to a real person.",
         "items": [
-          "On Solana, this is the default. Every wallet address is a cryptographic public key",
-          "Standard SPL token transfers are fully visible on-chain, but no address carries inherent identity"
+          "This is Solana's default model: every wallet is a public key",
+          "Standard SPL transfers are visible, but addresses do not carry built-in identity"
         ]
       },
       "confidentiality": {
         "title": "Confidentiality",
-        "description": "The participants may be known, but the contents of their transactions are hidden. Amounts, balances, and transfer data are encrypted so that only the parties involved can read them. Observers can verify that rules were followed without seeing the underlying values.",
+        "description": "Participants may be known, but amounts, balances, or transfer details stay private. Observers can still verify that rules were followed.",
         "items": [
-          "On Solana, Confidential Token Extensions encrypt transfer amounts and balances at the protocol level using zero-knowledge proofs",
-          "Enterprise payments and payroll without exposing compensation data",
-          "Stablecoin transfers where amounts stay private between sender and receiver",
-          "Trading strategies that remain hidden from front-runners"
+          "Confidential Token Extensions encrypt transfer amounts and balances with ZK proofs",
+          "Payroll and business payments can stay private",
+          "Stablecoin transfers can hide amounts between sender and receiver"
         ]
       },
       "anonymity": {
         "title": "Anonymity",
-        "description": "The transaction itself may be visible, but the link between sender and receiver is cryptographically broken. No observer can determine who paid whom. This goes beyond pseudonymity: even if you can see that a transfer happened, you cannot trace it back to a specific address or person.",
+        "description": "The transaction may be visible, but the sender-receiver link is broken. Observers can see that activity happened without tracing who paid whom.",
         "items": [
-          "On Solana, high throughput makes ZK-based anonymity systems practical at scale",
-          "Proof verification that would bottleneck slower chains runs within Solana's 400ms slot times",
-          "Protocols like Light Protocol offer anonymous state management in real-world applications"
+          "Solana throughput helps ZK-based anonymity systems run at scale",
+          "Proof verification can run inside fast settlement windows",
+          "Protocols like Light Protocol support anonymous state for apps"
         ]
       },
       "fullyPrivate": {
         "title": "Full Privacy",
-        "description": "Neither identity nor data is visible. Computation happens on encrypted inputs inside secure environments. Only proofs or final results are published on-chain. The chain verifies correctness without ever seeing the underlying data.",
+        "description": "Neither identity nor data is public. Apps compute over protected inputs, then publish proofs or final results on-chain.",
         "items": [
-          "On Solana, projects like Arcium and Inco bring encrypted multi-party computation and FHE to Solana programs",
-          "Private DeFi where order flow, positions, and strategies remain encrypted",
-          "Confidential DAO governance with sealed votes and hidden proposals",
-          "On-chain games with hidden state that players cannot inspect"
+          "Projects like Arcium and Inco bring private compute to Solana apps",
+          "Order flow, positions, and strategies can remain protected",
+          "Games can keep hidden state without leaving Solana"
         ]
       }
     },
     "ecosystem": {
       "title": "Privacy Ecosystem on Solana",
+      "arcane": {
+        "title": "Arcane",
+        "description": "Privacy infrastructure for trading, payments, and on-chain financial products."
+      },
       "contra": {
         "title": "Contra",
-        "description": "Fully private transactions and computation on Solana with end-to-end encryption"
+        "description": "Private transaction and compute tooling for Solana apps."
       },
       "encrypt": {
         "title": "Encrypt.xyz",
-        "description": "Fully private transaction infrastructure enabling end-to-end encrypted token transfers"
+        "description": "Private transfer infrastructure for encrypted token movement."
       },
       "privacyCash": {
         "title": "Privacy Cash",
-        "description": "Anonymous transaction protocol that breaks the link between sender and receiver"
-      },
-      "silentSwap": {
-        "title": "SilentSwap",
-        "description": "Anonymous token swaps with cryptographic sender-receiver unlinkability"
+        "description": "Private payments that break the link between sender and receiver."
       },
       "encifher": {
         "title": "Encifher",
-        "description": "Confidential DeFi protocol with encrypted order books and private trades"
+        "description": "Confidential DeFi tooling for private on-chain finance."
       },
       "magicBlock": {
         "title": "MagicBlock",
-        "description": "Fully private on-chain gaming with encrypted game state and hidden player actions"
+        "description": "Private ephemeral rollups for encrypted, real-time app state."
       },
       "lightProtocol": {
         "title": "Light Protocol",
-        "description": "ZK compression and anonymous state management for scalable private applications"
+        "description": "ZK compression and anonymous state tools for private apps."
       },
       "arcium": {
         "title": "Arcium",
-        "description": "Fully private computation network enabling encrypted multi-party computation on Solana"
+        "description": "Encrypted MPC network for private computation on Solana."
       },
       "confidentialTransfer": {
         "title": "Confidential Transfer",
-        "description": "Native Solana token extension that encrypts transfer amounts and balances at the protocol level using zero-knowledge proofs."
+        "description": "Solana token extension for encrypted transfer amounts and balances."
+      },
+      "heliusPrivacyProtocol": {
+        "title": "Helius Privacy Protocol",
+        "description": "ZK privacy layer for private payments, markets, and finance on Solana."
       },
       "inco": {
         "title": "Inco",
-        "description": "Fully homomorphic encryption (FHE) network for private smart contract execution"
+        "description": "Confidentiality layer for private transactions, DeFi, gaming, and governance."
       },
-      "zama": {
-        "title": "Zama",
-        "description": "Fully homomorphic encryption tooling for end-to-end private blockchain computation"
+      "ligero": {
+        "title": "Ligero",
+        "description": "ZK-powered infrastructure for private business payments."
       }
     },
     "principles": {
       "title": "Design Principles",
       "programmable": {
         "title": "Privacy Should Be Programmable",
-        "description": "Developers should be able to choose the right privacy level for their application. A payroll system has different requirements than a public governance vote. Privacy primitives should be composable building blocks, not all-or-nothing switches."
+        "description": "Developers should choose the privacy level their app needs. Payroll, trading, and governance do not all need the same disclosure model."
       },
       "coexist": {
         "title": "Privacy and Compliance Go Together",
-        "description": "Privacy does not mean avoiding regulation. With zero-knowledge proofs, users can prove solvency without exposing balances, verify eligibility without revealing identity, and satisfy audit requirements without making data public. Compliant privacy is not a compromise, it is better design."
+        "description": "Privacy can still support controls. ZK proofs and selective disclosure let teams prove facts without publishing raw data."
       },
       "performance": {
         "title": "Performance Matters",
-        "description": "Privacy technologies are often computationally heavy. ZK proof generation and verification, homomorphic encryption, and secure multi-party computation all demand significant resources. Solana's throughput makes these primitives usable in real-world applications."
+        "description": "Privacy costs compute. Solana's throughput helps make ZK proofs, MPC, and encrypted state practical for live apps."
       }
     },
     "useCases": {
       "title": "What Privacy Unlocks",
-      "description": "Privacy is not just about hiding data. It enables entirely new categories of applications that cannot exist on transparent chains.",
+      "description": "Privacy is not only about hiding data. It lets apps handle sensitive money, identity, and strategy on-chain.",
       "items": [
         {
           "title": "Private Payments",
-          "description": "Send and receive tokens without exposing amounts or balances to the public. Essential for salary payments, business transactions, and personal transfers.",
+          "description": "Send tokens without exposing amounts or balances to the public.",
           "privacyType": "confidential"
         },
         {
           "title": "Private Trading",
-          "description": "Execute trades without revealing strategy, position size, or timing to front-runners and MEV bots. Confidential order flow protects both retail and institutional traders.",
+          "description": "Keep strategy, position size, and timing away from public mempools.",
           "privacyType": "confidential"
         },
         {
           "title": "Confidential Payroll",
-          "description": "Pay employees and contractors on-chain without making compensation data public. Employers retain audit capability while keeping individual amounts private.",
+          "description": "Pay teams on-chain while keeping individual compensation private.",
           "privacyType": "confidential"
         },
         {
           "title": "Private DAO Voting",
-          "description": "Vote on proposals without revealing individual choices until results are finalized. Prevents vote-buying, social pressure, and strategic last-minute swings.",
+          "description": "Hide individual votes until results are finalized.",
           "privacyType": "anonymous"
         },
         {
           "title": "Encrypted Identity",
-          "description": "Prove attributes like age, citizenship, or credential ownership without revealing the underlying data. Zero-knowledge identity enables compliant privacy.",
+          "description": "Prove attributes without revealing the underlying data.",
           "privacyType": "anonymous"
         },
         {
           "title": "Confidential AI Agents",
-          "description": "Autonomous agents that transact, hold assets, and execute strategies without leaking proprietary logic or user data to on-chain observers.",
+          "description": "Let agents transact without leaking user data or proprietary logic.",
           "privacyType": "fullyPrivate"
         }
       ]
     },
     "cta": {
       "title": "Build with Confidential Tokens",
-      "description": "Confidential Token Extensions are live on Solana mainnet. Encrypt balances, hide transfer amounts, and verify with zero-knowledge proofs, all at the protocol level. No external dependencies required.",
+      "description": "Confidential Token Extensions are live on Solana mainnet. Encrypt balances, hide transfer amounts, and verify with ZK proofs at the protocol level.",
       "button": "Read the Guide",
       "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
     }


### PR DESCRIPTION
## Summary
- add Arcane, Helius Privacy Protocol, and Ligero to the privacy ecosystem list
- keep Inco in the ecosystem list and remove Zama and SilentSwap from the privacy page
- tighten the privacy page copy to make project and section descriptions shorter