### PR TITLE
feat: Add highlighted events section to Breakpoint homepage

### DIFF
--- a/apps/breakpoint/.env.example
+++ b/apps/breakpoint/.env.example
@@ -7,3 +7,6 @@ AIRTABLE_VIEW_ID_SPEAKERS=viwK6atCbxFZWGyvk
 AIRTABLE_BASE_ID_AGENDA=apph4y5MDXBxJ2uZy
 AIRTABLE_TABLE_ID_AGENDA=tbl802700wD64jBNI
 AIRTABLE_VIEW_ID_AGENDA=viw9MdyVxScVNZaZX
+
+# Optional: Luma API key for the highlighted events feed (public calendars work without it)
+LUMA_PRIVATE_API_KEY=

--- a/apps/breakpoint/next.config.ts
+++ b/apps/breakpoint/next.config.ts
@@ -23,10 +23,6 @@ const nextConfig: NextConfig = {
         protocol: "https",
         hostname: "**.lu.ma",
       },
-      {
-        protocol: "https",
-        hostname: "cdn.lu.ma",
-      },
     ],
   },
   experimental: {

--- a/apps/breakpoint/next.config.ts
+++ b/apps/breakpoint/next.config.ts
@@ -13,6 +13,22 @@ const nextConfig: NextConfig = {
   env: {
     NEXT_PUBLIC_APP_NAME: "breakpoint",
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "**.lumacdn.com",
+      },
+      {
+        protocol: "https",
+        hostname: "**.lu.ma",
+      },
+      {
+        protocol: "https",
+        hostname: "cdn.lu.ma",
+      },
+    ],
+  },
   experimental: {
     externalDir: true,
   },

--- a/apps/breakpoint/src/app/[locale]/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/page.tsx
@@ -8,6 +8,7 @@ import WhyAttendSection from "@/components/sections/WhyAttendSection";
 import GallerySection from "@/components/sections/GallerySection";
 import StatsSection from "@/components/sections/StatsSection";
 import SponsorsSection from "@/components/sections/SponsorsSection";
+import EventsSection from "@/components/sections/EventsSection";
 import HighlightsSection from "@/components/sections/HighlightsSection";
 import AnnouncementsSection from "@/components/sections/AnnouncementsSection";
 import FAQSection from "@/components/sections/FAQSection";
