### PR TITLE
security: template README HTML rendering

### DIFF
--- a/apps/templates/__tests__/markdown-to-html.test.ts
+++ b/apps/templates/__tests__/markdown-to-html.test.ts
@@ -8,6 +8,7 @@ describe("markdownToHtml", () => {
 # Safe heading
 
 <img src=x onerror="alert(1)">
+<img src="data:image/svg+xml,<svg onload=alert(1)>">
 <a href="javascript:alert(1)" onclick="alert(1)">bad</a>
 <script>alert(1)</script>
 `);
@@ -16,6 +17,7 @@ describe("markdownToHtml", () => {
     expect(html).not.toContain("<script");
     expect(html).not.toContain("onerror");
     expect(html).not.toContain("onclick");
+    expect(html).not.toContain("data:image");
     expect(html).not.toContain("javascript:");
     expect(html).toContain("<a>bad</a>");
   });
@@ -38,6 +40,20 @@ Use **pnpm** and visit [Solana](https://solana.com).
     expect(html).toContain('<img src="./logo.png" alt="Logo" />');
     expect(html).toContain("<ul>");
     expect(html).toContain("<li>Create a wallet</li>");
+  });
+
+  it("adds noopener and noreferrer to target blank links", async () => {
+    const html = await markdownToHtml(`
+<a href="https://example.com" target="_blank">external</a>
+<a href="https://solana.com" target="_blank" rel="nofollow">solana</a>
+`);
+
+    expect(html).toContain(
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer">external</a>',
+    );
+    expect(html).toContain(
+      '<a href="https://solana.com" target="_blank" rel="nofollow noopener noreferrer">solana</a>',
+    );
   });
 
   it("keeps Shiki highlighted code markup without placeholder data", async () => {

--- a/apps/templates/__tests__/markdown-to-html.test.ts
+++ b/apps/templates/__tests__/markdown-to-html.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { markdownToHtml } from "../src/lib/markdown-to-html";
+
+describe("markdownToHtml", () => {
+  it("strips executable HTML from template README content", async () => {
+    const html = await markdownToHtml(`
+# Safe heading
+
+<img src=x onerror="alert(1)">
+<a href="javascript:alert(1)" onclick="alert(1)">bad</a>
+<script>alert(1)</script>
+`);
+
+    expect(html).toContain("<h1>Safe heading</h1>");
+    expect(html).not.toContain("<script");
+    expect(html).not.toContain("onerror");
+    expect(html).not.toContain("onclick");
+    expect(html).not.toContain("javascript:");
+    expect(html).toContain("<a>bad</a>");
+  });
+
+  it("preserves normal README markdown and safe links", async () => {
+    const html = await markdownToHtml(`
+## Install
+
+Use **pnpm** and visit [Solana](https://solana.com).
+
+![Logo](./logo.png)
+
+- Create a wallet
+- Run the app
+`);
+
+    expect(html).toContain("<h2>Install</h2>");
+    expect(html).toContain("<strong>pnpm</strong>");
+    expect(html).toContain('<a href="https://solana.com">Solana</a>');
+    expect(html).toContain('<img src="./logo.png" alt="Logo" />');
+    expect(html).toContain("<ul>");
+    expect(html).toContain("<li>Create a wallet</li>");
+  });
+
+  it("keeps Shiki highlighted code markup without placeholder data", async () => {
+    const html = await markdownToHtml(`
+\`\`\`ts
+const answer: number = 42;
+\`\`\`
+`);
+
+    expect(html).toContain("<pre");
+    expect(html).toContain("shiki");
+    expect(html).toContain("<code>");
+    expect(html).toContain("answer");
+    expect(html).not.toContain("data-code-id");
+    expect(html).not.toContain("data-code=");
+  });
+});

--- a/apps/templates/package.json
+++ b/apps/templates/package.json
@@ -9,6 +9,7 @@
     "lint": "pnpm exec eslint . && pnpm -w exec prettier --ignore-path .prettierignore --check apps/templates",
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write apps/templates",
     "check-types": "tsc --noEmit",
+    "test": "vitest run",
     "i18n:lingo": "pnpm --dir ../.. i18n:app templates",
     "clean": "rm -rf node_modules .next"
   },
@@ -30,6 +31,7 @@
     "react-dom": "catalog:",
     "react-feather": "^2.0.10",
     "rtl-detect": "^1.1.2",
+    "sanitize-html": "^2.17.5",
     "shiki": "^3.13.0",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7"
@@ -40,13 +42,15 @@
     "@types/react": "^19.0.14",
     "@types/react-dom": "^19.0.6",
     "@types/rtl-detect": "^1.0.3",
+    "@types/sanitize-html": "^2.16.1",
     "@workspace/config-eslint": "workspace:*",
     "@workspace/config-typescript": "workspace:*",
     "autoprefixer": "^10.4.27",
     "postcss": "^8.4.49",
     "sass": "^1.92.1",
     "tailwindcss": "^3.4.19",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vitest": "catalog:"
   },
   "packageManager": "pnpm@10.15.1"
 }

