### PR TITLE
Add Breakpoint 2026 and Accelerate events calendars

### DIFF
--- a/apps/web/src/app/[locale]/events/page.tsx
+++ b/apps/web/src/app/[locale]/events/page.tsx
@@ -18,12 +18,20 @@ export default async function Page(_props: Props) {
   });
 
   // Breakpoint 2026 calendar (https://luma.com/bp26)
-  const bp26Events = await fetchCalendarEvents("cal-vSUPHVSJHqgysCR", {
+  const breakpointEvents = await fetchCalendarEvents("evgrp-f8F1bDAHhBNDM1f", {
     period: "future",
   });
 
+  // Solana Accelerate calendar (https://luma.com/solana-accelerate)
+  const solanaAccelerateEvents = await fetchCalendarEvents(
+    "cal-78uQDEIMsmrT3GN",
+    {
+      period: "future",
+    },
+  );
+
   // Merge Breakpoint 2026 events with main events
-  mainEvents = [...mainEvents, ...bp26Events];
+  mainEvents = [...mainEvents, ...breakpointEvents, ...solanaAccelerateEvents];
 
   // Solanamerica calendar
   const usEvents = await fetchCalendarEvents("cal-TLgSVhf1CeO04x3", {


### PR DESCRIPTION
## Summary
- fetch Breakpoint 2026 events from the Luma event group
- fetch Solana Accelerate events from its Luma calendar
- merge both calendars into the main events feed before sorting and deduping

## Validation
- pnpm --filter solana-com lint
- confirmed /en/events HTML includes Solana Breakpoint 2026 from the merged events list