### PR TITLE
Add data API products to products page

### DIFF
--- a/apps/web/src/data/navigation-hubs.ts
+++ b/apps/web/src/data/navigation-hubs.ts
@@ -328,24 +328,16 @@ const navigationHubStaticConfigs = {
       },
       {
         href: "/data",
-        eyebrow: "Data products",
-        title: "Explore network data and token APIs.",
-        description:
-          "Use Solana Data for network metrics, Tokens API for market and token data, and Pay.sh for paid API workflows.",
-        cta: "Open Solana Data",
         links: [
           {
             href: "/data",
-            title: "Solana Data",
           },
           {
             href: "https://pay.sh",
-            title: "Pay.sh",
             external: true,
           },
           {
             href: "https://tokens.xyz",
-            title: "Tokens API",
             external: true,
           },
         ],
@@ -422,27 +414,16 @@ const navigationHubStaticConfigs = {
         ],
       },
       {
-        title: "Data and API products",
-        description:
-          "Dashboards and API products for network, token, and paid resource workflows.",
         links: [
           {
             href: "/data",
-            title: "Solana Data",
-            description: "Network, stablecoin, and DeFi metrics.",
           },
           {
             href: "https://pay.sh",
-            title: "Pay.sh",
-            description:
-              "Pay-as-you-go API access for agents and command-line tools.",
             external: true,
           },
           {
             href: "https://tokens.xyz",
-            title: "Tokens API",
-            description:
-              "Token, price, and liquidity APIs for Solana applications.",
             external: true,
           },
         ],

--- a/apps/web/src/data/navigation-hubs.ts
+++ b/apps/web/src/data/navigation-hubs.ts
@@ -326,6 +326,30 @@ const navigationHubStaticConfigs = {
           },
         ],
       },
+      {
+        href: "/data",
+        eyebrow: "Data products",
+        title: "Explore network data and token APIs.",
+        description:
+          "Use Solana Data for network metrics, Tokens API for market and token data, and Pay.sh for paid API workflows.",
+        cta: "Open Solana Data",
+        links: [
+          {
+            href: "/data",
+            title: "Solana Data",
+          },
+          {
+            href: "https://pay.sh",
+            title: "Pay.sh",
+            external: true,
+          },
+          {
+            href: "https://tokens.xyz",
+            title: "Tokens API",
+            external: true,
+          },
+        ],
+      },
     ],
     feature: {
       href: "/x402",
@@ -394,6 +418,32 @@ const navigationHubStaticConfigs = {
           },
           {
             href: "/developers/guides",
+          },
+        ],
+      },
+      {
+        title: "Data and API products",
+        description:
+          "Dashboards and API products for network, token, and paid resource workflows.",
+        links: [
+          {
+            href: "/data",
+            title: "Solana Data",
+            description: "Network, stablecoin, and DeFi metrics.",
+          },
+          {
+            href: "https://pay.sh",
+            title: "Pay.sh",
+            description:
+              "Pay-as-you-go API access for agents and command-line tools.",
+            external: true,
+          },
+          {
+            href: "https://tokens.xyz",
+            title: "Tokens API",
+            description:
+              "Token, price, and liquidity APIs for Solana applications.",
+            external: true,
           },
         ],
       },

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -1272,10 +1272,10 @@
     },
     "products": {
       "metaTitle": "Solana Products",
-      "metaDescription": "Find Solana Developer Platform, x402, Agent Registry, Skills, Actions and blinks, Solana Pay, Commerce Kit, Kora, RPC providers, and docs.",
+      "metaDescription": "Find Solana Developer Platform, Pay.sh, Solana Data, Tokens API, x402, Agent Registry, Skills, Actions and blinks, Solana Pay, Commerce Kit, Kora, RPC providers, and docs.",
       "eyebrow": "Products",
       "title": "Find Solana products and tools for building",
-      "description": "Explore APIs, agent tools, payments, transaction links, commerce tools, and docs for building on Solana.",
+      "description": "Explore APIs, data products, agent tools, payments, transaction links, commerce tools, and docs for building on Solana.",
       "primaryCta": {
         "title": "Solana Developer Platform"
       },
@@ -1300,18 +1300,18 @@
         },
         {
           "value": "Build",
-          "label": "Docs and templates",
-          "description": "Developer docs, RPC providers, token docs, and guides help teams start building."
+          "label": "Data and docs",
+          "description": "Solana Data, Tokens API, developer docs, RPC providers, and guides help teams start building."
         }
       ],
       "overview": {
         "eyebrow": "Product map",
         "title": "A simple map of platform, agent, and payment tools.",
-        "description": "Start with platform APIs, agent tools, or payment products, then use the docs to build.",
+        "description": "Start with platform APIs, data products, agent tools, or payment products, then use the docs to build.",
         "points": [
           {
             "title": "Platform layer",
-            "description": "Solana Developer Platform and RPC resources support financial, payment, and data-heavy products."
+            "description": "Solana Developer Platform, Solana Data, Tokens API, and RPC resources support financial, payment, and data-heavy products."
           },
           {
             "title": "Agent layer",
@@ -1377,6 +1377,23 @@
               "title": "Kora"
             }
           ]
+        },
+        {
+          "eyebrow": "Data products",
+          "title": "Explore network data and token APIs.",
+          "description": "Use Solana Data for network metrics, Tokens API for market and token data, and Pay.sh for paid API workflows.",
+          "cta": "Open Solana Data",
+          "links": [
+            {
+              "title": "Solana Data"
+            },
+            {
+              "title": "Pay.sh"
+            },
+            {
+              "title": "Tokens API"
+            }
+          ]
         }
       ],
       "feature": {
@@ -1386,7 +1403,7 @@
         "cta": "Open x402"
       },
       "resourceHeading": "Product resources",
-      "resourceDescription": "Platform APIs, agent tools, payment products, and docs for building on Solana.",
+      "resourceDescription": "Platform APIs, data products, agent tools, payment products, and docs for building on Solana.",
       "sections": [
         {
           "title": "Platforms and tools",
@@ -1475,6 +1492,24 @@
             {
               "title": "Developer guides",
               "description": "Guides for building products and apps."
+            }
+          ]
+        },
+        {
+          "title": "Data and API products",
+          "description": "Dashboards and API products for network, token, and paid resource workflows.",
+          "links": [
+            {
+              "title": "Solana Data",
+              "description": "Network, stablecoin, and DeFi metrics."
+            },
+            {
+              "title": "Pay.sh",
+              "description": "Pay-as-you-go API access for agents and command-line tools."
+            },
+            {
+              "title": "Tokens API",
+              "description": "Token, price, and liquidity APIs for Solana applications."
             }
           ]
         }


### PR DESCRIPTION
## Summary
- Add a Data products pathway to `/products` for Solana Data, Pay.sh, and Tokens API.
- Add a Data and API products directory section with links to `/data`, `https://pay.sh`, and `https://tokens.xyz`.
- Update the English products metadata and page copy to mention Pay.sh, Solana Data, and Tokens API.
- Keep static navigation hub entries structural only; visible copy remains in `common.json`.

## Testing
- `python3 -m json.tool packages/i18n/messages/web/en/common.json`
- `pnpm --filter solana-com lint`
- `pnpm --filter solana-com test -- src/__tests__/components/data/solana-data-dashboard.test.ts`
- Playwright smoke check against local `/products` verified visible labels and link targets for Solana Data, Pay.sh, and Tokens API after removing duplicated static copy.