### PR TITLE
Add SVS action authorization community skill

### DIFF
--- a/apps/web/src/data/skills/communitySkills.ts
+++ b/apps/web/src/data/skills/communitySkills.ts
@@ -33,6 +33,14 @@ export const COMMUNITY_SKILLS: CommunitySkill[] = [
     url: "https://github.com/tenequm/skills/tree/bedc922b6301179fbc2772079692cd3d748762d2/skills/solana-development",
     category: PROGRAMS,
   },
+  {
+    slug: "svs-action-authorization",
+    title: "SVS Action Authorization",
+    description:
+      "Authorize consequential Solana agent actions with signed identity, human approval, receipt registry proof, and fail-closed verification.",
+    url: "https://github.com/SVS-Protocol/svs-agent-skill/tree/v1.0.0/skills/svs-action-authorization",
+    category: TOOLING,
+  },
 
   // ── AI Coding Skills – DeFi ─────────────────────────────────────────
   {


### PR DESCRIPTION
### Problem

Solana agent builders need a narrow, installable skill for routing consequential actions through signed bot identity, policy review, human approval when required, on-chain receipt evidence, and fail-closed verification before execution.

### Summary of Changes

Adds one community Tooling listing for the public SVS Action Authorization skill. The catalog URL is pinned to the pre-existing `v1.0.0` tag.

Repository: https://github.com/SVS-Protocol/svs-agent-skill
Tag: `v1.0.0`
Commit: `c1dcabc14cb6316710437fc438ce95457c1547e5`
Skill path: `skills/svs-action-authorization`
Maintainer: `@SVS-Protocol` / `@CryptoZaddy-dev`
Security contact: `hello@svsprotocol.com` with `SECURITY` in the subject

The skill contains instructions and examples only. It has no scripts, package manifest, lifecycle hooks, remote bootstrap commands, or automatic transaction execution. Its example install is pinned to `@svsprotocol/solana@0.4.0`. Integrators provide scoped `SVS_BOT_API_KEY` and `SVS_BOT_REQUEST_SIGNING_SECRET` credentials; the skill explicitly forbids requesting wallet private keys or seed phrases and keeps wallet signing in the wallet.

Fixes #

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] No user input or external-service rendering changes.
- [x] No new dependencies.
- [x] No production error-handling paths changed.
- [x] Not a Critical change; threat-model note is n/a.

New dependencies: none.

Threat-model note: n/a. This is an immutable link-only catalog entry; the linked skill's safety boundary and SECURITY.md are included in the tagged release.
