### PR TITLE
docs: clarify message version prefix

### DIFF
--- a/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
+++ b/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
@@ -165,6 +165,15 @@ pub struct MessageHeader {
 
 </WithMentions>
 
+<Callout type="info" title="Legacy and versioned message prefixes">
+  In a legacy transaction message, the first message byte is
+  `num_required_signatures`, followed by the other two `MessageHeader` bytes. In
+  a versioned transaction message, the first byte is a version prefix instead;
+  the three-byte `MessageHeader` starts immediately after that prefix. See
+  [versioned transactions](/docs/core/transactions/versioned-transactions) for
+  the full v0 message layout.
+</Callout>
+
 ![Diagram showing the three parts of the message header](/assets/docs/core/transactions/message_header.png)
 
 ### Account addresses


### PR DESCRIPTION
### Problem

The transaction structure docs explain the `MessageHeader` fields but do not explicitly call out that versioned transaction messages have a version-prefix byte before the three-byte message header. That can make the first byte sound like it always encodes both required signatures and transaction version.

### Summary of Changes

- Add an info callout under the `MessageHeader` section.
- Clarify that legacy messages start with `num_required_signatures`, while versioned messages start with a version prefix and then the three-byte `MessageHeader`.
- Link to the versioned transactions page for the full v0 layout.

Fixes #359

### Validation

- `pnpm --filter solana-docs lint`

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] Input from users or external services is validated before use; no `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit` passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependencies: none

Threat-model note for Critical changes: n/a
