### PR TITLE
Streamline Epoch 1000 UX

### DIFF
--- a/apps/web/src/app/[locale]/epoch1000/card/page.tsx
+++ b/apps/web/src/app/[locale]/epoch1000/card/page.tsx
@@ -1,9 +1,11 @@
 import type { Metadata } from "next";
-import { Link } from "@workspace/i18n/routing";
+import { getAlternates, Link } from "@workspace/i18n/routing";
+import { getTranslations } from "@workspace/i18n/server";
 import Reveal from "@/components/epoch1000/Reveal";
 import { tierFor } from "@/lib/epoch1000/tiers";
 
 interface Props {
+  params: Promise<{ locale: string }>;
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }
 
@@ -11,29 +13,47 @@ function first(v: string | string[] | undefined): string {
   return Array.isArray(v) ? (v[0] ?? "") : (v ?? "");
 }
 
-function ogQuery(sp: Record<string, string | string[] | undefined>): string {
+function ogQuery(
+  sp: Record<string, string | string[] | undefined>,
+  locale?: string,
+): string {
   const p = new URLSearchParams();
   for (const key of ["s", "fe", "c", "t", "x", "w"]) {
     const v = first(sp[key]);
     if (v) p.set(key, v);
   }
+  if (locale) p.set("l", locale);
   return p.toString();
 }
 
 export async function generateMetadata({
+  params,
   searchParams,
 }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "epoch1000.card" });
   const sp = await searchParams;
   const survived = first(sp.s) || "0";
   const capped = first(sp.x) === "1";
   const firstEpoch = first(sp.fe);
   const tier = tierFor(parseInt(survived, 10) || 0);
