### PR TITLE
feat(breakpoint): audience variants for paid campaigns via ?v= param

### DIFF
--- a/apps/breakpoint/src/components/sections/HeroSection.tsx
+++ b/apps/breakpoint/src/components/sections/HeroSection.tsx
@@ -9,9 +9,12 @@ import ImageTreatment from "@/components/ImageTreatment";
 import TextScramble from "@/components/TextScramble";
 import WordReveal from "@/components/WordReveal";
 import { publicAssetPath } from "@/config";
+import { GENERAL_ADMISSION_HREF } from "@/content/links";
+import { useVariant } from "@/lib/use-variant";
 
 export default function HeroSection() {
   const t = useTranslations("breakpoint");
+  const variant = useVariant();
   const [interacting, setInteracting] = useState(false);
   const [cursorY, setCursorY] = useState(50);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
@@ -100,20 +103,36 @@ export default function HeroSection() {
       </div>
 
       <div className="container relative z-10 h-full">
-        <div className="absolute left-4 right-4 top-[283px] md:inset-x-auto md:left-8 md:right-auto md:top-60 md:h-[326px] md:w-[939px] xl:w-[926px]">
+        <div
+          className={`absolute left-4 right-4 md:inset-x-auto md:left-8 md:right-auto md:top-60 md:h-[326px] md:w-[939px] xl:w-[926px] ${
+            // Variant headlines run to four lines on mobile; start higher so
+            // the date/venue block stays inside the fixed-height hero.
+            variant ? "top-[224px]" : "top-[283px]"
+          }`}
+        >
           <TextScramble
+            key={variant?.slug ?? "default"}
             as="h1"
-            text={t("hero.headline")}
+            text={variant?.heroHeadline ?? t("hero.headline")}
             durationMs={1000}
             className="type-h1 whitespace-pre-line text-white md:absolute md:left-0 md:top-0 md:w-[763px] xl:w-[926px]"
           />
           <div className="mt-8 md:absolute md:left-0 md:top-[180px] md:mt-0">
-            <Button
-              label={t("hero.cta")}
-              variant="primary"
-              arrow
-              onClick={() => setSubscribeOpen(true)}
-            />
+            {variant ? (
+              <Button
+                label={variant.heroCtaLabel}
+                variant="primary"
+                arrow
+                href={GENERAL_ADMISSION_HREF}
+              />
+            ) : (
+              <Button
+                label={t("hero.cta")}
+                variant="primary"
+                arrow
+                onClick={() => setSubscribeOpen(true)}
+              />
+            )}
           </div>
           <div className="type-eyebrow mt-12 grid w-[326px] max-w-full grid-cols-1 gap-x-[24px] gap-y-6 text-white md:absolute md:left-0 md:top-[284px] md:mt-0 md:w-[676px] md:grid-cols-[326px_minmax(0,326px)] md:gap-y-2 xl:w-[609px] xl:grid-cols-[293px_minmax(0,292px)]">
             <WordReveal text={t("hero.date")} stepMs={70} startDelayMs={1100} />

--- a/apps/breakpoint/src/components/sections/NarrativeSection.tsx
+++ b/apps/breakpoint/src/components/sections/NarrativeSection.tsx
@@ -3,37 +3,62 @@
 import React from "react";
 import { useTranslations } from "@workspace/i18n/client";
 import WordReveal from "@/components/WordReveal";
+import { useVariant } from "@/lib/use-variant";
 
 export default function NarrativeSection() {
   const t = useTranslations("breakpoint");
+  const variant = useVariant();
 
   const bodyClass = "type-h3 text-white";
 
-  const body1 = t("narrative.body1");
-  const body2 = t.raw("narrative.body2") as string;
-  const body1WordCount = body1.split(/\s+/).length;
+  const eyebrow = variant?.positioningStatement ?? t("narrative.eyebrow");
+  const paragraphs: { text: string; html: boolean }[] = variant
+    ? variant.narrativeParagraphs.map((text) => ({ text, html: false }))
+    : [
+        { text: t("narrative.body1"), html: false },
+        { text: t.raw("narrative.body2") as string, html: true },
+      ];
+
+  let revealDelayMs = 0;
 
   return (
-    <section className="bg-black pt-2xl md:pt-[120px]">
+    <section
+      key={variant?.slug ?? "default"}
+      className="bg-black pt-2xl md:pt-[120px]"
+    >
       <div className="container grid grid-cols-1 gap-x-[24px] gap-y-8 md:grid-cols-[repeat(16,minmax(0,1fr))]">
         <WordReveal
           as="h2"
-          text={t("narrative.eyebrow")}
+          text={eyebrow}
           stepMs={60}
           className="type-eyebrow text-white md:col-[1/span_5] md:self-start"
         />
 
         <div className="md:col-[7/span_10]">
-          <WordReveal as="p" text={body1} stepMs={60} className={bodyClass} />
-          {body2 && (
-            <WordReveal
-              as="p"
-              text={body2}
-              html
-              startDelayMs={body1WordCount * 60 + 200}
-              className={`mt-[1.15em] ${bodyClass}`}
-            />
-          )}
+          {paragraphs.map(({ text, html }, index) => {
+            if (!text) return null;
+            // Default copy keeps the original word-by-word handoff between its
+            // two short paragraphs; variant blurbs are longer, so each
+            // paragraph reveals on its own as it scrolls into view.
+            const startDelayMs = variant ? 0 : revealDelayMs;
+            revealDelayMs += text.split(/\s+/).length * 60 + 200;
+            const stepMs = variant && index > 0 ? 20 : 60;
+            const paragraphClass =
+              variant && index > 0 ? "type-p-large text-white" : bodyClass;
+            return (
+              <WordReveal
+                key={index}
+                as="p"
+                text={text}
+                html={html}
+                stepMs={stepMs}
+                startDelayMs={startDelayMs}
+                className={
+                  index === 0 ? paragraphClass : `mt-[1.15em] ${paragraphClass}`
+                }
+              />
+            );
+          })}
         </div>
       </div>
     </section>

--- a/apps/breakpoint/src/components/sections/StatsSection.tsx
+++ b/apps/breakpoint/src/components/sections/StatsSection.tsx
@@ -9,6 +9,7 @@ import Button from "@/components/Button";
 import SectionHeadline from "@/components/SectionHeadline";
 import WordReveal from "@/components/WordReveal";
 import { BREAKPOINT_2025_ARCHIVES_URL } from "@/content/links";
+import { useVariant } from "@/lib/use-variant";
 
 interface StatItem {
   key: string;
@@ -58,6 +59,17 @@ const widths = [
 const stripColors: TreatmentColor[] = ["green", "purple", "blue"];
 export default function StatsSection() {
   const t = useTranslations("breakpoint");
+  const variant = useVariant();
+
+  const stats = variant
+    ? variant.stats
+    : statItems.map((item) => ({
+        value: t(item.valueKey),
+        suffix: t(item.suffixKey),
+        label: t(item.labelKey),
+      }));
+  const gridColsClass =
+    stats.length === 4 ? "md:grid-cols-4" : "md:grid-cols-3";
 
   return (
     <section className="pt-20 md:pt-[120px]">
@@ -75,22 +87,25 @@ export default function StatsSection() {
           </SectionHeadline>
         </div>
 
-        <div className="mt-xl flex flex-col gap-s md:mt-16 md:grid md:grid-cols-3 md:gap-6">
-          {statItems.map((item, idx) => (
+        <div
+          key={variant?.slug ?? "default"}
+          className={`mt-xl flex flex-col gap-s md:mt-16 md:grid md:gap-6 ${gridColsClass}`}
+        >
+          {stats.map((item, idx) => (
             <div
-              key={item.key}
+              key={`${item.label}-${idx}`}
               className="flex flex-col items-center gap-xs text-center md:gap-3 md:pb-4"
             >
               <WordReveal
                 as="span"
-                text={`${t(item.valueKey)}${t(item.suffixKey)}`}
+                text={`${item.value}${item.suffix}`}
                 stepMs={120}
                 startDelayMs={idx * 140}
                 className="type-h2 block text-white"
               />
               <WordReveal
                 as="p"
-                text={t(item.labelKey)}
+                text={item.label}
                 stepMs={55}
                 startDelayMs={idx * 140 + 180}
                 className="type-eyebrow text-white md:max-w-[40ch]"

--- a/apps/breakpoint/src/components/sections/TicketsSection.tsx
+++ b/apps/breakpoint/src/components/sections/TicketsSection.tsx
@@ -10,6 +10,7 @@ import {
   STUDENT_APPLICATION_HREF,
 } from "@/content/links";
 import { getAnchorLinkProps } from "@/lib/links";
+import { useVariant } from "@/lib/use-variant";
 
 declare global {
   interface Window {
@@ -174,6 +175,7 @@ function HorizontalTicketCard({
 
 export default function TicketsSection() {
   const t = useTranslations("breakpoint");
+  const variant = useVariant();
 
   useEffect(() => {
     window.luma?.initCheckout?.();
@@ -186,7 +188,9 @@ export default function TicketsSection() {
     <section className="bg-black pt-2xl md:pt-[120px]">
       <div className="container flex w-full flex-col gap-l">
         <div className="flex flex-col items-center gap-6 text-center">
-          <h2 className="type-h3 text-white">{t("tickets.headline")}</h2>
+          <h2 className="type-h3 mx-auto max-w-[24ch] text-white">
+            {variant?.ticketsHeadline ?? t("tickets.headline")}
+          </h2>
         </div>
 
         <div className="grid grid-cols-1 gap-xs md:grid-cols-bp-desktop md:gap-s">

--- a/apps/breakpoint/src/content/variants.ts
+++ b/apps/breakpoint/src/content/variants.ts
@@ -1,0 +1,177 @@
+/**
+ * Audience variants for the Breakpoint home page.
+ *
+ * Paid campaigns land on `/breakpoint?v=<slug>` and the page swaps its
+ * messaging layer (hero, narrative, stats, tickets closing line) to match the
+ * ad the visitor clicked. A missing or unknown `v` renders the default page,
+ * so a bad link can never 404 or show a broken variant. The swap happens
+ * client-side after hydration so the page stays fully static — see
+ * `useVariant` in `src/lib/use-variant.ts`.
+ */
+
+export const VARIANT_PARAM = "v";
+export const VARIANT_FALLBACK_PARAM = "utm_content";
+
+export type VariantStat = {
+  value: string;
+  suffix: string;
+  label: string;
+};
+
+export type VariantConfig = {
+  slug: string;
+  /** Hero headline; `\n` forces a line break like the default headline. */
+  heroHeadline: string;
+  heroCtaLabel: string;
+  /** Ad-continuity positioning statement, rendered as the narrative eyebrow. */
+  positioningStatement: string;
+  /** Narrative body paragraphs, revealed in order. */
+  narrativeParagraphs: string[];
+  stats: VariantStat[];
+  /** Closing conversion line, rendered as the tickets section headline. */
+  ticketsHeadline: string;
+};
+
+const developers: VariantConfig = {
+  slug: "developers",
+  heroHeadline: "Building at the\nSpeed of Solana",
+  heroCtaLabel: "Get tickets",
+  positioningStatement:
+    "Firedancer is live. Alpenglow is coming. Meet the engineers shipping the fastest chain in production — and build what comes next.",
+  narrativeParagraphs: [
+    "At Breakpoint 2025 in Abu Dhabi, the headline was Firedancer — the promise of a faster, more resilient network that no longer ran on a single piece of software.",
+    "That promise has been kept. Firedancer, which demonstrated over 1 million transactions per second in controlled testing, reached Solana mainnet. The Alpenglow consensus upgrade is bringing finality down from roughly 12.8 seconds toward about 150 milliseconds — close to a 100x improvement.",
+    "These upgrades unlock use cases that weren't possible before: latency-sensitive apps, high-frequency DeFi, payments, real-time games. And the progress is measurable — Solana processed more than 10 billion transactions in the first quarter of 2026 alone.",
+    "At Breakpoint 2026 in London, hear directly from the engineers and founders building all of it — core protocol, infra, payment rails, and the next wave of onchain apps.",
+  ],
+  stats: [
+    { value: "1M", suffix: "+", label: "TPS demonstrated by Firedancer" },
+    {
+      value: "150",
+      suffix: "ms",
+      label: "Finality with Alpenglow — close to a 100x improvement",
+    },
+    { value: "10B", suffix: "+", label: "Transactions processed in Q1 2026" },
+  ],
+  ticketsHeadline:
+    "Claim your ticket and help write the next chapter of what's possible onchain.",
+};
+
+const ai: VariantConfig = {
+  slug: "ai",
+  heroHeadline: "Home Base for the\nAgentic Economy",
+  heroCtaLabel: "Get tickets",
+  positioningStatement:
+    "AI agents already make millions of payments on Solana. Meet the people building the infrastructure of the agentic internet.",
+  narrativeParagraphs: [
+    "Autonomous AI agents transact in fractions of a cent — paying for an API call, a data query, a few seconds of compute. Those economics simply don't work on higher-fee chains, which is why Solana has quietly become home base for the agentic economy.",
+    "The network has already processed 15 million payments initiated by agents, and roughly 65% of agentic payments settling through the x402 standard now run on Solana. x402 is an open payment standard stewarded by the Linux Foundation, with backing from Google, Stripe, Visa, and Mastercard. Through gateways like Pay.sh, an agent can fund a wallet in about a minute and pay per request for Google Cloud services like Gemini and Vertex AI alongside 50-plus other APIs — no accounts, no subscriptions.",
+    "At Breakpoint 2026 in London, the people building this stack will be on stage and in the halls — agent frameworks, payment rails, and the companies wiring AI to money. Hear what they shipped, what's next, and where the opportunities are.",
+  ],
+  stats: [
+    {
+      value: "15M",
+      suffix: "",
+      label: "Payments initiated by AI agents on Solana",
+    },
+    {
+      value: "65",
+      suffix: "%",
+      label: "Of x402 agentic payments settle on Solana",
+    },
+    { value: "50", suffix: "+", label: "APIs payable per-request via Pay.sh" },
+  ],
+  ticketsHeadline:
+    "Be in the room where AI meets money. Get your Breakpoint 2026 ticket.",
+};
+
+const finance: VariantConfig = {
+  slug: "finance",
+  heroHeadline: "Where Global Finance\nComes Onchain",
+  heroCtaLabel: "Get tickets",
+  positioningStatement:
+    "Equities, bonds, and billions in real-world assets now trade on Solana. Meet the institutions and builders making markets onchain.",
+  narrativeParagraphs: [
+    "At Breakpoint 2025, the conversation about tokenized real-world assets revolved around their promise. The case was simple but powerful: Solana's speed and near-zero transaction costs make it a natural home for global finance.",
+    "Over the next year, that narrative moved from promise to reality. Equities, bonds, precious metals, and private-company stock were tokenized in record numbers — and found real liquidity onchain.",
+    "The value of real-world assets tokenized on Solana climbed past $2 billion in early 2026, up 43% in a single quarter. More wallets hold tokenized RWAs on Solana than on any other blockchain, and tokenized equities like Tesla and NVIDIA trade with instant settlement — Solana has captured roughly 97% of all onchain tokenized-equity spot volume.",
+    "At Breakpoint 2026 in London — a global capital of finance — hear directly from the institutions and founders driving this shift: the progress made, and where the story goes next.",
+  ],
+  stats: [
+    {
+      value: "$2B",
+      suffix: "+",
+      label: "In real-world assets tokenized on Solana",
+    },
+    { value: "43", suffix: "%", label: "RWA growth in a single quarter" },
+    {
+      value: "97",
+      suffix: "%",
+      label: "Of onchain tokenized-equity spot volume",
+    },
+    {
+      value: "#1",
+      suffix: "",
+      label: "Chain by wallets holding tokenized RWAs",
+    },
+  ],
+  ticketsHeadline:
+    "Buy your ticket and be in the room where the next chapter of onchain finance is written.",
+};
+
+const collectibles: VariantConfig = {
+  slug: "collectibles",
+  heroHeadline: "Every Asset,\nOnchain",
+  heroCtaLabel: "Get tickets",
+  positioningStatement:
+    "From Pokémon cards to dinosaur bones, collectors are trading real-world assets on Solana with instant liquidity and global reach.",
+  narrativeParagraphs: [
+    "From SpaceX stock to Pokémon cards, Solana has emerged as the best network to trade every asset. Global access, instant liquidity, and fast, near-free execution have enabled novel ways to invest, collect, and trade for millions of users.",
+    "The value of real-world assets tokenized on Solana climbed past $2 billion in early 2026, up 43% in a single quarter — and today, more wallets hold tokenized RWAs on Solana than on any other blockchain. Precious metals, luxury goods, sports and gaming collectibles, even dinosaur bones: if it can be collected, it's coming onchain.",
+    "At Breakpoint 2026, the companies and people powering this trend will be in the room. Hear how blockchain is transforming legacy assets — directly from the people driving the transformation.",
+  ],
+  stats: [
+    {
+      value: "$2B",
+      suffix: "+",
+      label: "In real-world assets tokenized on Solana",
+    },
+    { value: "43", suffix: "%", label: "RWA growth in a single quarter" },
+    {
+      value: "#1",
+      suffix: "",
+      label: "Chain by wallets holding tokenized RWAs",
+    },
+  ],
+  ticketsHeadline:
+    "Get your ticket and meet the people bringing every asset onchain.",
+};
+
+export const VARIANTS: Record<string, VariantConfig> = {
+  developers,
+  ai,
+  finance,
+  collectibles,
+};
+
+export function resolveVariant(
+  value: string | null | undefined,
+): VariantConfig | null {
+  if (!value) return null;
+  return VARIANTS[value.toLowerCase()] ?? null;
+}
+
+/**
+ * `?v=` is the canonical variant key; an exact-slug `utm_content` works as a
+ * fallback so a link tagged only with UTMs still personalizes. Creative-level
+ * values like `utm_content=finance-video-b` don't match and fall back to the
+ * default page.
+ */
+export function resolveVariantFromParams(
+  params: URLSearchParams,
+): VariantConfig | null {
+  return (
+    resolveVariant(params.get(VARIANT_PARAM)) ??
+    resolveVariant(params.get(VARIANT_FALLBACK_PARAM))
+  );
+}

--- a/apps/breakpoint/src/content/variants.ts
+++ b/apps/breakpoint/src/content/variants.ts
@@ -158,7 +158,9 @@ export function resolveVariant(
   value: string | null | undefined,
 ): VariantConfig | null {
   if (!value) return null;
-  return VARIANTS[value.toLowerCase()] ?? null;
+  const key = value.toLowerCase();
+  if (!Object.hasOwn(VARIANTS, key)) return null;
+  return VARIANTS[key] ?? null;
 }
 
 /**

--- a/apps/breakpoint/src/lib/use-variant.ts
+++ b/apps/breakpoint/src/lib/use-variant.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  resolveVariantFromParams,
+  type VariantConfig,
+} from "@/content/variants";
+
+/**
+ * Resolves the audience variant from the `?v=` query param (with an
+ * exact-slug `utm_content` fallback — see `resolveVariantFromParams`).
+ *
+ * Reads `window.location` in an effect instead of `useSearchParams` so the
+ * page prerenders (and hydrates) with the default copy and stays fully
+ * static — one CDN cache entry no matter what params paid traffic carries.
+ * Returns `null` on the server, on first client render, and for unknown
+ * values, in which case callers fall back to the default translations.
+ */
+export function useVariant(): VariantConfig | null {
+  const [variant, setVariant] = useState<VariantConfig | null>(null);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    setVariant(resolveVariantFromParams(params));
+  }, []);
+
+  return variant;
+}

--- a/apps/breakpoint/src/tests/variants.test.tsx
+++ b/apps/breakpoint/src/tests/variants.test.tsx
@@ -1,0 +1,99 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  resolveVariant,
+  resolveVariantFromParams,
+  VARIANTS,
+} from "@/content/variants";
+import { useVariant } from "@/lib/use-variant";
+
+describe("resolveVariant", () => {
+  it("resolves every configured variant slug", () => {
+    for (const slug of Object.keys(VARIANTS)) {
+      expect(resolveVariant(slug)?.slug).toBe(slug);
+    }
+  });
+
+  it("is case-insensitive", () => {
+    expect(resolveVariant("Developers")?.slug).toBe("developers");
+    expect(resolveVariant("AI")?.slug).toBe("ai");
+  });
+
+  it("falls back to null for missing or unknown values", () => {
+    expect(resolveVariant(null)).toBeNull();
+    expect(resolveVariant(undefined)).toBeNull();
+    expect(resolveVariant("")).toBeNull();
+    expect(resolveVariant("gaming")).toBeNull();
+    expect(resolveVariant("developers ")).toBeNull();
+  });
+});
+
+describe("resolveVariantFromParams", () => {
+  it("prefers ?v= over utm_content", () => {
+    const params = new URLSearchParams("v=ai&utm_content=finance");
+    expect(resolveVariantFromParams(params)?.slug).toBe("ai");
+  });
+
+  it("falls back to an exact-slug utm_content when v is absent", () => {
+    const params = new URLSearchParams(
+      "utm_source=meta&utm_content=developers",
+    );
+    expect(resolveVariantFromParams(params)?.slug).toBe("developers");
+  });
+
+  it("ignores creative-level utm_content values", () => {
+    const params = new URLSearchParams("utm_content=finance-video-b");
+    expect(resolveVariantFromParams(params)).toBeNull();
+  });
+
+  it("returns null with no params", () => {
+    expect(resolveVariantFromParams(new URLSearchParams(""))).toBeNull();
+  });
+});
+
+describe("variant configs", () => {
+  it("carry complete copy for every swapped section", () => {
+    for (const variant of Object.values(VARIANTS)) {
+      expect(variant.heroHeadline).toBeTruthy();
+      expect(variant.heroCtaLabel).toBeTruthy();
+      expect(variant.positioningStatement).toBeTruthy();
+      expect(variant.ticketsHeadline).toBeTruthy();
+      expect(variant.narrativeParagraphs.length).toBeGreaterThanOrEqual(3);
+      expect(variant.narrativeParagraphs.length).toBeLessThanOrEqual(4);
+      expect(variant.stats.length).toBeGreaterThanOrEqual(3);
+      expect(variant.stats.length).toBeLessThanOrEqual(4);
+      for (const stat of variant.stats) {
+        expect(stat.value).toBeTruthy();
+        expect(stat.label).toBeTruthy();
+      }
+    }
+  });
+});
+
+function VariantProbe() {
+  const variant = useVariant();
+  return <output>{variant?.slug ?? "default"}</output>;
+}
+
+describe("useVariant", () => {
+  afterEach(() => {
+    cleanup();
+    window.history.replaceState(null, "", "/");
+  });
+
+  it("resolves the variant from ?v= after hydration", async () => {
+    window.history.replaceState(null, "", "/?v=finance&utm_source=brave");
+    render(<VariantProbe />);
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent("finance");
+    });
+  });
+
+  it("renders the default when the param is absent or unknown", async () => {
+    window.history.replaceState(null, "", "/?v=unknown");
+    render(<VariantProbe />);
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent("default");
+    });
+  });
+});

--- a/apps/breakpoint/src/tests/variants.test.tsx
+++ b/apps/breakpoint/src/tests/variants.test.tsx
@@ -26,6 +26,12 @@ describe("resolveVariant", () => {
     expect(resolveVariant("gaming")).toBeNull();
     expect(resolveVariant("developers ")).toBeNull();
   });
+
+  it("ignores inherited object property names", () => {
+    expect(resolveVariant("__proto__")).toBeNull();
+    expect(resolveVariant("constructor")).toBeNull();
+    expect(resolveVariant("toString")).toBeNull();
+  });
 });
 
 describe("resolveVariantFromParams", () => {


### PR DESCRIPTION
## Summary

- Add Breakpoint page audience variants selected by the `?v=` URL parameter.
- Wire hero, narrative, stats, and tickets copy to the selected variant with default fallback behavior.
- Add coverage for variant selection, fallbacks, and affected section rendering.

## Tests

- `pnpm --filter solana-com-breakpoint test`