### PR TITLE
Add Orbis to ecosystem — x402 API marketplace with native Solana USDC payments

### DIFF
--- a/packages/ecosystem-data/assets/companies/orbis/logo.svg
+++ b/packages/ecosystem-data/assets/companies/orbis/logo.svg
@@ -1,0 +1,12 @@
+<svg width="180" height="180" viewBox="0 0 180 180" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="180" y2="180" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#1a2b6b"/>
+      <stop offset="100%" stop-color="#2563eb"/>
+    </linearGradient>
+  </defs>
+  <rect width="180" height="180" rx="38" fill="url(#bg)"/>
+  <circle cx="90" cy="90" r="60" stroke="white" stroke-width="7.5" fill="none"/>
+  <ellipse cx="90" cy="90" rx="60" ry="22.5" stroke="white" stroke-width="6.5" fill="none"/>
+  <ellipse cx="90" cy="90" rx="22.5" ry="60" stroke="white" stroke-width="6.5" fill="none"/>
+</svg>

--- a/packages/ecosystem-data/src/companies/records/orbis.ts
+++ b/packages/ecosystem-data/src/companies/records/orbis.ts
@@ -1,0 +1,33 @@
+import type { CompanyRecord } from "../../types";
+import orbisLogo from "../../../assets/companies/orbis/logo.svg";
+
+export const orbis = {
+  id: "orbis",
+  slug: "orbis",
+  name: "Orbis",
+  profile: {
+    tagline: "Pay-per-call APIs for AI agents.",
+    summary:
+      "Orbis is an x402 API marketplace with 2,000+ endpoints for AI agents, accepting Solana USDC and Base USDC micropayments with no API keys or subscriptions.",
+    description:
+      "Orbis is a pay-per-call API marketplace built on the x402 protocol, providing AI agents with access to 2,000+ endpoints across crypto data, web search, social data, geolocation, and utilities. Agents pay in USDC on Solana mainnet or Base with no API keys or subscriptions required. The platform natively supports both eip155:8453 (Base) and solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp (Solana mainnet) payment networks.",
+    sector: "Developer Tools",
+    type: "Platform",
+    links: {
+      website: "https://orbisapi.com",
+    },
+    socials: {
+      x: "https://x.com/orbisapi",
+      github: "https://github.com/orbisapi",
+    },
+  },
+  defaultLogoId: "logo",
+  logos: [
+    {
+      id: "logo",
+      fileName: "logo.svg",
+      format: "svg",
+      source: orbisLogo,
+    },
+  ],
+} satisfies CompanyRecord;

--- a/packages/ecosystem-data/src/companies/registry.ts
+++ b/packages/ecosystem-data/src/companies/registry.ts
@@ -51,6 +51,7 @@ import { metaplex } from "./records/metaplex";
 import { monkeDao } from "./records/monke-dao";
 import { morganStanley } from "./records/morgan-stanley";
 import { openmined } from "./records/openmined";
+import { orbis } from "./records/orbis";
 import { orbitflare } from "./records/orbitflare";
 import { osl } from "./records/osl";
 import { pancakeswap } from "./records/pancakeswap";
@@ -149,6 +150,7 @@ export const companies = [
   monkeDao,
   morganStanley,
   openmined,
+  orbis,
   orbitflare,
   osl,
   pancakeswap,


### PR DESCRIPTION
## What is Orbis?

[Orbis](https://orbisapi.com) is a pay-per-call API marketplace built on the x402 protocol, providing AI agents with access to 2,000+ endpoints across crypto data, web search, social data, geolocation, and utilities.

## Why it belongs in the Solana ecosystem

- **Native Solana USDC payments** — Orbis accepts `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp` alongside Base (`eip155:8453`), making it one of the few live x402 providers with dual-chain support
- **AI agent infrastructure** — agents pay autonomously in USDC per request with no API keys or subscriptions
- **400k+ settled payments on-chain** — actively used in production
- **Sector**: Developer Tools

## Changes

- `packages/ecosystem-data/assets/companies/orbis/logo.svg` — Orbis logo
- `packages/ecosystem-data/src/companies/records/orbis.ts` — company record
- `packages/ecosystem-data/src/companies/registry.ts` — import + entry (alphabetical between `openmined` and `orbitflare`)

## Links
- Site: https://orbisapi.com
- OpenAPI: https://orbisapi.com/openapi.json
- x402 discovery: https://orbisapi.com/.well-known/x402