### PR TITLE
ci: sign media auto-format commits

### DIFF
--- a/.github/workflows/staging-media-format.yml
+++ b/.github/workflows/staging-media-format.yml
@@ -28,6 +28,16 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
+      - name: Import GPG signing key
+        id: import-gpg
+        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
+        with:
+          gpg_private_key: ${{ secrets.MEDIA_FORMAT_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.MEDIA_FORMAT_GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -112,8 +122,8 @@ jobs:
             exit 0
           fi
 
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.import-gpg.outputs.name }}"
+          git config user.email "${{ steps.import-gpg.outputs.email }}"
           git add apps/media/content apps/media/public/uploads/posts
-          git commit -m "chore(media): auto-format media content"
+          git commit -S -m "chore(media): auto-format media content"
           git push


### PR DESCRIPTION
### Problem

The staging media auto-format workflow creates commits with a plain local `git commit`, which fails repositories or branches that require signed commits.

### Summary of Changes

Added a pinned GPG import step to `.github/workflows/staging-media-format.yml` and changed the formatter commit step to use the imported key identity with `git commit -S`.

This expects repository secrets named `MEDIA_FORMAT_GPG_PRIVATE_KEY` and `MEDIA_FORMAT_GPG_PASSPHRASE`. No private key material is committed.

Fixes #

---

### Change classification (SDLC §2)

- [x] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs (uses GitHub repository secrets only).
- [x] Input from users or external services is validated before use; no `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit` passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependencies: none. Adds a pinned GitHub Action already used elsewhere in this repository: `crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd`.

Threat-model note: the workflow can now sign commits using the configured media-format GPG private key stored in GitHub Actions secrets. If the workflow or secrets are compromised, an attacker could create signed formatter commits on non-main branches covered by this workflow. The private key must belong to a GitHub identity/email that GitHub can verify, and access to the two new secrets should be limited to the environment/repository scope required for this workflow.

Validation:

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/staging-media-format.yml"); puts "YAML OK"'`
- `pnpm exec prettier --check .github/workflows/staging-media-format.yml`
- `git diff --check -- .github/workflows/staging-media-format.yml`
