### PR TITLE
fix: i18n source locale overwrites

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -36,6 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: node scripts/i18n/verify-source-locales.mjs
       - uses: lingodotdev/lingo.dev@main
         env:
           GH_TOKEN: ${{ github.token }}
@@ -58,6 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - run: node scripts/i18n/verify-source-locales.mjs
       - uses: lingodotdev/lingo.dev@main
         env:
           GH_TOKEN: ${{ github.token }}

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
@@ -3,13 +3,6 @@ title: Apply Pending Balance
 description: Learn how to apply pending balance to make funds available.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to apply pending balance to available balance
 
 Before tokens can be transferred confidentially, the public token balance must

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
@@ -4,13 +4,6 @@ description:
   Learn how to create a token mint with the Confidential Transfer extension.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to create a mint with Confidential Transfer extension
 
 The Confidential Transfer extension enables private token transfers by adding

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
@@ -4,13 +4,6 @@ description:
   Learn how to create a token account with the Confidential Transfer extension.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to create a token account with the Confidential Transfer extension
 
 The Confidential Transfer extension enables private token transfers by adding

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
@@ -3,13 +3,6 @@ title: Deposit Tokens
 description: Learn how to deposit tokens to confidential state.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to deposit tokens to confidential pending balance
 
 Before tokens can be transferred confidentially, the public token balance must

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/index.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/index.mdx
@@ -5,13 +5,6 @@ description:
   optional features to token mints and accounts.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## What are Confidential Transfers?
 
 Confidential transfers enable you to transfer tokens between token accounts
@@ -104,6 +97,13 @@ corresponding pages:
     href="/docs/tokens/extensions/confidential-transfer/transfer-tokens"
   >
     How to confidentially transfer tokens between token accounts
+  </Card>
+  <Card
+    title="Integration Guide"
+    href="/docs/tokens/extensions/confidential-transfer/integration-guide"
+  >
+    How wallets, explorers, and exchanges can support confidential transfer
+    tokens
   </Card>
   <Card
     title="Issuer Guide"

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/issuer-guide.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/issuer-guide.mdx
@@ -20,14 +20,6 @@ while leaving account addresses, the mint, and owners public. They rely on the
 ZK ElGamal Proof Program for onchain proof verification, so the mint is usable
 on clusters where that program is enabled.
 
-<Callout type="warn" title="Availability">
-  Confidential transfers require the Token-2022
-  [`program@v11.0.0`](https://github.com/solana-program/token-2022/releases/tag/program%40v11.0.0)
-  or later. They are available on devnet today and are scheduled to be enabled
-  on mainnet in June 2026. The Token Extension Program is deployed separately to
-  each cluster, so confirm the deployment on the cluster you target.
-</Callout>
-
 ## Decisions you make at creation
 
 The Confidential Transfer extension must be initialized before the mint is

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/meta.json
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/meta.json
@@ -7,6 +7,7 @@
     "apply-pending-balance",
     "withdraw-tokens",
     "transfer-tokens",
+    "integration-guide",
     "issuer-guide"
   ]
 }

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
@@ -4,13 +4,6 @@ description:
   Learn how to transfer tokens privately from one token account to another.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to confidentially transfer tokens from one token account to another
 
 To confidentially transfer tokens from one token account to another, both the

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
@@ -3,13 +3,6 @@ title: Withdraw Tokens
 description: Learn how to withdraw tokens from confidential state.
 ---
 
-<Callout type="warn">
-  The ZK ElGamal Program is temporarily disabled on the mainnet and devnet as it
-  undergoes a security audit. This means that confidential transfers extension
-  is currently unavailable. While the concepts are still valid, the code
-  examples will not run.
-</Callout>
-
 ## How to withdraw tokens from confidential available balance
 
 To withdraw tokens from confidential available balance to public balance:

--- a/apps/docs/content/docs/en/tokens/extensions/permissioned-burn.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/permissioned-burn.mdx
@@ -43,14 +43,6 @@ _rs`AuthorityType::PermissionedBurn`_. Setting the authority to `None` disables
 permissioned burning and re-enables the standard burn instructions. The
 extension data itself stays on the mint.
 