-  const title = `Epoch 1000 Survivor Card — ${tier.name}`;
-  const description = `Survived ${survived}${capped ? "+" : ""} of Solana's first 1,000 epochs${firstEpoch ? ` — on chain since epoch ${firstEpoch}` : ""}. ${tier.line}`;
-  const image = `/api/epoch1000/og?${ogQuery(sp)}`;
+  const survivedLabel = `${survived}${capped ? "+" : ""}`;
+  const title = t("meta.title", { survived: survivedLabel });
+  const description = t(
+    firstEpoch
+      ? "meta.description.withFirstEpoch"
+      : "meta.description.withoutFirstEpoch",
+    {
+      survived: survivedLabel,
+      firstEpoch,
+      tierLine: t(`tiers.${tier.id}.line`),
+    },
+  );
+  const image = `/api/epoch1000/og?${ogQuery(sp, locale)}`;
   return {
     title,
     description,
+    alternates: getAlternates("/epoch1000/card", locale),
     openGraph: {
       title,
       description,
@@ -48,45 +68,57 @@ export async function generateMetadata({
   };
 }
 
-export default async function CardPage({ searchParams }: Props) {
+export default async function CardPage({ params, searchParams }: Props) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "epoch1000.card" });
   const sp = await searchParams;
-  const query = ogQuery(sp);
+  const query = ogQuery(sp, locale);
   const survived = Math.max(0, parseInt(first(sp.s), 10) || 0);
   const capped = first(sp.x) === "1";
   const firstEpoch = first(sp.fe);
   const wallet = first(sp.w);
   const tier = tierFor(survived);
+  const tierName = t(`tiers.${tier.id}.name`);
   const survivedLabel = `${survived}${capped ? "+" : ""}`;
+  const walletLabel = wallet || t("summary.defaultWallet");
 
   return (
     <main className="w-full max-w-3xl mx-auto px-5 sm:px-8 py-12 sm:py-20 flex flex-col items-center text-center gap-8 sm:gap-10 min-h-screen">
       <header className="flex flex-col items-center gap-4 sm:gap-5">
         <p className="font-brand-mono text-xs sm:text-sm tracking-[0.2em] text-ep-dust uppercase">
-          Solana mainnet · Epoch 1000
+          {t("eyebrow")}
         </p>
         <h1
           className="font-black tracking-tight text-4xl sm:text-6xl leading-none"
           style={{ color: tier.color }}
         >
-          {tier.name}
+          {t("heading", { survived: survivedLabel })}
         </h1>
         <p className="text-sm sm:text-base text-ep-dim max-w-xl">
-          {wallet ? (
-            <span className="font-mono text-ep-ink">{wallet}</span>
-          ) : (
-            "This wallet"
-          )}{" "}
-          survived{" "}
-          <span className="font-semibold text-ep-ink">{survivedLabel}</span> of
-          Solana&apos;s first 1,000 epochs
-          {firstEpoch ? ` — on chain since epoch ${firstEpoch}` : ""}.
+          {t.rich(
+            firstEpoch ? "summary.withFirstEpoch" : "summary.withoutFirstEpoch",
+            {
+              walletLabel,
+              survived: survivedLabel,
+              firstEpoch,
+              wallet: (chunks) =>
+                wallet ? (
+                  <span className="font-mono text-ep-ink">{chunks}</span>
+                ) : (
+                  <>{chunks}</>
+                ),
+              strong: (chunks) => (
+                <span className="font-semibold text-ep-ink">{chunks}</span>
+              ),
+            },
+          )}
         </p>
       </header>
 
       <Reveal className="w-full">
         <img
           src={`/api/epoch1000/og?${query}`}
-          alt={`Survivor card: ${tier.name}, survived ${survivedLabel} of Solana's first 1,000 epochs`}
+          alt={t("imageAlt", { tier: tierName, survived: survivedLabel })}
           className="w-full rounded-xl border border-ep-edge"
           style={{ boxShadow: `0 20px 100px -30px ${tier.color}66` }}
           width={1200}
@@ -95,30 +127,22 @@ export default async function CardPage({ searchParams }: Props) {
       </Reveal>
 
       <Reveal className="flex flex-col items-center gap-6 sm:gap-8">
-        <p className="text-sm text-ep-dim max-w-xl">
-          An epoch is roughly two days of uninterrupted Solana blocks — epoch
-          1000 marks over six years of mainnet without missing a beat. Every
-          survivor card shows how much of that history a wallet lived through.
-        </p>
-
         <div className="flex flex-col items-center gap-3">
           <div className="flex flex-wrap justify-center gap-3">
             <Link
               href="/epoch1000#checker"
               className="bg-ep-ink text-ep-void font-semibold rounded-full px-7 py-3 text-sm hover:bg-ep-dim transition-colors duration-200"
             >
-              Check your wallet
+              {t("ctaCheck")}
             </Link>
             <Link
               href="/epoch1000"
               className="border border-ep-edge rounded-full px-7 py-3 text-sm text-ep-dim hover:text-ep-ink transition-colors duration-200"
             >
-              Explore the celebration
+              {t("ctaExplore")}
             </Link>
           </div>
-          <p className="text-xs text-ep-dust">
-            No connect. No signature. Just paste an address.
-          </p>
+          <p className="text-xs text-ep-dust">{t("privacyNote")}</p>
         </div>
       </Reveal>
     </main>

--- a/apps/web/src/app/[locale]/epoch1000/card/page.tsx
+++ b/apps/web/src/app/[locale]/epoch1000/card/page.tsx
@@ -26,8 +26,8 @@ export async function generateMetadata({
   const survived = first(sp.s) || "0";
   const capped = first(sp.x) === "1";
   const tier = tierFor(parseInt(survived, 10) || 0);
-  const title = `Survived ${survived}${capped ? "+" : ""} epochs on Solana — ${tier.name}`;
-  const description = `First seen in epoch ${first(sp.fe) || "?"}. How many of Solana's first 1000 epochs did you survive?`;
+  const title = `Epoch 1000 survivor card - ${tier.name}`;
+  const description = `Survived ${survived}${capped ? "+" : ""} Solana epochs. First seen in epoch ${first(sp.fe) || "?"}.`;
   const image = `/api/epoch1000/og?${ogQuery(sp)}`;
   return {
     title,

--- a/apps/web/src/app/[locale]/epoch1000/card/page.tsx
+++ b/apps/web/src/app/[locale]/epoch1000/card/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
-import Link from "next/link";
+import { Link } from "@workspace/i18n/routing";
+import Reveal from "@/components/epoch1000/Reveal";
 import { tierFor } from "@/lib/epoch1000/tiers";
 
 interface Props {
@@ -25,9 +26,10 @@ export async function generateMetadata({
   const sp = await searchParams;
   const survived = first(sp.s) || "0";
   const capped = first(sp.x) === "1";
+  const firstEpoch = first(sp.fe);
   const tier = tierFor(parseInt(survived, 10) || 0);
-  const title = `Epoch 1000 survivor card - ${tier.name}`;
-  const description = `Survived ${survived}${capped ? "+" : ""} Solana epochs. First seen in epoch ${first(sp.fe) || "?"}.`;
+  const title = `Epoch 1000 Survivor Card — ${tier.name}`;
+  const description = `Survived ${survived}${capped ? "+" : ""} of Solana's first 1,000 epochs${firstEpoch ? ` — on chain since epoch ${firstEpoch}` : ""}. ${tier.line}`;
   const image = `/api/epoch1000/og?${ogQuery(sp)}`;
   return {
     title,
@@ -49,34 +51,76 @@ export async function generateMetadata({
 export default async function CardPage({ searchParams }: Props) {
   const sp = await searchParams;
   const query = ogQuery(sp);
-  const survived = parseInt(first(sp.s), 10) || 0;
+  const survived = Math.max(0, parseInt(first(sp.s), 10) || 0);
   const capped = first(sp.x) === "1";
+  const firstEpoch = first(sp.fe);
+  const wallet = first(sp.w);
   const tier = tierFor(survived);
+  const survivedLabel = `${survived}${capped ? "+" : ""}`;
 
   return (
-    <main className="w-full max-w-3xl mx-auto px-5 sm:px-8 py-10 sm:py-16 flex flex-col gap-8 min-h-screen">
-      <h1 className="font-bold tracking-tight text-xl sm:text-2xl">
-        <span style={{ color: tier.color }}>{tier.name}</span> · survived{" "}
-        {survived}
-        {capped ? "+" : ""} epochs
-      </h1>
+    <main className="w-full max-w-3xl mx-auto px-5 sm:px-8 py-12 sm:py-20 flex flex-col items-center text-center gap-8 sm:gap-10 min-h-screen">
+      <header className="flex flex-col items-center gap-4 sm:gap-5">
+        <p className="font-brand-mono text-xs sm:text-sm tracking-[0.2em] text-ep-dust uppercase">
+          Solana mainnet · Epoch 1000
+        </p>
+        <h1
+          className="font-black tracking-tight text-4xl sm:text-6xl leading-none"
+          style={{ color: tier.color }}
+        >
+          {tier.name}
+        </h1>
+        <p className="text-sm sm:text-base text-ep-dim max-w-xl">
+          {wallet ? (
+            <span className="font-mono text-ep-ink">{wallet}</span>
+          ) : (
+            "This wallet"
+          )}{" "}
+          survived{" "}
+          <span className="font-semibold text-ep-ink">{survivedLabel}</span> of
+          Solana&apos;s first 1,000 epochs
+          {firstEpoch ? ` — on chain since epoch ${firstEpoch}` : ""}.
+        </p>
+      </header>
 
-      <img
-        src={`/api/epoch1000/og?${query}`}
-        alt={`Survivor card: ${tier.name}, survived ${survived} epochs on Solana`}
-        className="w-full rounded-lg border border-ep-edge"
-        width={1200}
-        height={630}
-      />
+      <Reveal className="w-full">
+        <img
+          src={`/api/epoch1000/og?${query}`}
+          alt={`Survivor card: ${tier.name}, survived ${survivedLabel} of Solana's first 1,000 epochs`}
+          className="w-full rounded-xl border border-ep-edge"
+          style={{ boxShadow: `0 20px 100px -30px ${tier.color}66` }}
+          width={1200}
+          height={630}
+        />
+      </Reveal>
 
-      <p className="text-sm text-ep-dim">{tier.line}</p>
+      <Reveal className="flex flex-col items-center gap-6 sm:gap-8">
+        <p className="text-sm text-ep-dim max-w-xl">
+          An epoch is roughly two days of uninterrupted Solana blocks — epoch
+          1000 marks over six years of mainnet without missing a beat. Every
+          survivor card shows how much of that history a wallet lived through.
+        </p>
 
-      <Link
-        href="/epoch1000#checker"
-        className="self-start bg-ep-ink text-ep-void font-semibold rounded-full px-7 py-3 text-sm hover:bg-ep-dim transition"
-      >
-        Check your own wallet
-      </Link>
+        <div className="flex flex-col items-center gap-3">
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/epoch1000#checker"
+              className="bg-ep-ink text-ep-void font-semibold rounded-full px-7 py-3 text-sm hover:bg-ep-dim transition-colors duration-200"
+            >
+              Check your wallet
+            </Link>
+            <Link
+              href="/epoch1000"
+              className="border border-ep-edge rounded-full px-7 py-3 text-sm text-ep-dim hover:text-ep-ink transition-colors duration-200"
+            >
+              Explore the celebration
+            </Link>
+          </div>
+          <p className="text-xs text-ep-dust">
+            No connect. No signature. Just paste an address.
+          </p>
+        </div>
+      </Reveal>
     </main>
   );
 }

--- a/apps/web/src/app/[locale]/epoch1000/page.tsx
+++ b/apps/web/src/app/[locale]/epoch1000/page.tsx
@@ -1,8 +1,12 @@
 import Epoch1000Experience from "@/components/epoch1000/Epoch1000Experience";
+import type { Metadata } from "next";
 import { getAlternates, Link } from "@workspace/i18n/routing";
 import { getTranslations } from "@workspace/i18n/server";
 
 type Props = { params: Promise<{ locale: string }> };
+
+const EPOCH1000_PATH = "/epoch1000";
+const EPOCH1000_SOCIAL_IMAGE = "/api/epoch1000/og?s=1000&fe=0&c=1000";
 
 export default async function Page() {
   const t = await getTranslations("epoch1000.page");
@@ -33,20 +37,35 @@ export default async function Page() {
   );
 }
 
-export async function generateMetadata({ params }: Props) {
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
   const t = await getTranslations("epoch1000.meta");
+  const title = t("title");
+  const description = t("description");
+  const alternates = getAlternates(EPOCH1000_PATH, locale);
 
   return {
-    title: t("title"),
-    description: t("description"),
-    alternates: getAlternates("/epoch1000", locale),
+    title,
+    description,
+    alternates,
     openGraph: {
       title: t("openGraphTitle"),
       description: t("openGraphDescription"),
+      type: "website",
+      url: alternates.canonical,
+      images: [
+        {
+          url: EPOCH1000_SOCIAL_IMAGE,
+          width: 1200,
+          height: 630,
+        },
+      ],
     },
     twitter: {
       card: "summary_large_image",
+      title,
+      description,
+      images: [EPOCH1000_SOCIAL_IMAGE],
     },
   };
 }

--- a/apps/web/src/app/[locale]/epoch1000/page.tsx
+++ b/apps/web/src/app/[locale]/epoch1000/page.tsx
@@ -13,10 +13,7 @@ export default async function Page() {
 
   return (
     <main className="w-full max-w-6xl mx-auto px-5 sm:px-8 pt-6 sm:pt-8 pb-8 sm:pb-12 flex flex-col gap-10 sm:gap-14 min-h-screen">
-      <header className="flex items-center justify-between gap-4 border-b border-ep-edge/70 pb-4">
-        <p className="text-xs font-brand-mono uppercase tracking-[0.3em] text-ep-dust">
-          {t("eyebrow")}
-        </p>
+      <header className="flex justify-end border-b border-ep-edge/70 pb-4">
         <Link
           href="/epoch1000#checker"
           className="text-xs font-brand-mono text-ep-dust hover:text-ep-ink transition-colors duration-200 shrink-0 rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4"

--- a/apps/web/src/app/api/epoch1000/og/route.tsx
+++ b/apps/web/src/app/api/epoch1000/og/route.tsx
@@ -16,9 +16,6 @@ const CACHE_CONTROL =
 const CELLS = 50; // 1 cell = 20 epochs of the first 1000
 const EPOCHS_PER_CELL = 1000 / CELLS;
 
-const SOLANA_MARK_SVG = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 397.7 311.7"><defs><linearGradient id="g" gradientUnits="userSpaceOnUse" x1="360.879" y1="351.455" x2="141.213" y2="-69.294" gradientTransform="matrix(1 0 0 -1 0 314)"><stop offset="0" stop-color="#00FFA3"/><stop offset="1" stop-color="#DC1FFF"/></linearGradient></defs><path fill="url(#g)" d="M64.6 237.9c2.4-2.4 5.7-3.8 9.2-3.8h317.4c5.8 0 8.7 7 4.6 11.1l-62.7 62.7c-2.4 2.4-5.7 3.8-9.2 3.8H6.5c-5.8 0-8.7-7-4.6-11.1l62.7-62.7z"/><path fill="url(#g)" d="M64.6 3.8C67.1 1.4 70.4 0 73.8 0h317.4c5.8 0 8.7 7 4.6 11.1l-62.7 62.7c-2.4 2.4-5.7 3.8-9.2 3.8H6.5c-5.8 0-8.7-7-4.6-11.1L64.6 3.8z"/><path fill="url(#g)" d="M333.1 120.1c-2.4-2.4-5.7-3.8-9.2-3.8H6.5c-5.8 0-8.7 7-4.6 11.1l62.7 62.7c2.4 2.4 5.7 3.8 9.2 3.8h317.4c5.8 0 8.7-7 4.6-11.1l-62.7-62.7z"/></svg>`;
-const SOLANA_MARK_URI = `data:image/svg+xml,${encodeURIComponent(SOLANA_MARK_SVG)}`;
-
 function fmtDate(ts: number | null): string {
   if (!ts) return "";
   return new Date(ts * 1000).toLocaleDateString("en-US", {
@@ -49,6 +46,23 @@ function getFontData() {
   return fontDataPromise;
 }
 
+let solanaLogoPromise: Promise<string>;
+
+function getSolanaLogo() {
+  solanaLogoPromise ??= readFile(
+    path.join(
+      process.cwd(),
+      "public",
+      "src",
+      "img",
+      "branding",
+      "solanaLogo.png",
+    ),
+  ).then((data) => `data:image/png;base64,${data.toString("base64")}`);
+
+  return solanaLogoPromise;
+}
+
 export async function GET(req: Request) {
   const p = new URL(req.url).searchParams;
   const survived = Math.max(0, parseInt(p.get("s") ?? "0", 10) || 0);
@@ -61,8 +75,19 @@ export async function GET(req: Request) {
   const wallet = p.get("w") ?? "";
   const capped = p.get("x") === "1";
   const tier = tierFor(survived);
+  const survivedLabel = capped ? `${survived}+` : String(survived);
+  const firstSeenLabel = blockTime
+    ? `Epoch ${firstEpoch} · ${fmtDate(blockTime)}`
+    : `Epoch ${firstEpoch}`;
+  const percentOfFirst1000 = Math.min(
+    100,
+    Math.max(0, Math.round((survived / 1000) * 100)),
+  );
 
-  const [diatype700, dsemi400, dsemi600] = await getFontData();
+  const [[diatype700, dsemi400, dsemi600], solanaLogo] = await Promise.all([
+    getFontData(),
+    getSolanaLogo(),
+  ]);
 
   const firstCell = Math.min(
     CELLS - 1,
@@ -85,6 +110,7 @@ export async function GET(req: Request) {
         padding: "56px 64px",
         fontFamily: "DSemi",
         color: "#FFFFFF",
+        boxSizing: "border-box",
       }}
     >
       {/* header */}
@@ -95,7 +121,9 @@ export async function GET(req: Request) {
           alignItems: "center",
         }}
       >
-        <img src={SOLANA_MARK_URI} width={46} height={36} alt="" />
+        <div style={{ display: "flex", alignItems: "center", gap: 18 }}>
+          <img src={solanaLogo} width={175} height={26} alt="" />
+        </div>
         <div
           style={{
             display: "flex",
@@ -115,60 +143,118 @@ export async function GET(req: Request) {
       </div>
 
       {/* main stat */}
-      <div style={{ display: "flex", flexDirection: "column", marginTop: 44 }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          marginTop: 58,
+        }}
+      >
         <div
           style={{
-            fontSize: 24,
-            letterSpacing: "0.3em",
-            color: "#757575",
+            fontSize: 25,
+            letterSpacing: "0.18em",
+            color: "#BDBDBD",
+            textTransform: "uppercase",
           }}
         >
-          SURVIVED
+          Epoch 1000 survivor card
         </div>
-        <div style={{ display: "flex", alignItems: "baseline", gap: 24 }}>
+        <div style={{ display: "flex", alignItems: "flex-end", gap: 24 }}>
           <div
             style={{
               fontFamily: "Diatype",
               fontWeight: 700,
-              fontSize: 176,
-              lineHeight: 1.05,
+              fontSize: 154,
+              lineHeight: 0.92,
               color: tier.color,
             }}
           >
-            {/* satori crashes on numeric JSX children — keep this a string */}
-            {capped ? `${survived}+` : String(survived)}
+            {/* satori crashes on numeric JSX children - keep this a string */}
+            {survivedLabel}
           </div>
           <div
             style={{
-              fontFamily: "Diatype",
-              fontWeight: 700,
-              fontSize: 44,
-              color: "#FFFFFF",
+              display: "flex",
+              flexDirection: "column",
+              marginBottom: 18,
+              gap: 6,
             }}
           >
-            EPOCHS
+            <span
+              style={{
+                display: "flex",
+                fontFamily: "Diatype",
+                fontWeight: 700,
+                fontSize: 44,
+                color: "#FFFFFF",
+              }}
+            >
+              EPOCHS
+            </span>
+            <span
+              style={{
+                display: "flex",
+                fontSize: 24,
+                color: "#8B8B8B",
+                letterSpacing: "0.14em",
+              }}
+            >
+              SURVIVED
+            </span>
           </div>
         </div>
         <div
-          style={{ display: "flex", fontSize: 26, color: "#B0B0B0", gap: 10 }}
+          style={{
+            display: "flex",
+            fontSize: 26,
+            color: "#B0B0B0",
+            gap: 10,
+            marginTop: 16,
+          }}
         >
-          <span style={{ color: "#757575" }}>first seen</span>
-          <span style={{ fontWeight: 600 }}>{`epoch ${firstEpoch}`}</span>
-          {blockTime ? (
-            <span
-              style={{ color: "#757575" }}
-            >{`· ${fmtDate(blockTime)}`}</span>
-          ) : null}
+          <span style={{ color: "#757575" }}>First seen</span>
+          <span style={{ fontWeight: 600 }}>{firstSeenLabel}</span>
         </div>
       </div>
 
-      {/* thousand grid — github-contributions strip of square cells */}
+      {/* thousand grid - github-contributions strip of square cells */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          width: 1046,
+          marginTop: 62,
+          fontSize: 21,
+        }}
+      >
+        <span
+          style={{
+            color: "#8B8B8B",
+            letterSpacing: "0.18em",
+            textTransform: "uppercase",
+          }}
+        >
+          First 1000 epochs
+        </span>
+        <span
+          style={{
+            color: GH_LEVELS[3],
+            fontWeight: 600,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+          }}
+        >
+          {`${percentOfFirst1000}%`}
+        </span>
+      </div>
       <div
         style={{
           display: "flex",
           gap: 4,
           width: 1046,
-          marginTop: 52,
+          marginTop: 14,
         }}
       >
         {Array.from({ length: CELLS }, (_, i) => {
@@ -198,9 +284,6 @@ export async function GET(req: Request) {
         }}
       >
         <span>EPOCH 0</span>
-        <span style={{ color: GH_LEVELS[3], fontWeight: 600 }}>
-          {`${(survived / 10).toFixed(0)}% OF SOLANA'S FIRST 1000 EPOCHS`}
-        </span>
         <span>EPOCH 1000</span>
       </div>
 
@@ -221,7 +304,7 @@ export async function GET(req: Request) {
             fontWeight: 600,
           }}
         >
-          {wallet || "ANONYMOUS SURVIVOR"}
+          {wallet || "Anonymous survivor"}
         </div>
         <div style={{ display: "flex", color: "#757575" }}>
           solana.com/epoch1000

--- a/apps/web/src/app/api/epoch1000/og/route.tsx
+++ b/apps/web/src/app/api/epoch1000/og/route.tsx
@@ -107,7 +107,7 @@ export async function GET(req: Request) {
         flexDirection: "column",
         backgroundColor: "#000000",
         backgroundImage: `radial-gradient(ellipse 900px 500px at 85% -10%, ${tier.glow}55, transparent 70%)`,
-        padding: "56px 64px",
+        padding: "46px 64px",
         fontFamily: "DSemi",
         color: "#FFFFFF",
         boxSizing: "border-box",
@@ -147,7 +147,7 @@ export async function GET(req: Request) {
         style={{
           display: "flex",
           flexDirection: "column",
-          marginTop: 58,
+          marginTop: 34,
         }}
       >
         <div
@@ -190,7 +190,7 @@ export async function GET(req: Request) {
                 color: "#FFFFFF",
               }}
             >
-              EPOCHS
+              EPOCHS SURVIVED
             </span>
             <span
               style={{
@@ -200,7 +200,7 @@ export async function GET(req: Request) {
                 letterSpacing: "0.14em",
               }}
             >
-              SURVIVED
+              OF THE FIRST 1000
             </span>
           </div>
         </div>
@@ -210,11 +210,22 @@ export async function GET(req: Request) {
             fontSize: 26,
             color: "#B0B0B0",
             gap: 10,
-            marginTop: 16,
+            marginTop: 12,
           }}
         >
           <span style={{ color: "#757575" }}>First seen</span>
           <span style={{ fontWeight: 600 }}>{firstSeenLabel}</span>
+        </div>
+        <div
+          style={{
+            display: "flex",
+            marginTop: 10,
+            fontSize: 27,
+            fontWeight: 600,
+            color: tier.color,
+          }}
+        >
+          {`"${tier.line}"`}
         </div>
       </div>
 
@@ -225,7 +236,7 @@ export async function GET(req: Request) {
           justifyContent: "space-between",
           alignItems: "center",
           width: 1046,
-          marginTop: 62,
+          marginTop: 34,
           fontSize: 21,
         }}
       >
@@ -306,8 +317,10 @@ export async function GET(req: Request) {
         >
           {wallet || "Anonymous survivor"}
         </div>
-        <div style={{ display: "flex", color: "#757575" }}>
-          solana.com/epoch1000
+        <div style={{ display: "flex", gap: 10, color: "#757575" }}>
+          <span style={{ color: "#FFFFFF", fontWeight: 600 }}>Check yours</span>
+          <span>·</span>
+          <span>solana.com/epoch1000</span>
         </div>
       </div>
     </div>,

--- a/apps/web/src/app/api/epoch1000/og/route.tsx
+++ b/apps/web/src/app/api/epoch1000/og/route.tsx
@@ -1,11 +1,11 @@
 import { ImageResponse } from "next/og";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import { loadMergedMessages, resolveLocale } from "@workspace/i18n/messages";
 import { tierFor } from "@/lib/epoch1000/tiers";
 import {
   GH_CELL_BORDER,
   GH_EMPTY,
-  GH_LEVELS,
   githubGreen,
 } from "@/lib/epoch1000/github-colors";
 
@@ -15,15 +15,48 @@ const CACHE_CONTROL =
   "public, max-age=0, s-maxage=86400, stale-while-revalidate=86400";
 const CELLS = 50; // 1 cell = 20 epochs of the first 1000
 const EPOCHS_PER_CELL = 1000 / CELLS;
+type MessageTree = Record<string, unknown>;
+type MessageValues = Record<string, number | string>;
 
-function fmtDate(ts: number | null): string {
-  if (!ts) return "";
-  return new Date(ts * 1000).toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-    timeZone: "UTC",
-  });
+const messageCache = new Map<string, Promise<MessageTree>>();
+
+function messagesFor(localeParam: string | null) {
+  const locale = resolveLocale(localeParam);
+  let messages = messageCache.get(locale);
+
+  if (!messages) {
+    messages = loadMergedMessages({
+      app: "web",
+      locale,
+    }) as Promise<MessageTree>;
+    messageCache.set(locale, messages);
+  }
+
+  return messages;
+}
+
+async function getCardMessage(localeParam: string | null) {
+  const messages = await messagesFor(localeParam);
+
+  return (key: string, values: MessageValues = {}) => {
+    const template = `epoch1000.card.${key}`
+      .split(".")
+      .reduce<unknown>(
+        (acc, part) =>
+          acc && typeof acc === "object" && part in acc
+            ? (acc as MessageTree)[part]
+            : undefined,
+        messages,
+      );
+
+    if (typeof template !== "string") {
+      return `epoch1000.card.${key}`;
+    }
+
+    return template.replace(/\{(\w+)\}/g, (match, name) =>
+      name in values ? String(values[name]) : match,
+    );
+  };
 }
 
 async function font(file: string) {
@@ -71,23 +104,17 @@ export async function GET(req: Request) {
     firstEpoch,
     parseInt(p.get("c") ?? "0", 10) || 0,
   );
-  const blockTime = parseInt(p.get("t") ?? "0", 10) || null;
   const wallet = p.get("w") ?? "";
   const capped = p.get("x") === "1";
   const tier = tierFor(survived);
   const survivedLabel = capped ? `${survived}+` : String(survived);
-  const firstSeenLabel = blockTime
-    ? `Epoch ${firstEpoch} · ${fmtDate(blockTime)}`
-    : `Epoch ${firstEpoch}`;
-  const percentOfFirst1000 = Math.min(
-    100,
-    Math.max(0, Math.round((survived / 1000) * 100)),
-  );
 
-  const [[diatype700, dsemi400, dsemi600], solanaLogo] = await Promise.all([
+  const [t, [diatype700, dsemi400, dsemi600], solanaLogo] = await Promise.all([
+    getCardMessage(p.get("l")),
     getFontData(),
     getSolanaLogo(),
   ]);
+  const tierName = t(`tiers.${tier.id}.name`);
 
   const firstCell = Math.min(
     CELLS - 1,
@@ -113,7 +140,6 @@ export async function GET(req: Request) {
         boxSizing: "border-box",
       }}
     >
-      {/* header */}
       <div
         style={{
           display: "flex",
@@ -128,45 +154,48 @@ export async function GET(req: Request) {
           style={{
             display: "flex",
             alignItems: "center",
-            gap: 12,
-            border: `2px solid ${tier.color}`,
-            color: tier.color,
-            borderRadius: 999,
-            padding: "10px 26px",
+            color: "#8B8B8B",
             fontSize: 24,
-            fontWeight: 600,
-            letterSpacing: "0.14em",
+            letterSpacing: "0.16em",
+            textTransform: "uppercase",
           }}
         >
-          {tier.name}
+          {t("og.epoch1000")}
         </div>
       </div>
 
-      {/* main stat */}
       <div
         style={{
           display: "flex",
           flexDirection: "column",
-          marginTop: 34,
+          marginTop: 54,
         }}
       >
         <div
           style={{
-            fontSize: 25,
+            display: "flex",
+            fontSize: 28,
             letterSpacing: "0.18em",
-            color: "#BDBDBD",
+            color: "#8B8B8B",
             textTransform: "uppercase",
           }}
         >
-          Epoch 1000 survivor card
+          {t("og.walletAge")}
         </div>
-        <div style={{ display: "flex", alignItems: "flex-end", gap: 24 }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "flex-end",
+            gap: 30,
+            marginTop: 8,
+          }}
+        >
           <div
             style={{
               fontFamily: "Diatype",
               fontWeight: 700,
-              fontSize: 154,
-              lineHeight: 0.92,
+              fontSize: 202,
+              lineHeight: 0.88,
               color: tier.color,
             }}
           >
@@ -177,8 +206,7 @@ export async function GET(req: Request) {
             style={{
               display: "flex",
               flexDirection: "column",
-              marginBottom: 18,
-              gap: 6,
+              marginBottom: 20,
             }}
           >
             <span
@@ -186,86 +214,55 @@ export async function GET(req: Request) {
                 display: "flex",
                 fontFamily: "Diatype",
                 fontWeight: 700,
-                fontSize: 44,
+                fontSize: 54,
                 color: "#FFFFFF",
               }}
             >
-              EPOCHS SURVIVED
-            </span>
-            <span
-              style={{
-                display: "flex",
-                fontSize: 24,
-                color: "#8B8B8B",
-                letterSpacing: "0.14em",
-              }}
-            >
-              OF THE FIRST 1000
+              {t("og.epochsOld")}
             </span>
           </div>
         </div>
         <div
           style={{
             display: "flex",
-            fontSize: 26,
-            color: "#B0B0B0",
-            gap: 10,
-            marginTop: 12,
-          }}
-        >
-          <span style={{ color: "#757575" }}>First seen</span>
-          <span style={{ fontWeight: 600 }}>{firstSeenLabel}</span>
-        </div>
-        <div
-          style={{
-            display: "flex",
-            marginTop: 10,
-            fontSize: 27,
+            alignItems: "center",
+            gap: 14,
+            marginTop: 18,
+            fontSize: 24,
             fontWeight: 600,
-            color: tier.color,
           }}
         >
-          {`"${tier.line}"`}
+          <div
+            style={{
+              display: "flex",
+              border: "2px solid #2A2F36",
+              color: "#BDBDBD",
+              borderRadius: 999,
+              padding: "10px 22px",
+            }}
+          >
+            {t("og.sinceEpoch", { epoch: firstEpoch })}
+          </div>
+          <div
+            style={{
+              display: "flex",
+              border: `2px solid ${tier.color}`,
+              color: tier.color,
+              borderRadius: 999,
+              padding: "10px 22px",
+            }}
+          >
+            {tierName}
+          </div>
         </div>
       </div>
 
-      {/* thousand grid - github-contributions strip of square cells */}
       <div
         style={{
           display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
           width: 1046,
-          marginTop: 34,
-          fontSize: 21,
-        }}
-      >
-        <span
-          style={{
-            color: "#8B8B8B",
-            letterSpacing: "0.18em",
-            textTransform: "uppercase",
-          }}
-        >
-          First 1000 epochs
-        </span>
-        <span
-          style={{
-            color: GH_LEVELS[3],
-            fontWeight: 600,
-            letterSpacing: "0.08em",
-            textTransform: "uppercase",
-          }}
-        >
-          {`${percentOfFirst1000}%`}
-        </span>
-      </div>
-      <div
-        style={{
-          display: "flex",
           gap: 4,
-          width: 1046,
-          marginTop: 14,
+          marginTop: 48,
         }}
       >
         {Array.from({ length: CELLS }, (_, i) => {
@@ -294,33 +291,30 @@ export async function GET(req: Request) {
           marginTop: 12,
         }}
       >
-        <span>EPOCH 0</span>
-        <span>EPOCH 1000</span>
+        <span>{t("og.startEpoch")}</span>
+        <span>{t("og.endEpoch")}</span>
       </div>
 
-      {/* footer */}
       <div
         style={{
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
           marginTop: "auto",
-          fontSize: 24,
+          fontSize: 22,
         }}
       >
         <div
           style={{
             display: "flex",
-            color: wallet ? "#FFFFFF" : "#757575",
+            color: "#757575",
             fontWeight: 600,
           }}
         >
-          {wallet || "Anonymous survivor"}
+          {t("og.proof", { wallet: wallet || t("og.anonymousWallet") })}
         </div>
-        <div style={{ display: "flex", gap: 10, color: "#757575" }}>
-          <span style={{ color: "#FFFFFF", fontWeight: 600 }}>Check yours</span>
-          <span>·</span>
-          <span>solana.com/epoch1000</span>
+        <div style={{ display: "flex", color: "#757575" }}>
+          {t("og.footerUrl")}
         </div>
       </div>
     </div>,

--- a/apps/web/src/components/epoch1000/Epoch1000Experience.tsx
+++ b/apps/web/src/components/epoch1000/Epoch1000Experience.tsx
@@ -51,13 +51,12 @@ export default function Epoch1000Experience({ title, description }: Props) {
             {live ? (
               <>
                 <span className="ep-live-dot mr-2 inline-block h-2 w-2 rounded-full bg-[#14f195] align-middle" />
-                LIVE FROM MAINNET · SLOT{" "}
-                {numberFormatter.format(live.absoluteSlot)}
+                LIVE · SLOT {numberFormatter.format(live.absoluteSlot)}
               </>
             ) : error ? (
-              "COULDN'T REACH MAINNET - REFRESH TO RETRY"
+              "MAINNET UNAVAILABLE"
             ) : (
-              <span className="animate-pulse">SYNCING WITH MAINNET…</span>
+              <span className="animate-pulse">SYNCING...</span>
             )}
           </p>
 
@@ -84,7 +83,7 @@ export default function Epoch1000Experience({ title, description }: Props) {
 
           <p className="text-sm sm:text-base text-ep-dim max-w-xl">
             {arrived
-              ? "One thousand epochs of mainnet-beta. 432,000,000,000 slots, give or take a fork. gm to everyone who was here for any of it."
+              ? "Epoch 1000 is here. Celebrate the builders, validators, apps, and users who kept mainnet moving."
               : description}
           </p>
 
@@ -100,23 +99,29 @@ export default function Epoch1000Experience({ title, description }: Props) {
                   }}
                 />
               </div>
-              <p className="font-brand-mono text-xs sm:text-sm text-ep-dust tabular-nums">
-                T-MINUS{" "}
-                <span className="text-ep-ink">
-                  {numberFormatter.format(live.slotsRemaining)}
-                </span>{" "}
-                SLOTS · ≈{" "}
-                <span className="text-ep-ink">
-                  {days}d {pad(hours)}h {pad(mins)}m {pad(secs)}s
-                </span>{" "}
-                · ARRIVING ~
-                {live.eta
-                  .toLocaleDateString("en-US", {
-                    month: "short",
-                    day: "numeric",
-                  })
-                  .toUpperCase()}
-              </p>
+              <div className="grid grid-cols-1 gap-2 font-brand-mono text-xs text-ep-dust tabular-nums sm:grid-cols-3 sm:text-sm">
+                <div className="flex items-center justify-between gap-3 rounded-full border border-ep-edge bg-ep-panel/70 px-4 py-2">
+                  <span className="uppercase tracking-[0.12em]">Slots</span>
+                  <span className="text-ep-ink">
+                    {numberFormatter.format(live.slotsRemaining)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between gap-3 rounded-full border border-ep-edge bg-ep-panel/70 px-4 py-2">
+                  <span className="uppercase tracking-[0.12em]">Time</span>
+                  <span className="text-ep-ink">
+                    {days}d {pad(hours)}h {pad(mins)}m {pad(secs)}s
+                  </span>
+                </div>
+                <div className="flex items-center justify-between gap-3 rounded-full border border-ep-edge bg-ep-panel/70 px-4 py-2">
+                  <span className="uppercase tracking-[0.12em]">ETA</span>
+                  <span className="text-ep-ink">
+                    {live.eta.toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </span>
+                </div>
+              </div>
             </div>
           )}
         </div>
@@ -136,13 +141,13 @@ export default function Epoch1000Experience({ title, description }: Props) {
 
       {/* ── The thousand grid ────────────────────────────────────────── */}
       <Reveal>
-        <section id="timeline" className="flex flex-col gap-5 scroll-mt-24">
+        <section id="timeline" className="flex flex-col gap-4 scroll-mt-24">
           <div className="flex items-end justify-between gap-4">
             <h2 className="font-bold tracking-tight text-3xl sm:text-4xl">
-              Six years, <span className="text-sol-gradient">one grid.</span>
+              Mainnet timeline
             </h2>
             <p className="font-brand-mono text-[11px] sm:text-xs text-ep-dust tracking-[0.15em] whitespace-nowrap pb-1.5">
-              EPOCH 0 → 999
+              EPOCHS 0-999
             </p>
           </div>
           <ThousandGrid
@@ -152,22 +157,12 @@ export default function Epoch1000Experience({ title, description }: Props) {
             accent={tier?.color}
             accentLabel={
               result && tier
-                ? `${tier.name} · EPOCH ${result.firstEpoch} → NOW`
+                ? `${tier.name} · EPOCH ${result.firstEpoch} TO NOW`
                 : undefined
             }
           />
-          <p className="font-brand-mono text-[11px] sm:text-xs text-ep-dust">
-            one cell per epoch · bright cells mark moments · check a wallet
-            above to paint your era
-          </p>
         </section>
       </Reveal>
-
-      <footer className="border-t border-ep-edge pt-6 pb-2">
-        <p className="font-brand-mono text-[11px] sm:text-xs text-ep-dust text-center tracking-[0.15em]">
-          432,000 SLOTS PER EPOCH · ~2 DAYS EACH · MAINNET-BETA SINCE MARCH 2020
-        </p>
-      </footer>
     </div>
   );
 }

--- a/apps/web/src/components/epoch1000/ThousandGrid.tsx
+++ b/apps/web/src/components/epoch1000/ThousandGrid.tsx
@@ -135,8 +135,8 @@ export default function ThousandGrid({
   const readout = useMemo(() => {
     if (hovered === null) {
       return {
-        text: "EPOCH 0 → 999 · MAR 2020 → NOW",
-        hint: "scrub to travel",
+        text: "EPOCHS 0-999",
+        hint: "scrub",
         moment: null as string | null,
       };
     }

--- a/apps/web/src/components/epoch1000/WalletChecker.tsx
+++ b/apps/web/src/components/epoch1000/WalletChecker.tsx
@@ -8,10 +8,10 @@ import {
 } from "@/lib/epoch1000/public-key";
 
 const LOADING_LINES = [
-  "walking your history back to genesis…",
-  "counting slots…",
-  "asking the validators about you…",
-  "replaying the ledger…",
+  "checking...",
+  "finding first tx...",
+  "scanning history...",
+  "building card...",
 ];
 
 interface Props {
@@ -75,7 +75,7 @@ export default function WalletChecker({ onResult }: Props) {
     : "";
   const tweet = result
     ? encodeURIComponent(
-        `I've survived ${result.epochsSurvived}${result.capped ? "+" : ""} epochs on Solana - ${result.tier}.\n\nWere you here? ${cardUrl}`,
+        `I've survived ${result.epochsSurvived}${result.capped ? "+" : ""} Solana epochs - ${result.tier}.\n\n${cardUrl}`,
       )
     : "";
 
@@ -100,12 +100,11 @@ export default function WalletChecker({ onResult }: Props) {
     <section id="checker" className="flex flex-col gap-6">
       <div>
         <h2 className="font-bold tracking-tight text-3xl sm:text-4xl">
-          Were you <span className="text-sol-gradient">here?</span>
+          Check <span className="text-sol-gradient">wallet</span>
         </h2>
         <p className="mt-2 text-sm text-ep-dim">
-          Paste any wallet address - no connect, no signature. We find its first
-          mainnet transaction, light up your era on the timeline below, and
-          stamp your survivor card.
+          Find your first epoch and share your survivor card. No connect, no
+          signature.
         </p>
       </div>
 
@@ -131,7 +130,7 @@ export default function WalletChecker({ onResult }: Props) {
           disabled={loading || !isAddressValid}
           className="!bg-ep-ink text-ep-void font-semibold rounded-full px-7 py-3 text-sm disabled:opacity-40 disabled:cursor-not-allowed hover:!bg-ep-dim transition"
         >
-          {loading ? "checking…" : "Check wallet"}
+          {loading ? "Checking..." : "Check"}
         </button>
       </form>
 
@@ -171,7 +170,7 @@ export default function WalletChecker({ onResult }: Props) {
                 onChange={(e) => setShowAddress(e.target.checked)}
                 className="accent-[#14f195]"
               />
-              show wallet on card
+              Show wallet
             </label>
             <a
               href={`https://twitter.com/intent/tweet?text=${tweet}`}
@@ -179,7 +178,7 @@ export default function WalletChecker({ onResult }: Props) {
               rel="noopener noreferrer"
               className="bg-ep-ink text-ep-void font-semibold rounded-full px-5 py-2 hover:bg-ep-dim transition"
             >
-              Share on X
+              Share
             </a>
             <button
               onClick={copyLink}
@@ -192,12 +191,12 @@ export default function WalletChecker({ onResult }: Props) {
               download={`epoch1000-${result.firstEpoch}.png`}
               className="border border-ep-edge rounded-full px-5 py-2 text-ep-dim hover:text-ep-ink transition"
             >
-              Download PNG
+              PNG
             </a>
           </div>
 
           <p className="text-xs text-ep-dust">
-            First transaction:{" "}
+            First seen:{" "}
             <a
               href={`https://solscan.io/tx/${result.firstSignature}`}
               target="_blank"
@@ -208,7 +207,7 @@ export default function WalletChecker({ onResult }: Props) {
               {result.firstSlot.toLocaleString("en-US")}
             </a>
             {result.capped &&
-              ` - this wallet has over ${result.scanned.toLocaleString("en-US")} transactions, so we report the oldest we could reach. True survival may be even longer.`}
+              ` - oldest found across ${result.scanned.toLocaleString("en-US")} transactions.`}
           </p>
         </div>
       )}

--- a/apps/web/src/components/index/campaigns/epoch1000/Epoch1000Hero.tsx
+++ b/apps/web/src/components/index/campaigns/epoch1000/Epoch1000Hero.tsx
@@ -101,7 +101,6 @@ export const Epoch1000Hero: React.FC = () => {
   const statSlotsLabel = t("statSlots");
   const statProgressLabel = t("statProgress");
   const statEtaLabel = t("statEta");
-  const slotLabel = t("slotLabel");
   const numberFormatter = useMemo(
     () => new Intl.NumberFormat(locale),
     [locale],
@@ -179,14 +178,14 @@ export const Epoch1000Hero: React.FC = () => {
           })}
         </h1>
         <p
-          className="eh-rise text-nd-mid-em-text font-medium mt-3 nd-body-xl max-w-[560px]"
+          className="eh-rise text-nd-mid-em-text font-medium pt-3 nd-body-xl max-w-[560px]"
           style={{ animationDelay: "300ms" }}
         >
           {t("subtitle")}
         </p>
 
         <div
-          className="eh-rise mt-4 md:mt-6 flex flex-col sm:flex-row items-center gap-3 sm:gap-5"
+          className="eh-rise pt-4 md:pt-6 flex flex-col sm:flex-row items-center gap-3 sm:gap-5"
           style={{ animationDelay: "400ms" }}
         >
           <Button
@@ -213,12 +212,12 @@ export const Epoch1000Hero: React.FC = () => {
           </Link>
         </div>
 
-        {/* live console — the chain ticking underneath the monument */}
+        {/* Compact live status under the monument. */}
         <div
-          className="eh-rise mt-auto pt-4 md:pt-6 w-full max-w-4xl"
+          className="eh-rise mt-auto pt-4 md:pt-6 w-full max-w-3xl"
           style={{ animationDelay: "500ms" }}
         >
-          <div className="rounded-xl bg-black/[0.3] px-4 py-2 md:px-6 md:py-4">
+          <div className="rounded-xl bg-black/[0.3] px-4 py-2.5 md:px-6 md:py-4">
             <div className="flex items-baseline justify-between font-brand-mono text-[11px] md:text-xs uppercase tracking-[0.2em] text-nd-mid-em-text">
               <span>{statProgressLabel}</span>
               <span className="tabular-nums">
@@ -235,7 +234,7 @@ export const Epoch1000Hero: React.FC = () => {
                 }}
               />
             </div>
-            <div className="mt-2 md:mt-3 flex flex-wrap items-center justify-center sm:justify-between gap-x-6 gap-y-1.5 md:gap-y-2 font-brand-mono text-[11px] md:text-xs text-nd-mid-em-text tabular-nums">
+            <div className="mt-2 md:mt-3 flex flex-wrap items-center justify-center gap-x-5 gap-y-1.5 md:gap-y-2 font-brand-mono text-[11px] md:text-xs text-nd-mid-em-text tabular-nums">
               {live ? (
                 <>
                   <span className="flex items-center gap-2 whitespace-nowrap">
@@ -246,22 +245,17 @@ export const Epoch1000Hero: React.FC = () => {
                     <span className="hidden sm:block">
                       <BlockStream absoluteSlot={live.absoluteSlot} />
                     </span>
-                    <span>
-                      {slotLabel} {numberFormatter.format(live.absoluteSlot)}
+                  </span>
+                  <span className="whitespace-nowrap uppercase tracking-[0.1em]">
+                    {statSlotsLabel}{" "}
+                    <span className="text-nd-high-em-text">
+                      {numberFormatter.format(live.slotsRemaining)}
                     </span>
                   </span>
-                  <span className="flex flex-wrap justify-center gap-x-4 gap-y-1 uppercase tracking-[0.1em]">
-                    <span className="whitespace-nowrap">
-                      {statSlotsLabel}{" "}
-                      <span className="text-nd-high-em-text">
-                        {numberFormatter.format(live.slotsRemaining)}
-                      </span>
-                    </span>
-                    <span className="whitespace-nowrap">
-                      {statEtaLabel}{" "}
-                      <span className="text-nd-high-em-text">
-                        {etaFormatter.format(live.eta)}
-                      </span>
+                  <span className="whitespace-nowrap uppercase tracking-[0.1em]">
+                    {statEtaLabel}{" "}
+                    <span className="text-nd-high-em-text">
+                      {etaFormatter.format(live.eta)}
                     </span>
                   </span>
                 </>

--- a/apps/web/src/lib/epoch1000/tiers.ts
+++ b/apps/web/src/lib/epoch1000/tiers.ts
@@ -1,4 +1,13 @@
+export type TierId =
+  | "genesis"
+  | "diamond"
+  | "obsidian"
+  | "veteran"
+  | "survivor"
+  | "settler";
+
 export interface Tier {
+  id: TierId;
   name: string;
   /** Minimum epochs survived to qualify. */
   min: number;
@@ -13,6 +22,7 @@ export interface Tier {
 /** Ordered highest to lowest. Survival = current epoch − first epoch. */
 export const TIERS: Tier[] = [
   {
+    id: "genesis",
     name: "GENESIS CLASS",
     min: 900,
     color: "#FFD66B",
@@ -20,6 +30,7 @@ export const TIERS: Tier[] = [
     line: "Here before almost everyone.",
   },
   {
+    id: "diamond",
     name: "DIAMOND CLASS",
     min: 750,
     color: "#A5F3FC",
@@ -27,6 +38,7 @@ export const TIERS: Tier[] = [
     line: "Forged under pressure.",
   },
   {
+    id: "obsidian",
     name: "OBSIDIAN CLASS",
     min: 600,
     color: "#C084FC",
@@ -34,6 +46,7 @@ export const TIERS: Tier[] = [
     line: "Cooled in the fire of the bear.",
   },
   {
+    id: "veteran",
     name: "VETERAN CLASS",
     min: 450,
     color: "#14F195",
@@ -41,6 +54,7 @@ export const TIERS: Tier[] = [
     line: "Seen some things.",
   },
   {
+    id: "survivor",
     name: "SURVIVOR CLASS",
     min: 250,
     color: "#60A5FA",
@@ -48,6 +62,7 @@ export const TIERS: Tier[] = [
     line: "Still here. Still early.",
   },
   {
+    id: "settler",
     name: "SETTLER CLASS",
     min: 0,
     color: "#9CA3AF",

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -7745,7 +7745,7 @@
       "bannerLabel": "Get started now"
     },
     "epochHero": {
-      "eyebrow": "Solana Mainnet-Beta · March 2020 → Now",
+      "eyebrow": "Solana Mainnet · March 2020 → Now",
       "title": "One thousand epochs \n<light>in the making.</light>",
       "subtitle": "Every ~2 days since 2020, Solana has closed an epoch — 432,000 slots of blocks, votes, and payments. Epoch 1000 is almost here.",
       "cta": "Join the celebration",

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -7719,16 +7719,15 @@
   },
   "epoch1000": {
     "meta": {
-      "title": "Epoch 1000 — One Thousand Epochs of Solana",
-      "description": "Counting down to Solana's 1,000th epoch. Check any wallet to see which epoch it first landed on-chain and how many it has survived.",
-      "openGraphTitle": "EPOCH1000 — Solana's 1000th epoch",
-      "openGraphDescription": "Counting down to Solana's 1000th epoch. How many epochs have you survived?"
+      "title": "Epoch 1000 Celebration | Solana",
+      "description": "Celebrate Solana mainnet's 1,000th epoch. Track the live countdown, check a wallet's first epoch, and share a survivor card.",
+      "openGraphTitle": "EPOCH1000 — Solana's 1,000th epoch",
+      "openGraphDescription": "Celebrate Solana mainnet reaching epoch 1000. How many epochs has your wallet survived?"
     },
     "page": {
-      "eyebrow": "Solana Mainnet · March 2020 → Now",
-      "checkerLink": "check your wallet ↓",
-      "title": "<gradient>1000</gradient> EPOCHS",
-      "description": "Every ~2 days, Solana closes an epoch: 432,000 slots of blocks, votes, mints, and sends. The 1,000th is almost here — check how many you've survived."
+      "checkerLink": "Check wallet",
+      "title": "EPOCH <gradient>1000</gradient>",
+      "description": "A live celebration of Solana mainnet reaching 1,000 epochs. Track the countdown, then check when your wallet first joined."
     }
   },
   "index": {
@@ -7745,18 +7744,17 @@
       "bannerLabel": "Get started now"
     },
     "epochHero": {
-      "eyebrow": "Solana Mainnet · March 2020 → Now",
-      "title": "One thousand epochs \n<light>in the making.</light>",
-      "subtitle": "Every ~2 days since 2020, Solana has closed an epoch — 432,000 slots of blocks, votes, and payments. Epoch 1000 is almost here.",
+      "eyebrow": "Solana Mainnet Celebration",
+      "title": "Epoch 1000 \n<light>is almost here.</light>",
+      "subtitle": "A live countdown to Solana's 1,000th epoch and the wallets that made it there.",
       "cta": "Join the celebration",
-      "secondaryCta": "How many epochs have you survived?",
-      "statEpoch": "Current epoch",
-      "statSlots": "Slots to epoch 1000",
-      "statProgress": "Epoch progress",
-      "statEta": "Estimated arrival",
-      "slotLabel": "Slot",
-      "liveLabel": "Live from mainnet",
-      "offline": "Syncing with mainnet…"
+      "secondaryCta": "Check wallet",
+      "statEpoch": "Epoch",
+      "statSlots": "Slots left",
+      "statProgress": "Progress",
+      "statEta": "ETA",
+      "liveLabel": "Live",
+      "offline": "Syncing..."
     },
     "events": {
       "title": "Meet Solana IRL. <light>Build connections.</light>",

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -7728,6 +7728,63 @@
       "checkerLink": "Check wallet",
       "title": "EPOCH <gradient>1000</gradient>",
       "description": "A live celebration of Solana mainnet reaching 1,000 epochs. Track the countdown, then check when your wallet first joined."
+    },
+    "card": {
+      "meta": {
+        "title": "I've been on Solana for {survived} epochs",
+        "description": {
+          "withFirstEpoch": "I've been on Solana for {survived} epochs, since epoch {firstEpoch}. {tierLine}",
+          "withoutFirstEpoch": "I've been on Solana for {survived} epochs. {tierLine}"
+        }
+      },
+      "eyebrow": "Epoch 1000",
+      "heading": "I'm {survived} epochs deep",
+      "summary": {
+        "defaultWallet": "address hidden",
+        "withFirstEpoch": "I'm <strong>{survived}</strong> epochs deep on Solana. Proof: <wallet>{walletLabel}</wallet> / since epoch {firstEpoch}.",
+        "withoutFirstEpoch": "I'm <strong>{survived}</strong> epochs deep on Solana. Proof: <wallet>{walletLabel}</wallet>."
+      },
+      "imageAlt": "Solana age card: {survived} epochs on Solana, {tier}",
+      "ctaCheck": "Make yours",
+      "ctaExplore": "Explore",
+      "privacyNote": "No wallet connect.",
+      "og": {
+        "epoch1000": "Epoch 1000",
+        "walletAge": "I've been on Solana for",
+        "epochsOld": "epochs",
+        "sinceEpoch": "since epoch {epoch}",
+        "startEpoch": "epoch 0",
+        "endEpoch": "epoch 1000",
+        "proof": "proof: {wallet}",
+        "anonymousWallet": "hidden",
+        "footerUrl": "solana.com/epoch1000"
+      },
+      "tiers": {
+        "genesis": {
+          "name": "Genesis Class",
+          "line": "Here before almost everyone."
+        },
+        "diamond": {
+          "name": "Diamond Class",
+          "line": "Forged under pressure."
+        },
+        "obsidian": {
+          "name": "Obsidian Class",
+          "line": "Cooled in the fire of the bear."
+        },
+        "veteran": {
+          "name": "Veteran Class",
+          "line": "Seen some things."
+        },
+        "survivor": {
+          "name": "Survivor Class",
+          "line": "Still here. Still early."
+        },
+        "settler": {
+          "name": "Settler Class",
+          "line": "Welcome aboard. Epoch 2000 awaits."
+        }
+      }
     }
   },
   "index": {

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -7719,7 +7719,7 @@
   },
   "epoch1000": {
     "meta": {
-      "title": "Epoch 1000 Celebration | Solana",
+      "title": "Epoch 1000 Celebration",
       "description": "Celebrate Solana mainnet's 1,000th epoch. Track the live countdown, check a wallet's first epoch, and share a survivor card.",
       "openGraphTitle": "EPOCH1000 — Solana's 1,000th epoch",
       "openGraphDescription": "Celebrate Solana mainnet reaching epoch 1000. How many epochs has your wallet survived?"


### PR DESCRIPTION
## Summary
- tighten Epoch 1000 metadata and page/hero copy
- simplify live status, countdown, and wallet checker messaging
- clean up timeline grid labeling and remove extra footer copy

## Testing
- pnpm --filter solana-com lint
- pnpm --filter solana-com check-types (no check-types script for selected package)