### PR TITLE
Fix Italian rich message apostrophes

### DIFF
--- a/packages/i18n/messages/web/it/common.json
+++ b/packages/i18n/messages/web/it/common.json
@@ -3056,7 +3056,7 @@
         },
         "energy": {
           "title": "Efficiente dal punto di vista energetico",
-          "description": "La rete proof of stake di Solana e altre innovazioni riducono al minimo il suo impatto sull'<envLink>ambiente</envLink>. Ogni transazione Solana utilizza circa la stessa energia di alcune ricerche su Google."
+          "description": "La rete proof of stake di Solana e altre innovazioni riducono al minimo il suo impatto sull’<envLink>ambiente</envLink>. Ogni transazione Solana utilizza circa la stessa energia di alcune ricerche su Google."
         }
       }
     }
@@ -4626,7 +4626,7 @@
       "description": "Distribuisci la tua app su Solana e coinvolgi milioni di appassionati di crypto. Costruisci una community da zero e collegati al più grande ecosistema di strumenti che spaziano dalla DeFi alle DAO, NFT e altro ancora."
     },
     "projects": {
-      "title": "<light>Esplora l'<br></br>ecosistema e</light> l'impatto",
+      "title": "<light>Esplora l’<br></br>ecosistema e</light> l’impatto",
       "bonk": {
         "name": "Bonk",
         "description": "La più grande e distribuita community di memecoin con oltre 400 integrazioni di token.",
@@ -4735,7 +4735,7 @@
       "description": "Distribuisci la tua app su Solana e coinvolgi milioni di utenti crypto. Mentre l'AI continua a plasmare lo sviluppo tecnologico, la necessità di sistemi aperti e senza permessi diventa sempre più significativa. Solana fornisce le fondamenta per un ecosistema di intelligenza aperta, abilitando proprietà decentralizzata, allocazione efficiente delle risorse e trasferimento di valore senza interruzioni per l'AI."
     },
     "projects": {
-      "title": "<light>Esplora l'<br></br>ecosistema e</light> l'impatto",
+      "title": "<light>Esplora l’<br></br>ecosistema e</light> l’impatto",
       "inference": {
         "name": "Inference",
         "description": "Inference.net è un marketplace di inferenza AI in tempo reale che abbina capacità GPU inutilizzata con gli sviluppatori, elaborando oltre 1T di token di inferenza.",
@@ -6408,7 +6408,7 @@
       "description": "La scienza decentralizzata (DeSci) è un movimento che ripensa il modo in cui la ricerca scientifica viene finanziata, condotta, validata e condivisa. Su blockchain come Solana, DeSci allinea comunità globali per finanziare la scienza in modo trasparente, premiare i contributori e condividere conoscenze. Nel suo nucleo, DeSci mira ad accelerare le scoperte e trasformare la ricerca in impatto concreto."
     },
     "projects": {
-      "title": "<light>Esplora l'<br></br>ecosistema e l'</light>impatto",
+      "title": "<light>Esplora l’<br></br>ecosistema e l’</light>impatto",
       "bioprotocol": {
         "name": "Bio Protocol",
         "description": "Bio Protocol è una piattaforma di lancio DeSci per la ricerca biotecnologica in fase iniziale, che aiuta gli scienziati a raccogliere fondi, generare valore dai loro studi e condividere i risultati commerciali.",


### PR DESCRIPTION
## Summary
- Replace straight apostrophes before Italian rich-message tags with typographic apostrophes so ICU does not treat the following tag as escaped text.
- Covers the reported `/it/solutions/ai` title plus the same pattern in adjacent Italian rich messages.

## Test plan
- `jq -e . packages/i18n/messages/web/it/common.json >/dev/null`
- `pnpm exec prettier --check packages/i18n/messages/web/it/common.json`
- focused `intl-messageformat` parse check for the updated Italian rich-message keys
- `curl -sS -D - 'http://localhost:3010/it/solutions/ai?nxtPlocale=it' -o /tmp/solana-it-solutions-ai.html` returned `200 OK` with no `INVALID_MESSAGE` in Next dev output\n- `pnpm --filter @workspace/i18n lint`