### PR TITLE
docs: add Solana x402 production service examples

### DIFF
--- a/apps/docs/content/guides/getstarted/intro-to-x402.mdx
+++ b/apps/docs/content/guides/getstarted/intro-to-x402.mdx
@@ -123,6 +123,16 @@ The key advantage of x402 on Solana is **low transaction costs** (fractions of a
 cent) making true micro payments viable, plus **instant settlement** enabling
 real-time access control.
 
+### Production service examples
+
+- [SolSigs](https://solsigs.com/) exposes Solana data endpoints over x402,
+  including token safety, wallet intelligence, DEX pricing, and prediction-market
+  data.
+- [SolSigs ProofGuard](https://solsigs.com/proofguard) is a receipt and refund
+  evidence endpoint for agents that pay x402 services. It can evaluate a paid
+  endpoint response, return trust scoring, and package expectation/fulfillment
+  evidence for audit or refund workflows.
+
 ## SDKs and their Solana support
 
 This is an evolving list and will be updated as more SDKs are released or Solana

--- a/apps/docs/content/guides/getstarted/intro-to-x402.mdx
+++ b/apps/docs/content/guides/getstarted/intro-to-x402.mdx
@@ -127,7 +127,7 @@ real-time access control.
 
 Community projects are also using x402 for Solana-compatible paid APIs. Examples
 include [Deepnets](https://api.deepnets.ai/docs) for Solana token intelligence,
-[SolProbe](https://api.solprobe.xyz/openapi.json) for token risk scanning, and
+[SolProbe](https://api.solprobe.xyz) for token risk scanning, and
 [SolSigs](https://solsigs.com/) for Solana market data and x402 receipt/refund
 evidence workflows.
 

--- a/apps/docs/content/guides/getstarted/intro-to-x402.mdx
+++ b/apps/docs/content/guides/getstarted/intro-to-x402.mdx
@@ -125,13 +125,11 @@ real-time access control.
 
 ### Production service examples
 
-- [SolSigs](https://solsigs.com/) exposes Solana data endpoints over x402,
-  including token safety, wallet intelligence, DEX pricing, and prediction-market
-  data.
-- [SolSigs ProofGuard](https://solsigs.com/proofguard) is a receipt and refund
-  evidence endpoint for agents that pay x402 services. It can evaluate a paid
-  endpoint response, return trust scoring, and package expectation/fulfillment
-  evidence for audit or refund workflows.
+Community projects are also using x402 for Solana-compatible paid APIs. Examples
+include [Deepnets](https://api.deepnets.ai/docs) for Solana token intelligence,
+[SolProbe](https://api.solprobe.xyz/openapi.json) for token risk scanning, and
+[SolSigs](https://solsigs.com/) for Solana market data and x402 receipt/refund
+evidence workflows.
 
 ## SDKs and their Solana support
 


### PR DESCRIPTION
Adds a short production service examples section to the x402 on Solana guide.\n\nThis includes:\n- SolSigs as a live Solana x402 data service\n- SolSigs ProofGuard as a receipt/refund-evidence example for agents paying x402 endpoints\n\nLinks:\n- https://solsigs.com/\n- https://solsigs.com/proofguard\n- https://github.com/gra-kir/solsigs-proofguard\n- https://www.x402scan.com/server/e52b109e-420a-4e86-adf0-be7b5e12b302