-<Callout type="warn" title="Availability">
-  Permissioned burn ships in the Token-2022
-  [`program@v11.0.0`](https://github.com/solana-program/token-2022/releases/tag/program%40v11.0.0).
-  It is available on devnet today and is scheduled to be enabled on mainnet in
-  June 2026. The Token Extension Program is deployed separately to each cluster,
-  so confirm the deployment on the cluster you target includes v11.0.0 or later.
-</Callout>
-
 A local test validator also bundles an older Token-2022 build, so to run the
 examples on this page, load the v11.0.0 program from devnet into your test
 validator:

--- a/apps/docs/i18n.json
+++ b/apps/docs/i18n.json
@@ -4,7 +4,6 @@
   "locale": {
     "source": "en",
     "targets": [
-      "en",
       "ar",
       "de",
       "el",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -88,7 +88,7 @@
     "dev": "next dev --port 3003",
     "start": "next start",
     "i18n:lingo": "pnpm i18n:lingo:content",
-    "i18n:lingo:content": "npx lingo.dev@latest run",
+    "i18n:lingo:content": "pnpm -w i18n:verify-source-locales && npx lingo.dev@latest run",
     "lint": "pnpm exec eslint . && pnpm -w exec prettier --ignore-path .prettierignore --check apps/docs",
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write apps/docs",
     "postinstall": "fumadocs-mdx",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:fix": "turbo run lint:fix",
     "test": "turbo run test",
     "i18n:audit": "node ./scripts/i18n/audit-messages.mjs",
+    "i18n:verify-source-locales": "node ./scripts/i18n/verify-source-locales.mjs",
     "i18n": "node ./scripts/i18n/run.mjs all",
     "i18n:ui": "node ./scripts/i18n/run.mjs ui",
     "i18n:docs": "node ./scripts/i18n/run.mjs docs",

--- a/packages/i18n/i18n.json
+++ b/packages/i18n/i18n.json
@@ -4,7 +4,6 @@
   "locale": {
     "source": "en",
     "targets": [
-      "en",
       "ar",
       "de",
       "el",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write packages/i18n",
     "check-types": "tsc --noEmit",
     "test": "vitest run",
-    "i18n:lingo": "npx lingo.dev@latest run"
+    "i18n:lingo": "pnpm -w i18n:verify-source-locales && npx lingo.dev@latest run"
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/scripts/i18n/run.mjs
+++ b/scripts/i18n/run.mjs
@@ -69,6 +69,8 @@ function runDocsContent() {
 
 const [, , target, app] = process.argv;
 
+run("node", ["./scripts/i18n/verify-source-locales.mjs"], rootDir);
+
 switch (target) {
   case "all":
     runUi();

--- a/scripts/i18n/verify-source-locales.mjs
+++ b/scripts/i18n/verify-source-locales.mjs
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const rootDir = process.cwd();
+const configPaths = ["apps/docs/i18n.json", "packages/i18n/i18n.json"];
+
+let hasError = false;
+
+for (const configPath of configPaths) {
+  const absolutePath = path.join(rootDir, configPath);
+  const config = JSON.parse(fs.readFileSync(absolutePath, "utf8"));
+  const sourceLocale = config.locale?.source;
+  const targetLocales = config.locale?.targets;
+
+  if (!sourceLocale || !Array.isArray(targetLocales)) {
+    console.error(`${configPath}: missing locale.source or locale.targets`);
+    hasError = true;
+    continue;
+  }
+
+  if (targetLocales.includes(sourceLocale)) {
+    console.error(
+      `${configPath}: source locale "${sourceLocale}" must not be listed in locale.targets`,
+    );
+    hasError = true;
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+}
+
+console.log("i18n source locale guard passed");


### PR DESCRIPTION
## Summary
- restore authored English docs content from #1573/#1524 that was regressed by the Lingo #1572 update
- restore the confidential transfer integration guide card/nav entry and remove stale availability warnings
- prevent future Lingo runs from treating `en` as a generated target locale
- add a source-locale verification guard to local i18n scripts and the GitHub i18n workflow

## Validation
- `pnpm i18n:verify-source-locales`
- `pnpm --filter solana-docs lint`
- `pnpm --filter @workspace/i18n lint`
- `pnpm --filter solana-docs postinstall`
- `git diff --check`