### PR TITLE
Fix Bun template generation command

### DIFF
--- a/apps/templates/src/components/templates/templates-ui-generate-command.tsx
+++ b/apps/templates/src/components/templates/templates-ui-generate-command.tsx
@@ -15,6 +15,8 @@ function getCommand(pm: string, template: string) {
     case "yarn":
       // Yarn only supports the `latest` tag
       return `yarn create solana-dapp -t ${template}`;
+    case "bun":
+      return `bunx create-solana-dapp@latest -t ${template}`;
     default:
       // All other package managers support the `@latest` tag and best practice is to always use it explicitly
       return `${pm} create solana-dapp@latest -t ${template}`;


### PR DESCRIPTION
### Problem

The templates app currently emits `bun create solana-dapp@latest -t ...` for Bun users. Issue #1549 reports that this command does not work reliably on Windows/PowerShell/WSL, while `bunx create-solana-dapp@latest -t ...` does.

### Summary of Changes

- Add an explicit Bun branch in the template command generator.
- Emit `bunx create-solana-dapp@latest -t ...` for Bun while leaving npm, pnpm, and yarn behavior unchanged.

Fixes #1549

### Validation

- `pnpm --filter solana-templates lint` (passes with existing warnings in unrelated files)

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] Input from users or external services is validated before use; no `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit` passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependencies: none

Threat-model note for Critical changes: n/a
