### PR TITLE
fix: use GitHub-verified signing for automated commits

### DIFF
--- a/.github/workflows/generate-llms-txt.yml
+++ b/.github/workflows/generate-llms-txt.yml
@@ -35,7 +35,8 @@ jobs:
           echo "LLMs.txt file generated"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        id: create-pr
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           branch-token: ${{ secrets.GITHUB_TOKEN }}
           sign-commits: true
@@ -46,3 +47,10 @@ jobs:
           base: main
           maintainer-can-modify: true
           delete-branch: true
+      - name: Verify pull request commits
+        if:
+          steps.create-pr.outputs.pull-request-operation != 'none' &&
+          steps.create-pr.outputs.pull-request-commits-verified != 'true'
+        run: |
+          echo "Pull request commits were not verified by GitHub."
+          exit 1

--- a/.github/workflows/i18n.yml
+++ b/.github/workflows/i18n.yml
@@ -37,28 +37,33 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: node scripts/i18n/verify-source-locales.mjs
-      - name: Import GPG signing key
-        id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
-        with:
-          gpg_private_key: ${{ secrets.LINGODOTDEV_GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.LINGODOTDEV_GPG_PASSPHRASE }}
-          git_config_global: true
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-      - uses: lingodotdev/lingo.dev@a4664c984ca4caba4346f8e81e5823c0cda57789 # main
+      - name: Run Lingo.dev
+        working-directory: packages/i18n
         env:
-          GH_TOKEN: ${{ github.token }}
-          LINGODOTDEV_GPG_SIGN: "true"
+          LINGO_API_KEY: ${{ secrets.LINGODOTDEV_API_KEY }}
+          LINGODOTDEV_API_KEY: ${{ secrets.LINGODOTDEV_API_KEY }}
+        run: npx --yes lingo.dev@latest run
+      - name: Create signed pull request
+        id: create-pr
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
-          api-key: ${{ secrets.LINGODOTDEV_API_KEY }}
-          pull-request: true
-          pull-request-title: "i18n: Lingo (ui)"
+          sign-commits: true
           commit-message: "i18n: Lingo Translation Update (ui)"
-          commit-author-name: ${{ steps.import-gpg.outputs.name }}
-          commit-author-email: ${{ steps.import-gpg.outputs.email }}
-          working-directory: "packages/i18n"
-          parallel: true
+          title: "i18n: Lingo (ui)"
+          body: "Automated Lingo.dev translation update for shared UI catalogs."
+          branch: i18n/lingo-ui
+          base: main
+          delete-branch: true
+          add-paths: |
+            packages/i18n/messages
+            packages/i18n/i18n.lock
+      - name: Verify pull request commits
+        if:
+          steps.create-pr.outputs.pull-request-operation != 'none' &&
+          steps.create-pr.outputs.pull-request-commits-verified != 'true'
+        run: |
+          echo "Pull request commits were not verified by GitHub."
+          exit 1
 
   i18n-docs:
     name: Run i18n for docs content
@@ -72,25 +77,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: node scripts/i18n/verify-source-locales.mjs
-      - name: Import GPG signing key
-        id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
-        with:
-          gpg_private_key: ${{ secrets.LINGODOTDEV_GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.LINGODOTDEV_GPG_PASSPHRASE }}
-          git_config_global: true
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-      - uses: lingodotdev/lingo.dev@a4664c984ca4caba4346f8e81e5823c0cda57789 # main
+      - name: Run Lingo.dev
+        working-directory: apps/docs
         env:
-          GH_TOKEN: ${{ github.token }}
-          LINGODOTDEV_GPG_SIGN: "true"
+          LINGO_API_KEY: ${{ secrets.LINGODOTDEV_API_KEY }}
+          LINGODOTDEV_API_KEY: ${{ secrets.LINGODOTDEV_API_KEY }}
+        run: npx --yes lingo.dev@latest run
+      - name: Create signed pull request
+        id: create-pr
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
-          api-key: ${{ secrets.LINGODOTDEV_API_KEY }}
-          pull-request: true
-          pull-request-title: "i18n: Lingo (docs)"
+          sign-commits: true
           commit-message: "i18n: Lingo Translation Update (docs)"
