### PR TITLE
docs: update GitHub Actions workflows link to solana-foundation org

### DIFF
--- a/apps/docs/content/guides/advanced/idls.mdx
+++ b/apps/docs/content/guides/advanced/idls.mdx
@@ -326,7 +326,7 @@ explorers yet.
 The best practise for program deploys is to use a Multisig like
 [Squads](https://squads.so/) and to make this process as easy as possible you
 use the
-[Solana GitHub Actions workflows](https://github.com/solana-developers/github-workflows).
+[Solana GitHub Actions workflows](https://github.com/solana-foundation/github-workflows).
 
 Like this the program will automatically be upgraded, IDL uploaded, the build
 verified and then there will be a transaction proposed for your multisig to sign


### PR DESCRIPTION
## Summary
- The `solana-developers/github-workflows` repo moved to the `solana-foundation` org
- Updated the IDLs guide link (`apps/docs/content/guides/advanced/idls.mdx`) to point at `solana-foundation/github-workflows`

## Test Plan
- Repo-wide grep confirms no remaining `solana-developers/github-actions` or `solana-developers/github-workflows` references
- No `.github/workflows/*` files used those external repos, so no CI changes were needed