--- a/apps/templates/src/lib/markdown-to-html.ts
+++ b/apps/templates/src/lib/markdown-to-html.ts
@@ -1,4 +1,5 @@
 import { marked } from "marked";
+import sanitizeHtml from "sanitize-html";
 import { codeToHtml } from "shiki";
 
 /**
@@ -14,6 +15,87 @@ const renderer = {
 };
 
 marked.use({ renderer });
+
+const ALLOWED_TAGS = [
+  "a",
+  "blockquote",
+  "br",
+  "code",
+  "dd",
+  "del",
+  "details",
+  "div",
+  "dl",
+  "dt",
+  "em",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "img",
+  "kbd",
+  "li",
+  "ol",
+  "p",
+  "pre",
+  "s",
+  "span",
+  "strong",
+  "sub",
+  "summary",
+  "sup",
+  "table",
+  "tbody",
+  "td",
+  "th",
+  "thead",
+  "tr",
+  "ul",
+];
+
+const ALLOWED_ATTRIBUTES: sanitizeHtml.IOptions["allowedAttributes"] = {
+  a: ["href", "name", "rel", "target", "title"],
+  code: ["class", "style"],
+  div: ["class"],
+  img: ["alt", "height", "src", "title", "width"],
+  pre: ["class", "style", "tabindex"],
+  span: ["class", "style"],
+  td: ["align", "colspan", "rowspan"],
+  th: ["align", "colspan", "rowspan"],
+};
+
+const ALLOWED_STYLES: sanitizeHtml.IOptions["allowedStyles"] = {
+  "*": {
+    "background-color": [
+      /^#[0-9a-f]{3,8}$/i,
+      /^rgb(a)?\([\d\s,%.]+\)$/i,
+      /^hsl(a)?\([\d\s,%.]+\)$/i,
+    ],
+    color: [
+      /^#[0-9a-f]{3,8}$/i,
+      /^rgb(a)?\([\d\s,%.]+\)$/i,
+      /^hsl(a)?\([\d\s,%.]+\)$/i,
+    ],
+    "font-style": [/^italic$/, /^normal$/],
+    "font-weight": [/^\d{3}$/, /^bold$/, /^normal$/],
+    "text-decoration": [/^underline$/, /^none$/],
+  },
+};
+
+const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: ALLOWED_TAGS,
+  allowedAttributes: ALLOWED_ATTRIBUTES,
+  allowedSchemes: ["http", "https", "mailto", "tel"],
+  allowedSchemesByTag: {
+    img: ["http", "https"],
+  },
+  allowedStyles: ALLOWED_STYLES,
+  allowProtocolRelative: false,
+  disallowedTagsMode: "discard",
+};
 
 /**
  * Convert markdown to HTML with syntax highlighting
@@ -61,5 +143,5 @@ export async function markdownToHtml(markdown: string): Promise<string> {
     }
   }
 
-  return result;
+  return sanitizeHtml(result, SANITIZE_OPTIONS);
 }

--- a/apps/templates/src/lib/markdown-to-html.ts
+++ b/apps/templates/src/lib/markdown-to-html.ts
@@ -80,10 +80,24 @@ const ALLOWED_STYLES: sanitizeHtml.IOptions["allowedStyles"] = {
       /^hsl(a)?\([\d\s,%.]+\)$/i,
     ],
     "font-style": [/^italic$/, /^normal$/],
-    "font-weight": [/^\d{3}$/, /^bold$/, /^normal$/],
+    "font-weight": [
+      /^(?:[1-9]\d{0,2}|1000)$/,
+      /^bold$/,
+      /^bolder$/,
+      /^lighter$/,
+      /^normal$/,
+    ],
     "text-decoration": [/^underline$/, /^none$/],
   },
 };
+
+function ensureNoopenerNoreferrer(rel: string | undefined): string {
+  const tokens = new Set((rel ?? "").split(/\s+/).filter(Boolean));
+  tokens.add("noopener");
+  tokens.add("noreferrer");
+
+  return Array.from(tokens).join(" ");
+}
 
 const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   allowedTags: ALLOWED_TAGS,
@@ -95,6 +109,21 @@ const SANITIZE_OPTIONS: sanitizeHtml.IOptions = {
   allowedStyles: ALLOWED_STYLES,
   allowProtocolRelative: false,
   disallowedTagsMode: "discard",
+  transformTags: {
+    a: (tagName, attribs) => {
+      if (attribs.target?.toLowerCase() !== "_blank") {
+        return { tagName, attribs };
+      }
+
+      return {
+        tagName,
+        attribs: {
+          ...attribs,
+          rel: ensureNoopenerNoreferrer(attribs.rel),
+        },
+      };
+    },
+  },
 };
 
 /**

--- a/apps/templates/vitest.config.ts
+++ b/apps/templates/vitest.config.ts
@@ -1,0 +1,12 @@
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["__tests__/**/*.test.ts"],
+    alias: {
+      "@/": `${path.resolve(__dirname, "./src")}/`,
+    },
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -745,6 +745,9 @@ importers:
       rtl-detect:
         specifier: ^1.1.2
         version: 1.1.2
