### PR TITLE
docs(x402): add AlgoVoi facilitator to intro-to-x402

### DIFF
--- a/apps/docs/content/docs/en/payments/agentic-payments/intro-to-x402.mdx
+++ b/apps/docs/content/docs/en/payments/agentic-payments/intro-to-x402.mdx
@@ -133,6 +133,7 @@ support is added.
 | [Corbits](#corbits)                     | Yes                      | Convenient SDK for 402 on Solana                           | [Docs](https://corbits.dev/)                                  |
 | [MCPay.tech](#mcpaytech)                | Yes                      | Pay for MCP servers in micropayments                       | [Website](https://mcpay.tech/)                                |
 | [PayAI Facilitator](#payai-facilitator) | Yes                      | x402 facilitator with solana support                       | [payai.network](https://payai.network/)                       |
+| [AlgoVoi](#algovoi)                     | Yes                      | Multi-chain x402 facilitator with Solana support           | [algovoi.co.uk](https://algovoi.co.uk)                        |
 | [Coinbase](#coinbase)                   | Yes / Python in progress | The coinbase reference implementation of the x402 protocol | [GitHub](https://github.com/coinbase/x402)                    |
 | [ACK](#ack)                             | In PR                    | An agent payment protocol with x402 support                | [GitHub](https://github.com/agentcommercekit/ack)             |
 | [Crossmint](#crossmint)                 | In development           | Payments, wallets; agentic finance; not x402-specific      | [crossmint.com](https://www.crossmint.com/)                   |
@@ -327,6 +328,12 @@ across different networks. Site: https://x402scan.com/
 
 Thirdweb Nexus develops a x402 wrapper around API keys (currently in
 development). Site: https://nexus.thirdweb.com/
+
+### AlgoVoi
+
+Multi-chain x402 facilitator with Solana support, including Solana Actions and
+Solana Pay integration. Also covers Algorand, VOI, Hedera, Stellar, Base, and
+Tempo. Site: https://algovoi.co.uk
 
 ## Native example
 


### PR DESCRIPTION
Adds AlgoVoi to the x402 SDKs list in `intro-to-x402.mdx`: a one-line row in the summary table plus a short h3 section, matching the existing PayAI / x402scan / Nexus / Crossmint pattern (neutral two-sentence description with the site URL).

This resubmits #1413. That PR was reviewed by @h4rkl, the requested wording changes were made to match the surrounding entries, and Greptile passed it as documentation-only. It was closed only because the branch contained an unsigned commit. This PR's single commit is signed and verified per the repository's signed-commits requirement.

Single file, docs only. No dependencies, no code changes.
