### PR TITLE
Add Fee Payers methodology note

### DIFF
--- a/apps/web/src/app/[locale]/data/data-config.ts
+++ b/apps/web/src/app/[locale]/data/data-config.ts
@@ -253,6 +253,13 @@ export const chartDefinitions = [
     metrics: ["Fee Payers"],
     aggregation: "avg",
     seriesField: "provider",
+    methodology: [
+      {
+        provider: "Artemis",
+        description:
+          "Distinct signers of successful transactions, not just fee payers, capturing fee-sponsored users.",
+      },
+    ],
   },
   {
     id: "total-stake",

--- a/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
+++ b/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
@@ -1027,7 +1027,7 @@ function ChartCard({
     <article className="relative p-3 md:p-6 xl:p-8 flex flex-col gap-4 md:gap-5">
       <div className="flex items-start justify-between gap-4">
         <div className="flex min-w-0 items-center gap-2">
-          <h2 className="text-[20px] xl:text-[24px] leading-[1.25] font-medium tracking-normal">
+          <h2 className="m-0 text-[20px] xl:text-[24px] leading-[1.25] font-medium tracking-normal">
             {title}
           </h2>
           {methodologyNotes.length > 0 ? (

--- a/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
+++ b/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
@@ -1026,7 +1026,7 @@ function ChartCard({
   return (
     <article className="relative p-3 md:p-6 xl:p-8 flex flex-col gap-4 md:gap-5">
       <div className="flex items-start justify-between gap-4">
-        <div className="flex min-w-0 items-start gap-2">
+        <div className="flex min-w-0 items-center gap-2">
           <h2 className="text-[20px] xl:text-[24px] leading-[1.25] font-medium tracking-normal">
             {title}
           </h2>


### PR DESCRIPTION
## Summary
- Add the Artemis methodology note for the Fee Payers chart.
- Reuse the existing chart-title methodology tooltip path so the info hover appears when Artemis is selected.
- Vertically align chart methodology icons with chart title text by removing inherited heading margin.

## Testing
- pnpm --filter solana-com lint
- pnpm --filter solana-com test -- src/__tests__/components/data/time-series-chart.test.ts src/__tests__/components/data/time-series-chart-legend.test.tsx
- Playwright local measurement with mocked Artemis Fee Payers data: desktop 1440x1000 buttonDeltaPx=0/svgDeltaPx=0; mobile 390x900 buttonDeltaPx=0/svgDeltaPx=0