### PR TITLE
Fix news masthead featured ordering

### DIFF
--- a/apps/media/__tests__/latest-content-filters.test.ts
+++ b/apps/media/__tests__/latest-content-filters.test.ts
@@ -509,6 +509,14 @@ describe("latest content filters", () => {
           author: "solana-foundation",
           tags: [{ tag: "featured" }],
         },
+        "middle-featured-post": {
+          status: "published",
+          title: "Middle Featured Post",
+          description: "middle featured post",
+          publishedAt: "2026-03-10T12:00:00.000Z",
+          author: "solana-foundation",
+          tags: [{ tag: "featured" }],
+        },
       };
 
       readerMock.collections.posts.list.mockResolvedValue(Object.keys(posts));
@@ -520,7 +528,15 @@ describe("latest content filters", () => {
 
       expect(result.posts.map((item) => item.id)).toEqual([
         "newer-featured-post",
+        "middle-featured-post",
         "older-featured-post",
+      ]);
+
+      const limitedResult = await fetchFeaturedPosts({ limit: 2 });
+
+      expect(limitedResult.posts.map((item) => item.id)).toEqual([
+        "newer-featured-post",
+        "middle-featured-post",
       ]);
     });
 

--- a/apps/media/__tests__/latest-content-filters.test.ts
+++ b/apps/media/__tests__/latest-content-filters.test.ts
@@ -72,7 +72,11 @@ vi.mock("@/lib/content-renderer", () => ({
 }));
 
 import { fetchLatestLinks } from "@/lib/keystatic/link-data";
-import { fetchFeaturedPost, fetchLatestPosts } from "@/lib/keystatic/post-data";
+import {
+  fetchFeaturedPost,
+  fetchFeaturedPosts,
+  fetchLatestPosts,
+} from "@/lib/keystatic/post-data";
 import { fetchLatestReports } from "@/lib/keystatic/report-data";
 import * as keystaticPostData from "@/lib/keystatic/post-data";
 import { GET as getLatestLinks } from "@/app/api/links/latest/route";
@@ -304,6 +308,52 @@ describe("latest content filters", () => {
       expect(result.posts[0]?.publishedAt).toBe("2026-03-10T00:00:00.000Z");
     });
 
