### PR TITLE
fix: refresh Solana data dashboard twice daily and watermark

### DIFF
--- a/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
+++ b/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
@@ -17,6 +17,7 @@ import {
 import { useSearchParams } from "next/navigation";
 import {
   Fragment,
+  type ReactNode,
   useCallback,
   useEffect,
   useMemo,
@@ -999,21 +1000,41 @@ function ChartCard({
         </span>
       </div>
 
-      {series.length > 0 ? (
-        <TimeSeriesChart
-          height={chartHeight}
-          series={series}
-          valueLabel={chart.valueLabel}
-        />
-      ) : (
-        <div className="flex h-[320px] items-center justify-center border border-dashed border-nd-border-light text-sm text-nd-mid-em-text font-brand-mono uppercase tracking-normal">
-          {t("empty.noDataForSelection")}
-        </div>
-      )}
+      <ChartWatermarkFrame>
+        {series.length > 0 ? (
+          <TimeSeriesChart
+            height={chartHeight}
+            series={series}
+            valueLabel={chart.valueLabel}
+          />
+        ) : (
+          <div className="flex h-[320px] items-center justify-center border border-dashed border-nd-border-light text-sm text-nd-mid-em-text font-brand-mono uppercase tracking-normal">
+            {t("empty.noDataForSelection")}
+          </div>
+        )}
+      </ChartWatermarkFrame>
 
       <ChartOrdinal index={index} />
       {isRefreshing ? <ChartRefreshingOverlay /> : null}
     </article>
+  );
+}
+
+function ChartWatermarkFrame({ children }: { children: ReactNode }) {
+  return (
+    <div className="relative">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 bottom-0 z-0 flex h-[320px] items-center justify-center overflow-hidden"
+      >
+        <img
+          alt=""
+          className="h-auto w-[45%] min-w-[220px] max-w-[300px] opacity-[0.1] mix-blend-screen brightness-0 invert"
+          src="/src/img/branding/solanaLogo.svg"
+        />
+      </div>
+      <div className="relative z-[1]">{children}</div>
+    </div>
   );
 }
 

--- a/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
+++ b/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
@@ -84,7 +84,7 @@ const defaultRangeDays = 90;
 const emptyRows: MetricRow[] = [];
 const kpiCount = 4;
 const chartHeight = 320;
-const dataRefreshIntervalMs = 24 * 60 * 60 * 1000;
+const dataRefreshIntervalMs = 12 * 60 * 60 * 1000;
 const dataDedupingIntervalMs = 60 * 1000;
 const dataAggregatorRepositoryUrl =
   "https://github.com/solana-foundation/solana-data-aggregator";

--- a/apps/web/src/app/api/databricks/data/route.ts
+++ b/apps/web/src/app/api/databricks/data/route.ts
@@ -19,7 +19,7 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
-const DATABRICKS_CACHE_REVALIDATE_SECONDS = 24 * 60 * 60;
+const DATABRICKS_CACHE_REVALIDATE_SECONDS = 12 * 60 * 60;
 const BROWSER_CACHE_SECONDS = 60;
 const EDGE_STALE_SECONDS = 24 * 60 * 60;
 const DEFAULT_RANGE_DAYS = 90;
@@ -27,8 +27,8 @@ const IS_PRODUCTION = isProduction();
 const NO_STORE_CACHE_CONTROL = "no-store, max-age=0";
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const DATA_REFRESH_TIME_ZONE = "America/New_York";
-// Source jobs run around 9 AM Eastern; roll dashboard caches at 10 AM Eastern.
-const DATA_REFRESH_HOUR = 10;
+// Source jobs run around 9 AM and 9 PM Eastern; roll dashboard caches an hour later.
+const DATA_REFRESH_HOURS = [10, 22] as const;
 const DATA_UNAVAILABLE_ERROR =
   "Solana data is unavailable right now. Try again in a moment.";
 
@@ -153,16 +153,19 @@ function getDatabricksCacheKey(config: DatabricksConfig, rangeDays: number) {
 
 function getDatabricksRefreshCacheKey(now = new Date()) {
   const parts = getTimeZoneDateTimeParts(now, DATA_REFRESH_TIME_ZONE);
+  const latestRefreshHour = getLatestScheduledRefreshHour(parts.hour);
+  const refreshHour =
+    latestRefreshHour ?? DATA_REFRESH_HOURS[DATA_REFRESH_HOURS.length - 1];
   const refreshDate = new Date(
     Date.UTC(
       parts.year,
       parts.month - 1,
-      parts.day +
-        (hasPassedScheduledRefresh(parts, DATA_REFRESH_HOUR) ? 0 : -1),
+      parts.day + (latestRefreshHour === undefined ? -1 : 0),
+      refreshHour,
     ),
   );
 
-  return refreshDate.toISOString().slice(0, 10);
+  return `${refreshDate.toISOString().slice(0, 10)}-${String(refreshHour).padStart(2, "0")}`;
 }
 
 function getSuccessCacheControl(now = new Date()) {
@@ -190,23 +193,26 @@ function getScheduledRefreshDate(
   parts: ReturnType<typeof getTimeZoneDateTimeParts>,
   now: Date,
 ) {
-  const dayOffset = hasPassedScheduledRefresh(parts, DATA_REFRESH_HOUR) ? 1 : 0;
+  const nextRefreshHour = getNextScheduledRefreshHour(parts.hour);
+  const refreshHour = nextRefreshHour ?? DATA_REFRESH_HOURS[0];
+  const dayOffset = nextRefreshHour === undefined ? 1 : 0;
 
   return zonedTimeToUtc(
     parts.year,
     parts.month,
     parts.day + dayOffset,
-    DATA_REFRESH_HOUR,
+    refreshHour,
     DATA_REFRESH_TIME_ZONE,
     now,
   );
 }
 
-function hasPassedScheduledRefresh(
-  parts: ReturnType<typeof getTimeZoneDateTimeParts>,
-  hour: number,
-) {
-  return parts.hour >= hour;
+function getLatestScheduledRefreshHour(hour: number) {
+  return DATA_REFRESH_HOURS.findLast((refreshHour) => hour >= refreshHour);
+}
+
+function getNextScheduledRefreshHour(hour: number) {
+  return DATA_REFRESH_HOURS.find((refreshHour) => hour < refreshHour);
 }
 
 function zonedTimeToUtc(

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -2,12 +2,12 @@
   "dataDashboard": {
     "metadata": {
       "title": "Solana Data",
-      "description": "Explore Solana network, stablecoin, and DeFi metrics refreshed daily."
+      "description": "Explore Solana network, stablecoin, and DeFi metrics refreshed twice daily."
     },
     "header": {
-      "eyebrow": "Daily network data",
+      "eyebrow": "Twice-daily network data",
       "title": "Solana data",
-      "description": "Network, stablecoin, and DeFi metrics refreshed daily from leading on-chain providers."
+      "description": "Network, stablecoin, and DeFi metrics refreshed twice daily from leading on-chain providers."
     },
     "controls": {
       "ariaLabel": "Controls",
@@ -104,9 +104,9 @@
       "noProviders": "No providers selected",
       "providerListSeparator": " / ",
       "lastDays": "Last {days, plural, one {# day} other {# days}}",
-      "refreshCadence": "Refreshes daily after 10 AM ET",
+      "refreshCadence": "Refreshes twice daily after 10 AM and 10 PM ET",
       "lastRefreshed": "Last refreshed",
-      "lagNotice": "Lagging by 2 days to support all tools' refresh schedules.",
+      "lagNotice": "Lagging by 1 day to support all tools' refresh schedules.",
       "source": "Data aggregator",
       "backfillRequests": "Backfill requests",
       "backfillCadence": "Backfills are supported monthly on the 1st."


### PR DESCRIPTION
### Problem

The Solana data dashboard copy and cache schedule still described a daily refresh cadence, while the dashboard should reflect twice-daily network data updates and show a subtle Solana watermark on charts.

### Summary of Changes

- Updates Databricks dashboard cache rotation from daily to 10 AM and 10 PM ET refresh windows.
- Updates dashboard metadata, header, footer cadence, and lag copy to match the twice-daily schedule.
- Adds a non-interactive chart watermark using the official Solana logo asset with a white CSS filter.

Fixes #

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the browser).
- [x] Input from users or external services is validated before use; no `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit` passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependencies: none. `pnpm audit` was not run because this PR does not change dependencies.

Threat-model note for Critical changes: n/a.

Validation:

- `pnpm --filter solana-com lint` passes with existing warnings.
- `pnpm --filter solana-com exec tsc --noEmit --project tsconfig.json` passes.
- Browser check confirmed 9 filtered full-logo watermarks render on `/data` with no client errors.