### PR TITLE
docs: add Solana x402 production service examples

### DIFF
--- a/apps/docs/content/guides/getstarted/intro-to-x402.mdx
+++ b/apps/docs/content/guides/getstarted/intro-to-x402.mdx
@@ -123,6 +123,14 @@ The key advantage of x402 on Solana is **low transaction costs** (fractions of a
 cent) making true micro payments viable, plus **instant settlement** enabling
 real-time access control.
 
+### Production service examples
+
+Community projects are also using x402 for Solana-compatible paid APIs. Examples
+include [Deepnets](https://api.deepnets.ai/docs) for Solana token intelligence,
+[SolProbe](https://api.solprobe.xyz) for token risk scanning, and
+[SolSigs](https://solsigs.com/) for Solana market data and x402 receipt/refund
+evidence workflows.
+
 ## SDKs and their Solana support
 
 This is an evolving list and will be updated as more SDKs are released or Solana


### PR DESCRIPTION
### Problem

The x402 intro guide explains the protocol but doesn't show readers any
live production services using it on Solana, so developers finishing the
guide have no concrete endpoints to test against.

### Summary of Changes

Adds a short "Production service examples" section to
guides/getstarted/intro-to-x402.mdx listing three live community-run
x402 services on Solana (Deepnets, SolProbe, SolSigs). Docs-only, 8
lines, no code or configuration changes.

Fixes #

---

### Change classification (SDLC §2)

- [x] **Low** — no security impact (docs, tests, dev tooling, content)

---

Note: this supersedes #1623, which was closed due to unsigned commits.
This PR is a single signed/verified commit (a867c2c) with the same
content, per the maintainer's guidance. Thanks @h4rkl for the clear
instructions.