### PR TITLE
docs: update compute estimation to kit v6.10 resource-limits API

### DIFF
--- a/apps/docs/content/docs/en/payments/production-readiness.mdx
+++ b/apps/docs/content/docs/en/payments/production-readiness.mdx
@@ -226,7 +226,7 @@ const estimateResourceLimits = estimateResourceLimitsFactory({ rpc });
 const estimateAndSetResourceLimits = estimateAndSetResourceLimitsFactory(
   estimateResourceLimits
 );
-const txWithComputeUnitLimit = await estimateAndSetResourceLimits(tx);
+const txWithResourceLimits = await estimateAndSetResourceLimits(tx);
 ```
 
 In production, if you are repeating the same type of transaction multiple times,

--- a/apps/docs/content/docs/en/payments/production-readiness.mdx
+++ b/apps/docs/content/docs/en/payments/production-readiness.mdx
@@ -229,6 +229,13 @@ const estimateAndSetResourceLimits = estimateAndSetResourceLimitsFactory(
 const txWithResourceLimits = await estimateAndSetResourceLimits(tx);
 ```
 
+<Callout type="info">
+  If you build and send transactions with a kit plugin client, you typically
+  don't need this step — the client adds compute budget instructions for you
+  when it sends (`.sendTransaction()`). The manual flow above is for when you
+  assemble transactions directly with `@solana/kit`.
+</Callout>
+
 In production, if you are repeating the same type of transaction multiple times,
 you should consider caching the compute estimate for the transaction type to
 avoid the overhead of estimating the compute units every time.

--- a/apps/docs/content/docs/en/payments/production-readiness.mdx
+++ b/apps/docs/content/docs/en/payments/production-readiness.mdx
@@ -210,23 +210,23 @@ a block (and important for managing your priority fees).
 The Solana JSON RPC API has a
 [`simulatetransaction`](/docs/rpc/http/simulatetransaction) method that can be
 used to estimate the compute units required for a transaction, which includes an
-estimate of the compute units that will be used. The
-[`@solana-program/compute-budget`](https://github.com/solana-program/compute-budget)
-package provides a helper function to easily estimate the compute units required
-for a transaction (which uses the `simulatetransaction` method under the hood).
+estimate of the compute units that will be used.
+[`@solana/kit`](https://github.com/anza-xyz/kit) provides helper functions that
+estimate a transaction's resource limits and set them on the message in one step
+(using the `simulatetransaction` method under the hood). For version 1
+transactions these helpers also estimate the loaded accounts data size limit.
 
 ```ts
 import {
-  estimateComputeUnitLimitFactory,
-  updateOrAppendSetComputeUnitLimitInstruction
-} from "@solana-program/compute-budget";
+  estimateResourceLimitsFactory,
+  estimateAndSetResourceLimitsFactory
+} from "@solana/kit";
 
-const estimateComputeUnitLimit = estimateComputeUnitLimitFactory({ rpc });
-const computeUnitLimit = await estimateComputeUnitLimit(tx);
-const txWithComputeUnitLimit = updateOrAppendSetComputeUnitLimitInstruction(
-  computeUnitLimit,
-  tx
+const estimateResourceLimits = estimateResourceLimitsFactory({ rpc });
+const estimateAndSetResourceLimits = estimateAndSetResourceLimitsFactory(
+  estimateResourceLimits
 );
+const txWithComputeUnitLimit = await estimateAndSetResourceLimits(tx);
 ```
 
 In production, if you are repeating the same type of transaction multiple times,


### PR DESCRIPTION

The compute-unit estimation snippet in the payments production-readiness guide used the older `estimateComputeUnitLimitFactory` + manual `updateOrAppendSetComputeUnitLimitInstruction` flow.

## Changes
- Switch to `@solana/kit`'s `estimateResourceLimitsFactory` / `estimateAndSetResourceLimitsFactory` (estimate-and-set in one call), the recommended API as of kit v6.10.0 ([release notes](https://github.com/anza-xyz/kit/releases/tag/v6.10.0)).
- Note that these helpers also estimate the loaded accounts data size limit for version 1 transactions.

English source only; other locales regenerate on merge.

closes DEV-727