### PR TITLE
Update brand guidelines link

### DIFF
--- a/apps/web/src/components/branding/BrandingWelcome.tsx
+++ b/apps/web/src/components/branding/BrandingWelcome.tsx
@@ -11,7 +11,7 @@ const BrandingWelcome = () => {
       <p className="small">
         {t.rich("branding.welcome.description-2", {
           guidelinesLink: (chunks) => (
-            <InlineLink to="https://docs.google.com/document/d/1gOjdCVI2tp-hpCJciSNZAR93cxgw_gh2/edit?usp=sharing&ouid=109711680778628598493&rtpof=true&sd=true">
+            <InlineLink to="https://docs.google.com/document/d/1gOjdCVI2tp-hpCJciSNZAR93cxgw_gh2/edit?usp=sharing">
               {chunks}
             </InlineLink>
           ),

--- a/apps/web/src/components/branding/BrandingWelcome.tsx
+++ b/apps/web/src/components/branding/BrandingWelcome.tsx
@@ -11,7 +11,7 @@ const BrandingWelcome = () => {
       <p className="small">
         {t.rich("branding.welcome.description-2", {
           guidelinesLink: (chunks) => (
-            <InlineLink to="https://drive.google.com/file/d/1e6etjSgFltRAPNPWQlkAJJfU25hKbm35/view">
+            <InlineLink to="https://docs.google.com/document/d/1gOjdCVI2tp-hpCJciSNZAR93cxgw_gh2/edit?usp=sharing&ouid=109711680778628598493&rtpof=true&sd=true">
               {chunks}
             </InlineLink>
           ),


### PR DESCRIPTION
## Summary
- Updates the Brand & Press page's Solana Foundation Brand Guidelines link to the new Google Docs URL.

## Testing
- pnpm -w exec prettier --ignore-path .prettierignore --write /Users/karambit/Sites/solana-com-worktrees/update-brand-guidelines-link/apps/web/src/components/branding/BrandingWelcome.tsx
- git diff --check