### PR TITLE
Fix docs sidebar in mobile landscape

### DIFF
--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -151,6 +151,7 @@
     -webkit-backdrop-filter: blur(12px);
     backdrop-filter: blur(12px);
     font-size: 15px;
+    visibility: hidden;
   }
 
   .fumadocs #nd-sidebar[data-open="false"] {

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -126,6 +126,47 @@
   max-width: 250px;
 }
 
+/*
+ * Mobile devices in landscape can cross Fumadocs' md breakpoint by width
+ * while still having very limited vertical space. Keep the docs in the
+ * mobile drawer layout for those viewports instead of pinning the sidebar.
+ */
+@media (orientation: landscape) and (max-height: 500px) and (pointer: coarse) {
+  .fumadocs #nd-docs-layout {
+    --fd-sidebar-width: 100vw !important;
+  }
+
+  .fumadocs #nd-sidebar {
+    position: fixed !important;
+    top: var(--fd-nav-height);
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 30;
+    width: 100vw;
+    height: calc(100dvh - var(--fd-nav-height));
+    max-width: none;
+    max-height: calc(100dvh - var(--fd-nav-height)) !important;
+    background: hsl(var(--background) / 0.8);
+    -webkit-backdrop-filter: blur(12px);
+    backdrop-filter: blur(12px);
+    font-size: 15px;
+  }
+
+  .fumadocs #nd-sidebar[data-open="false"] {
+    visibility: hidden !important;
+    pointer-events: none;
+  }
+
+  .fumadocs #nd-sidebar[data-open="true"] {
+    visibility: visible !important;
+  }
+
+  .fumadocs #fd-sidebar-toggle {
+    display: block !important;
+  }
+}
+
 .fumadocs #nd-sidebar [data-radix-scroll-area-viewport] {
   mask-image: none !important;
   padding-left: 0rem !important;


### PR DESCRIPTION
## Summary
- hides the Fumadocs sidebar by default for short touch landscape viewports that cross the desktop width breakpoint
- keeps the sidebar available as a full-width drawer from the existing toggle
- leaves normal desktop sidebar behavior unchanged

Fixes #194

## Validation
- `pnpm --filter solana-docs lint`
- Playwright against `http://localhost:3003/docs/core/transactions/transaction-structure`
  - mobile landscape `844x390`, `isMobile: true`, `hasTouch: true`: HTTP 200, no console/page errors, no horizontal overflow, closed sidebar hidden with zero article overlap, toggle opens full-width drawer
  - desktop `1280x900`: HTTP 200, no console/page errors, sidebar remains sticky and mobile toggle remains hidden

## Notes
- First-visit Playwright run showed the shared cookie consent banner can cover the bottom-left docs sidebar toggle until the user accepts or opts out. I treated that as existing shared chrome behavior and validated this sidebar fix with the persisted `cookie_consent` localStorage value the app already uses.
