### PR TITLE
ci: test guides by actually following them, auto-fix failures on main

### DIFF
--- a/.github/workflows/guides-ci.yml
+++ b/.github/workflows/guides-ci.yml
@@ -1,0 +1,236 @@
+name: Guides CI
+
+# Walks through changed developer guides with an agent that follows the guide
+# exactly as a reader would, and fails if the guide is broken. On pushes to
+# main, failures additionally produce an auto-fix PR (opened by the
+# solana-docs-checker GitHub App).
+#
+# Required secrets:
+#   ANTHROPIC_API_KEY                - API key used by the walkthrough agent
+#   DOCS_CHECKER_APP_ID              - solana-docs-checker GitHub App id
+#   DOCS_CHECKER_APP_PRIVATE_KEY     - private key for that GitHub App
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      guides:
+        description: >-
+          Comma-separated guide paths to test (apps/docs/content/guides/...), or
+          "all"
+        required: true
+        default: all
+
+concurrency:
+  group:
+    guides-ci-${{ github.event_name }}-${{ github.event.pull_request.number ||
+    github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  detect:
+    name: Detect changed guides
+    runs-on: ubuntu-latest
+    outputs:
+      guides: ${{ steps.changed.outputs.guides }}
+      any: ${{ steps.changed.outputs.any }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Collect guide files to test
+        id: changed
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BEFORE_SHA: ${{ github.event.before }}
+          INPUT_GUIDES: ${{ inputs.guides }}
+        run: |
+          set -euo pipefail
+          pathspec=':(glob)apps/docs/content/guides/**/*.mdx'
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            if [ "$INPUT_GUIDES" = "all" ]; then
+              files=$(git ls-files "$pathspec")
+            else
+              files=$(echo "$INPUT_GUIDES" | tr ',' '\n' | sed 's/^ *//;s/ *$//')
+            fi
+          elif [ "$EVENT" = "pull_request" ]; then
+            base=$(git merge-base "$BASE_SHA" HEAD)
+            files=$(git diff --name-only --diff-filter=d "$base" HEAD -- "$pathspec")
+          else
+            base="$BEFORE_SHA"
+            if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
+              base=$(git rev-parse HEAD~1)
+            fi
+            files=$(git diff --name-only --diff-filter=d "$base" HEAD -- "$pathspec")
+          fi
+
+          # Keep only files that exist (guards manual dispatch typos)
+          existing=""
+          while IFS= read -r f; do
+            [ -n "$f" ] && [ -f "$f" ] && existing="$existing$f"$'\n'
+          done <<< "$files"
+
+          guides=$(printf '%s' "$existing" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "Guides to test: $guides"
+          echo "guides=$guides" >> "$GITHUB_OUTPUT"
+          if [ "$guides" = "[]" ]; then
+            echo "any=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "any=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  test:
+    name: Walk through guide
+    needs: detect
+    if: needs.detect.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        guide: ${{ fromJSON(needs.detect.outputs.guides) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Follow the guide
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Read scripts/guides-ci/test-guide-prompt.md in this repository and
+            follow those instructions exactly.
+
+            Guide to test: ${{ matrix.guide }}
+            Write the JSON report to: ${{ runner.temp }}/guide-report.json
+          claude_args: |
+            --model claude-opus-4-8
+            --max-turns 250
+            --allowedTools "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch"
+
+      - name: Evaluate report
+        run:
+          node scripts/guides-ci/check-report.mjs
+          "$RUNNER_TEMP/guide-report.json"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: guide-report-${{ strategy.job-index }}
+          path: ${{ runner.temp }}/guide-report.json
+          if-no-files-found: ignore
+
+  # Single job for branch protection: mark this one as the required check.
+  # It passes when no guides changed and fails when any walkthrough failed.
+  gate:
+    name: Guides CI gate
+    needs: [detect, test]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        env:
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [ "$TEST_RESULT" = "failure" ] || [ "$TEST_RESULT" = "cancelled" ]; then
+            echo "One or more guide walkthroughs failed."
+            exit 1
+          fi
+          echo "All guide walkthroughs passed (or no guides changed)."
+
+  autofix:
+    name: Open fix PR
+    needs: [detect, test]
+    if:
+      always() && github.event_name == 'push' && needs.test.result == 'failure'
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Create bot token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DOCS_CHECKER_APP_ID }}
+          private-key: ${{ secrets.DOCS_CHECKER_APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Download walkthrough reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: guide-report-*
+          path: reports
+          merge-multiple: false
+
+      - name: Fix failing guides
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Read scripts/guides-ci/fix-guides-prompt.md in this repository and
+            follow those instructions exactly.
+
+            The walkthrough reports are under: reports/
+            Write the PR title to: ${{ runner.temp }}/pr-title.txt
+            Write the PR body to: ${{ runner.temp }}/pr-body.md
+          claude_args: |
+            --model claude-opus-4-8
+            --max-turns 250
+            --allowedTools "Bash,Read,Write,Edit,Glob,Grep,WebFetch,WebSearch"
+
+      - name: Read PR title
+        id: pr
+        run: |
+          title="docs: fix guide steps failing the automated guide check"
+          if [ -s "$RUNNER_TEMP/pr-title.txt" ]; then
+            title=$(head -n 1 "$RUNNER_TEMP/pr-title.txt" | cut -c1-150)
+          fi
+          echo "title=$title" >> "$GITHUB_OUTPUT"
+          if [ ! -s "$RUNNER_TEMP/pr-body.md" ]; then
+            echo "Automated guide check found failing guides on main; this PR fixes them. See the Guides CI run for reports." > "$RUNNER_TEMP/pr-body.md"
+          fi
+
+      - name: Get bot user id
+        id: bot
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+        run:
+          echo "id=$(gh api "/users/${APP_SLUG}%5Bbot%5D" --jq .id)" >>
+          "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          branch: guides-autofix/${{ github.run_id }}
+          base: main
+          add-paths: apps/docs/content/guides/**
+          commit-message: ${{ steps.pr.outputs.title }}
+          title: ${{ steps.pr.outputs.title }}
+          body-path: ${{ runner.temp }}/pr-body.md
+          committer:
+            ${{ steps.app-token.outputs.app-slug }}[bot] <${{
+            steps.bot.outputs.id }}+${{ steps.app-token.outputs.app-slug
+            }}[bot]@users.noreply.github.com>
+          author:
+            ${{ steps.app-token.outputs.app-slug }}[bot] <${{
+            steps.bot.outputs.id }}+${{ steps.app-token.outputs.app-slug
+            }}[bot]@users.noreply.github.com>
+          delete-branch: true

--- a/.github/workflows/guides-ci.yml
+++ b/.github/workflows/guides-ci.yml
@@ -23,6 +23,10 @@ on:
           "all"
         required: true
         default: all
+      open_fix_prs:
+        description: Open an auto-fix PR if guides fail
+        type: boolean
+        default: false
 
 concurrency:
   group:
@@ -143,8 +147,9 @@ jobs:
     name: Open fix PR
     needs: [detect, test]
     if:
-      always() && github.event_name == 'schedule' && needs.test.result ==
-      'failure'
+      always() && needs.test.result == 'failure' && (github.event_name ==
+      'schedule' || (github.event_name == 'workflow_dispatch' &&
+      inputs.open_fix_prs))
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/guides-ci.yml
+++ b/.github/workflows/guides-ci.yml
@@ -135,8 +135,13 @@ jobs:
     steps:
       - name: Check results
         env:
+          DETECT_RESULT: ${{ needs.detect.result }}
           TEST_RESULT: ${{ needs.test.result }}
         run: |
+          if [ "$DETECT_RESULT" != "success" ]; then
+            echo "Detecting changed guides failed, so nothing was tested."
+            exit 1
+          fi
           if [ "$TEST_RESULT" = "failure" ] || [ "$TEST_RESULT" = "cancelled" ]; then
             echo "One or more guide walkthroughs failed."
             exit 1

--- a/.github/workflows/guides-ci.yml
+++ b/.github/workflows/guides-ci.yml
@@ -1,9 +1,9 @@
 name: Guides CI
 
-# Walks through changed developer guides with an agent that follows the guide
-# exactly as a reader would, and fails if the guide is broken. On pushes to
-# main, failures additionally produce an auto-fix PR (opened by the
-# solana-docs-checker GitHub App).
+# Walks through developer guides with an agent that follows the guide exactly
+# as a reader would, and fails if the guide is broken. On PRs it tests the
+# guides the PR touches. Once a week it sweeps every guide, and failures
+# produce an auto-fix PR (opened by the solana-docs-checker GitHub App).
 #
 # Required secrets:
 #   ANTHROPIC_API_KEY                - API key used by the walkthrough agent
@@ -12,9 +12,9 @@ name: Guides CI
 
 on:
   pull_request:
-  push:
-    branches:
-      - main
+  schedule:
+    # Weekly sweep of all guides, Mondays 08:00 UTC
+    - cron: "0 8 * * 1"
   workflow_dispatch:
     inputs:
       guides:
@@ -47,26 +47,17 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          BEFORE_SHA: ${{ github.event.before }}
           INPUT_GUIDES: ${{ inputs.guides }}
         run: |
           set -euo pipefail
           pathspec=':(glob)apps/docs/content/guides/**/*.mdx'
 
-          if [ "$EVENT" = "workflow_dispatch" ]; then
-            if [ "$INPUT_GUIDES" = "all" ]; then
-              files=$(git ls-files "$pathspec")
-            else
-              files=$(echo "$INPUT_GUIDES" | tr ',' '\n' | sed 's/^ *//;s/ *$//')
-            fi
-          elif [ "$EVENT" = "pull_request" ]; then
-            base=$(git merge-base "$BASE_SHA" HEAD)
-            files=$(git diff --name-only --diff-filter=d "$base" HEAD -- "$pathspec")
+          if [ "$EVENT" = "schedule" ] || { [ "$EVENT" = "workflow_dispatch" ] && [ "$INPUT_GUIDES" = "all" ]; }; then
+            files=$(git ls-files "$pathspec")
+          elif [ "$EVENT" = "workflow_dispatch" ]; then
+            files=$(echo "$INPUT_GUIDES" | tr ',' '\n' | sed 's/^ *//;s/ *$//')
           else
-            base="$BEFORE_SHA"
-            if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
-              base=$(git rev-parse HEAD~1)
-            fi
+            base=$(git merge-base "$BASE_SHA" HEAD)
             files=$(git diff --name-only --diff-filter=d "$base" HEAD -- "$pathspec")
           fi
 
@@ -152,7 +143,8 @@ jobs:
     name: Open fix PR
     needs: [detect, test]
     if:
-      always() && github.event_name == 'push' && needs.test.result == 'failure'
+      always() && github.event_name == 'schedule' && needs.test.result ==
+      'failure'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     permissions:

--- a/.github/workflows/guides-ci.yml
+++ b/.github/workflows/guides-ci.yml
@@ -218,6 +218,7 @@ jobs:
           "$GITHUB_OUTPUT"
 
       - name: Create pull request
+        id: create-pr
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ steps.app-token.outputs.token }}
@@ -236,3 +237,13 @@ jobs:
             steps.bot.outputs.id }}+${{ steps.app-token.outputs.app-slug
             }}[bot]@users.noreply.github.com>
           delete-branch: true
+
+      - name: Tag maintainer
+        if: steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+        run:
+          gh pr comment "$PR_NUMBER" -R "${{ github.repository }}" --body
+          "@catmcgee the guide walkthrough found failures and this PR fixes them
+          — please review."

--- a/.github/workflows/guides-ci.yml
+++ b/.github/workflows/guides-ci.yml
@@ -42,7 +42,7 @@ jobs:
       guides: ${{ steps.changed.outputs.guides }}
       any: ${{ steps.changed.outputs.any }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           fetch-depth: 0
 
@@ -95,10 +95,10 @@ jobs:
       matrix:
         guide: ${{ fromJSON(needs.detect.outputs.guides) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Follow the guide
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
@@ -119,7 +119,7 @@ jobs:
 
       - name: Upload report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: guide-report-${{ strategy.job-index }}
           path: ${{ runner.temp }}/guide-report.json
@@ -164,24 +164,24 @@ jobs:
     steps:
       - name: Create bot token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.DOCS_CHECKER_APP_ID }}
           private-key: ${{ secrets.DOCS_CHECKER_APP_PRIVATE_KEY }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Download walkthrough reports
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           pattern: guide-report-*
           path: reports
           merge-multiple: false
 
       - name: Fix failing guides
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
@@ -219,7 +219,7 @@ jobs:
 
       - name: Create pull request
         id: create-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7
         with:
           token: ${{ steps.app-token.outputs.token }}
           branch: guides-autofix/${{ github.run_id }}

--- a/scripts/guides-ci/check-report.mjs
+++ b/scripts/guides-ci/check-report.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+/**
+ * Reads the JSON report written by the guide walkthrough agent, prints a
+ * summary (and a GitHub job summary when available), and exits non-zero if
+ * the guide failed or no usable report was produced.
+ *
+ * Usage: node check-report.mjs <path-to-report.json>
+ */
+import { readFileSync, existsSync, appendFileSync } from "node:fs";
+
+const reportPath = process.argv[2];
+
+function summarize(markdown) {
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, markdown + "\n");
+  }
+}
+
+function fail(message) {
+  console.error(`✗ ${message}`);
+  summarize(`### Guide check failed\n\n${message}`);
+  process.exit(1);
+}
+
+if (!reportPath) fail("No report path given to check-report.mjs");
+if (!existsSync(reportPath)) {
+  fail(
+    `The walkthrough agent did not produce a report at ${reportPath}. ` +
+      "Treating the run as failed — check the agent logs above.",
+  );
+}
+
+let report;
+try {
+  report = JSON.parse(readFileSync(reportPath, "utf8"));
+} catch (err) {
+  fail(`Report at ${reportPath} is not valid JSON: ${err.message}`);
+}
+
+const { guide = "(unknown guide)", status, summary = "", issues = [] } = report;
+const blockers = issues.filter((i) => i.severity === "blocker");
+const warnings = issues.filter((i) => i.severity !== "blocker");
+
+const lines = [`### Guide walkthrough: \`${guide}\``, "", summary, ""];
+for (const issue of issues) {
+  lines.push(
+    `- **${issue.severity}** — ${issue.section}: ${issue.description}`,
+    issue.evidence ? `  - Evidence: ${issue.evidence}` : "",
+    issue.suggested_fix ? `  - Suggested fix: ${issue.suggested_fix}` : "",
+  );
+}
+const body = lines.filter(Boolean).join("\n");
+console.log(body);
+
+if (status === "fail" || blockers.length > 0) {
+  summarize(`${body}\n\n**Result: FAIL** (${blockers.length} blocker(s))`);
+  process.exit(1);
+}
+if (status !== "pass") {
+  fail(`Report has unexpected status ${JSON.stringify(status)}`);
+}
+summarize(`${body}\n\n**Result: PASS** (${warnings.length} warning(s))`);

--- a/scripts/guides-ci/check-report.mjs
+++ b/scripts/guides-ci/check-report.mjs
@@ -38,8 +38,10 @@ try {
 }
 
 const { guide = "(unknown guide)", status, summary = "", issues = [] } = report;
-const blockers = issues.filter((i) => i.severity === "blocker");
-const warnings = issues.filter((i) => i.severity !== "blocker");
+// Any real defect in the guide fails CI; only pure environment noise
+// (network flakiness, missing third-party credentials) is tolerated.
+const defects = issues.filter((i) => i.severity !== "environment");
+const envNotes = issues.filter((i) => i.severity === "environment");
 
 const lines = [`### Guide walkthrough: \`${guide}\``, "", summary, ""];
 for (const issue of issues) {
@@ -52,11 +54,13 @@ for (const issue of issues) {
 const body = lines.filter(Boolean).join("\n");
 console.log(body);
 
-if (status === "fail" || blockers.length > 0) {
-  summarize(`${body}\n\n**Result: FAIL** (${blockers.length} blocker(s))`);
+if (status === "fail" || defects.length > 0) {
+  summarize(`${body}\n\n**Result: FAIL** (${defects.length} guide issue(s))`);
   process.exit(1);
 }
 if (status !== "pass") {
   fail(`Report has unexpected status ${JSON.stringify(status)}`);
 }
-summarize(`${body}\n\n**Result: PASS** (${warnings.length} warning(s))`);
+summarize(
+  `${body}\n\n**Result: PASS** (${envNotes.length} environment note(s))`,
+);

--- a/scripts/guides-ci/fix-guides-prompt.md
+++ b/scripts/guides-ci/fix-guides-prompt.md
@@ -1,9 +1,11 @@
 # Guide fix instructions
 
 The scheduled guide walkthrough ran against main and one or more guides failed.
-The JSON reports from those walkthroughs are in the `reports/` directory of the
-current working tree (one file per guide, schema described below). Your job is
-to edit the failing guides so a reader can complete them again.
+The JSON reports from those walkthroughs are under the `reports/` directory of
+the current working tree, one per guide, each nested in its own subdirectory
+(`reports/guide-report-N/guide-report.json`) — find them all with a recursive
+search. Your job is to edit the failing guides so a reader can complete them
+again.
 
 Report schema:
 `{ guide, status, summary, steps_run, issues: [{ section, severity, description, evidence, suggested_fix }] }`.

--- a/scripts/guides-ci/fix-guides-prompt.md
+++ b/scripts/guides-ci/fix-guides-prompt.md
@@ -1,10 +1,9 @@
 # Guide fix instructions
 
-A push to main was checked by the automated guide walkthrough and one or more
-guides failed. The JSON reports from those walkthroughs are in the `reports/`
-directory of the current working tree (one file per guide, schema described
-below). Your job is to edit the failing guides so a reader can complete them
-again.
+The scheduled guide walkthrough ran against main and one or more guides failed.
+The JSON reports from those walkthroughs are in the `reports/` directory of the
+current working tree (one file per guide, schema described below). Your job is
+to edit the failing guides so a reader can complete them again.
 
 Report schema:
 `{ guide, status, summary, steps_run, issues: [{ section, severity, description, evidence, suggested_fix }] }`.

--- a/scripts/guides-ci/fix-guides-prompt.md
+++ b/scripts/guides-ci/fix-guides-prompt.md
@@ -7,8 +7,9 @@ to edit the failing guides so a reader can complete them again.
 
 Report schema:
 `{ guide, status, summary, steps_run, issues: [{ section, severity, description, evidence, suggested_fix }] }`.
-Only guides with `status: "fail"` need fixing; their `blocker` issues are what
-must be resolved.
+Only guides with `status: "fail"` need fixing. Both `blocker` and `warning`
+issues fail CI and must be resolved; `environment` issues (network flakiness,
+missing credentials) are not guide defects and need no edit.
 
 ## How to fix
 

--- a/scripts/guides-ci/fix-guides-prompt.md
+++ b/scripts/guides-ci/fix-guides-prompt.md
@@ -1,0 +1,46 @@
+# Guide fix instructions
+
+A push to main was checked by the automated guide walkthrough and one or more
+guides failed. The JSON reports from those walkthroughs are in the `reports/`
+directory of the current working tree (one file per guide, schema described
+below). Your job is to edit the failing guides so a reader can complete them
+again.
+
+Report schema:
+`{ guide, status, summary, steps_run, issues: [{ section, severity, description, evidence, suggested_fix }] }`.
+Only guides with `status: "fail"` need fixing; their `blocker` issues are what
+must be resolved.
+
+## How to fix
+
+1. Read every report. For each failing guide, read the guide file itself and the
+   blocker issues.
+2. Verify before editing: reproduce the failing step in a scratch directory
+   outside the repo (e.g. `~/guide-fix-run`) so you know the real cause, then
+   confirm your corrected command/code actually works there. If a blocker cannot
+   be reproduced at all, leave that part of the guide alone and note it in the
+   PR body.
+3. Make the smallest edit to the guide `.mdx` that makes the step work: updated
+   command, corrected code snippet, bumped version, fixed path or link, or a
+   short added step the reader needs. Preserve the guide's voice, structure,
+   frontmatter, and formatting. Do not rewrite sections that work, and do not
+   modernize things that aren't broken.
+4. Address `warning` issues only when the fix is trivial and zero-risk (a dead
+   link, a typo in a command). Otherwise leave warnings for humans.
+5. Do not touch any file outside `apps/docs/content/guides/` in the repository.
+   Do not run git commit or git push — committing and opening the PR is handled
+   by a later workflow step.
+
+## PR text
+
+When the edits are done, write two files (paths are given in the task prompt):
+
+- A title file containing one line in the repo's commit style, e.g.
+  `docs: fix broken install step in token airdrop guide`. This is used as both
+  the PR title and the commit message. It must read like a normal commit written
+  by a docs maintainer: no AI/assistant/Claude references, no emoji, no
+  attribution lines.
+- A body file in markdown with three short sections: what was failing (with the
+  key evidence from the reports), what was changed in each guide, and how the
+  fix was verified. It's fine for the body to say the failures were found by the
+  automated guide check.

--- a/scripts/guides-ci/test-guide-prompt.md
+++ b/scripts/guides-ci/test-guide-prompt.md
@@ -34,13 +34,14 @@ The guide file path and the report output path are given in the task prompt.
   the guide allows it or the choice of cluster doesn't matter.
 - Devnet faucets and RPC endpoints are flaky. Retry a failing network step 2-3
   times before drawing conclusions. A persistent pure-network failure (airdrop
-  rate limit, RPC timeout) is an environment issue: record it as a `warning`,
-  not a blocker, and validate the remaining steps as far as you can.
+  rate limit, RPC timeout) is not a defect in the guide: record it with severity
+  `environment` and validate the remaining steps as far as you can.
 - If a step requires credentials or third-party accounts you cannot create
   (Supabase project, paid API key, wallet with real funds, app store accounts),
   do not fail the guide. Go as far as you can without them, statically verify
-  the code for that step (compile / typecheck / lint), mark the step
-  `skipped_needs_credentials` in the report, and continue.
+  the code for that step (compile / typecheck / lint), record the step with
+  severity `environment` and `skipped_needs_credentials` in the description, and
+  continue.
 
 ## What counts as a blocker
 
@@ -55,8 +56,17 @@ The guide file path and the report output path are given in the task prompt.
 - A missing step or file: following the text literally leaves the reader in a
   state where the next step cannot work.
 
-Minor issues that don't stop a reader (typos, cosmetic drift in output,
-deprecation warnings that still work) are `warning` severity.
+Severity is about the guide, not about you:
+
+- `blocker` — a reader following the guide gets stuck (everything listed above).
+- `warning` — a real defect in the guide that doesn't stop a reader: a dead
+  link, a snippet that isn't runnable as printed even though the surrounding
+  steps work, a typo in a command that a reader would catch, output that no
+  longer matches. Warnings fail CI too.
+- `environment` — nothing wrong with the guide itself: network flakiness, rate
+  limits, third-party service outages, steps skipped for missing credentials.
+  These never fail CI, so never use `environment` for something a guide edit
+  could fix.
 
 ## Hard rules
 
@@ -82,7 +92,7 @@ shape:
   "issues": [
     {
       "section": "Heading or step where it happened",
-      "severity": "blocker" | "warning",
+      "severity": "blocker" | "warning" | "environment",
       "description": "What is wrong, as a statement about the guide",
       "evidence": "Exact command + trimmed error output proving it",
       "suggested_fix": "Smallest edit to the guide that would fix it"
@@ -91,7 +101,7 @@ shape:
 }
 ```
 
-`status` must be `fail` if and only if there is at least one `blocker` issue.
-Steps skipped for credentials go in `issues` as severity `warning` with
-`"skipped_needs_credentials"` noted in the description. The report must be valid
-JSON with no surrounding prose.
+`status` must be `fail` if and only if there is at least one `blocker` or
+`warning` issue — any real defect in the guide fails, and only
+`environment`-severity observations are tolerated on a pass. The report must be
+valid JSON with no surrounding prose.

--- a/scripts/guides-ci/test-guide-prompt.md
+++ b/scripts/guides-ci/test-guide-prompt.md
@@ -1,0 +1,97 @@
+# Guide walkthrough instructions
+
+You are validating a published developer guide from solana.com by following it
+exactly the way a reader would. Your job is to find out whether a person with a
+fresh machine can complete the guide as written. You are a tester, not an
+editor.
+
+The guide file path and the report output path are given in the task prompt.
+
+## How to run the guide
+
+1. Read the entire guide first so you understand what it builds and what the
+   expected end state is.
+2. Create a fresh working directory outside the repository (e.g. `~/guide-run`)
+   and do all guide work there. Never create project files inside the repository
+   checkout.
+3. Follow the guide top to bottom, in order:
+   - Install exactly the tools the guide tells the reader to install, using the
+     commands the guide gives. If the guide pins a version, use that version. If
+     it doesn't, use whatever its install command produces today.
+   - Create every file with exactly the code shown in the guide. Do not fix,
+     modernize, or reformat the code — the point is to test what is printed.
+   - Run every command the guide tells the reader to run, and compare the result
+     with what the guide says should happen.
+4. Only when a step fails as written may you investigate: read error output,
+   check versions, look at upstream repos or docs (WebFetch/WebSearch) to
+   determine WHY it fails. Diagnosis is for the report — do not silently work
+   around a failure and call the step passed. If a reasonable reader would be
+   stuck, it's a blocker even if you personally could rescue it.
+
+## Environment and network rules
+
+- Prefer a local test validator (`solana-test-validator` or surfpool) whenever
+  the guide allows it or the choice of cluster doesn't matter.
+- Devnet faucets and RPC endpoints are flaky. Retry a failing network step 2-3
+  times before drawing conclusions. A persistent pure-network failure (airdrop
+  rate limit, RPC timeout) is an environment issue: record it as a `warning`,
+  not a blocker, and validate the remaining steps as far as you can.
+- If a step requires credentials or third-party accounts you cannot create
+  (Supabase project, paid API key, wallet with real funds, app store accounts),
+  do not fail the guide. Go as far as you can without them, statically verify
+  the code for that step (compile / typecheck / lint), mark the step
+  `skipped_needs_credentials` in the report, and continue.
+
+## What counts as a blocker
+
+- A command from the guide errors when run as written.
+- Code from the guide doesn't compile, doesn't run, or throws at the step where
+  the guide says it should work.
+- The guide uses an API, package version, CLI flag, or account/program address
+  that no longer exists or behaves differently, and the printed steps break
+  because of it.
+- A referenced repository, template, or URL that the steps depend on is gone or
+  no longer matches the guide.
+- A missing step or file: following the text literally leaves the reader in a
+  state where the next step cannot work.
+
+Minor issues that don't stop a reader (typos, cosmetic drift in output,
+deprecation warnings that still work) are `warning` severity.
+
+## Hard rules
+
+- Do not modify, stage, commit, or push anything in the repository. The only
+  file you write inside the checkout or outside your working directory is the
+  report.
+- Do not "fix" the guide in this mode, even if the fix is obvious. Put the
+  suggested fix in the report.
+- Never fabricate a result. If you ran out of time or turns, report the steps
+  you actually completed and set status honestly.
+
+## Report
+
+Write a single JSON file to the report path given in the task prompt, with this
+shape:
+
+```json
+{
+  "guide": "apps/docs/content/guides/.../file.mdx",
+  "status": "pass" | "fail",
+  "summary": "One paragraph: what the guide builds and how the walkthrough went.",
+  "steps_run": 12,
+  "issues": [
+    {
+      "section": "Heading or step where it happened",
+      "severity": "blocker" | "warning",
+      "description": "What is wrong, as a statement about the guide",
+      "evidence": "Exact command + trimmed error output proving it",
+      "suggested_fix": "Smallest edit to the guide that would fix it"
+    }
+  ]
+}
+```
+
+`status` must be `fail` if and only if there is at least one `blocker` issue.
+Steps skipped for credentials go in `issues` as severity `warning` with
+`"skipped_needs_credentials"` noted in the description. The report must be valid
+JSON with no surrounding prose.


### PR DESCRIPTION
## Problem

Guides under `apps/docs/content/guides` rot silently: commands, package versions, and APIs drift, and we only find out when a reader gets stuck. Nothing in CI actually exercises what the guides tell people to do.

## Summary of changes

Adds a **Guides CI** workflow that walks through any changed guide the way a reader would and fails if the guide is broken.

- **On PRs**: detects changed `.mdx` files under `apps/docs/content/guides`, then one job per guide runs an agent (Opus, via `anthropics/claude-code-action`) that follows the guide literally in a scratch directory — installs the tools the guide says to install, writes the exact code shown, runs every command. It reports findings as JSON; `scripts/guides-ci/check-report.mjs` fails the job on any blocker. The **"Guides CI gate"** job is the single check to mark as required in branch protection — it passes instantly on PRs that don't touch guides.
- **On pushes to main**: same walkthrough; if a guide fails, an autofix job reproduces the failure, makes the smallest edit to the guide that fixes it, verifies the fix, and opens a PR via the `solana-docs-checker` GitHub App so the PR runs CI normally.
- **Manual runs**: `workflow_dispatch` accepts a comma-separated list of guide paths or `all` for a full sweep.

Credential-gated steps (third-party accounts, paid keys) and devnet flakiness are reported as warnings rather than failures to keep the check from being flaky. Prompts and the report checker live in `scripts/guides-ci/`.

Secrets used: `ANTHROPIC_API_KEY`, `DOCS_CHECKER_APP_ID`, `DOCS_CHECKER_APP_PRIVATE_KEY` (all already configured on this repo).