### PR TITLE
docs: clarify simulateTransaction inner instructions

### DIFF
--- a/apps/docs/content/docs/en/rpc/http/simulatetransaction.mdx
+++ b/apps/docs/content/docs/en/rpc/http/simulatetransaction.mdx
@@ -251,8 +251,10 @@ The minimum slot that the request can be evaluated at
 !values true false  
 !default false
 
-If `true` the response will include CPI instructions (`innerInstructions`).
-These inner instructions will be `jsonParsed` where possible, otherwise `json`.
+If `true` the response will include CPI instructions (`innerInstructions`). Each
+inner instruction is fully parsed (`jsonParsed`) where a parser is available,
+otherwise partially decoded with base-58 encoded program and account addresses.
+The compiled `json` form with account indexes is never returned.
 
 See [Inner Instructions](/docs/rpc/json-structures#inner-instructions) for the
 shared structure.
@@ -478,15 +480,16 @@ When `accounts[].data` is returned as an object, it contains:
 
 ## Example Result
 
-- The `JsonParsed` example shows the simulation result for a transaction that
+- The `Parsed` example shows the simulation result for a transaction that
   creates an
   [associated token account](/docs/tokens/basics/create-token-account#how-to-create-an-associated-token-account).
-- The `Json` example shows the simulation result for a transaction with a CPI
-  (`innerInstructions`) that can't be parsed.
+- The `Partially Decoded` example shows the simulation result for a transaction
+  with a CPI (`innerInstructions`) that can't be parsed. Accounts are returned
+  as base-58 encoded addresses, not indexes.
 
 <CodeTabs>
 
-```json !! title="JsonParsed Inner Instructions"
+```json !! title="Parsed Inner Instructions"
 {
   "jsonrpc": "2.0",
   "result": {
@@ -613,7 +616,7 @@ When `accounts[].data` is returned as an object, it contains:
 }
 ```
 
-```json !! title="Json Inner Instructions"
+```json !! title="Partially Decoded Inner Instructions"
 {
   "jsonrpc": "2.0",
   "result": {

--- a/apps/docs/content/docs/en/rpc/json-structures.mdx
+++ b/apps/docs/content/docs/en/rpc/json-structures.mdx
@@ -560,7 +560,9 @@ Simulation error. Uses the structure documented in
 
 Inner instructions captured during simulation. `null` unless CPI recording was
 requested. Uses the structure documented in
-[Inner Instructions](#inner-instructions).
+[Inner Instructions](#inner-instructions), always in the JSON Parsed form: each
+instruction is either fully parsed or partially decoded, never a compiled
+instruction with account indexes.
 
 ### !! loadedAccountsDataSize
 
@@ -2105,6 +2107,11 @@ detailed under `innerInstructions`.
   `transaction.message.instructions[index]` that made the CPI.
 - `instructions: array[object]` – List of CPI instructions invoked by the
   instruction at `index`, encoded as Json or JsonParsed objects.
+
+Transaction responses use the form matching the requested transaction encoding:
+`json` returns compiled instructions with account indexes, while `jsonParsed`
+returns parsed or partially decoded instructions with base-58 encoded addresses.
+[Simulation Results](#simulation-results) always use the JSON Parsed form.
 
 #### JSON Parsed
 


### PR DESCRIPTION
### Problem

The RPC docs describe `simulateTransaction` inner instructions in a way that can be read as the compiled `json` form with account indexes. Agave returns simulation inner instructions as fully parsed instructions where possible, otherwise partially decoded instructions with base-58 program and account addresses.

### Summary of Changes

- Clarify the `innerInstructions` config description on `simulateTransaction`.
- Rename the example result tabs to `Parsed` and `Partially Decoded`.
- Clarify the shared JSON structures page so simulation results are distinguished from transaction responses, where the requested transaction encoding controls the shape.

Fixes #844

### Validation

- `pnpm --filter solana-docs lint`

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] Input from users or external services is validated before use; no `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit` passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependencies: none

Threat-model note for Critical changes: n/a
