### PR TITLE
fix: align epoch1000 mainnet title and seo

### DIFF
--- a/apps/web/src/app/[locale]/epoch1000/page.tsx
+++ b/apps/web/src/app/[locale]/epoch1000/page.tsx
@@ -1,8 +1,12 @@
 import Epoch1000Experience from "@/components/epoch1000/Epoch1000Experience";
+import type { Metadata } from "next";
 import { getAlternates, Link } from "@workspace/i18n/routing";
 import { getTranslations } from "@workspace/i18n/server";
 
 type Props = { params: Promise<{ locale: string }> };
+
+const EPOCH1000_PATH = "/epoch1000";
+const EPOCH1000_SOCIAL_IMAGE = "/api/epoch1000/og?s=1000&fe=0&c=1000";
 
 export default async function Page() {
   const t = await getTranslations("epoch1000.page");
@@ -33,20 +37,35 @@ export default async function Page() {
   );
 }
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations("epoch1000.meta");
+  const title = t("title");
+  const description = t("description");
+  const alternates = getAlternates(EPOCH1000_PATH, locale);
 
   return {
-    title: t("title"),
-    description: t("description"),
-    alternates: getAlternates("/epoch1000", locale),
+    title,
+    description,
+    alternates,
     openGraph: {
       title: t("openGraphTitle"),
       description: t("openGraphDescription"),
+      type: "website",
+      url: alternates.canonical,
+      images: [
+        {
+          url: EPOCH1000_SOCIAL_IMAGE,
+          width: 1200,
+          height: 630,
+        },
+      ],
     },
     twitter: {
       card: "summary_large_image",
+      title,
+      description,
+      images: [EPOCH1000_SOCIAL_IMAGE],
     },
   };
 }

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -7745,7 +7745,7 @@
       "bannerLabel": "Get started now"
     },
     "epochHero": {
-      "eyebrow": "Solana Mainnet-Beta · March 2020 → Now",
+      "eyebrow": "Solana Mainnet · March 2020 → Now",
       "title": "One thousand epochs \n<light>in the making.</light>",
       "subtitle": "Every ~2 days since 2020, Solana has closed an epoch — 432,000 slots of blocks, votes, and payments. Epoch 1000 is almost here.",
       "cta": "Join the celebration",


### PR DESCRIPTION
### Problem

The Epoch 1000 campaign copy and route SEO needed to match the current Solana Mainnet wording and provide complete app-router social metadata for `/epoch1000`.

### Summary of Changes

- Updated the English web common message for the Epoch 1000 hero eyebrow from "Solana Mainnet-Beta" to "Solana Mainnet".
- Added explicit `/epoch1000` metadata alignment: canonical alternates, Open Graph URL/type, and the campaign OG image for Open Graph and Twitter cards.
- No security-relevant behavior changed.

Fixes: n/a

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
      No user or external input handling changed.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
      No dependencies changed.
- [x] Errors are handled explicitly — no silent failures on production paths.
      No runtime error handling changed.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.
      Not applicable.

New dependencies: none

Threat-model note for Critical changes: n/a

### Validation

- `node -e "JSON.parse(require('fs').readFileSync('packages/i18n/messages/web/en/common.json','utf8'))"`
- `pnpm -w exec prettier --check 'apps/web/src/app/[locale]/epoch1000/page.tsx'`
- `pnpm --filter solana-com exec tsc --noEmit`
- `pnpm --filter solana-com exec eslint 'src/app/[locale]/epoch1000/page.tsx'`
- Pre-commit lint-staged ran ESLint/Prettier on the changed route file and Prettier on the changed JSON file.
