### PR TITLE
docs: fix innerInstructions format for simulateTransaction

### DIFF
--- a/apps/docs/content/docs/en/rpc/http/simulatetransaction.mdx
+++ b/apps/docs/content/docs/en/rpc/http/simulatetransaction.mdx
@@ -251,8 +251,10 @@ The minimum slot that the request can be evaluated at
 !values true false  
 !default false
 
-If `true` the response will include CPI instructions (`innerInstructions`).
-These inner instructions will be `jsonParsed` where possible, otherwise `json`.
+If `true` the response will include CPI instructions (`innerInstructions`). Each
+inner instruction is fully parsed (`jsonParsed`) where a parser is available,
+otherwise partially decoded with base-58 encoded program and account addresses.
+The compiled `json` form with account indexes is never returned.
 
 See [Inner Instructions](/docs/rpc/json-structures#inner-instructions) for the
 shared structure.
@@ -478,15 +480,16 @@ When `accounts[].data` is returned as an object, it contains:
 
 ## Example Result
 
-- The `JsonParsed` example shows the simulation result for a transaction that
+- The `Parsed` example shows the simulation result for a transaction that
   creates an
   [associated token account](/docs/tokens/basics/create-token-account#how-to-create-an-associated-token-account).
-- The `Json` example shows the simulation result for a transaction with a CPI
-  (`innerInstructions`) that can't be parsed.
+- The `Partially Decoded` example shows the simulation result for a transaction
+  with a CPI (`innerInstructions`) that can't be parsed. Accounts are returned
+  as base-58 encoded addresses, not indexes.
 
 <CodeTabs>
 
-```json !! title="JsonParsed Inner Instructions"
+```json !! title="Parsed Inner Instructions"
 {
   "jsonrpc": "2.0",
   "result": {
@@ -613,7 +616,7 @@ When `accounts[].data` is returned as an object, it contains:
 }
 ```
 
-```json !! title="Json Inner Instructions"
+```json !! title="Partially Decoded Inner Instructions"
 {
   "jsonrpc": "2.0",
   "result": {

--- a/apps/docs/content/docs/en/rpc/json-structures.mdx
+++ b/apps/docs/content/docs/en/rpc/json-structures.mdx
@@ -560,7 +560,9 @@ Simulation error. Uses the structure documented in
 
 Inner instructions captured during simulation. `null` unless CPI recording was
 requested. Uses the structure documented in
-[Inner Instructions](#inner-instructions).
+[Inner Instructions](#inner-instructions), always in the JSON Parsed form: each
+instruction is either fully parsed or partially decoded, never a compiled
+instruction with account indexes.
 
 ### !! loadedAccountsDataSize
 
@@ -2105,6 +2107,11 @@ detailed under `innerInstructions`.
   `transaction.message.instructions[index]` that made the CPI.
 - `instructions: array[object]` – List of CPI instructions invoked by the
   instruction at `index`, encoded as Json or JsonParsed objects.
+
+Transaction responses use the form matching the requested transaction encoding:
+`json` returns compiled instructions with account indexes, while `jsonParsed`
+returns parsed or partially decoded instructions with base-58 encoded addresses.
+[Simulation Results](#simulation-results) always use the JSON Parsed form.
 
 #### JSON Parsed
 


### PR DESCRIPTION
### Problem

The RPC docs describe `simulateTransaction` inner instructions in the compiled `json` form (`programIdIndex`, account indexes), but Agave returns parsed or partially decoded instructions with base-58 addresses (`parse_ui_inner_instructions` in the transaction-status crate). Developers following the docs expect the wrong shape.

### Summary of Changes

Updated the two RPC docs pages so the documented `innerInstructions` shape for simulation matches the actual output: parsed or partially decoded, never compiled with account indexes. Renamed the example tabs accordingly and clarified when each form applies (transaction responses follow the requested encoding; simulation results are always parsed).

Fixes #844

---

### Change classification (SDLC §2)

- [ ] **Critical**
- [ ] **Standard**
- [x] **Low** — no security impact (docs, tests, dev tooling, content)