+    it("excludes posts by tag from latest post results", async () => {
+      const posts = {
+        "featured-post": {
+          status: "published",
+          title: "Featured Post",
+          description: "featured post",
+          publishedAt: "2026-03-12T00:00:00.000Z",
+          author: "solana-foundation",
+          categories: [{ category: "ecosystem" }],
+          tags: [{ tag: "featured" }],
+        },
+        "newer-regular-post": {
+          status: "published",
+          title: "Newer Regular Post",
+          description: "newer regular post",
+          publishedAt: "2026-03-11T00:00:00.000Z",
+          author: "solana-foundation",
+          categories: [{ category: "ecosystem" }],
+          tags: [{ tag: "defi" }],
+        },
+        "older-regular-post": {
+          status: "published",
+          title: "Older Regular Post",
+          description: "older regular post",
+          publishedAt: "2026-03-10T00:00:00.000Z",
+          author: "solana-foundation",
+          categories: [{ category: "ecosystem" }],
+          tags: [{ tag: "nft" }],
+        },
+      };
+
+      readerMock.collections.posts.list.mockResolvedValue(Object.keys(posts));
+      readerMock.collections.posts.read.mockImplementation((slug: string) =>
+        Promise.resolve(posts[slug as keyof typeof posts] ?? null),
+      );
+
+      const result = await fetchLatestPosts({
+        excludeTag: "featured",
+      });
+
+      expect(result.posts.map((item) => item.id)).toEqual([
+        "newer-regular-post",
+        "older-regular-post",
+      ]);
+    });
+
     it("matches mixed category and tag reference formats by slug", async () => {
       const posts = {
         "slug-match-post": {
@@ -433,6 +483,47 @@ describe("latest content filters", () => {
       expect(result.post?.id).toBe("live-featured-post");
     });
 
+    it("returns featured posts newest first", async () => {
+      const posts = {
+        "older-featured-post": {
+          status: "published",
+          title: "Older Featured Post",
+          description: "older featured post",
+          publishedAt: "2026-03-10T00:00:00.000Z",
+          author: "solana-foundation",
+          tags: [{ tag: "featured" }],
+        },
+        "regular-post": {
+          status: "published",
+          title: "Regular Post",
+          description: "regular post",
+          publishedAt: "2026-03-12T00:00:00.000Z",
+          author: "solana-foundation",
+          tags: [{ tag: "defi" }],
+        },
+        "newer-featured-post": {
+          status: "published",
+          title: "Newer Featured Post",
+          description: "newer featured post",
+          publishedAt: "2026-03-11T00:00:00.000Z",
+          author: "solana-foundation",
+          tags: [{ tag: "featured" }],
+        },
+      };
+
+      readerMock.collections.posts.list.mockResolvedValue(Object.keys(posts));
+      readerMock.collections.posts.read.mockImplementation((slug: string) =>
+        Promise.resolve(posts[slug as keyof typeof posts] ?? null),
+      );
+
+      const result = await fetchFeaturedPosts();
+
+      expect(result.posts.map((item) => item.id)).toEqual([
+        "newer-featured-post",
+        "older-featured-post",
+      ]);
+    });
+
     it("dedupes duplicate tag and category names in transformed posts", async () => {
       readerMock.collections.categories.read.mockImplementation(
         (slug: string) =>
@@ -560,7 +651,7 @@ describe("latest content filters", () => {
       ]);
     });
 
-    it("includes tag in the posts cache key and forwards it to the data layer", async () => {
+    it("includes tag exclusions in the posts cache key and forwards them to the data layer", async () => {
       const fetchLatestPostsSpy = vi
         .spyOn(keystaticPostData, "fetchLatestPosts")
         .mockResolvedValue({
@@ -588,12 +679,12 @@ describe("latest content filters", () => {
         });
 
       const response = (await getLatestPosts({
-        url: "https://example.com/api/posts/latest?limit=2&cursor=post-0&category=ecosystem&tag=defi",
+        url: "https://example.com/api/posts/latest?limit=2&cursor=post-0&category=ecosystem&tag=defi&excludeTag=featured",
       } as any)) as any;
 
       expect(unstableCacheMock).toHaveBeenCalledWith(
         expect.any(Function),
-        ["posts-2-post-0-ecosystem-defi"],
+        ["posts-2-post-0-ecosystem-defi-featured"],
         expect.objectContaining({
           tags: ["posts"],
         }),
@@ -603,6 +694,7 @@ describe("latest content filters", () => {
         cursor: "post-0",
         category: "ecosystem",
         tag: "defi",
+        excludeTag: "featured",
       });
       expect(extractPlainTextMock).toHaveBeenCalledWith("rich text");
       expect(response.body).toEqual({

--- a/apps/media/app/[locale]/news/client-page.tsx
+++ b/apps/media/app/[locale]/news/client-page.tsx
@@ -102,7 +102,7 @@ export default function PostsClientPage({
 
   const visiblePosts = useMemo(() => posts.filter(isPost), [posts]);
   const lead = featuredPosts[0] ?? null;
-  const railStories = featuredPosts.slice(1);
+  const railStories = featuredPosts.slice(1, 5);
   const latestStories = visiblePosts;
   const leadCategory = lead?.categories?.find(Boolean);
 

--- a/apps/media/app/[locale]/news/client-page.tsx
+++ b/apps/media/app/[locale]/news/client-page.tsx
@@ -28,7 +28,7 @@ const DEFAULT_PAGE_INFO: PageInfo = {
 
 interface PostsClientPageProps {
   campaign?: NewsCampaign | null;
-  featuredPost: PostItem | null;
+  featuredPosts: PostItem[];
   latestPosts: PostItem[];
   initialPageInfo?: PageInfo;
   navItems: NewsNavItem[];
@@ -38,25 +38,14 @@ function isPost(post: PostItem | null): post is PostItem {
   return Boolean(post);
 }
 
-function getPostsWithoutFeatured(
-  latestPosts: PostItem[],
-  featuredPost: PostItem | null,
-): PostItem[] {
-  return featuredPost
-    ? latestPosts.filter((post) => post?.id !== featuredPost.id)
-    : latestPosts;
-}
-
 export default function PostsClientPage({
   campaign,
-  featuredPost,
+  featuredPosts,
   latestPosts,
   initialPageInfo,
   navItems,
 }: PostsClientPageProps) {
-  const [posts, setPosts] = useState<(PostItem | null)[]>(() =>
-    getPostsWithoutFeatured(latestPosts, featuredPost),
-  );
+  const [posts, setPosts] = useState<(PostItem | null)[]>(() => latestPosts);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [pageInfo, setPageInfo] = useState(
     initialPageInfo ?? DEFAULT_PAGE_INFO,
@@ -71,7 +60,10 @@ export default function PostsClientPage({
 
     try {
       const cursor = currentCursor || pageInfo.endCursor;
-      const params = new URLSearchParams({ limit: "13" });
+      const params = new URLSearchParams({
+        limit: "13",
+        excludeTag: "featured",
+      });
       if (cursor) params.set("cursor", cursor);
 
       const res = await fetch(`/api/posts/latest?${params.toString()}`);
@@ -98,21 +90,20 @@ export default function PostsClientPage({
   }, [pageInfo.hasNextPage, pageInfo.endCursor, isLoadingMore, currentCursor]);
 
   useEffect(() => {
-    setPosts(getPostsWithoutFeatured(latestPosts || [], featuredPost));
+    setPosts(latestPosts || []);
 
     const lastPost = latestPosts[latestPosts.length - 1];
     if (lastPost?.cursor) {
       setCurrentCursor(lastPost.cursor);
+    } else {
+      setCurrentCursor(null);
     }
-  }, [latestPosts, featuredPost]);
+  }, [latestPosts]);
 
   const visiblePosts = useMemo(() => posts.filter(isPost), [posts]);
-  const lead = featuredPost ?? visiblePosts[0] ?? null;
-  // visiblePosts already excludes the featured post; only trim the first entry
-  // when it is standing in as the lead.
-  const pool = featuredPost ? visiblePosts : visiblePosts.slice(1);
-  const railStories = pool.slice(0, 4);
-  const latestStories = pool.slice(4);
+  const lead = featuredPosts[0] ?? null;
+  const railStories = featuredPosts.slice(1);
+  const latestStories = visiblePosts;
   const leadCategory = lead?.categories?.find(Boolean);
 
   return (

--- a/apps/media/app/[locale]/news/page.tsx
+++ b/apps/media/app/[locale]/news/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import PostsClientPage from "./client-page";
-import { fetchFeaturedPost, fetchLatestPosts } from "@/lib/post-data";
+import { fetchFeaturedPosts, fetchLatestPosts } from "@/lib/post-data";
 import { newsListingMetadata } from "@/lib/metadata";
 import { getActiveCampaign } from "@/lib/news-campaign";
 import { fetchNewsNavItemsWithPosts } from "@/lib/news-nav-data";
@@ -21,9 +21,9 @@ export default async function PostsPage({
 }: {
   params: Promise<{ locale: string }>;
 }) {
-  const [featuredPost, latestPosts, navItems] = await Promise.all([
-    fetchFeaturedPost(),
-    fetchLatestPosts({ limit: 13 }),
+  const [featuredPosts, latestPosts, navItems] = await Promise.all([
+    fetchFeaturedPosts(),
+    fetchLatestPosts({ limit: 13, excludeTag: "featured" }),
     fetchNewsNavItemsWithPosts(),
   ]);
   const campaign = getActiveCampaign("news-front");
@@ -31,7 +31,7 @@ export default async function PostsPage({
   return (
     <PostsClientPage
       campaign={campaign}
-      featuredPost={featuredPost.post}
+      featuredPosts={featuredPosts.posts}
       latestPosts={latestPosts.posts}
       initialPageInfo={latestPosts.pageInfo}
       navItems={navItems}

--- a/apps/media/app/[locale]/news/page.tsx
+++ b/apps/media/app/[locale]/news/page.tsx
@@ -7,6 +7,9 @@ import { fetchNewsNavItemsWithPosts } from "@/lib/news-nav-data";
 
 export const revalidate = 300;
 
+const FEATURED_MASTHEAD_LIMIT = 5;
+const LATEST_POSTS_LIMIT = 13;
+
 export async function generateMetadata({
   params,
 }: {
@@ -22,8 +25,11 @@ export default async function PostsPage({
   params: Promise<{ locale: string }>;
 }) {
   const [featuredPosts, latestPosts, navItems] = await Promise.all([
-    fetchFeaturedPosts({ limit: 5 }),
-    fetchLatestPosts({ limit: 13, excludeTag: "featured" }),
+    fetchFeaturedPosts({ limit: FEATURED_MASTHEAD_LIMIT }),
+    fetchLatestPosts({
+      limit: LATEST_POSTS_LIMIT,
+      excludeTag: "featured",
+    }),
     fetchNewsNavItemsWithPosts(),
   ]);
   const campaign = getActiveCampaign("news-front");

--- a/apps/media/app/[locale]/news/page.tsx
+++ b/apps/media/app/[locale]/news/page.tsx
@@ -22,7 +22,7 @@ export default async function PostsPage({
   params: Promise<{ locale: string }>;
 }) {
   const [featuredPosts, latestPosts, navItems] = await Promise.all([
-    fetchFeaturedPosts(),
+    fetchFeaturedPosts({ limit: 5 }),
     fetchLatestPosts({ limit: 13, excludeTag: "featured" }),
     fetchNewsNavItemsWithPosts(),
   ]);

--- a/apps/media/app/api/posts/latest/route.ts
+++ b/apps/media/app/api/posts/latest/route.ts
@@ -13,6 +13,7 @@ interface PostConnectionParams {
   cursor?: string;
   category?: string;
   tag?: string;
+  excludeTag?: string;
 }
 
 /**
@@ -25,6 +26,7 @@ async function fetchPosts(params: PostConnectionParams) {
       cursor: params.cursor,
       category: params.category,
       tag: params.tag,
+      excludeTag: params.excludeTag,
     });
 
     return {
@@ -74,6 +76,11 @@ function parseQueryParams(searchParams: URLSearchParams): PostConnectionParams {
     params.tag = tagParam;
   }
 
+  const excludeTagParam = searchParams.get("excludeTag");
+  if (excludeTagParam) {
+    params.excludeTag = excludeTagParam;
+  }
+
   return params;
 }
 
@@ -83,7 +90,7 @@ export async function GET(request: NextRequest) {
     const params = parseQueryParams(searchParams);
 
     // Create cache key from params to ensure different queries are cached separately
-    const cacheKey = `posts-${params.limit ?? DEFAULT_LIMIT}-${params.cursor || "start"}-${params.category || "all"}-${params.tag || "all"}`;
+    const cacheKey = `posts-${params.limit ?? DEFAULT_LIMIT}-${params.cursor || "start"}-${params.category || "all"}-${params.tag || "all"}-${params.excludeTag || "none"}`;
     const data = await unstable_cache(() => fetchPosts(params), [cacheKey], {
       tags: [CACHE_TAG],
       revalidate: REVALIDATE_SECONDS,

--- a/apps/media/content/posts/solana-ecosystem-roundup-march-2026.mdx
+++ b/apps/media/content/posts/solana-ecosystem-roundup-march-2026.mdx
@@ -13,7 +13,6 @@ publishedAt: 2026-04-05T19:03:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: featured
   - tag: reports
   - tag: ecosystem
   - tag: defi

--- a/apps/media/content/posts/state-of-solana-february-2026.mdx
+++ b/apps/media/content/posts/state-of-solana-february-2026.mdx
@@ -9,7 +9,6 @@ heroImage: /uploads/posts/state-of-solana-february-2026/feb-report.webp
 status: published
 author: solana-foundation
 tags:
-  - tag: featured
   - tag: reports
   - tag: ecosystem
   - tag: defi

--- a/apps/media/content/posts/world-series-of-poker.mdx
+++ b/apps/media/content/posts/world-series-of-poker.mdx
@@ -14,6 +14,7 @@ tags:
   - tag: gaming
   - tag: payments
   - tag: stablecoins
+  - tag: featured
 ---
 
 **For the first time in World Series of Poker history, players can enter into tournaments directly with crypto on Solana with zero processing fees. Solana Foundation will also serve as the official Presenting Sponsor of the 2026 World Series of Poker and 2026 World Series of Poker Paradise.**

--- a/apps/media/lib/keystatic/post-data.ts
+++ b/apps/media/lib/keystatic/post-data.ts
@@ -8,6 +8,7 @@ export interface LatestPostsParams {
   cursor?: string;
   category?: string;
   tag?: string;
+  excludeTag?: string;
 }
 
 export interface LatestPostsResponse {
@@ -21,9 +22,83 @@ export interface LatestPostsResponse {
 }
 
 type PostEntry = Awaited<ReturnType<typeof reader.collections.posts.read>>;
+const FEATURED_TAG = "featured";
+
+function normalizeFilter(value?: string): string | undefined {
+  const normalized = value?.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function getTaxonomySlug(
+  item: unknown,
+  key: "category" | "tag",
+): string | null {
+  if (typeof item === "string") {
+    return item;
+  }
+
+  if (item && typeof item === "object" && key in item) {
+    const value = (item as Record<string, unknown>)[key];
+    return value ? String(value) : null;
+  }
+
+  return null;
+}
 
 function dedupeStrings(values: string[]): string[] {
   return Array.from(new Set(values));
+}
+
+async function postMatchesCategory(
+  post: PostEntry,
+  normalizedCategory?: string,
+): Promise<boolean> {
+  if (!normalizedCategory) return true;
+  if (!post?.categories) return false;
+
+  for (const catRef of post.categories) {
+    const categorySlug = getTaxonomySlug(catRef, "category");
+    if (!categorySlug) continue;
+
+    if (categorySlug.toLowerCase() === normalizedCategory) {
+      return true;
+    }
+
+    const catData = await reader.collections.categories.read(categorySlug);
+    const categoryName = String(catData?.name || "").toLowerCase();
+
+    if (categoryName === normalizedCategory) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+async function postMatchesTag(
+  post: PostEntry,
+  normalizedTag?: string,
+): Promise<boolean> {
+  if (!normalizedTag) return true;
+  if (!post?.tags) return false;
+
+  for (const tagRef of post.tags) {
+    const tagSlug = getTaxonomySlug(tagRef, "tag");
+    if (!tagSlug) continue;
+
+    if (tagSlug.toLowerCase() === normalizedTag) {
+      return true;
+    }
+
+    const tagData = await reader.collections.tags.read(tagSlug);
+    const tagName = String(tagData?.name || "").toLowerCase();
+
+    if (tagName === normalizedTag) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export async function readPostBySlug(
@@ -93,15 +168,16 @@ async function transformPost(
   if (post.tags) {
     for (const tagItem of post.tags) {
       // Handle both string format (new) and object format (legacy)
+      const tagSlug = getTaxonomySlug(tagItem, "tag");
+      if (!tagSlug) continue;
+
       if (typeof tagItem === "string") {
-        tagNames.push(tagItem);
-      } else if (tagItem && typeof tagItem === "object" && "tag" in tagItem) {
+        tagNames.push(tagSlug);
+      } else {
         // Legacy format: relationship object
-        if (tagItem.tag) {
-          const tagData = await reader.collections.tags.read(tagItem.tag);
-          if (tagData?.name) {
-            tagNames.push(String(tagData.name));
-          }
+        const tagData = await reader.collections.tags.read(tagSlug);
+        if (tagData?.name) {
+          tagNames.push(String(tagData.name));
         }
       }
     }
@@ -209,69 +285,26 @@ export const fetchLatestPosts = async (
       return b.date.getTime() - a.date.getTime();
     });
 
-    const normalizedCategory = params.category?.trim().toLowerCase();
-    const normalizedTag = params.tag?.trim().toLowerCase();
+    const normalizedCategory = normalizeFilter(params.category);
+    const normalizedTag = normalizeFilter(params.tag);
+    const normalizedExcludeTag = normalizeFilter(params.excludeTag);
 
     // Filter by category and/or tag if specified
     let filteredPosts = postsWithDates;
-    if (normalizedCategory || normalizedTag) {
+    if (normalizedCategory || normalizedTag || normalizedExcludeTag) {
       filteredPosts = [];
 
       for (const item of postsWithDates) {
-        let matchesCategory = !normalizedCategory;
-        if (normalizedCategory && item.post?.categories) {
-          for (const catRef of item.post.categories) {
-            let categorySlug: string | null = null;
+        const matchesCategory = await postMatchesCategory(
+          item.post,
+          normalizedCategory,
+        );
+        const matchesTag = await postMatchesTag(item.post, normalizedTag);
+        const matchesExcludedTag = normalizedExcludeTag
+          ? await postMatchesTag(item.post, normalizedExcludeTag)
+          : false;
 
-            if (typeof catRef === "string") {
-              categorySlug = catRef;
-            } else if (catRef?.category) {
-              categorySlug = String(catRef.category);
-            }
-
-            if (categorySlug) {
-              const catData =
-                await reader.collections.categories.read(categorySlug);
-              const categoryName = String(catData?.name || "").toLowerCase();
-
-              if (
-                categoryName === normalizedCategory ||
-                categorySlug.toLowerCase() === normalizedCategory
-              ) {
-                matchesCategory = true;
-                break;
-              }
-            }
-          }
-        }
-
-        let matchesTag = !normalizedTag;
-        if (normalizedTag && item.post?.tags) {
-          for (const tagRef of item.post.tags) {
-            let tagSlug: string | null = null;
-
-            if (typeof tagRef === "string") {
-              tagSlug = tagRef;
-            } else if (tagRef?.tag) {
-              tagSlug = String(tagRef.tag);
-            }
-
-            if (tagSlug) {
-              const tagData = await reader.collections.tags.read(tagSlug);
-              const tagName = String(tagData?.name || "").toLowerCase();
-
-              if (
-                tagName === normalizedTag ||
-                tagSlug.toLowerCase() === normalizedTag
-              ) {
-                matchesTag = true;
-                break;
-              }
-            }
-          }
-        }
-
-        if (matchesCategory && matchesTag) {
+        if (matchesCategory && matchesTag && !matchesExcludedTag) {
           filteredPosts.push(item);
         }
       }
@@ -318,19 +351,28 @@ export interface FeaturedPostResponse {
   post: PostItem | null;
 }
 
+export interface FeaturedPostsParams {
+  limit?: number;
+}
+
+export interface FeaturedPostsResponse {
+  posts: PostItem[];
+}
+
 export async function fetchPublishedPostBySlug(slug: string, now?: Date) {
   const post = await readPostBySlug(slug, "fetchPublishedPostBySlug");
   return isPublishedPost(post, now) ? post : null;
 }
 
 /**
- * Fetch featured post from Keystatic
+ * Fetch featured posts from Keystatic, newest first.
  */
-export const fetchFeaturedPost = async (): Promise<FeaturedPostResponse> => {
+export const fetchFeaturedPosts = async (
+  params: FeaturedPostsParams = {},
+): Promise<FeaturedPostsResponse> => {
   try {
     const allSlugs = await reader.collections.posts.list();
 
-    // Collect all posts with "Featured" tag, then pick the most recent
     const featuredCandidates: Array<{
       slug: string;
       date: Date | null;
@@ -340,44 +382,24 @@ export const fetchFeaturedPost = async (): Promise<FeaturedPostResponse> => {
     for (const slug of allSlugs) {
       try {
         const post = await reader.collections.posts.read(slug);
-        if (isPublishedPost(post) && post.tags) {
-          let isFeatured = false;
-          for (const tagItem of post.tags) {
-            let tagSlug: string | null = null;
-            if (typeof tagItem === "string") {
-              tagSlug = tagItem;
-            } else if (
-              tagItem &&
-              typeof tagItem === "object" &&
-              "tag" in tagItem
-            ) {
-              if (tagItem.tag) {
-                tagSlug = tagItem.tag;
-              }
-            }
-            if (tagSlug === "featured") {
-              isFeatured = true;
-              break;
-            }
-          }
-
-          if (isFeatured) {
-            featuredCandidates.push({
-              slug,
-              date: parsePublishedAt(post.publishedAt),
-              post,
-            });
-          }
+        if (
+          isPublishedPost(post) &&
+          (await postMatchesTag(post, FEATURED_TAG))
+        ) {
+          featuredCandidates.push({
+            slug,
+            date: parsePublishedAt(post.publishedAt),
+            post,
+          });
         }
       } catch (error) {
         console.error(
-          `Failed to read post "${slug}" in fetchFeaturedPost:`,
+          `Failed to read post "${slug}" in fetchFeaturedPosts:`,
           error,
         );
       }
     }
 
-    // Sort by date descending and pick the most recent
     featuredCandidates.sort((a, b) => {
       if (!a.date && !b.date) return 0;
       if (!a.date) return 1;
@@ -385,15 +407,30 @@ export const fetchFeaturedPost = async (): Promise<FeaturedPostResponse> => {
       return b.date.getTime() - a.date.getTime();
     });
 
-    if (featuredCandidates.length > 0 && featuredCandidates[0]) {
-      const newest = featuredCandidates[0];
-      const transformed = await transformPost(newest.slug, newest.post);
-      return { post: transformed };
+    const limitedCandidates =
+      typeof params.limit === "number"
+        ? featuredCandidates.slice(0, params.limit)
+        : featuredCandidates;
+
+    const posts: PostItem[] = [];
+    for (const item of limitedCandidates) {
+      const transformed = await transformPost(item.slug, item.post);
+      if (transformed) {
+        posts.push(transformed);
+      }
     }
 
-    return { post: null };
+    return { posts };
   } catch (error) {
-    console.error("Failed to fetch featured post from Keystatic:", error);
-    return { post: null };
+    console.error("Failed to fetch featured posts from Keystatic:", error);
+    return { posts: [] };
   }
+};
+
+/**
+ * Fetch the most recent featured post from Keystatic.
+ */
+export const fetchFeaturedPost = async (): Promise<FeaturedPostResponse> => {
+  const response = await fetchFeaturedPosts({ limit: 1 });
+  return { post: response.posts[0] ?? null };
 };

--- a/apps/media/lib/post-data.ts
+++ b/apps/media/lib/post-data.ts
@@ -2,9 +2,12 @@
 export {
   fetchLatestPosts,
   fetchFeaturedPost,
+  fetchFeaturedPosts,
   fetchPublishedPostBySlug,
   readPostBySlug,
   type LatestPostsParams,
   type LatestPostsResponse,
   type FeaturedPostResponse,
+  type FeaturedPostsParams,
+  type FeaturedPostsResponse,
 } from "./keystatic/post-data";


### PR DESCRIPTION
### Problem

The news front masthead was mixing the single latest featured post with general recent posts in the right-hand list. Editorially featured posts should own the masthead package, ordered newest to oldest, while the Recent section should remain chronological and exclude featured items.

### Summary of Changes

- Added `fetchFeaturedPosts()` so the news front can fetch published `featured` tagged posts newest-first.
- Updated `/news` to render only the most recent featured post in the hero plus the next four featured posts in the right rail.
- Kept the campaign rail item appended alongside the featured rail stories when a campaign is active.
- Added `excludeTag` support to latest posts and the posts API so Recent and Load more skip `featured` posts.
- Added tests for featured ordering, featured result limiting, latest-post tag exclusion, and API cache/query forwarding.
- Updated featured tags for the March ecosystem roundup, February State of Solana report, and World Series of Poker post.

Fixes #

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the browser).
- [x] Input from users or external services is validated before use; no `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit` passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependencies: none. `pnpm audit` not run; this PR does not change dependencies.

Threat-model note for Critical changes: n/a.

Validation:

- `pnpm --filter solana-com-media test -- latest-content-filters`
- `pnpm --filter solana-com-media typecheck`
- `pnpm --filter solana-com-media lint` (passes with existing warnings only)
- `curl -I http://localhost:3002/news` returned `200 OK`
