### PR TITLE
Fix bun template generation command

### DIFF
--- a/apps/templates/src/components/templates/templates-ui-generate-command.tsx
+++ b/apps/templates/src/components/templates/templates-ui-generate-command.tsx
@@ -15,6 +15,8 @@ function getCommand(pm: string, template: string) {
     case "yarn":
       // Yarn only supports the `latest` tag
       return `yarn create solana-dapp -t ${template}`;
+    case "bun":
+      return `bunx create-solana-dapp@latest -t ${template}`;
     default:
       // All other package managers support the `@latest` tag and best practice is to always use it explicitly
       return `${pm} create solana-dapp@latest -t ${template}`;


### PR DESCRIPTION
 ### Problem

The generated Bun command on the Solana templates page is incorrect for creating a Solana dApp template. It currently falls through to the default command format and shows `bun create solana-dapp@latest -t ...`, which does not work reliably for Bun users, especially on Windows/PowerShell/WSL.

### Summary of Changes

Updated the templates command generator so the Bun option explicitly uses `bunx create-solana-dapp@latest -t ...`.

This matches the expected Bun package execution flow and fixes the broken generated command. No security-relevant behavior changed.

Fixes #1549

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the browser).
- [x] Input from users or external services is validated before use; no `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit` passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

none

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case impact if compromised, external dependency failure modes), or "n/a":

n/a

-->