### PR TITLE
docs: avoid wallet adapter legacy bundle

### DIFF
--- a/apps/docs/content/cookbook/wallets/connect-wallet-react.mdx
+++ b/apps/docs/content/cookbook/wallets/connect-wallet-react.mdx
@@ -65,9 +65,16 @@ If you are creating a new Nextjs project, install the following dependencies:
 $ npm install @solana/web3.js \
     @solana/wallet-adapter-base \
     @solana/wallet-adapter-react \
-    @solana/wallet-adapter-react-ui \
-    @solana/wallet-adapter-wallets
+    @solana/wallet-adapter-react-ui
 ```
+
+<Callout type="info">
+  This example uses Wallet Standard discovery with `wallets={[]}`, so it does
+  not need the `@solana/wallet-adapter-wallets` bundle. That bundle includes
+  legacy adapters and can install deprecated WalletConnect v1 dependencies. If
+  you need WalletConnect protocol support specifically, use Reown's [Solana
+  Adapter](https://docs.reown.com/advanced/providers/solana-adapter).
+</Callout>
 
 ### Create Solana Provider
 


### PR DESCRIPTION
## Summary
- remove the unused `@solana/wallet-adapter-wallets` package from the React wallet cookbook install command
- add a note explaining that the example uses Wallet Standard discovery with `wallets={[]}`
- point users who specifically need WalletConnect protocol support to Reown's Solana Adapter docs

## Validation
- `pnpm --filter solana-docs lint`
- `curl -I -L https://solana.com/developers/guides/wallets/add-solana-wallet-adapter-to-nextjs` returns 308 to `/developers/cookbook/wallets/connect-wallet-react`, then 200
- `curl -I -L https://docs.reown.com/advanced/providers/solana-adapter` returns 200
- Playwright against local `http://localhost:3003/developers/cookbook/wallets/connect-wallet-react`: HTTP 200, no console/page errors, no horizontal overflow; install snippet omits `@solana/wallet-adapter-wallets` and Reown link is present

Fixes #396