@@ -47,6 +48,7 @@ export default async function HomePage({
       <GallerySection />
       <StatsSection />
       <Marquee />
+      <EventsSection />
       <HighlightsSection />
       <AnnouncementsSection />
       <FAQSection />

--- a/apps/breakpoint/src/app/globals.css
+++ b/apps/breakpoint/src/app/globals.css
@@ -258,10 +258,12 @@
     font-family: var(--font-abc-favorit), Arial, sans-serif;
     margin: 0;
     min-width: 320px;
+    overflow-x: clip;
     text-rendering: optimizeLegibility;
   }
 
   html {
+    overflow-x: clip;
     scroll-behavior: smooth;
   }
 

--- a/apps/breakpoint/src/components/sections/EventsCarousel.tsx
+++ b/apps/breakpoint/src/components/sections/EventsCarousel.tsx
@@ -143,7 +143,7 @@ export default function EventsCarousel({
       <ul
         ref={scrollRef}
         aria-label={headline}
-        className="unstyled-list scrollbar-hidden -mr-[20px] flex touch-pan-x snap-x snap-mandatory gap-m overflow-x-auto overscroll-x-contain p-0 pr-[20px] [-webkit-overflow-scrolling:touch] md:mr-0 md:pr-0"
+        className="unstyled-list scrollbar-hidden -mr-[20px] flex touch-pan-x snap-x snap-mandatory gap-m overflow-x-auto overflow-y-hidden overscroll-x-contain p-0 pr-[20px] [-webkit-overflow-scrolling:touch] md:mr-0 md:pr-0"
         role="list"
       >
         {items.map((event) => {

--- a/apps/breakpoint/src/components/sections/EventsCarousel.tsx
+++ b/apps/breakpoint/src/components/sections/EventsCarousel.tsx
@@ -160,7 +160,7 @@ export default function EventsCarousel({
                 className="group block h-full w-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
                 {...getAnchorLinkProps({ href: event.url })}
               >
-                <span className="relative block aspect-[3/2] overflow-hidden border border-neutral-700 bg-neutral-800">
+                <span className="relative block aspect-square overflow-hidden border border-neutral-700 bg-neutral-800">
                   {event.coverUrl && (
                     <Image
                       src={event.coverUrl}

--- a/apps/breakpoint/src/components/sections/EventsCarousel.tsx
+++ b/apps/breakpoint/src/components/sections/EventsCarousel.tsx
@@ -65,7 +65,7 @@ function formatEventMeta(
       : `${startParts.day} ${startParts.month} – ${endParts.day} ${endParts.month}`;
 
   return {
-    time: null,
+    time: end ? `${timeFormat.format(start)}–${timeFormat.format(end)}` : null,
     date: `${dayRange}, ${endParts.year}`.toUpperCase(),
   };
 }

--- a/apps/breakpoint/src/components/sections/EventsCarousel.tsx
+++ b/apps/breakpoint/src/components/sections/EventsCarousel.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import React, { useCallback, useId, useRef } from "react";
+import Image from "next/image";
+import { useLocale } from "next-intl";
+import Button from "@/components/Button";
+import CarouselControls from "@/components/CarouselControls";
+import type { HighlightedEvent } from "@/content/events/types";
+import { SIDE_EVENTS_HREF } from "@/content/links";
+import { getAnchorLinkProps } from "@/lib/links";
+
+interface EventsCarouselProps {
+  headline: string;
+  scheduleCta: string;
+  communityCta: string;
+  items: HighlightedEvent[];
+}
+
+function getDateParts(date: Date, locale: string, timeZone: string) {
+  const parts = new Intl.DateTimeFormat(locale, {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone,
+  }).formatToParts(date);
+  const get = (type: string) =>
+    parts.find((part) => part.type === type)?.value ?? "";
+  return { day: get("day"), month: get("month"), year: get("year") };
+}
+
+function formatEventMeta(
+  event: HighlightedEvent,
+  locale: string,
+): { time: string | null; date: string } {
+  const start = new Date(event.startAt);
+  const end = event.endAt ? new Date(event.endAt) : null;
+  const timeZone = event.timezone ?? "Europe/London";
+
+  const timeFormat = new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+    hourCycle: "h23",
+    timeZone,
+  });
+
+  const startParts = getDateParts(start, locale, timeZone);
+  const endParts = end ? getDateParts(end, locale, timeZone) : null;
+  const sameDay =
+    !endParts ||
+    (startParts.day === endParts.day &&
+      startParts.month === endParts.month &&
+      startParts.year === endParts.year);
+
+  if (sameDay) {
+    return {
+      time: end
+        ? `${timeFormat.format(start)}–${timeFormat.format(end)}`
+        : timeFormat.format(start),
+      date: `${startParts.day} ${startParts.month}, ${startParts.year}`.toUpperCase(),
+    };
+  }
+
+  const dayRange =
+    startParts.month === endParts.month && startParts.year === endParts.year
+      ? `${startParts.day}–${endParts.day} ${endParts.month}`
+      : `${startParts.day} ${startParts.month} – ${endParts.day} ${endParts.month}`;
+
+  return {
+    time: null,
+    date: `${dayRange}, ${endParts.year}`.toUpperCase(),
+  };
+}
+
+export default function EventsCarousel({
+  headline,
+  scheduleCta,
+  communityCta,
+  items,
+}: EventsCarouselProps) {
+  const locale = useLocale();
+  const scrollRef = useRef<HTMLUListElement>(null);
+  const headingId = useId();
+
+  const scrollBy = useCallback((direction: number) => {
+    if (!scrollRef.current) return;
+
+    const firstCard =
+      scrollRef.current.querySelector<HTMLElement>("[data-event-card]");
+    const scrollAmount = firstCard
+      ? firstCard.offsetWidth + 32
+      : Math.min(scrollRef.current.clientWidth, 440);
+    const maxScroll =
+      scrollRef.current.scrollWidth - scrollRef.current.clientWidth;
+    const nextScroll = scrollRef.current.scrollLeft + direction * scrollAmount;
+
+    if (nextScroll < 0) {
+      scrollRef.current.scrollTo({ left: maxScroll, behavior: "smooth" });
+      return;
+    }
+
+    if (nextScroll > maxScroll) {
+      scrollRef.current.scrollTo({ left: 0, behavior: "smooth" });
+      return;
+    }
+
+    scrollRef.current.scrollBy({
+      left: direction * scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  return (
+    <div
+      aria-labelledby={headingId}
+      aria-roledescription="carousel"
+      className="flex flex-col gap-m md:gap-l"
+      role="region"
+    >
+      <div className="flex flex-col gap-s md:flex-row md:items-end md:justify-between">
+        <div className="flex flex-col items-start gap-s">
+          <h2 id={headingId} className="type-h3 max-w-[560px] text-white">
+            {headline}
+          </h2>
+          <div className="flex w-full flex-col gap-xs sm:w-auto sm:flex-row">
+            <Button
+              label={scheduleCta}
+              variant="primary"
+              href="/schedule"
+              arrow
+              className="w-full sm:w-auto"
+            />
+            <Button
+              label={communityCta}
+              variant="secondary"
+              href={SIDE_EVENTS_HREF}
+              arrow
+              className="w-full sm:w-auto"
+            />
+          </div>
+        </div>
+        <CarouselControls
+          className="shrink-0"
+          labelPrefix={headline}
+          onPrev={() => scrollBy(-1)}
+          onNext={() => scrollBy(1)}
+        />
+      </div>
+
+      <ul
+        ref={scrollRef}
+        aria-label={headline}
+        className="unstyled-list scrollbar-hidden -mr-[20px] flex touch-pan-x snap-x snap-mandatory gap-m overflow-x-auto overscroll-x-contain p-0 pr-[20px] [-webkit-overflow-scrolling:touch] md:mr-0 md:pr-0"
+        role="list"
+      >
+        {items.map((event) => {
+          const { time, date } = formatEventMeta(event, locale);
+
+          return (
+            <li
+              key={event.id}
+              data-event-card
+              className="block aspect-[3/2] w-[280px] shrink-0 snap-start md:w-[calc((100%-64px)/3)] md:min-w-[300px]"
+            >
+              <a
+                href={event.url}
+                className="group relative flex h-full w-full flex-col justify-end overflow-hidden border border-neutral-700 p-s focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
+                {...getAnchorLinkProps({ href: event.url })}
+              >
+                {event.coverUrl && (
+                  <>
+                    <Image
+                      src={event.coverUrl}
+                      alt=""
+                      fill
+                      sizes="(min-width: 768px) 33vw, 280px"
+                      className="object-cover transition-transform duration-300 group-hover:scale-105"
+                    />
+                    <span
+                      aria-hidden="true"
+                      className="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-black/20"
+                    />
+                  </>
+                )}
+                <span className="relative z-10 flex flex-col items-start">
+                  {time && (
+                    <span className="type-eyebrow text-white">{time}</span>
+                  )}
+                  <span className="type-eyebrow mt-3xs text-white">{date}</span>
+                  <span className="type-h5 mt-2xs text-white">
+                    {event.title}
+                  </span>
+                  <span className="sr-only">(opens in a new tab)</span>
+                </span>
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/apps/breakpoint/src/components/sections/EventsCarousel.tsx
+++ b/apps/breakpoint/src/components/sections/EventsCarousel.tsx
@@ -11,7 +11,6 @@ import { getAnchorLinkProps } from "@/lib/links";
 
 interface EventsCarouselProps {
   headline: string;
-  scheduleCta: string;
   communityCta: string;
   items: HighlightedEvent[];
 }
@@ -73,7 +72,6 @@ function formatEventMeta(
 
 export default function EventsCarousel({
   headline,
-  scheduleCta,
   communityCta,
   items,
 }: EventsCarouselProps) {
@@ -123,13 +121,6 @@ export default function EventsCarousel({
           </h2>
           <div className="flex w-full flex-col gap-xs sm:w-auto sm:flex-row">
             <Button
-              label={scheduleCta}
-              variant="primary"
-              href="/schedule"
-              arrow
-              className="w-full sm:w-auto"
-            />
-            <Button
               label={communityCta}
               variant="secondary"
               href={SIDE_EVENTS_HREF}
@@ -159,15 +150,15 @@ export default function EventsCarousel({
             <li
               key={event.id}
               data-event-card
-              className="block aspect-[3/2] w-[280px] shrink-0 snap-start md:w-[calc((100%-64px)/3)] md:min-w-[300px]"
+              className="block w-[280px] shrink-0 snap-start md:w-[calc((100%-64px)/3)] md:min-w-[300px]"
             >
               <a
                 href={event.url}
-                className="group relative flex h-full w-full flex-col justify-end overflow-hidden border border-neutral-700 p-s focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
+                className="group block h-full w-full focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
                 {...getAnchorLinkProps({ href: event.url })}
               >
-                {event.coverUrl && (
-                  <>
+                <span className="relative block aspect-[3/2] overflow-hidden border border-neutral-700 bg-neutral-800">
+                  {event.coverUrl && (
                     <Image
                       src={event.coverUrl}
                       alt=""
@@ -175,19 +166,20 @@ export default function EventsCarousel({
                       sizes="(min-width: 768px) 33vw, 280px"
                       className="object-cover transition-transform duration-300 group-hover:scale-105"
                     />
-                    <span
-                      aria-hidden="true"
-                      className="absolute inset-0 bg-gradient-to-t from-black via-black/60 to-black/20"
-                    />
-                  </>
-                )}
-                <span className="relative z-10 flex flex-col items-start">
-                  {time && (
-                    <span className="type-eyebrow text-white">{time}</span>
                   )}
-                  <span className="type-eyebrow mt-3xs text-white">{date}</span>
-                  <span className="type-h5 mt-2xs text-white">
+                </span>
+                <span className="flex min-h-[128px] flex-col items-start border-x border-b border-neutral-700 p-s">
+                  <span className="type-h5-fixed text-white transition-opacity duration-200 group-hover:opacity-70">
                     {event.title}
+                  </span>
+                  <span className="type-eyebrow mt-2xs flex flex-wrap gap-x-2xs gap-y-3xs text-text-secondary">
+                    <span>{date}</span>
+                    {time && (
+                      <>
+                        <span aria-hidden="true">/</span>
+                        <span>{time}</span>
+                      </>
+                    )}
                   </span>
                   <span className="sr-only">(opens in a new tab)</span>
                 </span>

--- a/apps/breakpoint/src/components/sections/EventsCarousel.tsx
+++ b/apps/breakpoint/src/components/sections/EventsCarousel.tsx
@@ -84,8 +84,11 @@ export default function EventsCarousel({
 
     const firstCard =
       scrollRef.current.querySelector<HTMLElement>("[data-event-card]");
+    const gap = firstCard
+      ? Number.parseFloat(getComputedStyle(scrollRef.current).columnGap)
+      : 0;
     const scrollAmount = firstCard
-      ? firstCard.offsetWidth + 32
+      ? firstCard.offsetWidth + (Number.isFinite(gap) ? gap : 0)
       : Math.min(scrollRef.current.clientWidth, 440);
     const maxScroll =
       scrollRef.current.scrollWidth - scrollRef.current.clientWidth;

--- a/apps/breakpoint/src/components/sections/EventsSection.tsx
+++ b/apps/breakpoint/src/components/sections/EventsSection.tsx
@@ -16,7 +16,6 @@ export default async function EventsSection() {
       <div className="container">
         <EventsCarousel
           headline={t("events.headline")}
-          scheduleCta={t("events.scheduleCta")}
           communityCta={t("events.communityCta")}
           items={events}
         />

--- a/apps/breakpoint/src/components/sections/EventsSection.tsx
+++ b/apps/breakpoint/src/components/sections/EventsSection.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { getTranslations } from "@workspace/i18n/server";
+import EventsCarousel from "@/components/sections/EventsCarousel";
+import { getHighlightedEvents } from "@/content/events/luma";
+
+export default async function EventsSection() {
+  const t = await getTranslations("breakpoint");
+  const events = await getHighlightedEvents();
+
+  if (events.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="pt-20 md:pt-[120px]">
+      <div className="container">
+        <EventsCarousel
+          headline={t("events.headline")}
+          scheduleCta={t("events.scheduleCta")}
+          communityCta={t("events.communityCta")}
+          items={events}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/breakpoint/src/content/events/luma.ts
+++ b/apps/breakpoint/src/content/events/luma.ts
@@ -9,6 +9,8 @@ const LUMA_API_BASE = "https://api.lu.ma";
 const LUMA_REQUEST_TIMEOUT_MS = 10_000;
 const EVENTS_CACHE_SECONDS = 1800;
 const EVENTS_CACHE_TAG = "breakpoint-events";
+const LUMA_PAGE_SIZE = 50;
+const LUMA_MAX_PAGES = 20;
 
 interface LumaEventData {
   api_id?: string;
@@ -21,6 +23,12 @@ interface LumaEventData {
   geo_address_info?: {
     city?: string;
   };
+}
+
+interface LumaCalendarItemsResponse {
+  entries?: { event?: LumaEventData }[];
+  has_more?: boolean;
+  next_cursor?: string | null;
 }
 
 function lumaHeaders(): HeadersInit {
@@ -72,19 +80,46 @@ function normalizeLumaEvent(event: LumaEventData): HighlightedEvent | null {
 }
 
 async function fetchCalendarEvents(): Promise<HighlightedEvent[]> {
-  const url = new URL(`${LUMA_API_BASE}/calendar/get-items`);
-  url.searchParams.set("calendar_api_id", BREAKPOINT_LUMA_CALENDAR_ID);
-  url.searchParams.set("series_mode", "sessions");
-  url.searchParams.set("period", "future");
-  url.searchParams.set("pagination_limit", "50");
+  const events: HighlightedEvent[] = [];
+  const seenCursors = new Set<string>();
+  let cursor: string | null = null;
 
-  const payload = (await fetchLumaJson(url)) as {
-    entries?: { event?: LumaEventData }[];
-  } | null;
+  for (let page = 0; page < LUMA_MAX_PAGES; page += 1) {
+    const url = new URL(`${LUMA_API_BASE}/calendar/get-items`);
+    url.searchParams.set("calendar_api_id", BREAKPOINT_LUMA_CALENDAR_ID);
+    url.searchParams.set("series_mode", "sessions");
+    url.searchParams.set("period", "future");
+    url.searchParams.set("pagination_limit", String(LUMA_PAGE_SIZE));
+    if (cursor) {
+      url.searchParams.set("pagination_cursor", cursor);
+    }
 
-  return (payload?.entries ?? [])
-    .map((entry) => (entry.event ? normalizeLumaEvent(entry.event) : null))
-    .filter((event): event is HighlightedEvent => event !== null);
+    const payload = (await fetchLumaJson(
+      url,
+    )) as LumaCalendarItemsResponse | null;
+
+    events.push(
+      ...(payload?.entries ?? [])
+        .map((entry) => (entry.event ? normalizeLumaEvent(entry.event) : null))
+        .filter((event): event is HighlightedEvent => event !== null),
+    );
+
+    const nextCursor = payload?.next_cursor ?? null;
+    if (!payload?.has_more || !nextCursor) {
+      return events;
+    }
+
+    if (seenCursors.has(nextCursor)) {
+      console.warn("Luma pagination returned a repeated cursor.");
+      return events;
+    }
+
+    seenCursors.add(nextCursor);
+    cursor = nextCursor;
+  }
+
+  console.warn(`Luma pagination exceeded ${LUMA_MAX_PAGES} pages.`);
+  return events;
 }
 
 async function fetchHighlightedEvents(): Promise<HighlightedEvent[]> {

--- a/apps/breakpoint/src/content/events/luma.ts
+++ b/apps/breakpoint/src/content/events/luma.ts
@@ -1,0 +1,136 @@
+import { unstable_cache } from "next/cache";
+import {
+  BREAKPOINT_LUMA_CALENDAR_ID,
+  BREAKPOINT_LUMA_EVENT_ID,
+  HIGHLIGHTED_EVENT_URLS,
+} from "@/content/links";
+import type { HighlightedEvent } from "./types";
+
+const LUMA_API_BASE = "https://api.lu.ma";
+const LUMA_REQUEST_TIMEOUT_MS = 10_000;
+const EVENTS_CACHE_SECONDS = 1800;
+const EVENTS_CACHE_TAG = "breakpoint-events";
+
+interface LumaEventData {
+  api_id?: string;
+  name?: string;
+  url?: string;
+  start_at?: string;
+  end_at?: string;
+  timezone?: string;
+  cover_url?: string;
+  geo_address_info?: {
+    city?: string;
+  };
+}
+
+function lumaHeaders(): HeadersInit {
+  const headers: Record<string, string> = { accept: "application/json" };
+  if (process.env.LUMA_PRIVATE_API_KEY) {
+    headers["x-luma-api-key"] = process.env.LUMA_PRIVATE_API_KEY;
+  }
+  return headers;
+}
+
+async function fetchLumaJson(url: URL): Promise<unknown | null> {
+  try {
+    const response = await fetch(url, {
+      headers: lumaHeaders(),
+      signal: AbortSignal.timeout(LUMA_REQUEST_TIMEOUT_MS),
+      next: {
+        revalidate: EVENTS_CACHE_SECONDS,
+        tags: [EVENTS_CACHE_TAG],
+      },
+    });
+
+    if (!response.ok) {
+      console.warn(`Luma request failed (${response.status}): ${url.pathname}`);
+      return null;
+    }
+
+    return await response.json();
+  } catch (error) {
+    console.warn(`Luma request errored: ${url.pathname}`, error);
+    return null;
+  }
+}
+
+function normalizeLumaEvent(event: LumaEventData): HighlightedEvent | null {
+  if (!event.api_id || !event.name || !event.start_at || !event.url) {
+    return null;
+  }
+
+  return {
+    id: event.api_id,
+    title: event.name,
+    url: `https://luma.com/${event.url}`,
+    coverUrl: event.cover_url ?? null,
+    startAt: event.start_at,
+    endAt: event.end_at ?? null,
+    timezone: event.timezone ?? null,
+    city: event.geo_address_info?.city ?? null,
+  };
+}
+
+async function fetchCalendarEvents(): Promise<HighlightedEvent[]> {
+  const url = new URL(`${LUMA_API_BASE}/calendar/get-items`);
+  url.searchParams.set("calendar_api_id", BREAKPOINT_LUMA_CALENDAR_ID);
+  url.searchParams.set("series_mode", "sessions");
+  url.searchParams.set("period", "future");
+  url.searchParams.set("pagination_limit", "50");
+
+  const payload = (await fetchLumaJson(url)) as {
+    entries?: { event?: LumaEventData }[];
+  } | null;
+
+  return (payload?.entries ?? [])
+    .map((entry) => (entry.event ? normalizeLumaEvent(entry.event) : null))
+    .filter((event): event is HighlightedEvent => event !== null);
+}
+
+async function fetchPinnedEvent(
+  slug: string,
+): Promise<HighlightedEvent | null> {
+  const url = new URL(`${LUMA_API_BASE}/url`);
+  url.searchParams.set("url", slug);
+
+  const payload = (await fetchLumaJson(url)) as {
+    kind?: string;
+    data?: LumaEventData & { event?: LumaEventData };
+  } | null;
+
+  if (payload?.kind !== "event" || !payload.data) {
+    return null;
+  }
+
+  return normalizeLumaEvent(payload.data.event ?? payload.data);
+}
+
+async function fetchHighlightedEvents(): Promise<HighlightedEvent[]> {
+  const [calendarEvents, ...pinnedEvents] = await Promise.all([
+    fetchCalendarEvents(),
+    ...HIGHLIGHTED_EVENT_URLS.map(fetchPinnedEvent),
+  ]);
+
+  const now = Date.now();
+  const events = new Map<string, HighlightedEvent>();
+
+  for (const event of [...calendarEvents, ...pinnedEvents]) {
+    if (!event || event.id === BREAKPOINT_LUMA_EVENT_ID) continue;
+    const endsAt = Date.parse(event.endAt ?? event.startAt);
+    if (Number.isFinite(endsAt) && endsAt < now) continue;
+    events.set(event.id, event);
+  }
+
+  return [...events.values()].sort(
+    (a, b) => Date.parse(a.startAt) - Date.parse(b.startAt),
+  );
+}
+
+export const getHighlightedEvents =
+  process.env.NODE_ENV === "production"
+    ? unstable_cache(fetchHighlightedEvents, ["breakpoint-events-luma"], {
+        revalidate: EVENTS_CACHE_SECONDS,
+        tags: [EVENTS_CACHE_TAG],
+      })
+    : fetchHighlightedEvents;

--- a/apps/breakpoint/src/content/events/luma.ts
+++ b/apps/breakpoint/src/content/events/luma.ts
@@ -2,7 +2,6 @@ import { unstable_cache } from "next/cache";
 import {
   BREAKPOINT_LUMA_CALENDAR_ID,
   BREAKPOINT_LUMA_EVENT_ID,
-  HIGHLIGHTED_EVENT_URLS,
 } from "@/content/links";
 import type { HighlightedEvent } from "./types";
 
@@ -88,34 +87,11 @@ async function fetchCalendarEvents(): Promise<HighlightedEvent[]> {
     .filter((event): event is HighlightedEvent => event !== null);
 }
 
-async function fetchPinnedEvent(
-  slug: string,
-): Promise<HighlightedEvent | null> {
-  const url = new URL(`${LUMA_API_BASE}/url`);
-  url.searchParams.set("url", slug);
-
-  const payload = (await fetchLumaJson(url)) as {
-    kind?: string;
-    data?: LumaEventData & { event?: LumaEventData };
-  } | null;
-
-  if (payload?.kind !== "event" || !payload.data) {
-    return null;
-  }
-
-  return normalizeLumaEvent(payload.data.event ?? payload.data);
-}
-
 async function fetchHighlightedEvents(): Promise<HighlightedEvent[]> {
-  const [calendarEvents, ...pinnedEvents] = await Promise.all([
-    fetchCalendarEvents(),
-    ...HIGHLIGHTED_EVENT_URLS.map(fetchPinnedEvent),
-  ]);
-
   const now = Date.now();
   const events = new Map<string, HighlightedEvent>();
 
-  for (const event of [...calendarEvents, ...pinnedEvents]) {
+  for (const event of await fetchCalendarEvents()) {
     if (!event || event.id === BREAKPOINT_LUMA_EVENT_ID) continue;
     const endsAt = Date.parse(event.endAt ?? event.startAt);
     if (Number.isFinite(endsAt) && endsAt < now) continue;

--- a/apps/breakpoint/src/content/events/types.ts
+++ b/apps/breakpoint/src/content/events/types.ts
@@ -1,0 +1,10 @@
+export interface HighlightedEvent {
+  id: string;
+  title: string;
+  url: string;
+  coverUrl: string | null;
+  startAt: string;
+  endAt: string | null;
+  timezone: string | null;
+  city: string | null;
+}

--- a/apps/breakpoint/src/content/links.ts
+++ b/apps/breakpoint/src/content/links.ts
@@ -12,9 +12,8 @@ export const CONTENT_CREATOR_APPLICATION_HREF =
   "https://solanafoundation.typeform.com/bp26-creator";
 export const CODE_OF_CONDUCT_HREF = "https://shorturl.at/lEMR1";
 export const SIDE_EVENTS_HREF = "https://luma.com/BP-SideEvents";
-export const BREAKPOINT_LUMA_CALENDAR_ID = "evgrp-f8F1bDAHhBNDM1f";
-// Highlighted side events pinned by Luma URL slug until they land on the calendar.
-export const HIGHLIGHTED_EVENT_URLS = ["dmxdc394"];
+// Public calendar: https://luma.com/BP-Highlight
+export const BREAKPOINT_LUMA_CALENDAR_ID = "cal-J8paV20F2tKUEXI";
 export const BREAKPOINT_2025_ARCHIVES_URL =
   "https://www.youtube.com/playlist?list=PLilwLeBwGuK53OUOcc_GsCcbqcU5V4H9Z";
 export const BP25_RECAP_YOUTUBE_ID = "394wb968J68";

--- a/apps/breakpoint/src/content/links.ts
+++ b/apps/breakpoint/src/content/links.ts
@@ -12,6 +12,9 @@ export const CONTENT_CREATOR_APPLICATION_HREF =
   "https://solanafoundation.typeform.com/bp26-creator";
 export const CODE_OF_CONDUCT_HREF = "https://shorturl.at/lEMR1";
 export const SIDE_EVENTS_HREF = "https://luma.com/BP-SideEvents";
+export const BREAKPOINT_LUMA_CALENDAR_ID = "evgrp-f8F1bDAHhBNDM1f";
+// Highlighted side events pinned by Luma URL slug until they land on the calendar.
+export const HIGHLIGHTED_EVENT_URLS = ["dmxdc394"];
 export const BREAKPOINT_2025_ARCHIVES_URL =
   "https://www.youtube.com/playlist?list=PLilwLeBwGuK53OUOcc_GsCcbqcU5V4H9Z";
 export const BP25_RECAP_YOUTUBE_ID = "394wb968J68";

--- a/apps/breakpoint/src/content/page.ts
+++ b/apps/breakpoint/src/content/page.ts
@@ -72,7 +72,6 @@ export type BreakpointMessages = {
   };
   events: {
     headline: string;
-    scheduleCta: string;
     communityCta: string;
   };
   highlights: {

--- a/apps/breakpoint/src/content/page.ts
+++ b/apps/breakpoint/src/content/page.ts
@@ -70,6 +70,11 @@ export type BreakpointMessages = {
       }
     >;
   };
+  events: {
+    headline: string;
+    scheduleCta: string;
+    communityCta: string;
+  };
   highlights: {
     eyebrow: string;
     headline: string;

--- a/packages/i18n/messages/breakpoint/en/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/en/breakpoint.json
@@ -107,6 +107,11 @@
         }
       }
     },
+    "events": {
+      "headline": "Explore events across the Breakpoint ecosystem",
+      "scheduleCta": "See the full schedule",
+      "communityCta": "See community events"
+    },
     "highlights": {
       "eyebrow": "From the community",
       "headline": "Highlights from Solana builders at Breakpoint",


### PR DESCRIPTION
## Problem

The events team wants side events surfaced on the Breakpoint site:
- **Highlighted events** (curated summits pre/during BP) should stand out with their Luma cover images
- **Community events** (open-submission calendar) just need a link out to the calendar

First highlighted event: [BlockZero 2026](https://luma.com/dmxdc394).

## Changes

- New **"Explore events across the Breakpoint ecosystem"** homepage section (between the second marquee and Highlights), matching the [BP26 pre-event homepage design](https://www.figma.com/design/Duxj8jI644XgdEY97yGLkz/-SHARED--Breakpoint-2026---Web-Library?node-id=5-214) at desktop/tablet/mobile
- `getHighlightedEvents()` (`src/content/events/luma.ts`) pulls the **Breakpoint 2026 Luma calendar** (`luma.com/bp26`) plus pinned event URLs (currently BlockZero, until it lands on the calendar). Main conference event is excluded, past events dropped, results deduped/sorted. 10s timeout + graceful empty fallback (the section simply hides if Luma is down), 30-min ISR-style caching
- Card carousel with Luma covers as full-bleed backgrounds behind a scrim; time/date rendered in the event's timezone; whole card links to the Luma event page
- CTAs: **See the full schedule** → `/breakpoint/schedule`, **See community events** → `luma.com/BP-SideEvents`
- `next/image` remote patterns added for Luma CDNs; optional `LUMA_PRIVATE_API_KEY` documented (public calendars work without it)
- New `events` i18n strings (en source; Lingo handles other locales)

## Notes

- "The Luma calendar" is assumed to be the BP26 calendar (`evgrp-f8F1bDAHhBNDM1f`, same one solana.com/events uses). If highlighted events end up on a separate calendar it's a one-constant swap in `src/content/links.ts`; adding/removing pinned events is a one-line change there too
- The FAQ banner shown in the same Figma frame belongs to the wider pre-event homepage redesign and is out of scope here

Verified locally: renders with live Luma data at 1440/768/375, tsc/eslint/prettier/vitest all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)