-          commit-author-name: ${{ steps.import-gpg.outputs.name }}
-          commit-author-email: ${{ steps.import-gpg.outputs.email }}
-          working-directory: "apps/docs"
-          parallel: true
+          title: "i18n: Lingo (docs)"
+          body: "Automated Lingo.dev translation update for docs content."
+          branch: i18n/lingo-docs
+          base: main
+          delete-branch: true
+          add-paths: |
+            apps/docs/content
+            apps/docs/i18n.lock
+      - name: Verify pull request commits
+        if:
+          steps.create-pr.outputs.pull-request-operation != 'none' &&
+          steps.create-pr.outputs.pull-request-commits-verified != 'true'
+        run: |
+          echo "Pull request commits were not verified by GitHub."
+          exit 1

--- a/.github/workflows/staging-media-format.yml
+++ b/.github/workflows/staging-media-format.yml
@@ -28,16 +28,6 @@ jobs:
           ref: ${{ github.ref }}
           fetch-depth: 0
 
-      - name: Import GPG signing key
-        id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@2dc316deee8e90f13e1a351ab510b4d5bc0c82cd # v7
-        with:
-          gpg_private_key: ${{ secrets.MEDIA_FORMAT_GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.MEDIA_FORMAT_GPG_PASSPHRASE }}
-          git_config_global: true
-          git_user_signingkey: true
-          git_commit_gpgsign: true
-
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -116,14 +106,11 @@ jobs:
           pnpm exec prettier --ignore-path .prettierignore --write
           apps/media/content
 
-      - name: Commit formatting changes
+      - name: Commit verified formatting changes
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          if git diff --quiet; then
-            exit 0
-          fi
-
-          git config user.name "${{ steps.import-gpg.outputs.name }}"
-          git config user.email "${{ steps.import-gpg.outputs.email }}"
-          git add apps/media/content apps/media/public/uploads/posts
-          git commit -S -m "chore(media): auto-format media content"
-          git push
+          node scripts/github/create-verified-commit.mjs \
+            "chore(media): auto-format media content" \
+            apps/media/content \
+            apps/media/public/uploads/posts

