### PR TITLE
Add Epoch 1000 validator edition page

### DIFF
--- a/apps/web/src/app/[locale]/epoch1000/validator/card/page.tsx
+++ b/apps/web/src/app/[locale]/epoch1000/validator/card/page.tsx
@@ -1,0 +1,160 @@
+import type { Metadata } from "next";
+import { getAlternates, Link } from "@workspace/i18n/routing";
+import { getTranslations } from "@workspace/i18n/server";
+import Reveal from "@/components/epoch1000/Reveal";
+import { tierFor } from "@/lib/epoch1000/tiers";
+
+interface Props {
+  params: Promise<{ locale: string }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}
+
+function first(v: string | string[] | undefined): string {
+  return Array.isArray(v) ? (v[0] ?? "") : (v ?? "");
+}
+
+function ogQuery(
+  sp: Record<string, string | string[] | undefined>,
+  locale?: string,
+): string {
+  const p = new URLSearchParams();
+  for (const key of ["s", "fe", "c", "t", "x", "w", "k", "vl"]) {
+    const v = first(sp[key]);
+    if (v) p.set(key, v);
+  }
+  if (!p.has("k")) p.set("k", "validator");
+  if (locale) p.set("l", locale);
+  return p.toString();
+}
+
+export async function generateMetadata({
+  params,
+  searchParams,
+}: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({
+    locale,
+    namespace: "epoch1000.validator.card",
+  });
+  const sp = await searchParams;
+  const survived = first(sp.s) || "0";
+  const capped = first(sp.x) === "1";
+  const firstEpoch = first(sp.fe);
+  const tier = tierFor(parseInt(survived, 10) || 0);
+  const survivedLabel = `${survived}${capped ? "+" : ""}`;
+  const title = t("meta.title", { survived: survivedLabel });
+  const description = t(
+    firstEpoch
+      ? "meta.description.withFirstEpoch"
+      : "meta.description.withoutFirstEpoch",
+    {
+      survived: survivedLabel,
+      firstEpoch,
+      tierLine: t(`tiers.${tier.id}.line`),
+    },
+  );
+  const image = `/api/epoch1000/og?${ogQuery(sp, locale)}`;
+  return {
+    title,
+    description,
+    alternates: getAlternates("/epoch1000/validator/card", locale),
+    openGraph: {
+      title,
+      description,
+      images: [{ url: image, width: 1200, height: 630 }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image],
+    },
+  };
+}
+
+export default async function ValidatorCardPage({
+  params,
+  searchParams,
+}: Props) {
+  const { locale } = await params;
+  const t = await getTranslations({
+    locale,
+    namespace: "epoch1000.validator.card",
+  });
+  const sp = await searchParams;
+  const query = ogQuery(sp, locale);
+  const survived = Math.max(0, parseInt(first(sp.s), 10) || 0);
+  const capped = first(sp.x) === "1";
+  const firstEpoch = first(sp.fe);
+  const voteAccount = first(sp.w);
+  const tier = tierFor(survived);
+  const tierName = t(`tiers.${tier.id}.name`);
+  const survivedLabel = `${survived}${capped ? "+" : ""}`;
+  const voteAccountLabel = voteAccount || t("summary.defaultVoteAccount");
+
+  return (
+    <main className="w-full max-w-3xl mx-auto px-5 sm:px-8 py-12 sm:py-20 flex flex-col items-center text-center gap-8 sm:gap-10 min-h-screen">
+      <header className="flex flex-col items-center gap-4 sm:gap-5">
+        <p className="font-brand-mono text-xs sm:text-sm tracking-[0.2em] text-ep-dust uppercase">
+          {t("eyebrow")}
+        </p>
+        <h1
+          className="font-black tracking-tight text-4xl sm:text-6xl leading-none"
+          style={{ color: tier.color }}
+        >
+          {t("heading", { survived: survivedLabel })}
+        </h1>
+        <p className="text-sm sm:text-base text-ep-dim max-w-xl">
+          {t.rich(
+            firstEpoch ? "summary.withFirstEpoch" : "summary.withoutFirstEpoch",
+            {
+              voteAccountLabel,
+              survived: survivedLabel,
+              firstEpoch,
+              voteAccount: (chunks) =>
+                voteAccount ? (
+                  <span className="font-mono text-ep-ink">{chunks}</span>
+                ) : (
+                  <>{chunks}</>
+                ),
+              strong: (chunks) => (
+                <span className="font-semibold text-ep-ink">{chunks}</span>
+              ),
+            },
+          )}
+        </p>
+      </header>
+
+      <Reveal className="w-full">
+        <img
+          src={`/api/epoch1000/og?${query}`}
+          alt={t("imageAlt", { tier: tierName, survived: survivedLabel })}
+          className="w-full rounded-xl border border-ep-edge"
+          style={{ boxShadow: `0 20px 100px -30px ${tier.color}66` }}
+          width={1200}
+          height={630}
+        />
+      </Reveal>
+
+      <Reveal className="flex flex-col items-center gap-6 sm:gap-8">
+        <div className="flex flex-col items-center gap-3">
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/epoch1000/validator#checker"
+              className="bg-ep-ink text-ep-void font-semibold rounded-full px-7 py-3 text-sm hover:bg-ep-dim transition-colors duration-200"
+            >
+              {t("ctaCheck")}
+            </Link>
+            <Link
+              href="/epoch1000/validator"
+              className="border border-ep-edge rounded-full px-7 py-3 text-sm text-ep-dim hover:text-ep-ink transition-colors duration-200"
+            >
+              {t("ctaExplore")}
+            </Link>
+          </div>
+          <p className="text-xs text-ep-dust">{t("privacyNote")}</p>
+        </div>
+      </Reveal>
+    </main>
+  );
+}

--- a/apps/web/src/app/[locale]/epoch1000/validator/page.tsx
+++ b/apps/web/src/app/[locale]/epoch1000/validator/page.tsx
@@ -1,4 +1,4 @@
-import Epoch1000Experience from "@/components/epoch1000/Epoch1000Experience";
+import ValidatorEpoch1000Experience from "@/components/epoch1000/ValidatorEpoch1000Experience";
 import Epoch1000EditionNav from "@/components/epoch1000/Epoch1000EditionNav";
 import type { Metadata } from "next";
 import { getAlternates } from "@workspace/i18n/routing";
@@ -6,28 +6,31 @@ import { getTranslations } from "@workspace/i18n/server";
 
 type Props = { params: Promise<{ locale: string }> };
 
