### PR TITLE
Fix Breakpoint code of conduct link

### DIFF
--- a/apps/breakpoint/src/content/links.ts
+++ b/apps/breakpoint/src/content/links.ts
@@ -10,7 +10,8 @@ export const PRESS_APPLICATION_HREF =
   "https://solanafoundation.typeform.com/bp26-press";
 export const CONTENT_CREATOR_APPLICATION_HREF =
   "https://solanafoundation.typeform.com/bp26-creator";
-export const CODE_OF_CONDUCT_HREF = "https://shorturl.at/lEMR1";
+export const CODE_OF_CONDUCT_HREF =
+  "https://solana.com/community/code-of-conduct";
 export const SIDE_EVENTS_HREF = "https://luma.com/BP-SideEvents";
 export const BREAKPOINT_2025_ARCHIVES_URL =
   "https://www.youtube.com/playlist?list=PLilwLeBwGuK53OUOcc_GsCcbqcU5V4H9Z";


### PR DESCRIPTION
### Problem

The Breakpoint footer/menu code-of-conduct link uses `https://shorturl.at/lEMR1`, which currently returns a Cloudflare challenge/non-content response to direct clients and was previously reported as broken in #714.

### Summary of Changes

- Replace the third-party shortlink with the canonical Solana Code of Conduct URL.
- Keep the existing footer and menu link wiring unchanged.

Fixes #714

### Validation

- `pnpm --filter solana-com-breakpoint lint`

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] Input from users or external services is validated before use; no `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit` passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependencies: none

Threat-model note for Critical changes: n/a
