### PR TITLE
fix: Reduce Solana data dashboard Databricks traffic

### DIFF
--- a/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
+++ b/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
@@ -1664,7 +1664,7 @@ function aggregate(sum: number, count: number, aggregation: Aggregation) {
 }
 
 async function fetchData(url: string, errorMessages: DataFetchErrorMessages) {
-  const response = await fetch(url, { cache: "no-store" });
+  const response = await fetch(url);
   const payload = await readDataPayload(response, errorMessages);
 
   if (!response.ok) {

--- a/apps/web/src/app/api/databricks/data/route.ts
+++ b/apps/web/src/app/api/databricks/data/route.ts
@@ -152,10 +152,12 @@ function getInMemoryCachedDatabricksData(
 
   pruneDatabricksDataRequests(cacheKey);
 
-  const request = fetchDatabricksData(config).catch((error: unknown) => {
-    databricksDataRequests.delete(cacheKey);
-    throw error;
-  });
+  const request = fetchDatabricksData(config);
+
+  request.then(
+    () => databricksDataRequests.delete(cacheKey),
+    () => databricksDataRequests.delete(cacheKey),
+  );
 
   databricksDataRequests.set(cacheKey, request);
 

--- a/apps/web/src/app/api/databricks/data/route.ts
+++ b/apps/web/src/app/api/databricks/data/route.ts
@@ -27,9 +27,6 @@ const DATABRICKS_CACHE_KEY_VERSION = "solana-data-databricks-metric-rows-v4";
 const IS_PRODUCTION = isProduction();
 const NO_STORE_CACHE_CONTROL = "no-store, max-age=0";
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
-const DATA_REFRESH_TIME_ZONE = "America/New_York";
-// Source jobs run around 9 AM and 9 PM Eastern; roll dashboard caches an hour later.
-const DATA_REFRESH_HOURS = [10, 22] as const;
 const DATA_UNAVAILABLE_ERROR =
   "Solana data is unavailable right now. Try again in a moment.";
 
@@ -113,13 +110,8 @@ function getDatabricksData(config: DatabricksConfig) {
 }
 
 function getCachedDatabricksData(config: DatabricksConfig) {
-  const refreshCacheKey = getDatabricksRefreshCacheKey();
   const dataCacheKey = getDatabricksCacheKey(config);
-  const cacheKeyParts = [
-    DATABRICKS_CACHE_KEY_VERSION,
-    refreshCacheKey,
-    dataCacheKey,
-  ];
+  const cacheKeyParts = [DATABRICKS_CACHE_KEY_VERSION, dataCacheKey];
 
   return unstable_cache(
     () => getInMemoryCachedDatabricksData(config, cacheKeyParts.join("|")),
@@ -188,24 +180,7 @@ function getDatabricksCacheKey(config: DatabricksConfig) {
   ].join("|");
 }
 
-function getDatabricksRefreshCacheKey(now = new Date()) {
-  const parts = getTimeZoneDateTimeParts(now, DATA_REFRESH_TIME_ZONE);
-  const latestRefreshHour = getLatestScheduledRefreshHour(parts.hour);
-  const refreshHour =
-    latestRefreshHour ?? DATA_REFRESH_HOURS[DATA_REFRESH_HOURS.length - 1];
-  const refreshDate = new Date(
-    Date.UTC(
-      parts.year,
-      parts.month - 1,
-      parts.day + (latestRefreshHour === undefined ? -1 : 0),
-      refreshHour,
-    ),
-  );
-
-  return `${refreshDate.toISOString().slice(0, 10)}-${String(refreshHour).padStart(2, "0")}`;
-}
-
-function getSuccessCacheControl(now = new Date()) {
+function getSuccessCacheControl() {
   if (!IS_PRODUCTION) {
     return NO_STORE_CACHE_CONTROL;
   }
@@ -213,104 +188,9 @@ function getSuccessCacheControl(now = new Date()) {
   return [
     "public",
     "max-age=0",
-    `s-maxage=${getSecondsUntilNextScheduledRefresh(now)}`,
+    `s-maxage=${DATABRICKS_CACHE_REVALIDATE_SECONDS}`,
     `stale-while-revalidate=${EDGE_STALE_SECONDS}`,
   ].join(", ");
-}
-
-function getSecondsUntilNextScheduledRefresh(now = new Date()) {
-  const parts = getTimeZoneDateTimeParts(now, DATA_REFRESH_TIME_ZONE);
-  const nextRefresh = getScheduledRefreshDate(parts, now);
-  const seconds = Math.ceil((nextRefresh.getTime() - now.getTime()) / 1000);
-
-  return Math.max(1, seconds);
-}
-
-function getScheduledRefreshDate(
-  parts: ReturnType<typeof getTimeZoneDateTimeParts>,
-  now: Date,
-) {
-  const nextRefreshHour = getNextScheduledRefreshHour(parts.hour);
-  const refreshHour = nextRefreshHour ?? DATA_REFRESH_HOURS[0];
-  const dayOffset = nextRefreshHour === undefined ? 1 : 0;
-
-  return zonedTimeToUtc(
-    parts.year,
-    parts.month,
-    parts.day + dayOffset,
-    refreshHour,
-    DATA_REFRESH_TIME_ZONE,
-    now,
-  );
-}
-
-function getLatestScheduledRefreshHour(hour: number) {
-  return DATA_REFRESH_HOURS.findLast((refreshHour) => hour >= refreshHour);
-}
-
-function getNextScheduledRefreshHour(hour: number) {
-  return DATA_REFRESH_HOURS.find((refreshHour) => hour < refreshHour);
-}
-
-function zonedTimeToUtc(
-  year: number,
-  month: number,
-  day: number,
-  hour: number,
-  timeZone: string,
-  referenceDate: Date,
-) {
-  const utcGuess = new Date(Date.UTC(year, month - 1, day, hour));
-  const firstPass = new Date(
-    utcGuess.getTime() - getTimeZoneOffsetMs(utcGuess, timeZone),
-  );
-  const secondPass = new Date(
-    utcGuess.getTime() - getTimeZoneOffsetMs(firstPass, timeZone),
-  );
-
-  return Math.abs(secondPass.getTime() - referenceDate.getTime()) <
-    DAY_IN_MS * 2
-    ? secondPass
-    : firstPass;
-}
-
-function getTimeZoneOffsetMs(date: Date, timeZone: string) {
-  const parts = getTimeZoneDateTimeParts(date, timeZone);
-  const zonedAsUtc = Date.UTC(
-    parts.year,
-    parts.month - 1,
-    parts.day,
-    parts.hour,
-    parts.minute,
-    parts.second,
-  );
-
-  return zonedAsUtc - date.getTime();
-}
-
-function getTimeZoneDateTimeParts(date: Date, timeZone: string) {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    day: "2-digit",
-    hour: "2-digit",
-    hourCycle: "h23",
-    minute: "2-digit",
-    month: "2-digit",
-    second: "2-digit",
-    timeZone,
-    year: "numeric",
-  }).formatToParts(date);
-  const valueByType = new Map(
-    parts.map((part) => [part.type, Number(part.value)]),
-  );
-
-  return {
-    day: valueByType.get("day") ?? 1,
-    hour: valueByType.get("hour") ?? 0,
-    minute: valueByType.get("minute") ?? 0,
-    month: valueByType.get("month") ?? 1,
-    second: valueByType.get("second") ?? 0,
-    year: valueByType.get("year") ?? 1970,
-  };
 }
 
 function getConfigErrorResponse(

--- a/apps/web/src/app/api/databricks/data/route.ts
+++ b/apps/web/src/app/api/databricks/data/route.ts
@@ -20,9 +20,10 @@ export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 const DATABRICKS_CACHE_REVALIDATE_SECONDS = 12 * 60 * 60;
-const BROWSER_CACHE_SECONDS = 60;
 const EDGE_STALE_SECONDS = 24 * 60 * 60;
 const DEFAULT_RANGE_DAYS = 90;
+const MAX_RANGE_DAYS = Math.max(...rangeOptions.map((option) => option.value));
+const DATABRICKS_CACHE_KEY_VERSION = "solana-data-databricks-metric-rows-v4";
 const IS_PRODUCTION = isProduction();
 const NO_STORE_CACHE_CONTROL = "no-store, max-age=0";
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
@@ -56,7 +57,7 @@ export async function GET(request: NextRequest) {
   const rangeDays = parseRangeDays(request.nextUrl.searchParams.get("days"));
 
   try {
-    const result = await getDatabricksData(configResult.config, rangeDays);
+    const result = await getDatabricksData(configResult.config);
 
     return json<DataApiResponse>(
       buildDataResponse(result, rangeDays),
@@ -105,20 +106,24 @@ function filterRowsByRange(rows: MetricRow[], rangeDays: number) {
   });
 }
 
-function getDatabricksData(config: DatabricksConfig, rangeDays: number) {
+function getDatabricksData(config: DatabricksConfig) {
   return IS_PRODUCTION
-    ? getCachedDatabricksData(config, rangeDays)
-    : fetchDatabricksData(config, rangeDays);
+    ? getCachedDatabricksData(config)
+    : fetchDatabricksData(config);
 }
 
-function getCachedDatabricksData(config: DatabricksConfig, rangeDays: number) {
+function getCachedDatabricksData(config: DatabricksConfig) {
+  const refreshCacheKey = getDatabricksRefreshCacheKey();
+  const dataCacheKey = getDatabricksCacheKey(config);
+  const cacheKeyParts = [
+    DATABRICKS_CACHE_KEY_VERSION,
+    refreshCacheKey,
+    dataCacheKey,
+  ];
+
   return unstable_cache(
-    () => fetchDatabricksData(config, rangeDays),
-    [
-      "solana-data-databricks-metric-rows-v3",
-      getDatabricksRefreshCacheKey(),
-      getDatabricksCacheKey(config, rangeDays),
-    ],
+    () => getInMemoryCachedDatabricksData(config, cacheKeyParts.join("|")),
+    cacheKeyParts,
     {
       revalidate: DATABRICKS_CACHE_REVALIDATE_SECONDS,
       tags: ["solana-data-databricks"],
@@ -126,12 +131,9 @@ function getCachedDatabricksData(config: DatabricksConfig, rangeDays: number) {
   )();
 }
 
-async function fetchDatabricksData(
-  config: DatabricksConfig,
-  rangeDays: number,
-) {
+async function fetchDatabricksData(config: DatabricksConfig) {
   const result = await getDatabricksSqlMetricRows(config, {
-    lookbackDays: rangeDays,
+    lookbackDays: MAX_RANGE_DAYS,
     metricNames,
   });
 
@@ -141,12 +143,47 @@ async function fetchDatabricksData(
   };
 }
 
-function getDatabricksCacheKey(config: DatabricksConfig, rangeDays: number) {
+const databricksDataRequests = new Map<
+  string,
+  Promise<Awaited<ReturnType<typeof fetchDatabricksData>>>
+>();
+
+function getInMemoryCachedDatabricksData(
+  config: DatabricksConfig,
+  cacheKey: string,
+) {
+  const cachedRequest = databricksDataRequests.get(cacheKey);
+
+  if (cachedRequest) {
+    return cachedRequest;
+  }
+
+  pruneDatabricksDataRequests(cacheKey);
+
+  const request = fetchDatabricksData(config).catch((error: unknown) => {
+    databricksDataRequests.delete(cacheKey);
+    throw error;
+  });
+
+  databricksDataRequests.set(cacheKey, request);
+
+  return request;
+}
+
+function pruneDatabricksDataRequests(activeCacheKey: string) {
+  for (const cacheKey of databricksDataRequests.keys()) {
+    if (cacheKey !== activeCacheKey) {
+      databricksDataRequests.delete(cacheKey);
+    }
+  }
+}
+
+function getDatabricksCacheKey(config: DatabricksConfig) {
   return [
     config.serverHostname,
     config.httpPath,
     config.warehouseId,
-    rangeDays,
+    MAX_RANGE_DAYS,
     metricNames.join(","),
   ].join("|");
 }
@@ -175,7 +212,7 @@ function getSuccessCacheControl(now = new Date()) {
 
   return [
     "public",
-    `max-age=${BROWSER_CACHE_SECONDS}`,
+    "max-age=0",
     `s-maxage=${getSecondsUntilNextScheduledRefresh(now)}`,
     `stale-while-revalidate=${EDGE_STALE_SECONDS}`,
   ].join(", ");


### PR DESCRIPTION
## Summary
- cache the dashboard Databricks dataset once per 12-hour server cache window instead of per selected date range
- fetch the maximum supported lookback once and slice rows per API request
- allow shared HTTP caching by removing the dashboard client no-store fetch and using public s-maxage response headers
- keep an in-flight promise dedupe so simultaneous cold-cache requests do not fan out to Databricks

## Validation
- pnpm --filter solana-com test -- solana-data-dashboard
- pnpm --filter solana-com lint

Note: `pnpm --filter solana-com exec tsc --noEmit` is currently blocked by the existing stale `.next/types/app/[locale]/skyline/page.ts` reference to a missing page module.