### PR TITLE
Update Epoch 1000 homepage hero wording

### DIFF
--- a/apps/web/src/components/index/campaigns/epoch1000/Epoch1000Hero.tsx
+++ b/apps/web/src/components/index/campaigns/epoch1000/Epoch1000Hero.tsx
@@ -93,14 +93,21 @@ export const Epoch1000Hero: React.FC = () => {
   const locale = useLocale();
   const t = useTranslations("index.epochHero");
   const { live } = useEpochData();
-  // Freeze a sensible epoch for the backdrop before live data lands
-  const gridEpoch = live?.epoch ?? 999;
+  // Epoch 1000 has passed; default the copy to the celebration state while live data loads.
+  const arrived = live?.arrived ?? true;
+  const titleKey = arrived ? "titleArrived" : "title";
+  const subtitleKey = arrived ? "subtitleArrived" : "subtitle";
+  const gridEpoch = Math.min(live?.epoch ?? GRID_TOTAL, GRID_TOTAL);
   const progress = live?.progress ?? 0;
+  const progressWidth = arrived ? 100 : Math.max(1, progress * 100);
   const ctaLabel = t("cta");
   const statEpochLabel = t("statEpoch");
   const statSlotsLabel = t("statSlots");
   const statProgressLabel = t("statProgress");
   const statEtaLabel = t("statEta");
+  const statMilestoneLabel = t("statMilestone");
+  const statReachedLabel = t("statReached");
+  const statSlotLabel = t("statSlot");
   const numberFormatter = useMemo(
     () => new Intl.NumberFormat(locale),
     [locale],
@@ -168,7 +175,7 @@ export const Epoch1000Hero: React.FC = () => {
           id="hero-title"
           style={{ animationDelay: "200ms" }}
         >
-          {t.rich("title", {
+          {t.rich(titleKey, {
             light: (chunks) => (
               <>
                 <br />
@@ -181,7 +188,7 @@ export const Epoch1000Hero: React.FC = () => {
           className="eh-rise text-nd-mid-em-text font-medium pt-3 nd-body-xl max-w-[560px]"
           style={{ animationDelay: "300ms" }}
         >
-          {t("subtitle")}
+          {t(subtitleKey)}
         </p>
 
         <div
@@ -219,16 +226,20 @@ export const Epoch1000Hero: React.FC = () => {
         >
           <div className="rounded-xl bg-black/[0.3] px-4 py-2.5 md:px-6 md:py-4">
             <div className="flex items-baseline justify-between font-brand-mono text-[11px] md:text-xs uppercase tracking-[0.2em] text-nd-mid-em-text">
-              <span>{statProgressLabel}</span>
+              <span>{arrived ? statMilestoneLabel : statProgressLabel}</span>
               <span className="tabular-nums">
-                {live ? percentFormatter.format(progress) : "—"}
+                {arrived
+                  ? statReachedLabel
+                  : live
+                    ? percentFormatter.format(progress)
+                    : "—"}
               </span>
             </div>
             <div className="mt-2 h-1.5 w-full rounded-full bg-white/10 overflow-hidden">
               <div
                 className="h-full rounded-full transition-[width] duration-300 ease-linear"
                 style={{
-                  width: `${Math.max(1, progress * 100)}%`,
+                  width: `${progressWidth}%`,
                   backgroundImage:
                     "linear-gradient(90deg, #9945ff 0%, #14f195 100%)",
                 }}
@@ -247,15 +258,19 @@ export const Epoch1000Hero: React.FC = () => {
                     </span>
                   </span>
                   <span className="whitespace-nowrap uppercase tracking-[0.1em]">
-                    {statSlotsLabel}{" "}
+                    {arrived ? statEpochLabel : statSlotsLabel}{" "}
                     <span className="text-nd-high-em-text">
-                      {numberFormatter.format(live.slotsRemaining)}
+                      {numberFormatter.format(
+                        arrived ? live.epoch : live.slotsRemaining,
+                      )}
                     </span>
                   </span>
                   <span className="whitespace-nowrap uppercase tracking-[0.1em]">
-                    {statEtaLabel}{" "}
+                    {arrived ? statSlotLabel : statEtaLabel}{" "}
                     <span className="text-nd-high-em-text">
-                      {etaFormatter.format(live.eta)}
+                      {arrived
+                        ? numberFormatter.format(live.absoluteSlot)
+                        : etaFormatter.format(live.eta)}
                     </span>
                   </span>
                 </>

--- a/apps/web/src/components/index/campaigns/epoch1000/Epoch1000Hero.tsx
+++ b/apps/web/src/components/index/campaigns/epoch1000/Epoch1000Hero.tsx
@@ -95,9 +95,11 @@ export const Epoch1000Hero: React.FC = () => {
   const { live } = useEpochData();
   // Epoch 1000 has passed; default the copy to the celebration state while live data loads.
   const arrived = live?.arrived ?? true;
+  const targetEpoch = live?.targetEpoch ?? GRID_TOTAL;
+  const displayEpoch = arrived ? targetEpoch : (live?.epoch ?? targetEpoch);
   const titleKey = arrived ? "titleArrived" : "title";
   const subtitleKey = arrived ? "subtitleArrived" : "subtitle";
-  const gridEpoch = Math.min(live?.epoch ?? GRID_TOTAL, GRID_TOTAL);
+  const gridEpoch = Math.min(live?.epoch ?? targetEpoch, targetEpoch);
   const progress = live?.progress ?? 0;
   const progressWidth = arrived ? 100 : Math.max(1, progress * 100);
   const ctaLabel = t("cta");
@@ -161,11 +163,9 @@ export const Epoch1000Hero: React.FC = () => {
           style={{ animationDelay: "100ms" }}
         >
           <Odometer
-            value={live?.epoch ?? null}
-            arrived={live?.arrived ?? false}
-            label={`${statEpochLabel}: ${
-              live ? numberFormatter.format(live.epoch) : "—"
-            }`}
+            value={displayEpoch}
+            arrived={arrived}
+            label={`${statEpochLabel}: ${numberFormatter.format(displayEpoch)}`}
             className="ep-odo--hero"
           />
         </div>
@@ -261,7 +261,7 @@ export const Epoch1000Hero: React.FC = () => {
                     {arrived ? statEpochLabel : statSlotsLabel}{" "}
                     <span className="text-nd-high-em-text">
                       {numberFormatter.format(
-                        arrived ? live.epoch : live.slotsRemaining,
+                        arrived ? displayEpoch : live.slotsRemaining,
                       )}
                     </span>
                   </span>

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -7803,13 +7803,18 @@
     "epochHero": {
       "eyebrow": "Solana Mainnet Celebration",
       "title": "Epoch 1000 \n<light>is almost here.</light>",
+      "titleArrived": "Epoch 1000 \n<light>is here.</light>",
       "subtitle": "A live countdown to Solana's 1,000th epoch and the wallets that made it there.",
+      "subtitleArrived": "Solana mainnet has reached its 1,000th epoch. Celebrate the wallets, builders, validators, apps, and users that made it there.",
       "cta": "Join the celebration",
       "secondaryCta": "Check wallet",
       "statEpoch": "Epoch",
       "statSlots": "Slots left",
       "statProgress": "Progress",
       "statEta": "ETA",
+      "statMilestone": "Milestone",
+      "statReached": "Reached",
+      "statSlot": "Slot",
       "liveLabel": "Live",
       "offline": "Syncing..."
     },


### PR DESCRIPTION
## Summary
- Update the homepage Epoch 1000 campaign hero to use reached-state wording now that epoch 1000 has ticked over.
- Keep the hero odometer and status epoch pinned to the campaign milestone at 1000 after arrival while live slot data continues updating.
- Add English fallback strings for the reached-state hero copy.

## Validation
- pnpm -w i18n:verify-source-locales
- pnpm --filter @workspace/i18n lint
- pnpm --filter solana-com exec tsc --noEmit --pretty false
- pnpm --filter solana-com lint (passes with existing unrelated warnings)
- git diff --check