### PR TITLE
docs: Remove Token-2022 mainnet availability callouts now that v11 is live

### DIFF
--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
@@ -3,13 +3,6 @@ title: Apply Pending Balance
 description: Learn how to apply pending balance to make funds available.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to apply pending balance to available balance
 
 Before tokens can be transferred confidentially, the public token balance must

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
@@ -4,13 +4,6 @@ description:
   Learn how to create a token mint with the Confidential Transfer extension.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to create a mint with Confidential Transfer extension
 
 The Confidential Transfer extension enables private token transfers by adding

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
@@ -4,13 +4,6 @@ description:
   Learn how to create a token account with the Confidential Transfer extension.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to create a token account with the Confidential Transfer extension
 
 The Confidential Transfer extension enables private token transfers by adding

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
@@ -3,13 +3,6 @@ title: Deposit Tokens
 description: Learn how to deposit tokens to confidential state.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to deposit tokens to confidential pending balance
 
 Before tokens can be transferred confidentially, the public token balance must

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/index.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/index.mdx
@@ -5,13 +5,6 @@ description:
   optional features to token mints and accounts.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## What are Confidential Transfers?
 
 Confidential transfers enable you to transfer tokens between token accounts

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/issuer-guide.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/issuer-guide.mdx
@@ -20,14 +20,6 @@ while leaving account addresses, the mint, and owners public. They rely on the
 ZK ElGamal Proof Program for onchain proof verification, so the mint is usable
 on clusters where that program is enabled.
 
-<Callout type="warn" title="Availability">
-  Confidential transfers require the Token-2022
-  [`program@v11.0.0`](https://github.com/solana-program/token-2022/releases/tag/program%40v11.0.0)
-  or later. They are available on devnet today and are scheduled to be enabled
-  on mainnet in June 2026. The Token Extension Program is deployed separately to
-  each cluster, so confirm the deployment on the cluster you target.
-</Callout>
-
 ## Decisions you make at creation
 
 The Confidential Transfer extension must be initialized before the mint is

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
@@ -4,13 +4,6 @@ description:
   Learn how to transfer tokens privately from one token account to another.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to confidentially transfer tokens from one token account to another
 
 To confidentially transfer tokens from one token account to another, both the

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
@@ -3,13 +3,6 @@ title: Withdraw Tokens
 description: Learn how to withdraw tokens from confidential state.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to withdraw tokens from confidential available balance
 
 To withdraw tokens from confidential available balance to public balance:

--- a/apps/docs/content/docs/en/tokens/extensions/permissioned-burn.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/permissioned-burn.mdx
@@ -43,14 +43,6 @@ _rs`AuthorityType::PermissionedBurn`_. Setting the authority to `None` disables
 permissioned burning and re-enables the standard burn instructions. The
 extension data itself stays on the mint.
 
-<Callout type="warn" title="Availability">
-  Permissioned burn ships in the Token-2022
-  [`program@v11.0.0`](https://github.com/solana-program/token-2022/releases/tag/program%40v11.0.0).
-  It is available on devnet today and is scheduled to be enabled on mainnet in
-  June 2026. The Token Extension Program is deployed separately to each cluster,
-  so confirm the deployment on the cluster you target includes v11.0.0 or later.
-</Callout>
-
 A local test validator also bundles an older Token-2022 build, so to run the
 examples on this page, load the v11.0.0 program from devnet into your test
 validator:


### PR DESCRIPTION
Token Extension Program v11.0.0 is now live on mainnet, so a few callouts in the docs are no longer accurate.

This removes:
- the "ZK ElGamal Program is temporarily disabled / confidential transfers currently unavailable / code examples will not run" warning from the confidential transfer pages (index, create-mint, create-token-account, deposit, apply-pending-balance, transfer, withdraw)
- the "available on devnet today and scheduled to be enabled on mainnet in June 2026" availability callouts from the confidential transfer issuer guide and the permissioned burn page

Left in place on purpose: the local test validator setup notes (you still load the program into a local validator to run the examples) and the permissioned burn instruction-ordering callout, since those are still accurate.

English source only. Translations regenerate from these.