### PR TITLE
Add ecosystem program examples section

### DIFF
--- a/apps/docs/content/docs/en/programs/examples.mdx
+++ b/apps/docs/content/docs/en/programs/examples.mdx
@@ -20,7 +20,9 @@ example programs within them:
 
 - [Basics](#basics)
 - [Tokens](#tokens)
-- [Token 2022 (Token Extensions)](#token-2022-token-extensions)
+- [Token Extensions (Token 2022)](#token-extensions-token-2022)
+
+There are also [ecosystem program examples](#ecosystem-solana-program-examples)
 
 ## Basics
 
@@ -61,7 +63,7 @@ interact with them in programs.
 | [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Shows how to transfer SPL token using CPIs into the token program.                                 | Anchor, Native |
 | [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | See Token 2022 (Token extensions).                                                                 | Anchor, Native |
 
-## Token 2022 (Token Extensions)
+## Token Extensions (Token 2022)
 
 Token 2022 is a new standard for tokens on Solana. It is a more flexible and
 lets you add 16 different extensions to a token mint to add more functionality
@@ -78,3 +80,12 @@ to it. A full list of the extensions can be found in the
 | [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Useful for example for achievements, referral programs or any soul bound tokens.                                  | Anchor, Native |
 | [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Every transfer of the tokens hold some tokens back in the token account which can then be collected.              | Anchor, Native |
 | [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Four examples to add additional functionality to your token using a CPI from the token program into your program. | Anchor         |
+
+## Ecosystem Solana program examples
+
+Third parties often maintain their own libraries of example Solana programs.
+These are maintained by the providers rather than by Solana Foundation.
+
+- [Quicknode's Solana Program Examples](https://github.com/quicknode/solana-program-examples)
+  provides additional programs, particularly for financial software, for both
+  newer Anchor versions and the Quasar framework.


### PR DESCRIPTION
### Problem

Not really a porblem, but Quicknode has their own Solana Program examples repo that includes more financial software, additional frameworks, Anchor 1.0 layouts and LiteSVM tests, etc. This would be a worthwhile addition to this page. I've added it under "Ecosystem Examples" heading at the bottom. 

### Summary of Changes

- Additonal "Ecosystem Examples" heading and link
- Also since "Token Extensions" is the official name and Token 2022 the codename, I corrected the link.

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

New dependencies: none

