### PR TITLE
Fix bun template generation command

### DIFF
--- a/apps/templates/src/components/templates/templates-ui-generate-command.tsx
+++ b/apps/templates/src/components/templates/templates-ui-generate-command.tsx
@@ -15,6 +15,8 @@ function getCommand(pm: string, template: string) {
     case "yarn":
       // Yarn only supports the `latest` tag
       return `yarn create solana-dapp -t ${template}`;
+    case "bun":
+      return `bunx create-solana-dapp@latest -t ${template}`;
     default:
       // All other package managers support the `@latest` tag and best practice is to always use it explicitly
       return `${pm} create solana-dapp@latest -t ${template}`;


### PR DESCRIPTION


**Title**

```text
Fix Bun template generation command
```

**Body**

```markdown
### Problem

The generated Bun command on the Solana templates page is incorrect for creating a Solana dApp template.

Before this change, selecting Bun fell through to the default package manager command format:

```bash
bun create solana-dapp@latest -t ...
```

That command does not work reliably for Bun users, especially in Windows/PowerShell environments.

Fixes #1549

### Summary of Changes

Updated the templates command generator so the Bun option explicitly uses:

```bash
bunx create-solana-dapp@latest -t ...
```

This matches Bun’s package execution flow and avoids the broken generated command.

### Verification

Commit signature:

- GitHub commit verification: `verified: true`
- Verification reason: `valid`

Local checks run:

```bash
corepack pnpm --filter ./apps/templates lint
corepack pnpm --filter ./apps/templates check-types
corepack pnpm --filter ./apps/templates build
```

Bun smoke test:

```bash
bunx create-solana-dapp@latest bun-smoke-app -t solana-foundation/templates/kit/nextjs --dry-run --skip-version-check --skip-install --skip-git --skip-init
```

The Bun dry run resolved the external template successfully and made no filesystem changes because `--dry-run` was used.

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical
- [x] **Low** — no security impact; UI command generation only

### Security checklist

- [x] No secrets, tokens, or credentials added.
- [x] No new dependencies added.
- [x] No user input handling or trust-boundary behavior changed.
- [x] No production execution path changed beyond generated command text.
- [x] Commit is signed and verified on GitHub.
```