+      sanitize-html:
+        specifier: ^2.17.5
+        version: 2.17.5
       shiki:
         specifier: ^3.13.0
         version: 3.13.0
@@ -770,6 +773,9 @@ importers:
       "@types/rtl-detect":
         specifier: ^1.0.3
         version: 1.0.3
+      "@types/sanitize-html":
+        specifier: ^2.16.1
+        version: 2.16.1
       "@workspace/config-eslint":
         specifier: workspace:*
         version: link:../../packages/config-eslint
@@ -791,6 +797,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      vitest:
+        specifier: "catalog:"
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@22.18.8)(jsdom@26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6))(vite@7.3.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1))
 
   apps/web:
     dependencies:
@@ -9336,6 +9345,12 @@ packages:
         integrity: sha512-qpstuHivwg/HoXxRrBo5/r/OVx5M2SkqJpVu2haasdLctt+jMGHWjqdbI0LL7Rk2wRmN/UHdHK4JZg9RUMcvKA==,
       }
 
+  "@types/sanitize-html@2.16.1":
+    resolution:
+      {
+        integrity: sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA==,
+      }
+
   "@types/shimmer@1.2.0":
     resolution:
       {
@@ -12030,6 +12045,13 @@ packages:
       }
     engines: { node: ">=0.12" }
 
+  entities@7.0.1:
+    resolution:
+      {
+        integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==,
+      }
+    engines: { node: ">=0.12" }
+
   environment@1.1.0:
     resolution:
       {
@@ -13295,6 +13317,12 @@ packages:
         integrity: sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==,
       }
 
+  htmlparser2@10.1.0:
+    resolution:
+      {
+        integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==,
+      }
+
   http-proxy-agent@7.0.2:
     resolution:
       {
@@ -14134,6 +14162,12 @@ packages:
         integrity: sha512-QJv/h939gDpvT+9SiLVlY7tZC3xB2qK57v0J04Sh9wpMb6MP1q8gB21L3WIo8T5P1MSMg3Ep14L7KkDCFG3y4w==,
       }
     engines: { node: ">=16.0.0" }
+
+  launder@1.7.1:
+    resolution:
+      {
+        integrity: sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==,
+      }
 
   layout-base@1.0.2:
     resolution:
@@ -15703,6 +15737,12 @@ packages:
       }
     engines: { node: ">=16" }
 
+  parse-srcset@1.0.2:
+    resolution:
+      {
+        integrity: sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==,
+      }
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     resolution:
       {
@@ -17155,6 +17195,12 @@ packages:
         integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==,
       }
     engines: { node: ">=10" }
+
+  sanitize-html@2.17.5:
+    resolution:
+      {
+        integrity: sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==,
+      }
 
   safer-buffer@2.1.2:
     resolution:
@@ -25795,6 +25841,10 @@ snapshots:
 
   "@types/rtl-detect@1.0.3": {}
 
+  "@types/sanitize-html@2.16.1":
+    dependencies:
+      htmlparser2: 10.1.0
+
   "@types/shimmer@1.2.0": {}
 
   "@types/supports-color@8.1.3": {}
@@ -27521,6 +27571,8 @@ snapshots:
 
   entities@6.0.1: {}
 
+  entities@7.0.1: {}
+
   environment@1.1.0: {}
 
   err-code@2.0.3: {}
@@ -28527,6 +28579,13 @@ snapshots:
       domutils: 3.2.2
       entities: 6.0.1
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
@@ -28988,6 +29047,10 @@ snapshots:
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.0.8
+
+  launder@1.7.1:
+    dependencies:
+      dayjs: 1.11.21
 
   layout-base@1.0.2: {}
 
@@ -30164,6 +30227,8 @@ snapshots:
       lines-and-columns: 2.0.4
       type-fest: 3.13.1
 
+  parse-srcset@1.0.2: {}
+
   parse5-htmlparser2-tree-adapter@7.1.0:
     dependencies:
       domhandler: 5.0.3
@@ -31229,6 +31294,16 @@ snapshots:
       is-regex: 1.2.1
 
   safe-stable-stringify@2.5.0: {}
+
+  sanitize-html@2.17.5:
+    dependencies:
+      deepmerge: 4.3.1
+      escape-string-regexp: 4.0.0
+      htmlparser2: 10.1.0
+      is-plain-object: 5.0.0
+      launder: 1.7.1
+      parse-srcset: 1.0.2
+      postcss: 8.5.15
 
   safer-buffer@2.1.2: {}
 


### PR DESCRIPTION
## Summary
- sanitize template README HTML after marked and Shiki render the final markup
- allow normal README tags plus Shiki code classes/styles while blocking scripts, event handlers, and unsafe URL protocols
- add Vitest coverage for malicious HTML, safe README content, relative images, and highlighted code output

## Validation
- pnpm install --frozen-lockfile
- node archive/solana-sanitize-template-html/scripts/template-html-safety-check.mjs
- pnpm --filter solana-templates test
- pnpm --filter solana-templates check-types
- pnpm --filter solana-templates lint
- pnpm --filter solana-templates build

Note: lint/build still report existing baseline warnings in the templates app, but no errors.
