### PR TITLE
fix: sign Lingo translation commits

### DIFF
--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -45,7 +45,7 @@ jobs:
           passphrase: ${{ secrets.LINGODOTDEV_GPG_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-      - uses: lingodotdev/lingo.dev@main
+      - uses: lingodotdev/lingo.dev@a4664c984ca4caba4346f8e81e5823c0cda57789 # main
         env:
           GH_TOKEN: ${{ github.token }}
           LINGODOTDEV_COMMIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
@@ -79,7 +79,7 @@ jobs:
           passphrase: ${{ secrets.LINGODOTDEV_GPG_PASSPHRASE }}
           git_user_signingkey: true
           git_commit_gpgsign: true
-      - uses: lingodotdev/lingo.dev@main
+      - uses: lingodotdev/lingo.dev@a4664c984ca4caba4346f8e81e5823c0cda57789 # main
         env:
           GH_TOKEN: ${{ github.token }}
           LINGODOTDEV_COMMIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -37,9 +37,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: node scripts/i18n/verify-source-locales.mjs
+      - name: Import GPG signing key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
+        with:
+          gpg_private_key: ${{ secrets.LINGODOTDEV_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.LINGODOTDEV_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - uses: lingodotdev/lingo.dev@main
         env:
           GH_TOKEN: ${{ github.token }}
+          LINGODOTDEV_COMMIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
+          LINGODOTDEV_COMMIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
+          LINGODOTDEV_GPG_SIGN: "true"
         with:
           api-key: ${{ secrets.LINGODOTDEV_API_KEY }}
           pull-request: true
@@ -60,9 +71,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: node scripts/i18n/verify-source-locales.mjs
+      - name: Import GPG signing key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
+        with:
+          gpg_private_key: ${{ secrets.LINGODOTDEV_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.LINGODOTDEV_GPG_PASSPHRASE }}
+          git_user_signingkey: true
+          git_commit_gpgsign: true
       - uses: lingodotdev/lingo.dev@main
         env:
           GH_TOKEN: ${{ github.token }}
+          LINGODOTDEV_COMMIT_AUTHOR_NAME: ${{ steps.import-gpg.outputs.name }}
+          LINGODOTDEV_COMMIT_AUTHOR_EMAIL: ${{ steps.import-gpg.outputs.email }}
+          LINGODOTDEV_GPG_SIGN: "true"
         with:
           api-key: ${{ secrets.LINGODOTDEV_API_KEY }}
           pull-request: true


### PR DESCRIPTION
## Summary
- import a GPG signing key before Lingo translation PR jobs run
- enable Lingo's GPG signing path for both UI and docs translation commits
- pin the GPG import action to the current v7 commit SHA

## Testing
- pnpm -w exec prettier --ignore-path .prettierignore --check .github/workflows/i18n.yml