-const EPOCH1000_PATH = "/epoch1000";
-const EPOCH1000_SOCIAL_IMAGE = "/api/epoch1000/og?s=1000&fe=0&c=1000";
+const VALIDATOR_PATH = "/epoch1000/validator";
+const VALIDATOR_SOCIAL_IMAGE =
+  "/api/epoch1000/og?s=1000&fe=0&c=1000&k=validator";
 
 export default async function Page() {
-  const t = await getTranslations("epoch1000.page");
+  const t = await getTranslations("epoch1000.validator.page");
+  const nav = await getTranslations("epoch1000.page");
 
   return (
     <main className="w-full max-w-6xl mx-auto px-5 sm:px-8 pt-6 sm:pt-8 pb-8 sm:pb-12 flex flex-col gap-10 sm:gap-14 min-h-screen">
       <header className="flex justify-end border-b border-ep-edge/70 pb-4">
         <Epoch1000EditionNav
-          active="wallet"
-          walletLabel={t("navWallet")}
-          validatorLabel={t("navValidator")}
+          active="validator"
+          walletLabel={nav("navWallet")}
+          validatorLabel={nav("navValidator")}
         />
       </header>
 
-      <Epoch1000Experience
+      <ValidatorEpoch1000Experience
         title={t.rich("title", {
           gradient: (chunks) => (
             <span className="text-sol-gradient">{chunks}</span>
           ),
         })}
+        subtitle={t("subtitle")}
         description={t("description")}
       />
     </main>
@@ -36,10 +39,10 @@ export default async function Page() {
 
 export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const { locale } = await params;
-  const t = await getTranslations("epoch1000.meta");
+  const t = await getTranslations("epoch1000.validator.meta");
   const title = t("title");
   const description = t("description");
-  const alternates = getAlternates(EPOCH1000_PATH, locale);
+  const alternates = getAlternates(VALIDATOR_PATH, locale);
 
   return {
     title,
@@ -52,7 +55,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       url: alternates.canonical,
       images: [
         {
-          url: EPOCH1000_SOCIAL_IMAGE,
+          url: VALIDATOR_SOCIAL_IMAGE,
           width: 1200,
           height: 630,
         },
@@ -62,7 +65,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
       card: "summary_large_image",
       title,
       description,
-      images: [EPOCH1000_SOCIAL_IMAGE],
+      images: [VALIDATOR_SOCIAL_IMAGE],
     },
   };
 }

--- a/apps/web/src/app/api/epoch1000/og/route.tsx
+++ b/apps/web/src/app/api/epoch1000/og/route.tsx
@@ -102,10 +102,39 @@ function getSolanaLogo() {
 }
 
 const remoteImageCache = new Map<string, Promise<string | null>>();
+const MAX_REMOTE_IMAGE_CACHE = 64;
+const ALLOWED_REMOTE_IMAGE_HOSTS = new Set(["trillium.so", "s3.amazonaws.com"]);
+
+function isAllowedRemoteImageUrl(urlString: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(urlString);
+  } catch {
+    return false;
+  }
+
+  if (url.protocol !== "https:") return false;
+  if (!ALLOWED_REMOTE_IMAGE_HOSTS.has(url.hostname)) return false;
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(url.hostname)) return false;
+  if (url.hostname === "localhost" || url.hostname.endsWith(".local")) {
+    return false;
+  }
+
+  return true;
+}
 
 function getRemoteImageDataUrl(url: string): Promise<string | null> {
+  if (!isAllowedRemoteImageUrl(url)) {
+    return Promise.resolve(null);
+  }
+
   let cached = remoteImageCache.get(url);
   if (!cached) {
+    if (remoteImageCache.size >= MAX_REMOTE_IMAGE_CACHE) {
+      const oldest = remoteImageCache.keys().next().value;
+      if (oldest) remoteImageCache.delete(oldest);
+    }
+
     cached = fetch(url)
       .then(async (res) => {
         if (!res.ok) return null;

--- a/apps/web/src/app/api/epoch1000/og/route.tsx
+++ b/apps/web/src/app/api/epoch1000/og/route.tsx
@@ -103,7 +103,8 @@ function getSolanaLogo() {
 
 const remoteImageCache = new Map<string, Promise<string | null>>();
 const MAX_REMOTE_IMAGE_CACHE = 64;
-const ALLOWED_REMOTE_IMAGE_HOSTS = new Set(["trillium.so", "s3.amazonaws.com"]);
+const MAX_REMOTE_IMAGE_BYTES = 512 * 1024;
+const ALLOWED_REMOTE_IMAGE_HOSTS = new Set(["trillium.so"]);
 
 function isAllowedRemoteImageUrl(urlString: string): boolean {
   let url: URL;
@@ -123,6 +124,40 @@ function isAllowedRemoteImageUrl(urlString: string): boolean {
   return true;
 }
 
+async function readLimitedResponseBody(
+  res: Response,
+  maxBytes: number,
+): Promise<Buffer | null> {
+  const contentLength = res.headers.get("content-length");
+  if (contentLength) {
+    const length = Number(contentLength);
+    if (!Number.isFinite(length) || length <= 0 || length > maxBytes) {
+      return null;
+    }
+  }
+
+  const body = res.body;
+  if (!body) return null;
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) return null;
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return Buffer.concat(chunks);
+}
+
 function getRemoteImageDataUrl(url: string): Promise<string | null> {
   if (!isAllowedRemoteImageUrl(url)) {
     return Promise.resolve(null);
@@ -138,7 +173,11 @@ function getRemoteImageDataUrl(url: string): Promise<string | null> {
     cached = fetch(url)
       .then(async (res) => {
         if (!res.ok) return null;
-        const buffer = Buffer.from(await res.arrayBuffer());
+        const buffer = await readLimitedResponseBody(
+          res,
+          MAX_REMOTE_IMAGE_BYTES,
+        );
+        if (!buffer) return null;
         const contentType = res.headers.get("content-type") ?? "image/jpeg";
         return `data:${contentType};base64,${buffer.toString("base64")}`;
       })

--- a/apps/web/src/app/api/epoch1000/og/route.tsx
+++ b/apps/web/src/app/api/epoch1000/og/route.tsx
@@ -35,11 +35,16 @@ function messagesFor(localeParam: string | null) {
   return messages;
 }
 
-async function getCardMessage(localeParam: string | null) {
+async function getCardMessage(
+  localeParam: string | null,
+  variant: "wallet" | "validator" = "wallet",
+) {
   const messages = await messagesFor(localeParam);
+  const rootKey =
+    variant === "validator" ? "epoch1000.validator.card" : "epoch1000.card";
 
   return (key: string, values: MessageValues = {}) => {
-    const template = `epoch1000.card.${key}`
+    const template = `${rootKey}.${key}`
       .split(".")
       .reduce<unknown>(
         (acc, part) =>
@@ -50,7 +55,7 @@ async function getCardMessage(localeParam: string | null) {
       );
 
     if (typeof template !== "string") {
-      return `epoch1000.card.${key}`;
+      return `${rootKey}.${key}`;
     }
 
     return template.replace(/\{(\w+)\}/g, (match, name) =>
@@ -96,6 +101,24 @@ function getSolanaLogo() {
   return solanaLogoPromise;
 }
 
+const remoteImageCache = new Map<string, Promise<string | null>>();
+
+function getRemoteImageDataUrl(url: string): Promise<string | null> {
+  let cached = remoteImageCache.get(url);
+  if (!cached) {
+    cached = fetch(url)
+      .then(async (res) => {
+        if (!res.ok) return null;
+        const buffer = Buffer.from(await res.arrayBuffer());
+        const contentType = res.headers.get("content-type") ?? "image/jpeg";
+        return `data:${contentType};base64,${buffer.toString("base64")}`;
+      })
+      .catch(() => null);
+    remoteImageCache.set(url, cached);
+  }
+  return cached;
+}
+
 export async function GET(req: Request) {
   const p = new URL(req.url).searchParams;
   const survived = Math.max(0, parseInt(p.get("s") ?? "0", 10) || 0);
@@ -106,14 +129,20 @@ export async function GET(req: Request) {
   );
   const wallet = p.get("w") ?? "";
   const capped = p.get("x") === "1";
+  const variant = p.get("k") === "validator" ? "validator" : "wallet";
+  const validatorLogoUrl = p.get("vl");
   const tier = tierFor(survived);
   const survivedLabel = capped ? `${survived}+` : String(survived);
 
-  const [t, [diatype700, dsemi400, dsemi600], solanaLogo] = await Promise.all([
-    getCardMessage(p.get("l")),
-    getFontData(),
-    getSolanaLogo(),
-  ]);
+  const [t, [diatype700, dsemi400, dsemi600], solanaLogo, validatorLogo] =
+    await Promise.all([
+      getCardMessage(p.get("l"), variant),
+      getFontData(),
+      getSolanaLogo(),
+      variant === "validator" && validatorLogoUrl
+        ? getRemoteImageDataUrl(validatorLogoUrl)
+        : Promise.resolve(null),
+    ]);
   const tierName = t(`tiers.${tier.id}.name`);
 
   const firstCell = Math.min(
@@ -167,94 +196,126 @@ export async function GET(req: Request) {
       <div
         style={{
           display: "flex",
-          flexDirection: "column",
+          justifyContent: "space-between",
+          alignItems: "center",
           marginTop: 54,
+          flex: 1,
         }}
       >
         <div
           style={{
             display: "flex",
-            fontSize: 28,
-            letterSpacing: "0.18em",
-            color: "#8B8B8B",
-            textTransform: "uppercase",
-          }}
-        >
-          {t("og.walletAge")}
-        </div>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "flex-end",
-            gap: 30,
-            marginTop: 8,
+            flexDirection: "column",
           }}
         >
           <div
             style={{
-              fontFamily: "Diatype",
-              fontWeight: 700,
-              fontSize: 202,
-              lineHeight: 0.88,
-              color: tier.color,
+              display: "flex",
+              fontSize: 28,
+              letterSpacing: "0.18em",
+              color: "#8B8B8B",
+              textTransform: "uppercase",
             }}
           >
-            {/* satori crashes on numeric JSX children - keep this a string */}
-            {survivedLabel}
+            {t(variant === "validator" ? "og.validatingAge" : "og.walletAge")}
           </div>
           <div
             style={{
               display: "flex",
-              flexDirection: "column",
-              marginBottom: 20,
+              alignItems: "flex-end",
+              gap: 30,
+              marginTop: 8,
             }}
           >
-            <span
+            <div
               style={{
-                display: "flex",
                 fontFamily: "Diatype",
                 fontWeight: 700,
-                fontSize: 54,
-                color: "#FFFFFF",
+                fontSize: 202,
+                lineHeight: 0.88,
+                color: tier.color,
               }}
             >
-              {t("og.epochsOld")}
-            </span>
-          </div>
-        </div>
-        <div
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 14,
-            marginTop: 18,
-            fontSize: 24,
-            fontWeight: 600,
-          }}
-        >
-          <div
-            style={{
-              display: "flex",
-              border: "2px solid #2A2F36",
-              color: "#BDBDBD",
-              borderRadius: 999,
-              padding: "10px 22px",
-            }}
-          >
-            {t("og.sinceEpoch", { epoch: firstEpoch })}
+              {/* satori crashes on numeric JSX children - keep this a string */}
+              {survivedLabel}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                marginBottom: 20,
+              }}
+            >
+              <span
+                style={{
+                  display: "flex",
+                  fontFamily: "Diatype",
+                  fontWeight: 700,
+                  fontSize: 54,
+                  color: "#FFFFFF",
+                }}
+              >
+                {t("og.epochsOld")}
+              </span>
+            </div>
           </div>
           <div
             style={{
               display: "flex",
-              border: `2px solid ${tier.color}`,
-              color: tier.color,
-              borderRadius: 999,
-              padding: "10px 22px",
+              alignItems: "center",
+              gap: 14,
+              marginTop: 18,
+              fontSize: 24,
+              fontWeight: 600,
             }}
           >
-            {tierName}
+            <div
+              style={{
+                display: "flex",
+                border: "2px solid #2A2F36",
+                color: "#BDBDBD",
+                borderRadius: 999,
+                padding: "10px 22px",
+              }}
+            >
+              {t("og.sinceEpoch", { epoch: firstEpoch })}
+            </div>
+            <div
+              style={{
+                display: "flex",
+                border: `2px solid ${tier.color}`,
+                color: tier.color,
+                borderRadius: 999,
+                padding: "10px 22px",
+              }}
+            >
+              {tierName}
+            </div>
           </div>
         </div>
+
+        {validatorLogo ? (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              marginLeft: 32,
+              marginRight: 8,
+            }}
+          >
+            <img
+              src={validatorLogo}
+              width={208}
+              height={208}
+              alt=""
+              style={{
+                borderRadius: 999,
+                border: `3px solid ${tier.color}88`,
+              }}
+            />
+          </div>
+        ) : null}
       </div>
 
       <div
@@ -311,7 +372,15 @@ export async function GET(req: Request) {
             fontWeight: 600,
           }}
         >
-          {t("og.proof", { wallet: wallet || t("og.anonymousWallet") })}
+          {t("og.proof", {
+            wallet:
+              wallet ||
+              t(
+                variant === "validator"
+                  ? "og.anonymousVoteAccount"
+                  : "og.anonymousWallet",
+              ),
+          })}
         </div>
         <div style={{ display: "flex", color: "#757575" }}>
           {t("og.footerUrl")}

--- a/apps/web/src/app/api/epoch1000/validator/check/route.ts
+++ b/apps/web/src/app/api/epoch1000/validator/check/route.ts
@@ -1,0 +1,143 @@
+import { NextResponse } from "next/server";
+import {
+  epochOfSlot,
+  getEpochInfo,
+  type EpochInfo,
+} from "@/lib/epoch1000/solana";
+import {
+  checkEpoch1000LookupRateLimit,
+  clientIpFromHeaders,
+} from "@/lib/epoch1000/rate-limit";
+import {
+  getCachedValidatorFirstTransaction,
+  getHotValidatorFirstTransaction,
+} from "@/lib/epoch1000/validator-cache";
+import {
+  isValidSolanaAddress,
+  SOLANA_ADDRESS_ERROR,
+} from "@/lib/epoch1000/public-key";
+import { tierFor } from "@/lib/epoch1000/tiers";
+import { type ValidatorLookup } from "@/lib/epoch1000/vote-account";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+const NO_STORE_HEADERS = {
+  "Cache-Control": "no-store",
+} as const;
+
+const NOT_FOUND_ERROR =
+  "No validator history found for this vote account. Trillium only indexes validators active in recent epochs.";
+
+export async function POST(req: Request) {
+  let voteAccount: unknown;
+  try {
+    ({ voteAccount } = await req.json());
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid request body" },
+      { status: 400 },
+    );
+  }
+
+  if (
+    typeof voteAccount !== "string" ||
+    !isValidSolanaAddress(voteAccount.trim())
+  ) {
+    return NextResponse.json({ error: SOLANA_ADDRESS_ERROR }, { status: 400 });
+  }
+
+  const address = voteAccount.trim();
+  const hotFirst = getHotValidatorFirstTransaction(address);
+
+  if (hotFirst) {
+    return validatorLookupResponse(address, hotFirst);
+  }
+
+  const rateLimit = checkEpoch1000LookupRateLimit({
+    ip: clientIpFromHeaders(req.headers),
+    wallet: address,
+  });
+
+  if (!rateLimit.ok) {
+    return NextResponse.json(
+      { error: rateLimit.error },
+      {
+        status: 429,
+        headers: {
+          ...NO_STORE_HEADERS,
+          "Retry-After": String(rateLimit.retryAfter),
+        },
+      },
+    );
+  }
+
+  try {
+    return await validatorLookupResponse(
+      address,
+      getCachedValidatorFirstTransaction(address),
+    );
+  } finally {
+    rateLimit.release();
+  }
+}
+
+async function validatorLookupResponse(
+  voteAccount: string,
+  firstPromise: Promise<ValidatorLookup | null>,
+) {
+  try {
+    const [first, info] = await Promise.all([firstPromise, getEpochInfo()]);
+
+    if (!first) {
+      return NextResponse.json(
+        { error: NOT_FOUND_ERROR },
+        {
+          status: 404,
+          headers: NO_STORE_HEADERS,
+        },
+      );
+    }
+
+    return NextResponse.json(
+      buildValidatorLookupPayload(voteAccount, first, info),
+      {
+        headers: NO_STORE_HEADERS,
+      },
+    );
+  } catch (err) {
+    return NextResponse.json(
+      {
+        error: err instanceof Error ? err.message : "Lookup failed. Try again.",
+      },
+      {
+        status: 502,
+        headers: NO_STORE_HEADERS,
+      },
+    );
+  }
+}
+
+function buildValidatorLookupPayload(
+  voteAccount: string,
+  first: ValidatorLookup,
+  info: EpochInfo,
+) {
+  const firstEpoch = epochOfSlot(first.slot);
+  const epochsSurvived = info.epoch - firstEpoch;
+  const tier = tierFor(epochsSurvived);
+
+  return {
+    address: voteAccount,
+    firstEpoch,
+    firstSlot: first.slot,
+    firstBlockTime: first.blockTime,
+    firstSignature: first.signature,
+    currentEpoch: info.epoch,
+    epochsSurvived,
+    tier: tier.name,
+    capped: first.capped,
+    scanned: first.scanned,
+    logoUrl: first.logoUrl,
+  };
+}

--- a/apps/web/src/components/epoch1000/Epoch1000EditionNav.tsx
+++ b/apps/web/src/components/epoch1000/Epoch1000EditionNav.tsx
@@ -1,0 +1,45 @@
+import { Link } from "@workspace/i18n/routing";
+
+interface Props {
+  active: "wallet" | "validator";
+  walletLabel: string;
+  validatorLabel: string;
+}
+
+export default function Epoch1000EditionNav({
+  active,
+  walletLabel,
+  validatorLabel,
+}: Props) {
+  const walletClass =
+    active === "wallet"
+      ? "text-ep-ink"
+      : "text-ep-dust hover:text-ep-ink transition-colors duration-200";
+  const validatorClass =
+    active === "validator"
+      ? "text-sol-gradient"
+      : "text-sol-gradient hover:opacity-80 transition-opacity duration-200";
+
+  return (
+    <nav
+      aria-label="Epoch 1000 editions"
+      className="flex items-center gap-2 text-xs font-brand-mono shrink-0"
+    >
+      <Link
+        href="/epoch1000#checker"
+        className={`rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 ${walletClass}`}
+      >
+        {walletLabel}
+      </Link>
+      <span className="text-ep-edge" aria-hidden>
+        |
+      </span>
+      <Link
+        href="/epoch1000/validator#checker"
+        className={`rounded-sm focus-visible:outline-2 focus-visible:outline-offset-4 ${validatorClass}`}
+      >
+        {validatorLabel}
+      </Link>
+    </nav>
+  );
+}

--- a/apps/web/src/components/epoch1000/ValidatorChecker.tsx
+++ b/apps/web/src/components/epoch1000/ValidatorChecker.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useState } from "react";
+import { cardParams, type CheckResult } from "@/lib/epoch1000/card-params";
+import {
+  isValidSolanaAddress,
+  SOLANA_ADDRESS_ERROR,
+} from "@/lib/epoch1000/public-key";
+
+const LOADING_LINES = [
+  "checking...",
+  "finding first vote...",
+  "scanning validator history...",
+  "building card...",
+];
+
+interface Props {
+  onResult?: (_result: CheckResult | null) => void;
+}
+
+export default function ValidatorChecker({ onResult }: Props) {
+  const [address, setAddress] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [loadingLine, setLoadingLine] = useState(LOADING_LINES[0]);
+  const [lookupError, setLookupError] = useState<string | null>(null);
+  const [result, setResult] = useState<CheckResult | null>(null);
+  const [showAddress, setShowAddress] = useState(true);
+  const [copied, setCopied] = useState(false);
+
+  async function check(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = address.trim();
+    if (loading) return;
+    if (!isValidSolanaAddress(trimmed)) {
+      setLookupError(null);
+      return;
+    }
+    setLoading(true);
+    setLookupError(null);
+    setResult(null);
+    onResult?.(null);
+    setCopied(false);
+    const rotator = setInterval(
+      () =>
+        setLoadingLine(
+          LOADING_LINES[Math.floor(Math.random() * LOADING_LINES.length)],
+        ),
+      2500,
+    );
+    try {
+      const res = await fetch("/api/epoch1000/validator/check", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ voteAccount: trimmed }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        setLookupError(json.error ?? "Lookup failed. Try again.");
+      } else {
+        setResult(json as CheckResult);
+        onResult?.(json as CheckResult);
+      }
+    } catch {
+      setLookupError("Lookup failed. Try again.");
+    } finally {
+      clearInterval(rotator);
+      setLoading(false);
+    }
+  }
+
+  const params = result ? cardParams(result, showAddress, "validator") : "";
+  const cardUrl = result
+    ? `${window.location.origin}/epoch1000/validator/card?${params}`
+    : "";
+  const tweet = result
+    ? encodeURIComponent(
+        `I've validated ${result.epochsSurvived}${result.capped ? "+" : ""} Solana epochs - ${result.tier}.\n\n${cardUrl}`,
+      )
+    : "";
+
+  async function copyLink() {
+    try {
+      await navigator.clipboard.writeText(cardUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard unavailable
+    }
+  }
+
+  const trimmedAddress = address.trim();
+  const hasAddress = trimmedAddress.length > 0;
+  const isAddressValid = hasAddress && isValidSolanaAddress(trimmedAddress);
+  const validationError =
+    hasAddress && !isAddressValid ? SOLANA_ADDRESS_ERROR : null;
+  const displayedError = validationError ?? lookupError;
+
+  return (
+    <section id="checker" className="flex flex-col gap-6">
+      <div>
+        <h2 className="font-bold tracking-tight text-3xl sm:text-4xl">
+          Check <span className="text-sol-gradient">validator</span>
+        </h2>
+        <p className="mt-2 text-sm text-ep-dim">
+          Enter a vote account to find your first validating epoch and share
+          your survivor card. No connect, no signature.
+        </p>
+      </div>
+
+      <form onSubmit={check} className="flex flex-col sm:flex-row gap-3">
+        <input
+          value={address}
+          onChange={(e) => {
+            setAddress(e.target.value);
+            setLookupError(null);
+          }}
+          placeholder="vote account address"
+          spellCheck={false}
+          autoComplete="off"
+          aria-label="Validator vote account address"
+          aria-invalid={validationError ? true : undefined}
+          aria-describedby={
+            displayedError ? "epoch1000-validator-error" : undefined
+          }
+          className="ep-glow-input flex-1 bg-ep-panel border border-ep-edge rounded-full px-5 py-3 font-mono text-sm placeholder:text-ep-dust"
+        />
+        <button
+          type="submit"
+          disabled={loading || !isAddressValid}
+          className="!bg-ep-ink text-ep-void font-semibold rounded-full px-7 py-3 text-sm disabled:opacity-40 disabled:cursor-not-allowed hover:!bg-ep-dim transition"
+        >
+          {loading ? "Checking..." : "Check"}
+        </button>
+      </form>
+
+      {loading && (
+        <p className="text-sm text-ep-dust animate-pulse" aria-live="polite">
+          {loadingLine}
+        </p>
+      )}
+
+      {displayedError && (
+        <p
+          id="epoch1000-validator-error"
+          className="text-sm text-red-400"
+          role="alert"
+        >
+          {displayedError}
+        </p>
+      )}
+
+      {result && (
+        <div className="flex flex-col gap-4">
+          <img
+            key={params}
+            src={`/api/epoch1000/og?${params}`}
+            alt={`Validator card: first seen epoch ${result.firstEpoch}, validated ${result.epochsSurvived} epochs`}
+            className="w-full rounded-lg border border-ep-edge"
+            width={1200}
+            height={630}
+          />
+
+          <div className="flex flex-wrap items-center gap-3 text-sm">
+            <label className="flex items-center gap-2 text-ep-dim cursor-pointer select-none mr-auto">
+              <input
+                type="checkbox"
+                checked={showAddress}
+                onChange={(e) => setShowAddress(e.target.checked)}
+                className="accent-[#14f195]"
+              />
+              Show vote account
+            </label>
+            <a
+              href={`https://twitter.com/intent/tweet?text=${tweet}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="bg-ep-ink text-ep-void font-semibold rounded-full px-5 py-2 hover:bg-ep-dim transition"
+            >
+              Share
+            </a>
+            <button
+              onClick={copyLink}
+              className="border border-ep-edge rounded-full px-5 py-2 text-ep-dim hover:text-ep-ink transition"
+            >
+              {copied ? "Copied" : "Copy link"}
+            </button>
+            <a
+              href={`/api/epoch1000/og?${params}`}
+              download={`epoch1000-validator-${result.firstEpoch}.png`}
+              className="border border-ep-edge rounded-full px-5 py-2 text-ep-dim hover:text-ep-ink transition"
+            >
+              PNG
+            </a>
+          </div>
+
+          <p className="text-xs text-ep-dust">
+            First seen:{" "}
+            <a
+              href={`https://solscan.io/account/${result.address}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline decoration-ep-edge underline-offset-4 hover:text-ep-dim"
+            >
+              epoch {result.firstEpoch} · slot{" "}
+              {result.firstSlot.toLocaleString("en-US")}
+            </a>
+          </p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/epoch1000/ValidatorChecker.tsx
+++ b/apps/web/src/components/epoch1000/ValidatorChecker.tsx
@@ -1,31 +1,37 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
 import { cardParams, type CheckResult } from "@/lib/epoch1000/card-params";
 import {
   isValidSolanaAddress,
   SOLANA_ADDRESS_ERROR,
 } from "@/lib/epoch1000/public-key";
 
-const LOADING_LINES = [
-  "checking...",
-  "finding first vote...",
-  "scanning validator history...",
-  "building card...",
-];
+const LOADING_LINE_KEYS = [
+  "loadingChecking",
+  "loadingFindingVote",
+  "loadingScanning",
+  "loadingBuilding",
+] as const;
 
 interface Props {
   onResult?: (_result: CheckResult | null) => void;
 }
 
 export default function ValidatorChecker({ onResult }: Props) {
+  const t = useTranslations("epoch1000.validator.checker");
   const [address, setAddress] = useState("");
   const [loading, setLoading] = useState(false);
-  const [loadingLine, setLoadingLine] = useState(LOADING_LINES[0]);
+  const [loadingLine, setLoadingLine] = useState<
+    (typeof LOADING_LINE_KEYS)[number]
+  >(LOADING_LINE_KEYS[0]);
   const [lookupError, setLookupError] = useState<string | null>(null);
   const [result, setResult] = useState<CheckResult | null>(null);
   const [showAddress, setShowAddress] = useState(true);
   const [copied, setCopied] = useState(false);
+
+  const numberFormatter = useMemo(() => new Intl.NumberFormat("en-US"), []);
 
   async function check(e: React.FormEvent) {
     e.preventDefault();
@@ -43,7 +49,9 @@ export default function ValidatorChecker({ onResult }: Props) {
     const rotator = setInterval(
       () =>
         setLoadingLine(
-          LOADING_LINES[Math.floor(Math.random() * LOADING_LINES.length)],
+          LOADING_LINE_KEYS[
+            Math.floor(Math.random() * LOADING_LINE_KEYS.length)
+          ],
         ),
       2500,
     );
@@ -55,13 +63,13 @@ export default function ValidatorChecker({ onResult }: Props) {
       });
       const json = await res.json();
       if (!res.ok) {
-        setLookupError(json.error ?? "Lookup failed. Try again.");
+        setLookupError(json.error ?? t("lookupFailed"));
       } else {
         setResult(json as CheckResult);
         onResult?.(json as CheckResult);
       }
     } catch {
-      setLookupError("Lookup failed. Try again.");
+      setLookupError(t("lookupFailed"));
     } finally {
       clearInterval(rotator);
       setLoading(false);
@@ -74,7 +82,12 @@ export default function ValidatorChecker({ onResult }: Props) {
     : "";
   const tweet = result
     ? encodeURIComponent(
-        `I've validated ${result.epochsSurvived}${result.capped ? "+" : ""} Solana epochs - ${result.tier}.\n\n${cardUrl}`,
+        t("tweet", {
+          epochsSurvived: result.epochsSurvived,
+          capped: result.capped ? "+" : "",
+          tier: result.tier,
+          cardUrl,
+        }),
       )
     : "";
 
@@ -99,12 +112,13 @@ export default function ValidatorChecker({ onResult }: Props) {
     <section id="checker" className="flex flex-col gap-6">
       <div>
         <h2 className="font-bold tracking-tight text-3xl sm:text-4xl">
-          Check <span className="text-sol-gradient">validator</span>
+          {t.rich("heading", {
+            gradient: (chunks) => (
+              <span className="text-sol-gradient">{chunks}</span>
+            ),
+          })}
         </h2>
-        <p className="mt-2 text-sm text-ep-dim">
-          Enter a vote account to find your first validating epoch and share
-          your survivor card. No connect, no signature.
-        </p>
+        <p className="mt-2 text-sm text-ep-dim">{t("description")}</p>
       </div>
 
       <form onSubmit={check} className="flex flex-col sm:flex-row gap-3">
@@ -114,10 +128,10 @@ export default function ValidatorChecker({ onResult }: Props) {
             setAddress(e.target.value);
             setLookupError(null);
           }}
-          placeholder="vote account address"
+          placeholder={t("placeholder")}
           spellCheck={false}
           autoComplete="off"
-          aria-label="Validator vote account address"
+          aria-label={t("inputAriaLabel")}
           aria-invalid={validationError ? true : undefined}
           aria-describedby={
             displayedError ? "epoch1000-validator-error" : undefined
@@ -129,13 +143,13 @@ export default function ValidatorChecker({ onResult }: Props) {
           disabled={loading || !isAddressValid}
           className="!bg-ep-ink text-ep-void font-semibold rounded-full px-7 py-3 text-sm disabled:opacity-40 disabled:cursor-not-allowed hover:!bg-ep-dim transition"
         >
-          {loading ? "Checking..." : "Check"}
+          {loading ? t("submitLoading") : t("submit")}
         </button>
       </form>
 
       {loading && (
         <p className="text-sm text-ep-dust animate-pulse" aria-live="polite">
-          {loadingLine}
+          {t(loadingLine)}
         </p>
       )}
 
@@ -154,7 +168,10 @@ export default function ValidatorChecker({ onResult }: Props) {
           <img
             key={params}
             src={`/api/epoch1000/og?${params}`}
-            alt={`Validator card: first seen epoch ${result.firstEpoch}, validated ${result.epochsSurvived} epochs`}
+            alt={t("imageAlt", {
+              firstEpoch: result.firstEpoch,
+              epochsSurvived: result.epochsSurvived,
+            })}
             className="w-full rounded-lg border border-ep-edge"
             width={1200}
             height={630}
@@ -168,7 +185,7 @@ export default function ValidatorChecker({ onResult }: Props) {
                 onChange={(e) => setShowAddress(e.target.checked)}
                 className="accent-[#14f195]"
               />
-              Show vote account
+              {t("showVoteAccount")}
             </label>
             <a
               href={`https://twitter.com/intent/tweet?text=${tweet}`}
@@ -176,33 +193,35 @@ export default function ValidatorChecker({ onResult }: Props) {
               rel="noopener noreferrer"
               className="bg-ep-ink text-ep-void font-semibold rounded-full px-5 py-2 hover:bg-ep-dim transition"
             >
-              Share
+              {t("share")}
             </a>
             <button
               onClick={copyLink}
               className="border border-ep-edge rounded-full px-5 py-2 text-ep-dim hover:text-ep-ink transition"
             >
-              {copied ? "Copied" : "Copy link"}
+              {copied ? t("copied") : t("copyLink")}
             </button>
             <a
               href={`/api/epoch1000/og?${params}`}
               download={`epoch1000-validator-${result.firstEpoch}.png`}
               className="border border-ep-edge rounded-full px-5 py-2 text-ep-dim hover:text-ep-ink transition"
             >
-              PNG
+              {t("png")}
             </a>
           </div>
 
           <p className="text-xs text-ep-dust">
-            First seen:{" "}
+            {t("firstSeen")}{" "}
             <a
               href={`https://solscan.io/account/${result.address}`}
               target="_blank"
               rel="noopener noreferrer"
               className="underline decoration-ep-edge underline-offset-4 hover:text-ep-dim"
             >
-              epoch {result.firstEpoch} · slot{" "}
-              {result.firstSlot.toLocaleString("en-US")}
+              {t("firstSeenEpoch", {
+                epoch: result.firstEpoch,
+                slot: numberFormatter.format(result.firstSlot),
+              })}
             </a>
           </p>
         </div>

--- a/apps/web/src/components/epoch1000/ValidatorEpoch1000Experience.tsx
+++ b/apps/web/src/components/epoch1000/ValidatorEpoch1000Experience.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import { ChevronDownIcon } from "lucide-react";
+import Odometer from "./Odometer";
+import Reveal from "./Reveal";
+import ThousandGrid from "./ThousandGrid";
+import ValidatorChecker from "./ValidatorChecker";
+import { useEpochData } from "./useEpochData";
+import { tierFor } from "@/lib/epoch1000/tiers";
+import type { CheckResult } from "@/lib/epoch1000/card-params";
+
+function pad(n: number): string {
+  return String(n).padStart(2, "0");
+}
+
+interface Props {
+  title: React.ReactNode;
+  subtitle?: React.ReactNode;
+  description: string;
+}
+
+export default function ValidatorEpoch1000Experience({
+  title,
+  subtitle,
+  description,
+}: Props) {
+  const { live, error } = useEpochData();
+  const [result, setResult] = useState<CheckResult | null>(null);
+
+  const tier = result ? tierFor(result.epochsSurvived) : null;
+  const arrived = live?.arrived ?? false;
+  const gridEpoch = live?.epoch ?? 999;
+
+  const numberFormatter = useMemo(() => new Intl.NumberFormat("en-US"), []);
+
+  const msRemaining = live?.msRemaining ?? 0;
+  const days = Math.floor(msRemaining / 86_400_000);
+  const hours = Math.floor((msRemaining % 86_400_000) / 3_600_000);
+  const mins = Math.floor((msRemaining % 3_600_000) / 60_000);
+  const secs = Math.floor((msRemaining % 60_000) / 1000);
+
+  return (
+    <div className="flex flex-col gap-16 sm:gap-24">
+      <section className="flex min-h-[calc(100svh-230px)] flex-col items-center text-center">
+        <div className="my-auto flex flex-col items-center gap-6 sm:gap-8">
+          <p
+            className="font-brand-mono text-xs sm:text-sm tracking-[0.2em] text-ep-dust tabular-nums"
+            aria-live="polite"
+          >
+            {live ? (
+              <>
+                <span className="ep-live-dot mr-2 inline-block h-2 w-2 rounded-full bg-[#14f195] align-middle" />
+                LIVE · SLOT {numberFormatter.format(live.absoluteSlot)}
+              </>
+            ) : error ? (
+              "MAINNET UNAVAILABLE"
+            ) : (
+              <span className="animate-pulse">SYNCING...</span>
+            )}
+          </p>
+
+          <Odometer
+            value={live?.epoch ?? null}
+            arrived={arrived}
+            label={
+              live
+                ? `Current epoch: ${live.epoch} of 1000`
+                : "Current epoch: syncing"
+            }
+            className="ep-odo--display"
+          />
+
+          <div className="flex flex-col items-center gap-2 sm:gap-3">
+            <h1 className="font-black tracking-tight text-4xl sm:text-6xl leading-tight">
+              {arrived ? (
+                <>
+                  EPOCH <span className="text-sol-gradient">1000</span> IS HERE.
+                </>
+              ) : (
+                title
+              )}
+            </h1>
+            {subtitle ? (
+              <p className="text-base sm:text-xl font-semibold tracking-wide text-sol-gradient">
+                {subtitle}
+              </p>
+            ) : null}
+          </div>
+
+          <p className="text-sm sm:text-base text-ep-dim max-w-xl">
+            {arrived
+              ? "Epoch 1000 is here. Celebrate the validators who kept mainnet moving."
+              : description}
+          </p>
+
+          {live && !arrived && (
+            <div className="w-full max-w-2xl flex flex-col gap-3">
+              <div className="h-1.5 w-full rounded-full bg-white/10 overflow-hidden">
+                <div
+                  className="h-full rounded-full transition-[width] duration-300 ease-linear"
+                  style={{
+                    width: `${Math.max(0.4, (live.epoch + live.progress) / 10)}%`,
+                    backgroundImage:
+                      "linear-gradient(90deg, #9945ff 0%, #14f195 100%)",
+                  }}
+                />
+              </div>
+              <div className="grid grid-cols-1 gap-2 font-brand-mono text-xs text-ep-dust tabular-nums sm:grid-cols-3 sm:text-sm">
+                <div className="flex items-center justify-between gap-3 rounded-full border border-ep-edge bg-ep-panel/70 px-4 py-2">
+                  <span className="uppercase tracking-[0.12em]">Slots</span>
+                  <span className="text-ep-ink">
+                    {numberFormatter.format(live.slotsRemaining)}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between gap-3 rounded-full border border-ep-edge bg-ep-panel/70 px-4 py-2">
+                  <span className="uppercase tracking-[0.12em]">Time</span>
+                  <span className="text-ep-ink">
+                    {days}d {pad(hours)}h {pad(mins)}m {pad(secs)}s
+                  </span>
+                </div>
+                <div className="flex items-center justify-between gap-3 rounded-full border border-ep-edge bg-ep-panel/70 px-4 py-2">
+                  <span className="uppercase tracking-[0.12em]">ETA</span>
+                  <span className="text-ep-ink">
+                    {live.eta.toLocaleDateString("en-US", {
+                      month: "short",
+                      day: "numeric",
+                    })}
+                  </span>
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <a
+          href="#checker"
+          className="ep-cue mt-6 pb-1 text-ep-dust hover:text-ep-ink transition-colors duration-200"
+          aria-label="Scroll to the validator checker"
+        >
+          <ChevronDownIcon aria-hidden className="size-5" strokeWidth={2} />
+        </a>
+      </section>
+
+      <Reveal>
+        <ValidatorChecker onResult={setResult} />
+      </Reveal>
+
+      <Reveal>
+        <section id="timeline" className="flex flex-col gap-4 scroll-mt-24">
+          <div className="flex items-end justify-between gap-4">
+            <h2 className="font-bold tracking-tight text-3xl sm:text-4xl">
+              Mainnet timeline
+            </h2>
+            <p className="font-brand-mono text-[11px] sm:text-xs text-ep-dust tracking-[0.15em] whitespace-nowrap pb-1.5">
+              EPOCHS 0-999
+            </p>
+          </div>
+          <ThousandGrid
+            interactive
+            currentEpoch={gridEpoch}
+            firstEpoch={result?.firstEpoch}
+            accent={tier?.color}
+            accentLabel={
+              result && tier
+                ? `${tier.name} · EPOCH ${result.firstEpoch} TO NOW`
+                : undefined
+            }
+          />
+        </section>
+      </Reveal>
+    </div>
+  );
+}

--- a/apps/web/src/lib/epoch1000/card-params.ts
+++ b/apps/web/src/lib/epoch1000/card-params.ts
@@ -11,10 +11,17 @@ export interface CheckResult {
   tier: string;
   capped: boolean;
   scanned: number;
+  logoUrl?: string | null;
 }
 
-/** Query string shared by the OG image route and the /epoch1000/card share page. */
-export function cardParams(result: CheckResult, showAddress: boolean): string {
+export type CardVariant = "wallet" | "validator";
+
+/** Query string shared by the OG image route and share pages. */
+export function cardParams(
+  result: CheckResult,
+  showAddress: boolean,
+  variant: CardVariant = "wallet",
+): string {
   const p = new URLSearchParams({
     s: String(result.epochsSurvived),
     fe: String(result.firstEpoch),
@@ -23,5 +30,7 @@ export function cardParams(result: CheckResult, showAddress: boolean): string {
   if (result.firstBlockTime) p.set("t", String(result.firstBlockTime));
   if (result.capped) p.set("x", "1");
   if (showAddress) p.set("w", shortAddress(result.address));
+  if (variant === "validator") p.set("k", "validator");
+  if (result.logoUrl) p.set("vl", result.logoUrl);
   return p.toString();
 }

--- a/apps/web/src/lib/epoch1000/validator-cache.ts
+++ b/apps/web/src/lib/epoch1000/validator-cache.ts
@@ -6,7 +6,7 @@ import {
 
 export const VALIDATOR_LOOKUP_CACHE_REVALIDATE_SECONDS = 60;
 
-const CACHE_KEY_VERSION = "epoch1000-validator-first-tx-v2";
+const CACHE_KEY_VERSION = "epoch1000-validator-first-tx-v3";
 const CACHE_TAG = "epoch1000-validator-lookup";
 const LOCAL_CACHE_MAX_ENTRIES = 1_000;
 

--- a/apps/web/src/lib/epoch1000/validator-cache.ts
+++ b/apps/web/src/lib/epoch1000/validator-cache.ts
@@ -1,0 +1,110 @@
+import { unstable_cache } from "next/cache";
+import {
+  findValidatorFirstTransaction,
+  type ValidatorLookup,
+} from "./vote-account";
+
+export const VALIDATOR_LOOKUP_CACHE_REVALIDATE_SECONDS = 60;
+
+const CACHE_KEY_VERSION = "epoch1000-validator-first-tx-v2";
+const CACHE_TAG = "epoch1000-validator-lookup";
+const LOCAL_CACHE_MAX_ENTRIES = 1_000;
+
+type LocalCacheEntry =
+  | {
+      status: "pending";
+      expiresAt: number;
+      promise: Promise<ValidatorLookup | null>;
+    }
+  | {
+      status: "settled";
+      expiresAt: number;
+      value: ValidatorLookup | null;
+    };
+
+const localCache = new Map<string, LocalCacheEntry>();
+
+export function getHotValidatorFirstTransaction(
+  voteAccount: string,
+  now = Date.now(),
+): Promise<ValidatorLookup | null> | null {
+  const entry = localCache.get(voteAccount);
+
+  if (!entry) {
+    return null;
+  }
+
+  if (entry.expiresAt <= now) {
+    localCache.delete(voteAccount);
+    return null;
+  }
+
+  if (entry.status === "pending") {
+    return entry.promise;
+  }
+
+  return Promise.resolve(entry.value);
+}
+
+export function getCachedValidatorFirstTransaction(
+  voteAccount: string,
+  now = Date.now(),
+): Promise<ValidatorLookup | null> {
+  const hot = getHotValidatorFirstTransaction(voteAccount, now);
+  if (hot) {
+    return hot;
+  }
+
+  const expiresAt = now + VALIDATOR_LOOKUP_CACHE_REVALIDATE_SECONDS * 1000;
+  const promise = unstable_cache(
+    () => findValidatorFirstTransaction(voteAccount),
+    [CACHE_KEY_VERSION, voteAccount],
+    {
+      revalidate: VALIDATOR_LOOKUP_CACHE_REVALIDATE_SECONDS,
+      tags: [CACHE_TAG],
+    },
+  )()
+    .then((value) => {
+      localCache.set(voteAccount, {
+        status: "settled",
+        expiresAt:
+          Date.now() + VALIDATOR_LOOKUP_CACHE_REVALIDATE_SECONDS * 1000,
+        value,
+      });
+      pruneLocalCache();
+      return value;
+    })
+    .catch((err) => {
+      const entry = localCache.get(voteAccount);
+      if (entry?.status === "pending" && entry.promise === promise) {
+        localCache.delete(voteAccount);
+      }
+
+      throw err;
+    });
+
+  localCache.set(voteAccount, { status: "pending", expiresAt, promise });
+  pruneLocalCache(now);
+
+  return promise;
+}
+
+export function resetEpoch1000ValidatorLookupCacheForTests() {
+  localCache.clear();
+}
+
+function pruneLocalCache(now = Date.now()) {
+  if (localCache.size <= LOCAL_CACHE_MAX_ENTRIES) return;
+
+  for (const [voteAccount, entry] of localCache) {
+    if (entry.expiresAt <= now) {
+      localCache.delete(voteAccount);
+    }
+  }
+
+  while (localCache.size > LOCAL_CACHE_MAX_ENTRIES) {
+    const oldest = localCache.keys().next().value;
+    if (!oldest) break;
+    localCache.delete(oldest);
+  }
+}

--- a/apps/web/src/lib/epoch1000/vote-account.ts
+++ b/apps/web/src/lib/epoch1000/vote-account.ts
@@ -25,18 +25,32 @@ export async function findValidatorFirstTransaction(
   if (res.status === 404) return null;
   if (!res.ok) throw new Error(`Trillium API failed: ${res.status}`);
 
-  const records = (await res.json()) as TrilliumValidatorReward[];
-  const record = records.find(
+  const payload: unknown = await res.json();
+  if (!Array.isArray(payload)) return null;
+
+  const records = payload as TrilliumValidatorReward[];
+  const matches = records.filter(
     (entry) => entry.vote_account_pubkey === voteAccount,
   );
-  if (!record || record.sw_first_epoch_with_stake == null) return null;
+  if (matches.length === 0) return null;
+
+  // Trillium returns per-epoch rows; sw_first_epoch_with_stake is only on some.
+  const recordWithFirstEpoch = matches.find(
+    (entry) => entry.sw_first_epoch_with_stake != null,
+  );
+  if (!recordWithFirstEpoch) return null;
+
+  const latestRecord = matches[0];
 
   return {
     signature: "",
-    slot: record.sw_first_epoch_with_stake * SLOTS_PER_EPOCH,
+    slot: recordWithFirstEpoch.sw_first_epoch_with_stake * SLOTS_PER_EPOCH,
     blockTime: null,
     capped: false,
     scanned: 0,
-    logoUrl: record.icon_url?.trim() || null,
+    logoUrl:
+      latestRecord?.icon_url?.trim() ||
+      recordWithFirstEpoch.icon_url?.trim() ||
+      null,
   };
 }

--- a/apps/web/src/lib/epoch1000/vote-account.ts
+++ b/apps/web/src/lib/epoch1000/vote-account.ts
@@ -1,0 +1,42 @@
+import type { FirstTx } from "./solana";
+
+const SLOTS_PER_EPOCH = 432_000;
+const TRILLIUM_VALIDATOR_REWARDS_URL =
+  "https://api.trillium.so/validator_rewards";
+
+interface TrilliumValidatorReward {
+  vote_account_pubkey: string;
+  sw_first_epoch_with_stake: number;
+  icon_url?: string | null;
+}
+
+export interface ValidatorLookup extends FirstTx {
+  logoUrl: string | null;
+}
+
+/** Validator history from Trillium's per-validator rewards endpoint. */
+export async function findValidatorFirstTransaction(
+  voteAccount: string,
+): Promise<ValidatorLookup | null> {
+  const res = await fetch(`${TRILLIUM_VALIDATOR_REWARDS_URL}/${voteAccount}`, {
+    cache: "no-store",
+  });
+
+  if (res.status === 404) return null;
+  if (!res.ok) throw new Error(`Trillium API failed: ${res.status}`);
+
+  const records = (await res.json()) as TrilliumValidatorReward[];
+  const record = records.find(
+    (entry) => entry.vote_account_pubkey === voteAccount,
+  );
+  if (!record || record.sw_first_epoch_with_stake == null) return null;
+
+  return {
+    signature: "",
+    slot: record.sw_first_epoch_with_stake * SLOTS_PER_EPOCH,
+    blockTime: null,
+    capped: false,
+    scanned: 0,
+    logoUrl: record.icon_url?.trim() || null,
+  };
+}

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -7799,6 +7799,28 @@
         "subtitle": "(Validator Edition)",
         "description": "A live celebration of Solana mainnet reaching 1,000 epochs. Track the countdown, then check when your validator first started securing the network."
       },
+      "checker": {
+        "heading": "Check <gradient>validator</gradient>",
+        "description": "Enter a vote account to find your first validating epoch and share your survivor card. No connect, no signature.",
+        "placeholder": "vote account address",
+        "inputAriaLabel": "Validator vote account address",
+        "submit": "Check",
+        "submitLoading": "Checking...",
+        "loadingChecking": "checking...",
+        "loadingFindingVote": "finding first vote...",
+        "loadingScanning": "scanning validator history...",
+        "loadingBuilding": "building card...",
+        "showVoteAccount": "Show vote account",
+        "share": "Share",
+        "copyLink": "Copy link",
+        "copied": "Copied",
+        "png": "PNG",
+        "firstSeen": "First seen:",
+        "firstSeenEpoch": "epoch {epoch} · slot {slot}",
+        "imageAlt": "Validator card: first seen epoch {firstEpoch}, validated {epochsSurvived} epochs",
+        "tweet": "I've validated {epochsSurvived}{capped} Solana epochs - {tier}.\n\n{cardUrl}",
+        "lookupFailed": "Lookup failed. Try again."
+      },
       "card": {
         "meta": {
           "title": "I've been validating Solana for {survived} epochs",

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -7725,7 +7725,8 @@
       "openGraphDescription": "Celebrate Solana mainnet reaching epoch 1000. How many epochs has your wallet survived?"
     },
     "page": {
-      "checkerLink": "Check wallet",
+      "navWallet": "Check wallet",
+      "navValidator": "Validator Edition",
       "title": "EPOCH <gradient>1000</gradient>",
       "description": "A live celebration of Solana mainnet reaching 1,000 epochs. Track the countdown, then check when your wallet first joined."
     },
@@ -7783,6 +7784,76 @@
         "settler": {
           "name": "Settler Class",
           "line": "Welcome aboard. Epoch 2000 awaits."
+        }
+      }
+    },
+    "validator": {
+      "meta": {
+        "title": "Epoch 1000 Validator Celebration",
+        "description": "Celebrate Solana mainnet's 1,000th epoch. Check a validator vote account's first epoch and share a survivor card.",
+        "openGraphTitle": "EPOCH1000 — Validator celebration",
+        "openGraphDescription": "How many epochs has your validator been securing Solana?"
+      },
+      "page": {
+        "title": "EPOCH <gradient>1000</gradient>",
+        "subtitle": "(Validator Edition)",
+        "description": "A live celebration of Solana mainnet reaching 1,000 epochs. Track the countdown, then check when your validator first started securing the network."
+      },
+      "card": {
+        "meta": {
+          "title": "I've been validating Solana for {survived} epochs",
+          "description": {
+            "withFirstEpoch": "I've been validating Solana for {survived} epochs, since epoch {firstEpoch}. {tierLine}",
+            "withoutFirstEpoch": "I've been validating Solana for {survived} epochs. {tierLine}"
+          }
+        },
+        "eyebrow": "Epoch 1000 · Validators",
+        "heading": "I've validated {survived} epochs",
+        "summary": {
+          "defaultVoteAccount": "vote account hidden",
+          "withFirstEpoch": "I've validated <strong>{survived}</strong> epochs on Solana. Proof: <voteAccount>{voteAccountLabel}</voteAccount> / since epoch {firstEpoch}.",
+          "withoutFirstEpoch": "I've validated <strong>{survived}</strong> epochs on Solana. Proof: <voteAccount>{voteAccountLabel}</voteAccount>."
+        },
+        "imageAlt": "Validator card: {survived} epochs validating Solana, {tier}",
+        "ctaCheck": "Make yours",
+        "ctaExplore": "Explore",
+        "privacyNote": "No wallet connect.",
+        "og": {
+          "epoch1000": "Epoch 1000",
+          "validatingAge": "I've been validating Solana for",
+          "epochsOld": "epochs",
+          "sinceEpoch": "since epoch {epoch}",
+          "startEpoch": "epoch 0",
+          "endEpoch": "epoch 1000",
+          "proof": "proof: {wallet}",
+          "anonymousVoteAccount": "hidden",
+          "footerUrl": "solana.com/epoch1000/validator"
+        },
+        "tiers": {
+          "genesis": {
+            "name": "Genesis Class",
+            "line": "Here before almost everyone."
+          },
+          "diamond": {
+            "name": "Diamond Class",
+            "line": "Forged under pressure."
+          },
+          "obsidian": {
+            "name": "Obsidian Class",
+            "line": "Cooled in the fire of the bear."
+          },
+          "veteran": {
+            "name": "Veteran Class",
+            "line": "Seen some things."
+          },
+          "survivor": {
+            "name": "Survivor Class",
+            "line": "Still here. Still early."
+          },
+          "settler": {
+            "name": "Settler Class",
+            "line": "Welcome aboard. Epoch 2000 awaits."
+          }
         }
       }
     }


### PR DESCRIPTION
Introduce /epoch1000/validator with vote account lookup via Trillium, validator survivor cards with logo support, and wallet/validator edition nav.

## Summary
- Adds `/epoch1000/validator` for validator vote account checks
- Uses Trillium API (`sw_first_epoch_with_stake`) for first validating epoch
- Generates shareable validator cards with logo and custom OG copy
- Adds "wallet | Validator Edition" navigation on epoch1000 pages