--- a/scripts/github/create-verified-commit.mjs
+++ b/scripts/github/create-verified-commit.mjs
@@ -1,0 +1,201 @@
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+
+const [message, ...pathspecs] = process.argv.slice(2);
+
+if (!message || pathspecs.length === 0) {
+  console.error(
+    "Usage: node scripts/github/create-verified-commit.mjs <message> <path>...",
+  );
+  process.exit(1);
+}
+
+const token = process.env.GITHUB_TOKEN;
+const repository = process.env.GITHUB_REPOSITORY;
+const branch = process.env.GITHUB_REF_NAME;
+
+if (!token || !repository || !branch) {
+  console.error(
+    "GITHUB_TOKEN, GITHUB_REPOSITORY, and GITHUB_REF_NAME are required.",
+  );
+  process.exit(1);
+}
+
+const [owner, repo] = repository.split("/");
+
+if (!owner || !repo) {
+  console.error(`Invalid GITHUB_REPOSITORY value: ${repository}`);
+  process.exit(1);
+}
+
+function git(args, options = {}) {
+  return execFileSync("git", args, {
+    encoding: options.encoding ?? "utf8",
+    stdio: options.stdio ?? ["ignore", "pipe", "pipe"],
+  });
+}
+
+function splitNul(output) {
+  return output.split("\0").filter(Boolean);
+}
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+async function github(endpoint, options = {}) {
+  const response = await fetch(`https://api.github.com${endpoint}`, {
+    ...options,
+    headers: {
+      Accept: "application/vnd.github+json",
+      Authorization: `Bearer ${token}`,
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(options.headers ?? {}),
+    },
+  });
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(
+      `${options.method ?? "GET"} ${endpoint} failed: ${response.status} ${body}`,
+    );
+  }
+
+  return response.json();
+}
+
+function getChangedPaths() {
+  const tracked = splitNul(
+    git(["diff", "--name-only", "-z", "--", ...pathspecs]),
+  );
+  const untracked = splitNul(
+    git([
+      "ls-files",
+      "--others",
+      "--exclude-standard",
+      "-z",
+      "--",
+      ...pathspecs,
+    ]),
+  );
+
+  return unique([...tracked, ...untracked]).sort();
+}
+
+function getFileMode(filePath) {
+  if (!fs.existsSync(filePath)) {
+    return "100644";
+  }
+
+  const indexEntry = git(["ls-files", "-s", "--", filePath]).trim();
+  if (indexEntry) {
+    return indexEntry.split(/\s+/, 1)[0];
+  }
+
+  const stat = fs.lstatSync(filePath);
+  if (stat.isSymbolicLink()) {
+    return "120000";
+  }
+
+  return stat.mode & 0o111 ? "100755" : "100644";
+}
+
+async function createTreeObject(filePath) {
+  const mode = getFileMode(filePath);
+
+  if (!fs.existsSync(filePath)) {
+    return {
+      path: filePath,
+      mode,
+      type: "blob",
+      sha: null,
+    };
+  }
+
+  const content =
+    mode === "120000"
+      ? Buffer.from(fs.readlinkSync(filePath), "utf8").toString("base64")
+      : fs.readFileSync(filePath).toString("base64");
+
+  const blob = await github(`/repos/${owner}/${repo}/git/blobs`, {
+    method: "POST",
+    body: JSON.stringify({
+      content,
+      encoding: "base64",
+    }),
+  });
+
+  return {
+    path: filePath,
+    mode,
+    type: "blob",
+    sha: blob.sha,
+  };
+}
+
+const changedPaths = getChangedPaths();
+
+if (changedPaths.length === 0) {
+  console.log("No changes to commit.");
+  process.exit(0);
+}
+
+const localHead = git(["rev-parse", "HEAD"]).trim();
+const refName = `heads/${branch}`;
+const encodedRefName = refName
+  .split("/")
+  .map((part) => encodeURIComponent(part))
+  .join("/");
+
+const ref = await github(`/repos/${owner}/${repo}/git/ref/${encodedRefName}`);
+const remoteHead = ref.object.sha;
+
+if (remoteHead !== localHead) {
+  throw new Error(
+    `Branch ${branch} advanced from ${localHead} to ${remoteHead}; refusing to create a stale formatting commit.`,
+  );
+}
+
+const baseCommit = await github(
+  `/repos/${owner}/${repo}/git/commits/${remoteHead}`,
+);
+const treeEntries = [];
+
+for (const filePath of changedPaths) {
+  treeEntries.push(await createTreeObject(path.posix.normalize(filePath)));
+}
+
+const tree = await github(`/repos/${owner}/${repo}/git/trees`, {
+  method: "POST",
+  body: JSON.stringify({
+    base_tree: baseCommit.tree.sha,
+    tree: treeEntries,
+  }),
+});
+
+const commit = await github(`/repos/${owner}/${repo}/git/commits`, {
+  method: "POST",
+  body: JSON.stringify({
+    message,
+    tree: tree.sha,
+    parents: [remoteHead],
+  }),
+});
+
+if (!commit.verification?.verified) {
+  throw new Error(
+    `GitHub did not verify commit ${commit.sha}: ${commit.verification?.reason ?? "unknown reason"}`,
+  );
+}
+
+await github(`/repos/${owner}/${repo}/git/refs/${encodedRefName}`, {
+  method: "PATCH",
+  body: JSON.stringify({
+    sha: commit.sha,
+    force: false,
+  }),
+});
+
+console.log(`Created verified commit ${commit.sha} on ${branch}.`);


### PR DESCRIPTION
## Summary
- replace Lingo-owned GPG commit creation with file generation plus pinned peter-evans/create-pull-request for generated translation PRs
- pin peter-evans/create-pull-request to 22a9089034f40e5a961c8808d113e2c98fb63676 (# v7)
- use sign-commits: true and verification guards for generated-content PR workflows
- restore media auto-format behavior so formatting commits land back on the triggering branch, using the GitHub commit API and failing if GitHub does not verify the commit

## Audit
- generated-content workflows that intentionally create PR branches: i18n, generate LLMs.txt
- user-branch CI cleanup workflow: staging media format, now commits directly to GITHUB_REF_NAME with a verified GitHub API commit
- non-git write workflow: publish-fab-menu only publishes packages

## Validation
- YAML parsed for relevant workflows
- pnpm exec prettier --check .github/workflows/staging-media-format.yml scripts/github/create-verified-commit.mjs
- node --check scripts/github/create-verified-commit.mjs
- no-op helper execution with dummy GitHub env
- git diff --check for touched workflow/helper
- local SSH verification of the branch commit