### PR TITLE
fix: keep news sitemap urlset non-empty

### DIFF
--- a/apps/media/__tests__/google-news-sitemap.test.ts
+++ b/apps/media/__tests__/google-news-sitemap.test.ts
@@ -88,10 +88,86 @@ describe("getGoogleNewsSitemapResponse", () => {
       "<news:publication_date>2026-04-13T13:00:00.000Z</news:publication_date>",
     );
     expect(xml).toContain("<news:title>Fresh Solana News</news:title>");
-    expect(xml).not.toContain("stale-post");
+    // The stale post pads the sitemap as a plain <url> entry, but only the
+    // fresh post carries <news:news> metadata.
+    expect(xml).toContain("<loc>https://solana.com/news/stale-post</loc>");
+    expect(xml.match(/<news:news>/g)).toHaveLength(1);
     expect(xml).not.toContain("Old Solana News");
     expect(xml).not.toContain("draft-post");
     expect(xml).not.toContain("future-post");
+    // Newest first: the fresh post precedes the padded older post.
+    expect(xml.indexOf("fresh-post")).toBeLessThan(xml.indexOf("stale-post"));
+  });
+
+  it("pads the sitemap with the newest older posts so the urlset is never empty", async () => {
+    const olderSlugs = Array.from(
+      { length: 15 },
+      (_, index) => `older-post-${index}`,
+    );
+
+    mockReader.collections.posts.list.mockResolvedValue(olderSlugs);
+    mockReader.collections.posts.read.mockImplementation((slug: string) => {
+      const index = Number(slug.replace("older-post-", ""));
+      return Promise.resolve({
+        status: "published",
+        title: `Older Solana News ${index}`,
+        publishedAt: new Date(
+          Date.UTC(2026, 3, 1, 12, 0, 0) - index * 24 * 60 * 60 * 1000,
+        ).toISOString(),
+      });
+    });
+
+    const response = await getGoogleNewsSitemapResponse(
+      new Date("2026-04-14T12:00:00.000Z"),
+    );
+    const xml = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(xml.match(/<url>/g)).toHaveLength(10);
+    expect(xml).toContain("<loc>https://solana.com/news/older-post-0</loc>");
+    expect(xml).toContain("<loc>https://solana.com/news/older-post-9</loc>");
+    expect(xml).not.toContain("older-post-10");
+    // None of the padded posts are within 48 hours, so no news metadata.
+    expect(xml).not.toContain("<news:news>");
+  });
+
+  it("includes only 48-hour posts when the window has enough articles", async () => {
+    const freshSlugs = Array.from(
+      { length: 12 },
+      (_, index) => `fresh-post-${index}`,
+    );
+
+    mockReader.collections.posts.list.mockResolvedValue([
+      ...freshSlugs,
+      "stale-post",
+    ]);
+    mockReader.collections.posts.read.mockImplementation((slug: string) => {
+      if (slug === "stale-post") {
+        return Promise.resolve({
+          status: "published",
+          title: "Old Solana News",
+          publishedAt: "2026-04-01T11:59:59.000Z",
+        });
+      }
+
+      const index = Number(slug.replace("fresh-post-", ""));
+      return Promise.resolve({
+        status: "published",
+        title: `Fresh Solana News ${index}`,
+        publishedAt: new Date(
+          Date.UTC(2026, 3, 13, 13, 0, 0) - index * 1000,
+        ).toISOString(),
+      });
+    });
+
+    const response = await getGoogleNewsSitemapResponse(
+      new Date("2026-04-14T12:00:00.000Z"),
+    );
+    const xml = await response.text();
+
+    expect(xml.match(/<url>/g)).toHaveLength(12);
+    expect(xml.match(/<news:news>/g)).toHaveLength(12);
+    expect(xml).not.toContain("stale-post");
   });
 
   it("escapes XML-sensitive characters in titles", async () => {

--- a/apps/media/lib/google-news-sitemap.ts
+++ b/apps/media/lib/google-news-sitemap.ts
@@ -9,6 +9,7 @@ const GOOGLE_NEWS_SITEMAP_CANONICAL_PATH = "/news/sitemap-news.xml";
 const PUBLICATION_NAME = "Solana";
 const PUBLICATION_LANGUAGE = "en";
 const GOOGLE_NEWS_LOOKBACK_HOURS = 48;
+const MIN_SITEMAP_URLS = 10;
 const MAX_NEWS_URLS = 1000;
 const XML_CONTENT_TYPE = "application/xml; charset=utf-8";
 const XML_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=600";
@@ -24,20 +25,19 @@ function escapeXml(value: string): string {
     .replace(/'/g, "&apos;");
 }
 
-type RecentPublishedPost = {
+type SitemapPost = {
   slug: string;
   title: string;
   publishedAt: Date;
+  isRecentNews: boolean;
 };
 
-async function getRecentPublishedPosts(
-  now: Date,
-): Promise<RecentPublishedPost[]> {
+async function getSitemapPosts(now: Date): Promise<SitemapPost[]> {
   const minNewsPublishedAt = new Date(
     now.getTime() - GOOGLE_NEWS_LOOKBACK_HOURS * 60 * 60 * 1000,
   );
   const allSlugs = await reader.collections.posts.list();
-  const posts: RecentPublishedPost[] = [];
+  const posts: SitemapPost[] = [];
 
   for (const slug of allSlugs) {
     const post = await fetchPublishedPostBySlug(slug, now);
@@ -50,7 +50,7 @@ async function getRecentPublishedPosts(
       continue;
     }
 
-    if (publishedAt < minNewsPublishedAt || publishedAt > now) {
+    if (publishedAt > now) {
       continue;
     }
 
@@ -58,6 +58,7 @@ async function getRecentPublishedPosts(
       slug,
       title: String(post.title || slug),
       publishedAt,
+      isRecentNews: publishedAt >= minNewsPublishedAt,
     });
   }
 
@@ -65,29 +66,44 @@ async function getRecentPublishedPosts(
     (left, right) => right.publishedAt.getTime() - left.publishedAt.getTime(),
   );
 
-  return posts.slice(0, MAX_NEWS_URLS);
+  // Google only wants <news:news> metadata on articles from the last 48
+  // hours, but an empty <urlset> is a "Missing XML tag" error in Search
+  // Console. Pad the sitemap with the newest older posts as plain <url>
+  // entries (no news metadata) so it always validates.
+  const recentNewsPosts = posts.filter((post) => post.isRecentNews);
+  if (recentNewsPosts.length >= MIN_SITEMAP_URLS) {
+    return recentNewsPosts.slice(0, MAX_NEWS_URLS);
+  }
+
+  return posts.slice(0, MIN_SITEMAP_URLS);
 }
 
 async function buildGoogleNewsSitemapXml(
   now: Date = new Date(),
 ): Promise<string> {
-  const posts = await getRecentPublishedPosts(now);
+  const posts = await getSitemapPosts(now);
   const urls = posts.map((post) => {
     const loc = `${NEWS_URL}/${post.slug}`;
     const lines = [
       "<url>",
       `<loc>${escapeXml(loc)}</loc>`,
       `<lastmod>${escapeXml(post.publishedAt.toISOString())}</lastmod>`,
-      "<news:news>",
-      "<news:publication>",
-      `<news:name>${escapeXml(PUBLICATION_NAME)}</news:name>`,
-      `<news:language>${escapeXml(PUBLICATION_LANGUAGE)}</news:language>`,
-      "</news:publication>",
-      `<news:publication_date>${escapeXml(post.publishedAt.toISOString())}</news:publication_date>`,
-      `<news:title>${escapeXml(post.title)}</news:title>`,
-      "</news:news>",
-      "</url>",
     ];
+
+    if (post.isRecentNews) {
+      lines.push(
+        "<news:news>",
+        "<news:publication>",
+        `<news:name>${escapeXml(PUBLICATION_NAME)}</news:name>`,
+        `<news:language>${escapeXml(PUBLICATION_LANGUAGE)}</news:language>`,
+        "</news:publication>",
+        `<news:publication_date>${escapeXml(post.publishedAt.toISOString())}</news:publication_date>`,
+        `<news:title>${escapeXml(post.title)}</news:title>`,
+        "</news:news>",
+      );
+    }
+
+    lines.push("</url>");
 
     return lines.join("");
   });


### PR DESCRIPTION
## Summary
- pad the Google News sitemap with the newest published posts when the 48-hour news window has fewer than 10 articles
- keep `<news:news>` metadata only on articles inside Google News' 48-hour window
- add coverage for sparse, fully populated, and padded sitemap cases

## Testing
- `pnpm --filter solana-com-media test -- google-news-sitemap`