### PR TITLE
Clarify devnet network ID in Agentic Payments x402 example

### DIFF
--- a/apps/docs/content/docs/en/payments/agentic-payments.mdx
+++ b/apps/docs/content/docs/en/payments/agentic-payments.mdx
@@ -69,7 +69,8 @@ app.use(
           {
             scheme: "exact",
             price: "$0.001",
-            network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+            network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",  // Solana Devnet
+            // Use "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" for Solana Mainnet (CAIP-2)
             payTo: svmAddress
           }
         ],
@@ -78,7 +79,7 @@ app.use(
       }
     },
     new x402ResourceServer(facilitatorClient).register(
-      "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+      "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",  // Solana Devnet
       new ExactSvmScheme()
     )
   )

--- a/apps/docs/content/docs/en/payments/agentic-payments/index.mdx
+++ b/apps/docs/content/docs/en/payments/agentic-payments/index.mdx
@@ -94,7 +94,8 @@ app.use(
           {
             scheme: "exact",
             price: "$0.001",
-            network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+            network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",  // Solana Devnet
+            // Use "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp" for Solana Mainnet (CAIP-2)
             payTo: svmAddress
           }
         ],
@@ -103,7 +104,7 @@ app.use(
       }
     },
     new x402ResourceServer(facilitatorClient).register(
-      "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",
+      "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1",  // Solana Devnet
       new ExactSvmScheme()
     )
   )


### PR DESCRIPTION
### Problem

The Express x402 middleware example on `/docs/payments/agentic-payments` uses 
`network: "solana:EtWTRABZaYq6iMfeYKouRu166VU2xqa1"` with no indication that this is the Solana Devnet CAIP-2 chain ID (confirmed against https://namespaces.chainagnostic.org/solana/caip2 and Coinbase's x402 docs). 
Mainnet's ID is `solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp`. A developer copying this example to build a real paid endpoint could end up on either network without realizing the distinction, since neither value is explained.

### Summary of Changes

Kept devnet as the example value but added comments clarifying which network it is and what the mainnet CAIP-2 equivalent would be, so the choice is explicit instead of silent.

Fixes #

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

New dependencies: none

Threat-model note: n/a - Low-risk documentation-only change.
