### PR TITLE
Fix confidential transfer link and Contra naming on privacy page

### DIFF
--- a/apps/web/src/app/[locale]/privacy/privacy-page.tsx
+++ b/apps/web/src/app/[locale]/privacy/privacy-page.tsx
@@ -886,7 +886,7 @@ function BuildCta({
 }) {
   const ctaHref =
     translations.ctaButtonHref ||
-    "/developers/guides/token-extensions/confidential-transfer";
+    "/docs/tokens/extensions/confidential-transfer";
   return (
     <div className="pp-cta-card">
       <div className="pp-stripe" />

--- a/apps/web/src/data/solutions/privacy.ts
+++ b/apps/web/src/data/solutions/privacy.ts
@@ -9,7 +9,7 @@ export const ECOSYSTEM_PROJECTS = [
   },
   {
     key: "confidentialTransfer",
-    href: "/developers/guides/token-extensions/confidential-transfer",
+    href: "/docs/tokens/extensions/confidential-transfer",
   },
   {
     key: "contra",

--- a/packages/i18n/messages/web/ar/common.json
+++ b/packages/i18n/messages/web/ar/common.json
@@ -10735,7 +10735,7 @@
         "description": "بنية تحتية للخصوصية في التداول والمدفوعات والمنتجات المالية على السلسلة."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "أدوات معاملات وحوسبة خاصة لتطبيقات سولانا."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "ابنِ باستخدام الرموز السرية",
       "description": "Token Extensions الخاصة بالسرية متاحة الآن على الشبكة الرئيسية لـ سولانا. قم بتشفير الأرصدة وإخفاء مبالغ التحويل والتحقق عبر إثباتات ZK على مستوى البروتوكول.",
       "button": "اقرأ الدليل",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/de/common.json
+++ b/packages/i18n/messages/web/de/common.json
@@ -10735,7 +10735,7 @@
         "description": "Datenschutz-Infrastruktur für Handel, Zahlungen und on-chain Finanzprodukte."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Private Transaktions- und Compute-Tooling für Solana-Apps."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Mit Confidential Tokens entwickeln",
       "description": "Confidential Token Extensions sind live auf dem Solana Mainnet. Verschlüsseln Sie Guthaben, verbergen Sie Übertragsbeträge und verifizieren Sie mit ZK-Proofs auf Protokollebene.",
       "button": "Anleitung lesen",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/el/common.json
+++ b/packages/i18n/messages/web/el/common.json
@@ -10735,7 +10735,7 @@
         "description": "Υποδομή απορρήτου για συναλλαγές, πληρωμές και χρηματοοικονομικά προϊόντα on-chain."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Εργαλεία ιδιωτικών συναλλαγών και υπολογισμών για εφαρμογές Solana."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Αναπτύξτε με Εμπιστευτικά Tokens",
       "description": "Τα Confidential Token Extensions είναι ενεργά στο mainnet του Solana. Κρυπτογραφήστε υπόλοιπα, αποκρύψτε ποσά μεταφορών και επαληθεύστε με ZK proofs σε επίπεδο πρωτοκόλλου.",
       "button": "Διαβάστε τον Οδηγό",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -10730,7 +10730,7 @@
         "description": "Privacy infrastructure for trading, payments, and on-chain financial products."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Private transaction and compute tooling for Solana apps."
       },
       "encrypt": {
@@ -10829,7 +10829,7 @@
       "title": "Build with Confidential Tokens",
       "description": "Confidential Token Extensions are live on Solana mainnet. Encrypt balances, hide transfer amounts, and verify with ZK proofs at the protocol level.",
       "button": "Read the Guide",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/es/common.json
+++ b/packages/i18n/messages/web/es/common.json
@@ -10735,7 +10735,7 @@
         "description": "Infraestructura de privacidad para trading, pagos y productos financieros en cadena."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Herramientas de transacciones y cómputo privado para aplicaciones de Solana."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Construye con Tokens Confidenciales",
       "description": "Las Token Extensions confidenciales están disponibles en la red principal de Solana. Cifra saldos, oculta montos de transferencia y verifica con pruebas ZK a nivel de protocolo.",
       "button": "Leer la Guía",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/fi/common.json
+++ b/packages/i18n/messages/web/fi/common.json
@@ -10735,7 +10735,7 @@
         "description": "Yksityisyyden infrastruktuuri kaupankäyntiä, maksuja ja ketjun rahoitustuotteita varten."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Yksityinen transaktio- ja laskentavälineistö Solana-sovelluksille."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Kehitä luottamuksellisten tokenien kanssa",
       "description": "Luottamukselliset Token Extensions ovat käytössä Solana-pääverkossa. Salaa saldot, piilota siirtosummat ja tarkista ZK-todisteiden avulla protokollatasolla.",
       "button": "Lue opas",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/fr/common.json
+++ b/packages/i18n/messages/web/fr/common.json
@@ -10735,7 +10735,7 @@
         "description": "Infrastructure de confidentialité pour le trading, les paiements et les produits financiers on-chain."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Outils de transactions privées et de calcul pour les applications Solana."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Développez avec les Tokens Confidentiels",
       "description": "Les Token Extensions confidentiels sont disponibles sur le mainnet Solana. Chiffrez les soldes, dissimulez les montants des transferts et vérifiez grâce aux preuves ZK au niveau du protocole.",
       "button": "Lire le Guide",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/id/common.json
+++ b/packages/i18n/messages/web/id/common.json
@@ -10735,7 +10735,7 @@
         "description": "Infrastruktur privasi untuk perdagangan, pembayaran, dan produk keuangan on-chain."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Alat transaksi dan komputasi privat untuk aplikasi Solana."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Bangun dengan Token Konfidensial",
       "description": "Confidential Token Extensions kini tersedia di mainnet Solana. Enkripsi saldo, sembunyikan jumlah transfer, dan verifikasi dengan bukti ZK di tingkat protokol.",
       "button": "Baca Panduan",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/it/common.json
+++ b/packages/i18n/messages/web/it/common.json
@@ -10735,7 +10735,7 @@
         "description": "Infrastruttura privacy per trading, pagamenti e prodotti finanziari on-chain."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Strumenti per transazioni private e calcolo per le app di Solana."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Costruisci con i Token Confidenziali",
       "description": "Le Token Extensions riservate sono attive sulla mainnet di Solana. Cifra i saldi, nascondi gli importi dei trasferimenti e verifica con prove ZK a livello di protocollo.",
       "button": "Leggi la Guida",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/ja/common.json
+++ b/packages/i18n/messages/web/ja/common.json
@@ -10735,7 +10735,7 @@
         "description": "取引、決済、オンチェーン金融商品向けのプライバシーインフラ。"
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Solanaアプリ向けのプライベートトランザクションおよびコンピュートツール。"
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "機密トークンで構築する",
       "description": "Confidential Token Extensions はSolanaメインネットで稼働中です。プロトコルレベルでZK証明を用いて、残高の暗号化、送金額の秘匿化、検証を実現します。",
       "button": "ガイドを読む",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/ko/common.json
+++ b/packages/i18n/messages/web/ko/common.json
@@ -10730,7 +10730,7 @@
         "description": "거래, 결제 및 온체인 금융 상품을 위한 프라이버시 인프라입니다."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Solana 앱을 위한 프라이빗 트랜잭션 및 컴퓨팅 도구입니다."
       },
       "encrypt": {
@@ -10829,7 +10829,7 @@
       "title": "기밀 토큰으로 구축하기",
       "description": "기밀 Token Extensions이 Solana 메인넷에서 운영 중입니다. 프로토콜 수준에서 잔액을 암호화하고, 전송 금액을 숨기며, ZK 증명으로 검증하세요.",
       "button": "가이드 읽기",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/nl/common.json
+++ b/packages/i18n/messages/web/nl/common.json
@@ -10735,7 +10735,7 @@
         "description": "Privacy-infrastructuur voor handel, betalingen en financiële producten op de blockchain."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Tooling voor privétransacties en -berekeningen voor Solana-apps."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Bouw met Confidential Tokens",
       "description": "Confidentiële Token Extensions zijn live op het Solana mainnet. Versleutel saldi, verberg overdrachtsbedragen en verifieer met ZK-bewijzen op protocolniveau.",
       "button": "Lees de Gids",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/pl/common.json
+++ b/packages/i18n/messages/web/pl/common.json
@@ -10735,7 +10735,7 @@
         "description": "Infrastruktura prywatności dla handlu, płatności i produktów finansowych on-chain."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Prywatne narzędzia do transakcji i obliczeń dla aplikacji Solana."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Twórz z tokenami poufnymi",
       "description": "Confidential Token Extensions są dostępne w sieci głównej Solana. Szyfruj salda, ukrywaj kwoty przelewów i weryfikuj za pomocą dowodów ZK na poziomie protokołu.",
       "button": "Przeczytaj przewodnik",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/pt/common.json
+++ b/packages/i18n/messages/web/pt/common.json
@@ -10735,7 +10735,7 @@
         "description": "Infraestrutura de privacidade para negociação, pagamentos e produtos financeiros on-chain."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Ferramentas de transações privadas e computação para aplicações Solana."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Desenvolva com Tokens Confidenciais",
       "description": "Token Extensions Confidenciais estão disponíveis na mainnet da Solana. Encripte saldos, oculte valores de transferência e verifique com provas ZK no nível do protocolo.",
       "button": "Leia o Guia",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/ru/common.json
+++ b/packages/i18n/messages/web/ru/common.json
@@ -10746,7 +10746,7 @@
         "description": "Инфраструктура конфиденциальности для трейдинга, платежей и финансовых продуктов на блокчейне."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Инструменты для приватных транзакций и вычислений в приложениях Solana."
       },
       "encrypt": {
@@ -10845,7 +10845,7 @@
       "title": "Создавайте с конфиденциальными токенами",
       "description": "Конфиденциальные Token Extensions уже работают в основной сети Solana. Шифруйте балансы, скрывайте суммы переводов и верифицируйте транзакции с помощью ZK-доказательств на уровне протокола.",
       "button": "Читать руководство",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/tr/common.json
+++ b/packages/i18n/messages/web/tr/common.json
@@ -10735,7 +10735,7 @@
         "description": "Alım satım, ödemeler ve zincir üzeri finansal ürünler için gizlilik altyapısı."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Solana uygulamaları için özel işlem ve hesaplama araçları."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Gizli Tokenlarla Geliştirin",
       "description": "Confidential Token Extensions, Solana mainnet'te canlıdır. Protokol düzeyinde bakiyeleri şifreleyin, transfer miktarlarını gizleyin ve ZK kanıtlarıyla doğrulayın.",
       "button": "Kılavuzu Okuyun",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/uk/common.json
+++ b/packages/i18n/messages/web/uk/common.json
@@ -10735,7 +10735,7 @@
         "description": "Інфраструктура конфіденційності для торгівлі, платежів та фінансових продуктів на блокчейні."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Інструменти для приватних транзакцій та обчислень у застосунках Solana."
       },
       "encrypt": {
@@ -10834,7 +10834,7 @@
       "title": "Розробляйте з конфіденційними токенами",
       "description": "Конфіденційні Token Extensions доступні в мережі Solana mainnet. Шифруйте баланси, приховуйте суми переказів і виконуйте верифікацію за допомогою ZK-доказів на рівні протоколу.",
       "button": "Читати посібник",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/vi/common.json
+++ b/packages/i18n/messages/web/vi/common.json
@@ -10730,7 +10730,7 @@
         "description": "Cơ sở hạ tầng bảo mật cho giao dịch, thanh toán và các sản phẩm tài chính trên chuỗi."
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "Công cụ giao dịch và tính toán riêng tư cho các ứng dụng Solana."
       },
       "encrypt": {
@@ -10829,7 +10829,7 @@
       "title": "Xây dựng với Token bảo mật",
       "description": "Confidential Token Extensions đã được triển khai trên Solana mainnet. Mã hóa số dư, ẩn số tiền chuyển khoản và xác minh bằng ZK proof ở cấp độ giao thức.",
       "button": "Đọc hướng dẫn",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {

--- a/packages/i18n/messages/web/zh/common.json
+++ b/packages/i18n/messages/web/zh/common.json
@@ -10730,7 +10730,7 @@
         "description": "面向交易、支付及链上金融产品的隐私基础设施。"
       },
       "contra": {
-        "title": "Contra",
+        "title": "Solana Private Channels",
         "description": "面向 Solana 应用的私密交易与计算工具。"
       },
       "encrypt": {
@@ -10829,7 +10829,7 @@
       "title": "使用机密代币构建",
       "description": "Confidential Token Extensions 已在 Solana 主网上线。在协议层面加密余额、隐藏转账金额，并通过零知识证明进行验证。",
       "button": "阅读指南",
-      "buttonHref": "/developers/guides/token-extensions/confidential-transfer"
+      "buttonHref": "/docs/tokens/extensions/confidential-transfer"
     }
   },
   "skills": {


### PR DESCRIPTION
## Problem

On solana.com/privacy, the Confidential Token Extensions links point to the old guide URL, and the Contra ecosystem card needs renaming.

## Changes

- Confidential transfer links (ecosystem card, CTA button, and its fallback) now point to /docs/tokens/extensions/confidential-transfer
- Renamed Contra to Solana Private Channels across all locales