### PR TITLE
fix: desktop nav menu scrolling

### DIFF
--- a/packages/ui-chrome/src/header-section-metadata.ts
+++ b/packages/ui-chrome/src/header-section-metadata.ts
@@ -45,7 +45,6 @@ export const HEADER_SECTION_METADATA: Array<
       { type: "equals", value: "/privacy" },
     ],
     contentAlign: "left",
-    contentClassName: "xl:overflow-y-auto xl:max-h-[90vh]",
   },
   {
     id: "products",
@@ -93,6 +92,5 @@ export const HEADER_SECTION_METADATA: Array<
       { type: "equals", value: "/solutions/request-for-startups" },
     ],
     contentAlign: "center",
-    contentClassName: "xl:overflow-y-auto xl:max-h-[90vh]",
   },
 ];

--- a/packages/ui-chrome/src/nav-menu.tsx
+++ b/packages/ui-chrome/src/nav-menu.tsx
@@ -130,7 +130,7 @@ function NavigationMenuContent({
         align === "center" && "xl:left-1/2 xl:-translate-x-1/2",
         align === "right" && "xl:right-0 xl:left-auto xl:translate-x-0",
         // Visual styling
-        "min-w-[320px] bg-[rgba(25,24,27,0.92)] p-2 xl:p-4 rounded-2xl text-[rgba(255,255,255,0.64)] text-[14px] xl:text-[15px] leading-[1.5] backdrop-blur-[20px] xl:border xl:border-white/[0.06] xl:shadow-[0_20px_60px_-12px_rgba(0,0,0,0.6)]",
+        "min-w-[320px] bg-[rgba(25,24,27,0.92)] p-2 xl:p-4 rounded-2xl text-[rgba(255,255,255,0.64)] text-[14px] xl:text-[15px] leading-[1.5] backdrop-blur-[20px] xl:max-h-[calc(100dvh-5rem)] xl:overflow-y-auto xl:overscroll-contain xl:border xl:border-white/[0.06] xl:shadow-[0_20px_60px_-12px_rgba(0,0,0,0.6)]",
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary
- cap desktop nav dropdown height to the available viewport below the sticky header
- make desktop dropdowns scrollable with contained overscroll
- remove stale per-section 90vh overrides so all top-level nav menus use the shared behavior

## Verification
- Playwright check at 1280x360 confirmed all desktop nav dropdowns stay within the viewport and scroll when content overflows
- pnpm --filter @solana-com/ui-chrome lint
- pnpm --filter @solana-com/ui-chrome check-types