### PR TITLE
fix: filter Sentry v8 rejection shapes

### DIFF
--- a/packages/sentry/src/__tests__/sentry-filters.test.ts
+++ b/packages/sentry/src/__tests__/sentry-filters.test.ts
@@ -27,19 +27,23 @@ const buildSyntheticRejectionEvent = ({
   serialized,
   synthetic = true,
   type = "UnhandledRejection",
+  value = "Non-Error promise rejection captured with keys: currentTarget, isTrusted, target, type",
+  mechanismType,
 }: {
   serialized?: unknown;
   synthetic?: boolean;
   type?: string;
+  value?: string;
+  mechanismType?: string;
 } = {}) => ({
   exception: {
     values: [
       {
         type,
-        value:
-          "Non-Error promise rejection captured with keys: currentTarget, isTrusted, target, type",
+        value,
         mechanism: {
           synthetic,
+          ...(mechanismType ? { type: mechanismType } : {}),
         },
       },
     ],
@@ -48,6 +52,25 @@ const buildSyntheticRejectionEvent = ({
     __serialized__: serialized,
   },
 });
+
+// Sentry SDK v8+ titles non-Error rejections with the rejected value's class
+// name and namespaces the mechanism type, unlike the v7 "UnhandledRejection"
+// shape the other builders model.
+const buildV8RejectionEvent = ({
+  serialized,
+  type = "Event",
+  value = "Event `Event` (type=error) captured as promise rejection",
+}: {
+  serialized?: unknown;
+  type?: string;
+  value?: string;
+} = {}) =>
+  buildSyntheticRejectionEvent({
+    serialized,
+    type,
+    value,
+    mechanismType: "auto.browser.global_handlers.onunhandledrejection",
+  });
 
 const buildResourceEventPayload = (
   elementMarker: string,
@@ -137,6 +160,49 @@ describe("sentryBeforeSend", () => {
     });
 
     expect(sentryBeforeSend(event)).toBeNull();
+  });
+
+  it("drops SDK v8+ resource load rejections typed by class name (JAVASCRIPT-NEXTJS-20 shape)", () => {
+    const event = buildV8RejectionEvent({
+      serialized: {
+        currentTarget: "[object Null]",
+        isTrusted: true,
+        target: " > html.dark.tw-dark > head > link",
+        type: "error",
+      },
+    });
+
+    expect(sentryBeforeSend(event)).toBeNull();
+  });
+
+  it("drops SDK v8+ empty-object rejections", () => {
+    const event = buildV8RejectionEvent({
+      serialized: {},
+      type: "Object",
+      value:
+        "Object captured as promise rejection with keys: [object has no keys]",
+    });
+
+    expect(sentryBeforeSend(event)).toBeNull();
+  });
+
+  it("drops SDK v8+ wallet extension rejections", () => {
+    const event = buildV8RejectionEvent({
+      serialized: { code: 4001, message: "User rejected the request." },
+      type: "Object",
+      value: "Object captured as promise rejection with keys: code, message",
+    });
+
+    expect(sentryBeforeSend(event)).toBeNull();
+  });
+
+  it("keeps resource-shaped events without any rejection marker", () => {
+    const event = buildSyntheticRejectionEvent({
+      serialized: buildResourceEventPayload("HTMLImageElement", "error"),
+      type: "Event",
+    });
+
+    expect(sentryBeforeSend(event)).toEqual(event);
   });
 
   it("drops trusted error events even without an element marker", () => {

--- a/packages/sentry/src/index.ts
+++ b/packages/sentry/src/index.ts
@@ -63,20 +63,23 @@ const RESOURCE_ELEMENT_MARKERS = [
 const RESOURCE_DOM_PATH_PATTERN =
   /(?:^|>)\s*(?:img|link|script|video|audio|source|track|iframe)(?:[.#[\s]|$)/i;
 
+type SentryExceptionValue = {
+  type?: string;
+  value?: string;
+  mechanism?: {
+    synthetic?: boolean;
+    type?: string;
+  };
+  stacktrace?: {
+    frames?: Array<{
+      filename?: string;
+    }>;
+  };
+};
+
 type SentryEventLike = {
   exception?: {
-    values?: Array<{
-      type?: string;
-      value?: string;
-      mechanism?: {
-        synthetic?: boolean;
-      };
-      stacktrace?: {
-        frames?: Array<{
-          filename?: string;
-        }>;
-      };
-    }>;
+    values?: Array<SentryExceptionValue>;
   };
   extra?: Record<string, unknown>;
   tags?: Record<string, unknown>;
@@ -197,14 +200,27 @@ function isThirdPartyFrame(filename: string): boolean {
   );
 }
 
-function isSerializedWalletExtensionRejection(
-  serialized: unknown,
-  exceptionType: string | undefined,
-  isSynthetic: boolean | undefined,
+// Sentry SDK v7 titles non-Error promise rejections "UnhandledRejection";
+// v8+ uses the rejected value's class name ("Event", "Object") and reports
+// the handler through namespaced mechanism types like
+// "auto.browser.global_handlers.onunhandledrejection" — accept both shapes.
+function isRejectionException(
+  exception: SentryExceptionValue | undefined,
 ): boolean {
   return Boolean(
-    isSynthetic &&
-    exceptionType === "UnhandledRejection" &&
+    exception &&
+    (exception.type === "UnhandledRejection" ||
+      exception.mechanism?.type?.includes("onunhandledrejection")),
+  );
+}
+
+function isSerializedWalletExtensionRejection(
+  serialized: unknown,
+  exception: SentryExceptionValue | undefined,
+): boolean {
+  return Boolean(
+    exception?.mechanism?.synthetic &&
+    isRejectionException(exception) &&
     serialized &&
     typeof serialized === "object" &&
     "code" in serialized &&
@@ -213,13 +229,14 @@ function isSerializedWalletExtensionRejection(
 }
 
 function isKnownExtensionRejectionMessage(
-  value: string | undefined,
-  exceptionType: string | undefined,
+  exception: SentryExceptionValue | undefined,
 ): boolean {
   return Boolean(
-    exceptionType === "UnhandledRejection" &&
-    value &&
-    EXTENSION_REJECTION_PATTERNS.some((pattern) => pattern.test(value)),
+    isRejectionException(exception) &&
+    exception?.value &&
+    EXTENSION_REJECTION_PATTERNS.some((pattern) =>
+      pattern.test(exception.value ?? ""),
+    ),
   );
 }
 
@@ -228,11 +245,8 @@ function isWalletExtensionError(event: SentryEventLike): boolean {
   const serialized = event.extra?.__serialized__;
 
   return (
-    isSerializedWalletExtensionRejection(
-      serialized,
-      exception?.type,
-      exception?.mechanism?.synthetic,
-    ) || isKnownExtensionRejectionMessage(exception?.value, exception?.type)
+    isSerializedWalletExtensionRejection(serialized, exception) ||
+    isKnownExtensionRejectionMessage(exception)
   );
 }
 
@@ -286,7 +300,7 @@ function isResourceLoadRejection(event: SentryEventLike): boolean {
 
   return Boolean(
     exception?.mechanism?.synthetic &&
-    exception.type === "UnhandledRejection" &&
+    isRejectionException(exception) &&
     isSerializedResourceEvent(event.extra?.__serialized__),
   );
 }
@@ -298,7 +312,7 @@ function isEmptyObjectRejection(event: SentryEventLike): boolean {
 
   return Boolean(
     exception?.mechanism?.synthetic &&
-    exception.type === "UnhandledRejection" &&
+    isRejectionException(exception) &&
     frames.length === 0 &&
     isRecord(serialized) &&
     Object.keys(serialized).length === 0,


### PR DESCRIPTION
## Summary
- recognize Sentry SDK v8+ unhandled rejection shapes by mechanism type
- keep filtering resource load, empty object, and wallet extension rejection noise
- add regression coverage for the v8+ event shapes

## Testing
- pnpm --filter @workspace/sentry test
- pnpm --filter @workspace/sentry check-types
- pnpm --filter @workspace/sentry lint