### PR TITLE
docs: migrate LiteSVM docs to /docs/tools/litesvm

### DIFF
--- a/apps/docs/content/docs/en/tools/index.mdx
+++ b/apps/docs/content/docs/en/tools/index.mdx
@@ -30,4 +30,8 @@ hidePageNavigation: true
     Drop-in solana-test-validator replacement for local development, testing,
     and Infrastructure-as-Code deploys.
   </Card>
+  <Card title="LiteSVM" href="/docs/tools/litesvm">
+    Test Solana programs in a fast in-process VM, without a validator, in Rust
+    and TypeScript.
+  </Card>
 </Cards>

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/meta.json
@@ -1,0 +1,9 @@
+{
+  "title": "Additional Crates",
+  "pages": [
+    "testing-with-litesvm-utils",
+    "testing-with-spl-tokens",
+    "testing-with-litesvm-loader",
+    "testing-with-anchor-litesvm"
+  ]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-anchor-litesvm/account-management.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-anchor-litesvm/account-management.mdx
@@ -1,0 +1,291 @@
+---
+title: Account Management
+description:
+  Fetching and deserializing Anchor accounts with automatic discriminator
+  handling
+---
+
+## Understanding Anchor Account Discriminators
+
+Anchor programs prepend an 8-byte discriminator to all account data. This
+discriminator is a hash of the account type name and is used to verify that
+account data matches the expected type.
+
+```
+┌─────────────────────────────────────────────────┐
+│ Account Data Layout                             │
+├────────────────┬────────────────────────────────┤
+│ Discriminator  │ Account Fields                 │
+│ (8 bytes)      │ (variable size)                │
+└────────────────┴────────────────────────────────┘
+```
+
+The `anchor-litesvm` account utilities handle this discriminator automatically.
+
+## Fetching Anchor Accounts
+
+### Basic Account Fetching
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use anchor_lang::prelude::*;
+use solana_signer::Signer;
+use solana_program::pubkey::Pubkey;
+
+#[account]
+pub struct UserAccount {
+    pub name: String,
+    pub balance: u64,
+    pub authority: Pubkey,
+}
+
+#[test]
+fn test_fetch_account() {
+    let mut ctx = AnchorLiteSVM::build_with_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"));
+
+    let user = ctx.create_funded_account(10_000_000_000).unwrap();
+
+    // ... initialize the account ...
+
+    let (user_pda, _) = Pubkey::find_program_address(
+        &[b"user", user.pubkey().as_ref()],
+        &PROGRAM_ID,
+    );
+
+    // Fetch and deserialize the account
+    let account: UserAccount = ctx.get_account(&user_pda).unwrap();
+
+    assert_eq!(account.name, "Alice");
+    assert_eq!(account.authority, user.pubkey());
+}
+```
+
+<Callout type="info">
+  `get_account<T>()` automatically validates the 8-byte discriminator to ensure the account data matches the expected type.
+</Callout>
+
+### Unchecked Deserialization
+
+For PDAs or custom account layouts where discriminator validation might fail,
+use `get_account_unchecked`:
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+
+#[test]
+fn test_fetch_unchecked() {
+    let ctx = AnchorLiteSVM::build_with_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"));
+
+    // Fetch without discriminator validation
+    let account: UserAccount = ctx.get_account_unchecked(&some_pda).unwrap();
+}
+```
+
+<Callout type="warn">
+  Use `get_account_unchecked` carefully. Without discriminator validation, you
+  might deserialize invalid data. Only use this when you're certain about the
+  account type.
+</Callout>
+
+## Using the Account Module Directly
+
+You can also use the account deserialization functions directly:
+
+```rust
+use anchor_litesvm::{get_anchor_account, get_anchor_account_unchecked};
+use litesvm::LiteSVM;
+
+#[test]
+fn test_direct_account_fetch() {
+    let mut svm = LiteSVM::new();
+    // ... setup ...
+
+    // Fetch with discriminator check
+    let account: UserAccount = get_anchor_account(&svm, &account_pubkey).unwrap();
+
+    // Fetch without discriminator check
+    let account: UserAccount = get_anchor_account_unchecked(&svm, &account_pubkey).unwrap();
+}
+```
+
+## Account Errors
+
+The `AccountError` enum provides detailed error information:
+
+```rust
+use anchor_litesvm::AccountError;
+
+#[test]
+fn test_handle_errors() {
+    let ctx = AnchorLiteSVM::build_with_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"));
+
+    let result: Result<UserAccount, AccountError> = ctx.get_account(&nonexistent_pubkey);
+
+    match result {
+        Ok(account) => println!("Found account: {}", account.name),
+        Err(AccountError::AccountNotFound(pubkey)) => {
+            println!("Account not found: {}", pubkey);
+        }
+        Err(AccountError::DiscriminatorMismatch) => {
+            println!("Wrong account type!");
+        }
+        Err(AccountError::DeserializationError(msg)) => {
+            println!("Failed to deserialize: {}", msg);
+        }
+    }
+}
+```
+
+| Error                          | Description                                       |
+| ------------------------------ | ------------------------------------------------- |
+| `AccountNotFound(Pubkey)`      | No account exists at the given address            |
+| `DiscriminatorMismatch`        | Account discriminator doesn't match expected type |
+| `DeserializationError(String)` | Failed to deserialize account data                |
+
+## Working with Multiple Account Types
+
+### Fetching Different Account Types
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use anchor_lang::prelude::*;
+
+#[account]
+pub struct Config {
+    pub admin: Pubkey,
+    pub fee_bps: u16,
+}
+
+#[account]
+pub struct UserProfile {
+    pub owner: Pubkey,
+    pub username: String,
+    pub created_at: i64,
+}
+
+#[account]
+pub struct Order {
+    pub user: Pubkey,
+    pub amount: u64,
+    pub status: OrderStatus,
+}
+
+#[derive(AnchorSerialize, AnchorDeserialize, Clone)]
+pub enum OrderStatus {
+    Pending,
+    Completed,
+    Cancelled,
+}
+
+#[test]
+fn test_multiple_account_types() {
+    let ctx = AnchorLiteSVM::build_with_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"));
+
+    // Each account type is deserialized correctly
+    let config: Config = ctx.get_account(&config_pda).unwrap();
+    let profile: UserProfile = ctx.get_account(&profile_pda).unwrap();
+    let order: Order = ctx.get_account(&order_pda).unwrap();
+
+    assert_eq!(config.fee_bps, 100);
+    assert_eq!(profile.username, "alice");
+    assert!(matches!(order.status, OrderStatus::Pending));
+}
+```
+
+### Checking Account Existence Before Fetching
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+
+#[test]
+fn test_check_before_fetch() {
+    let ctx = AnchorLiteSVM::build_with_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"));
+
+    let user_pda = Pubkey::new_unique();
+
+    // Check existence first
+    if ctx.account_exists(&user_pda) {
+        let account: UserAccount = ctx.get_account(&user_pda).unwrap();
+        println!("Found: {}", account.name);
+    } else {
+        println!("Account not initialized yet");
+    }
+}
+```
+
+## Complete Example
+
+Here's a comprehensive example demonstrating account management:
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use anchor_litesvm::TestHelpers;
+use anchor_lang::prelude::*;
+use solana_signer::Signer;
+use solana_program::pubkey::Pubkey;
+
+anchor_lang::declare_program!(counter);
+
+#[test]
+fn test_counter_workflow() {
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        id(),
+        include_bytes!("../target/deploy/counter.so"),
+    );
+
+    let authority = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+
+    // Derive the counter PDA
+    let (counter_pda, bump) = Pubkey::find_program_address(
+        &[b"counter", authority.pubkey().as_ref()],
+        &id(),
+    );
+
+    // Verify counter doesn't exist yet
+    assert!(!ctx.account_exists(&counter_pda));
+
+    // Initialize using generated client types
+    let init_ix = ctx.program()
+        .accounts(counter::client::accounts::Initialize {
+            authority: authority.pubkey(),
+            counter: counter_pda,
+            system_program: anchor_lang::system_program::ID,
+        })
+        .args(counter::client::args::Initialize {})
+        .instruction()
+        .unwrap();
+
+    ctx.execute_instruction(init_ix, &[&authority]).unwrap();
+
+    // Verify counter exists and has correct initial state
+    assert!(ctx.account_exists(&counter_pda));
+    let counter: counter::Counter = ctx.get_account(&counter_pda).unwrap();
+    assert_eq!(counter.count, 0);
+    assert_eq!(counter.authority, authority.pubkey());
+    assert_eq!(counter.bump, bump);
+
+    // Increment using generated client types
+    let increment_ix = ctx.program()
+        .accounts(counter::client::accounts::Increment {
+            authority: authority.pubkey(),
+            counter: counter_pda,
+        })
+        .args(counter::client::args::Increment {})
+        .instruction()
+        .unwrap();
+
+    ctx.execute_instruction(increment_ix, &[&authority]).unwrap();
+
+    // Verify incremented
+    let counter: counter::Counter = ctx.get_account(&counter_pda).unwrap();
+    assert_eq!(counter.count, 1);
+
+    // Increment again
+    ctx.execute_instruction(increment_ix.clone(), &[&authority]).unwrap();
+
+    let counter: counter::Counter = ctx.get_account(&counter_pda).unwrap();
+    assert_eq!(counter.count, 2);
+
+    println!("Counter test passed! Final count: {}", counter.count);
+}
+```

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-anchor-litesvm/events.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-anchor-litesvm/events.mdx
@@ -1,0 +1,300 @@
+---
+title: Events
+description: Parse and assert Anchor events from transaction logs
+---
+
+## Understanding Anchor Events
+
+Anchor programs can emit events that are logged during transaction execution.
+These events are Base64-encoded in the transaction logs with the prefix
+`Program data:`. The `anchor-litesvm` crate provides utilities to parse and
+assert these events.
+
+```
+┌─────────────────────────────────────────────────┐
+│ Anchor Event Structure                          │
+├────────────────┬────────────────────────────────┤
+│ Discriminator  │ Event Data                     │
+│ (8 bytes)      │ (serialized fields)            │
+└────────────────┴────────────────────────────────┘
+```
+
+## Defining Events
+
+First, define your events in your Anchor program:
+
+```rust
+use anchor_lang::prelude::*;
+
+#[event]
+pub struct TransferEvent {
+    pub from: Pubkey,
+    pub to: Pubkey,
+    pub amount: u64,
+    pub timestamp: i64,
+}
+
+#[event]
+pub struct InitializeEvent {
+    pub authority: Pubkey,
+    pub name: String,
+}
+```
+
+## Parsing Events
+
+### Parse All Events of a Type
+
+```rust
+use anchor_litesvm::{AnchorLiteSVM, EventHelpers};
+use solana_signer::Signer;
+
+#[test]
+fn test_parse_events() {
+    let mut ctx = AnchorLiteSVM::build_with_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"));
+
+    let user = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+
+    // Execute instruction that emits events
+    let ix = ctx.program()
+        .accounts(Transfer { /* ... */ })
+        .args(TransferArgs { amount: 1000 })
+        .instruction()
+        .unwrap();
+
+    let result = ctx.execute_instruction(ix, &[&user]).unwrap();
+
+    // Parse all TransferEvent events from the transaction
+    let events: Vec<TransferEvent> = result.parse_events().unwrap();
+
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0].amount, 1000);
+}
+```
+
+### Parse Single Event
+
+```rust
+use anchor_litesvm::{AnchorLiteSVM, EventHelpers};
+
+#[test]
+fn test_parse_single_event() {
+    let mut ctx = AnchorLiteSVM::build_with_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"));
+
+    // ... execute instruction ...
+
+    // Get the first event of the type
+    let event: TransferEvent = result.parse_event().unwrap();
+
+    println!("Transfer: {} -> {} ({})", event.from, event.to, event.amount);
+}
+```
+
+## Asserting Events
+
+### Assert Event Was Emitted
+
+```rust
+use anchor_litesvm::{AnchorLiteSVM, EventHelpers};
+
+#[test]
+fn test_assert_event_emitted() {
+    let mut ctx = AnchorLiteSVM::build_with_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"));
+
+    let user = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+
+    let ix = ctx.program()
+        .accounts(Initialize { /* ... */ })
+        .args(InitializeArgs { name: "test".to_string() })
+        .instruction()
+        .unwrap();
+
+    let result = ctx.execute_instruction(ix, &[&user]).unwrap();
+
+    // Assert that at least one InitializeEvent was emitted
+    result.assert_event_emitted::<InitializeEvent>();
+}
+```
+
+<Callout type="info">
+  `assert_event_emitted` will panic if no events of the specified type are found
+  in the transaction logs.
+</Callout>
+
+### Assert Event Count
+
+```rust
+use anchor_litesvm::{AnchorLiteSVM, EventHelpers};
+
+#[test]
+fn test_assert_event_count() {
+    let mut ctx = AnchorLiteSVM::build_with_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"));
+
+    // Execute instruction that emits multiple events
+    let ix = ctx.program()
+        .accounts(BatchTransfer { /* ... */ })
+        .args(BatchTransferArgs { recipients: vec![...], amounts: vec![...] })
+        .instruction()
+        .unwrap();
+
+    let result = ctx.execute_instruction(ix, &[&user]).unwrap();
+
+    // Assert exactly 3 TransferEvent events were emitted
+    result.assert_event_count::<TransferEvent>(3);
+}
+```
+
+### Check Event Existence
+
+```rust
+use anchor_litesvm::{AnchorLiteSVM, EventHelpers};
+
+#[test]
+fn test_has_event() {
+    let mut ctx = AnchorLiteSVM::build_with_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"));
+
+    // ... execute instruction ...
+
+    // Check without panicking
+    if result.has_event::<TransferEvent>() {
+        let event: TransferEvent = result.parse_event().unwrap();
+        println!("Transfer occurred: {}", event.amount);
+    } else {
+        println!("No transfer in this transaction");
+    }
+}
+```
+
+## Manual Event Parsing
+
+For advanced use cases, you can parse event data directly:
+
+```rust
+use anchor_litesvm::parse_event_data;
+
+#[test]
+fn test_manual_parse() {
+    // If you have the base64-encoded event data
+    let base64_data = "SGVsbG8gV29ybGQ="; // Example
+
+    let event: TransferEvent = parse_event_data(base64_data).unwrap();
+}
+```
+
+## Event Errors
+
+The `EventError` enum provides detailed error information:
+
+```rust
+use anchor_litesvm::EventError;
+
+match result.parse_event::<TransferEvent>() {
+    Ok(event) => println!("Amount: {}", event.amount),
+    Err(EventError::EventNotFound) => println!("No event found"),
+    Err(EventError::ParseError(msg)) => println!("Parse error: {}", msg),
+    Err(EventError::Base64Error) => println!("Invalid Base64 encoding"),
+    Err(EventError::InvalidFormat) => println!("Malformed event data"),
+    Err(EventError::AnchorError(msg)) => println!("Anchor error: {}", msg),
+}
+```
+
+| Error                 | Description                            |
+| --------------------- | -------------------------------------- |
+| `EventNotFound`       | No event of the specified type in logs |
+| `ParseError(String)`  | Failed to parse event data             |
+| `Base64Error`         | Failed to decode Base64                |
+| `InvalidFormat`       | Event data has invalid structure       |
+| `AnchorError(String)` | Anchor deserialization failed          |
+
+## Complete Example
+
+Here's a comprehensive example demonstrating event handling:
+
+```rust
+use anchor_litesvm::{AnchorLiteSVM, EventHelpers, TestHelpers};
+use anchor_lang::{prelude::*, system_program};
+use solana_signer::Signer;
+
+// declare_program! generates client types AND re-exports event structs
+anchor_lang::declare_program!(vault);
+
+#[test]
+fn test_vault_events() {
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        VAULT_PROGRAM_ID,
+        include_bytes!("../target/deploy/vault.so"),
+    );
+
+    let authority = ctx.svm.create_funded_account(100_000_000_000).unwrap();
+    let depositor = ctx.svm.create_funded_account(50_000_000_000).unwrap();
+
+    let vault_pda = ctx.svm.get_pda(
+        &[b"vault", authority.pubkey().as_ref()],
+        &VAULT_PROGRAM_ID,
+    );
+
+    // Create vault
+    let create_ix = ctx.program()
+        .accounts(vault::client::accounts::CreateVault {
+            authority: authority.pubkey(),
+            vault: vault_pda,
+            system_program: system_program::ID,
+        })
+        .args(vault::client::args::CreateVault {})
+        .instruction()
+        .unwrap();
+
+    let result = ctx.execute_instruction(create_ix, &[&authority]).unwrap();
+
+    // Assert VaultCreated event
+    result.assert_event_emitted::<vault::VaultCreated>();
+    let created_event: vault::VaultCreated = result.parse_event().unwrap();
+    assert_eq!(created_event.vault, vault_pda);
+    assert_eq!(created_event.authority, authority.pubkey());
+
+    // Deposit
+    let deposit_ix = ctx.program()
+        .accounts(vault::client::accounts::DepositToVault {
+            vault: vault_pda,
+            depositor: depositor.pubkey(),
+            system_program: system_program::ID,
+        })
+        .args(vault::client::args::Deposit { amount: 10_000_000_000 })
+        .instruction()
+        .unwrap();
+
+    let result = ctx.execute_instruction(deposit_ix, &[&depositor]).unwrap();
+
+    // Assert Deposit event
+    result.assert_event_emitted::<vault::Deposit>();
+    let deposit_event: vault::Deposit = result.parse_event().unwrap();
+    assert_eq!(deposit_event.amount, 10_000_000_000);
+    assert_eq!(deposit_event.depositor, depositor.pubkey());
+
+    // Withdrawal
+    let withdraw_ix = ctx.program()
+        .accounts(vault::client::accounts::WithdrawFromVault {
+            vault: vault_pda,
+            authority: authority.pubkey(),
+            recipient: authority.pubkey(),
+        })
+        .args(vault::client::args::Withdraw { amount: 5_000_000_000 })
+        .instruction()
+        .unwrap();
+
+    let result = ctx.execute_instruction(withdraw_ix, &[&authority]).unwrap();
+
+    // Check withdrawal event
+    assert!(result.has_event::<vault::Withdrawal>());
+    let withdraw_event: vault::Withdrawal = result.parse_event().unwrap();
+    assert_eq!(withdraw_event.amount, 5_000_000_000);
+
+    println!("All event tests passed!");
+}
+```
+
+<Callout type="info">
+  Events are a great way to verify that your program executed correctly without
+  having to fetch and deserialize accounts. They're especially useful for
+  tracking state changes over time.
+</Callout>

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-anchor-litesvm/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-anchor-litesvm/index.mdx
@@ -1,0 +1,278 @@
+---
+title: Quick Start
+description:
+  Learn how to use anchor-litesvm for testing Anchor programs with simplified
+  syntax
+---
+
+<div className="flex items-center gap-3 mb-6">
+  <a
+    href="https://crates.io/crates/anchor-litesvm"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-2 px-3 py-1.5 bg-fd-muted/50 hover:bg-fd-muted rounded-lg text-sm font-medium transition-colors border border-fd-border/50"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      className="w-4 h-4"
+      fill="currentColor"
+    >
+      <path d="M239.1 6.3l-208 78c-18.7 7-31.1 25-31.1 45v225.1c0 18.2 10.3 34.8 26.5 42.9l208 104c13.5 6.8 29.4 6.8 42.9 0l208-104c16.3-8.1 26.5-24.8 26.5-42.9V129.3c0-20-12.4-37.9-31.1-44.9l-208-78C262 2.2 250 2.2 239.1 6.3zM256 68.4l192 72v1.1l-192 78-192-78v-1.1l192-72zm32 356V275.5l160-65v133.9l-160 80z" />
+    </svg>
+    View <code>anchor-litesvm</code> on crates.io
+  </a>
+</div>
+
+## Installation
+
+Add the needed dependencies:
+
+```bash
+cargo add --dev anchor-litesvm litesvm litesvm-utils
+```
+
+## What is anchor-litesvm?
+
+The `anchor-litesvm` crate provides a **simplified syntax similar to
+anchor-client** but without RPC overhead. It achieves **78% code reduction**
+compared to raw LiteSVM while maintaining type safety with Anchor types.
+
+<Steps>
+<Step>
+**AnchorContext**
+- Production-compatible test context
+- Same API patterns as anchor-client
+- Manages LiteSVM instance, payer, and program
+- Execute instructions without RPC overhead
+</Step>
+
+<Step>
+  **Program API** - Fluent instruction building - Type-safe account and argument
+  handling - Familiar anchor-client syntax
+</Step>
+
+<Step>
+  **Account Deserialization** - Fetch and deserialize Anchor accounts -
+  Automatic discriminator handling - Support for PDAs and custom layouts
+</Step>
+
+<Step>
+**Event Parsing**
+- Parse events from transaction logs
+- Assert event emission
+- Type-safe event deserialization
+</Step>
+</Steps>
+
+## Quick Example
+
+With Anchor 1.0, use `declare_program!` to generate client types from your
+program's IDL. This macro creates `client::accounts::*` and `client::args::*`
+modules for type-safe instruction building:
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use anchor_litesvm::{AssertionHelpers, TestHelpers};
+use anchor_lang::system_program;
+use solana_sdk::signature::{read_keypair_file, Signer};
+
+// Generate client types from your program's IDL
+anchor_lang::declare_program!(my_program);
+
+#[test]
+fn test_anchor_program() {
+    // One-line setup — reads program keypair for the correct ID
+    let program_keypair = read_keypair_file("target/deploy/my_program-keypair.json").unwrap();
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        program_keypair.pubkey(),
+        include_bytes!("../target/deploy/my_program.so"),
+    );
+
+    // Create a funded account via TestHelpers on ctx.svm
+    let user = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+
+    // Derive PDA
+    let seed: u64 = 42;
+    let pda = ctx.svm.get_pda(
+        &[b"user", user.pubkey().as_ref(), &seed.to_le_bytes()],
+        &program_keypair.pubkey(),
+    );
+
+    // Build instruction using generated client types
+    let ix = ctx.program()
+        .accounts(my_program::client::accounts::Initialize {
+            user: user.pubkey(),
+            user_account: pda,
+            system_program: system_program::ID,
+        })
+        .args(my_program::client::args::Initialize {
+            seed,
+            name: "test".to_string(),
+        })
+        .instruction()
+        .unwrap();
+
+    // Execute and assert in one chain
+    ctx.execute_instruction(ix, &[&user])
+        .unwrap()
+        .assert_success();
+
+    // Fetch and deserialize the account
+    let account: my_program::MyAccount = ctx.get_account(&pda).unwrap();
+    assert_eq!(account.name, "test");
+}
+```
+
+<Callout type="info">
+  `declare_program!(my_program)` reads the IDL from `target/idl/my_program.json`
+  at compile time and generates the `client::accounts::*` and `client::args::*`
+  modules. This requires building your program first.
+</Callout>
+
+## Comparison: Raw LiteSVM vs anchor-litesvm
+
+### Before (Raw LiteSVM)
+
+```rust
+use litesvm::LiteSVM;
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+use solana_program::instruction::{AccountMeta, Instruction};
+use solana_message::Message;
+use solana_transaction::Transaction;
+
+let mut svm = LiteSVM::new();
+svm.add_program(program_id, program_bytes).unwrap();
+
+let payer = Keypair::new();
+svm.airdrop(&payer.pubkey(), 10_000_000_000).unwrap();
+
+// Manually compute 8-byte discriminator
+let discriminator = {
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(b"global:initialize");
+    let result = hasher.finalize();
+    result[..8].to_vec()
+};
+
+// Manually serialize args and build instruction
+let mut data = discriminator;
+data.extend_from_slice(&borsh::to_vec(&args).unwrap());
+
+let accounts = vec![
+    AccountMeta::new(user.pubkey(), true),
+    AccountMeta::new(user_pda, false),
+    AccountMeta::new_readonly(system_program::id(), false),
+];
+
+let ix = Instruction::new_with_bytes(program_id, &data, accounts);
+let tx = Transaction::new_signed_with_payer(
+    &[ix],
+    Some(&payer.pubkey()),
+    &[&payer],
+    svm.latest_blockhash(),
+);
+svm.send_transaction(tx).unwrap();
+
+// Manually deserialize with discriminator skip
+let account_data = svm.get_account(&pda).unwrap().data;
+let account: UserAccount = UserAccount::try_deserialize(
+    &mut &account_data[8..]
+).unwrap();
+```
+
+### After (anchor-litesvm)
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+
+anchor_lang::declare_program!(my_program);
+
+let mut ctx = AnchorLiteSVM::build_with_program(program_id, program_bytes);
+let user = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+
+let ix = ctx.program()
+    .accounts(my_program::client::accounts::Initialize {
+        user: user.pubkey(),
+        user_account: user_pda,
+        system_program: anchor_lang::system_program::ID,
+    })
+    .args(my_program::client::args::Initialize { name: "test".to_string() })
+    .instruction()
+    .unwrap();
+
+ctx.execute_instruction(ix, &[&user]).unwrap().assert_success();
+
+let account: my_program::UserAccount = ctx.get_account(&user_pda).unwrap();
+```
+
+## Key Components
+
+### AnchorLiteSVM Builder
+
+| Method                          | Description                    |
+| ------------------------------- | ------------------------------ |
+| `new()`                         | Creates a new builder instance |
+| `with_payer(keypair)`           | Sets a custom payer keypair    |
+| `deploy_program(id, bytes)`     | Adds a program to deploy       |
+| `build()`                       | Builds the AnchorContext       |
+| `build_with_program(id, bytes)` | Convenience for single program |
+| `build_with_programs(programs)` | Deploy multiple programs       |
+
+### AnchorContext
+
+| Method                               | Description                                                       |
+| ------------------------------------ | ----------------------------------------------------------------- |
+| `svm`                                | Direct access to the underlying `LiteSVM` instance (public field) |
+| `program_id`                         | The program ID (public field)                                     |
+| `program()`                          | Returns `Program` for instruction building                        |
+| `payer()`                            | Get the payer `Keypair`                                           |
+| `execute_instruction(ix, signers)`   | Execute a single instruction                                      |
+| `execute_instructions(ixs, signers)` | Execute multiple instructions in one tx                           |
+| `send_and_confirm_transaction(&tx)`  | Send a raw transaction                                            |
+| `get_account<T>(pubkey)`             | Fetch and deserialize an Anchor account                           |
+| `get_account_unchecked<T>(pubkey)`   | Fetch without discriminator check                                 |
+| `create_funded_account(lamports)`    | Create and fund a new keypair                                     |
+| `airdrop(pubkey, lamports)`          | Airdrop SOL to an address                                         |
+| `latest_blockhash()`                 | Get the current blockhash                                         |
+| `account_exists(pubkey)`             | Check if an account exists                                        |
+| `deploy_program(id, bytes)`          | Deploy an additional program (via `ProgramTestExt`)               |
+
+### Program
+
+| Method               | Description                                            |
+| -------------------- | ------------------------------------------------------ |
+| `accounts(accounts)` | Set instruction accounts (any `ToAccountMetas` type)   |
+| `args(args)`         | Set instruction arguments (any `InstructionData` type) |
+| `instruction()`      | Build the final `Instruction`                          |
+| `id()`               | Get the program ID                                     |
+
+### ctx.svm — TestHelpers & AssertionHelpers
+
+`ctx.svm` is a public `LiteSVM` field with `TestHelpers` and `AssertionHelpers`
+traits available via `litesvm-utils`:
+
+| Method                                                    | Description               |
+| --------------------------------------------------------- | ------------------------- |
+| `ctx.svm.create_funded_account(lamports)`                 | Create and fund a keypair |
+| `ctx.svm.create_token_mint(authority, decimals)`          | Create an SPL token mint  |
+| `ctx.svm.create_associated_token_account(mint, owner)`    | Create an ATA             |
+| `ctx.svm.mint_to(mint, token_account, authority, amount)` | Mint tokens               |
+| `ctx.svm.get_pda(seeds, program_id)`                      | Derive a PDA address      |
+| `ctx.svm.get_pda_with_bump(seeds, program_id)`            | Derive PDA with bump seed |
+| `ctx.svm.assert_token_balance(token_account, expected)`   | Assert token balance      |
+| `ctx.svm.assert_account_closed(pubkey)`                   | Assert account was closed |
+| `ctx.svm.assert_sol_balance(pubkey, expected)`            | Assert SOL balance        |
+
+## Troubleshooting
+
+### Common Errors
+
+| Error                   | Cause                                       | Solution                                                               |
+| ----------------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
+| `AccountNotFound`       | Account doesn't exist                       | Ensure account is created before fetching                              |
+| `DiscriminatorMismatch` | Wrong account type                          | Verify you're using the correct account struct                         |
+| `DeserializationError`  | Invalid account data                        | Check account was initialized correctly                                |
+| No programs added       | Called `build()` without `deploy_program()` | Add at least one program before building                               |
+| Missing client types    | `declare_program!` not called               | Run `anchor build` first to generate IDL, then call `declare_program!` |

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-anchor-litesvm/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-anchor-litesvm/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "anchor-litesvm",
+  "pages": ["index", "program-and-context", "account-management", "events"]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-anchor-litesvm/program-and-context.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-anchor-litesvm/program-and-context.mdx
@@ -1,0 +1,476 @@
+---
+title: Program & Context
+description:
+  Setting up test environments and building instructions with AnchorContext and
+  Program
+---
+
+## Generating Client Types with declare_program!
+
+Anchor 1.0 introduces `declare_program!`, which reads your program's IDL at
+compile time and generates type-safe `client::accounts::*` and `client::args::*`
+modules. This is the recommended way to build instructions in tests.
+
+```rust
+// At the top of your test file, generate client modules from the IDL
+anchor_lang::declare_program!(my_program);
+
+// Now use the generated types:
+// my_program::client::accounts::Initialize { ... }
+// my_program::client::args::Initialize { ... }
+// my_program::MyAccount (for account deserialization)
+```
+
+<Callout type="info">
+  Run `anchor build` first to generate `target/idl/my_program.json`.
+  `declare_program!` reads this file at compile time. The macro name must match
+  your program's crate name (snake_case).
+</Callout>
+
+## Setting Up the Test Environment
+
+The `AnchorLiteSVM` builder provides a fluent API for configuring your test
+environment.
+
+### Basic Setup
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use solana_sdk::signature::{read_keypair_file, Signer};
+
+anchor_lang::declare_program!(my_program);
+
+#[test]
+fn test_basic_setup() {
+    // Read the program keypair to get the correct program ID
+    let program_keypair = read_keypair_file("target/deploy/my_program-keypair.json").unwrap();
+
+    let mut ctx = AnchorLiteSVM::new()
+        .deploy_program(
+            program_keypair.pubkey(),
+            include_bytes!("../target/deploy/my_program.so"),
+        )
+        .build();
+
+    println!("Program deployed: {}", ctx.program().id());
+}
+```
+
+### Single Program Shorthand
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use solana_sdk::signature::{read_keypair_file, Signer};
+
+#[test]
+fn test_single_program() {
+    let program_keypair = read_keypair_file("target/deploy/my_program-keypair.json").unwrap();
+
+    // Convenience method for single-program setups
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        program_keypair.pubkey(),
+        include_bytes!("../target/deploy/my_program.so"),
+    );
+}
+```
+
+### Multiple Programs
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use solana_sdk::signature::{read_keypair_file, Signer};
+
+#[test]
+fn test_multiple_programs() {
+    let program_a_kp = read_keypair_file("target/deploy/program_a-keypair.json").unwrap();
+    let program_b_kp = read_keypair_file("target/deploy/program_b-keypair.json").unwrap();
+
+    // Deploy multiple programs — first one becomes the primary (ctx.program_id)
+    let mut ctx = AnchorLiteSVM::build_with_programs(&[
+        (program_a_kp.pubkey(), include_bytes!("../target/deploy/program_a.so") as &[u8]),
+        (program_b_kp.pubkey(), include_bytes!("../target/deploy/program_b.so") as &[u8]),
+    ]);
+
+    // Primary program is program_a
+    assert_eq!(ctx.program().id(), program_a_kp.pubkey());
+}
+```
+
+### Custom Payer
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+
+#[test]
+fn test_custom_payer() {
+    let custom_payer = Keypair::new();
+
+    let mut ctx = AnchorLiteSVM::new()
+        .with_payer(custom_payer)
+        .deploy_program(PROGRAM_ID, include_bytes!("../target/deploy/your_program.so"))
+        .build();
+
+    println!("Payer: {}", ctx.payer().pubkey());
+}
+```
+
+<Callout type="info">
+  If you don't specify a payer, `AnchorLiteSVM` automatically creates and funds
+  one for you.
+</Callout>
+
+## The AnchorContext
+
+`AnchorContext` is the main interface for interacting with your test
+environment.
+
+### Core Properties
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use solana_signer::Signer;
+
+#[test]
+fn test_context_properties() {
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        PROGRAM_ID,
+        include_bytes!("../target/deploy/your_program.so"),
+    );
+
+    // ctx.svm — direct access to the underlying LiteSVM instance (public field)
+    let balance = ctx.svm.get_balance(&some_pubkey);
+
+    // ctx.payer() — the payer keypair
+    let payer = ctx.payer();
+    println!("Payer pubkey: {}", payer.pubkey());
+
+    // ctx.program() — Program instance for instruction building
+    let program = ctx.program();
+    println!("Program ID: {}", program.id());
+
+    // ctx.latest_blockhash()
+    let blockhash = ctx.latest_blockhash();
+}
+```
+
+### Creating Funded Accounts
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use anchor_litesvm::TestHelpers;
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+
+#[test]
+fn test_create_accounts() {
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        PROGRAM_ID,
+        include_bytes!("../target/deploy/your_program.so"),
+    );
+
+    // Option 1: via AnchorContext (returns Result<Keypair>)
+    let user = ctx.create_funded_account(10_000_000_000).unwrap();
+
+    // Option 2: via ctx.svm with TestHelpers (same result)
+    let user2 = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+
+    // Airdrop to an existing address
+    let another_user = Keypair::new();
+    ctx.airdrop(&another_user.pubkey(), 5_000_000_000).unwrap();
+}
+```
+
+### Checking Account Existence
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+
+#[test]
+fn test_account_exists() {
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        PROGRAM_ID,
+        include_bytes!("../target/deploy/your_program.so"),
+    );
+
+    let some_pda = ctx.svm.get_pda(&[b"vault"], &PROGRAM_ID);
+
+    if ctx.account_exists(&some_pda) {
+        println!("Account exists!");
+    } else {
+        println!("Account not found");
+    }
+}
+```
+
+## Building Instructions with Program
+
+The `Program` struct provides a fluent API for building instructions that
+mirrors anchor-client. Use the types generated by `declare_program!` for type
+safety.
+
+### Basic Instruction Building
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use anchor_lang::system_program;
+use solana_signer::Signer;
+
+anchor_lang::declare_program!(my_program);
+
+#[test]
+fn test_build_instruction() {
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        PROGRAM_ID,
+        include_bytes!("../target/deploy/my_program.so"),
+    );
+
+    let user = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+    let user_pda = ctx.svm.get_pda(&[b"user", user.pubkey().as_ref()], &PROGRAM_ID);
+
+    // Build instruction using types generated by declare_program!
+    let ix = ctx.program()
+        .accounts(my_program::client::accounts::Initialize {
+            user: user.pubkey(),
+            user_account: user_pda,
+            system_program: system_program::ID,
+        })
+        .args(my_program::client::args::Initialize {
+            name: "test".to_string(),
+        })
+        .instruction()
+        .unwrap();
+
+    println!("Instruction built successfully!");
+}
+```
+
+<Callout type="info">
+  The `.accounts()` method accepts any type that implements `ToAccountMetas`,
+  which all Anchor account structs do automatically. Similarly, `.args()`
+  accepts any type implementing `InstructionData`.
+</Callout>
+
+### Executing Instructions
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use anchor_lang::system_program;
+use solana_signer::Signer;
+
+anchor_lang::declare_program!(my_program);
+
+#[test]
+fn test_execute_instruction() {
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        PROGRAM_ID,
+        include_bytes!("../target/deploy/my_program.so"),
+    );
+
+    let user = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+    let user_pda = ctx.svm.get_pda(&[b"user", user.pubkey().as_ref()], &PROGRAM_ID);
+
+    let ix = ctx.program()
+        .accounts(my_program::client::accounts::Initialize {
+            user: user.pubkey(),
+            user_account: user_pda,
+            system_program: system_program::ID,
+        })
+        .args(my_program::client::args::Initialize { name: "test".to_string() })
+        .instruction()
+        .unwrap();
+
+    // Execute — returns TransactionResult
+    ctx.execute_instruction(ix, &[&user])
+        .unwrap()
+        .assert_success();
+}
+```
+
+### Executing Multiple Instructions
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use solana_signer::Signer;
+
+anchor_lang::declare_program!(my_program);
+
+#[test]
+fn test_execute_multiple_instructions() {
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        PROGRAM_ID,
+        include_bytes!("../target/deploy/my_program.so"),
+    );
+
+    let user = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+
+    let ix1 = ctx.program()
+        .accounts(my_program::client::accounts::Initialize { /* ... */ })
+        .args(my_program::client::args::Initialize { name: "first".to_string() })
+        .instruction()
+        .unwrap();
+
+    let ix2 = ctx.program()
+        .accounts(my_program::client::accounts::Update { /* ... */ })
+        .args(my_program::client::args::Update { name: "second".to_string() })
+        .instruction()
+        .unwrap();
+
+    // Execute multiple instructions in one transaction
+    ctx.execute_instructions(vec![ix1, ix2], &[&user])
+        .unwrap()
+        .assert_success();
+}
+```
+
+### Using send_and_confirm_transaction
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use solana_signer::Signer;
+use solana_transaction::Transaction;
+
+#[test]
+fn test_send_transaction() {
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        PROGRAM_ID,
+        include_bytes!("../target/deploy/your_program.so"),
+    );
+
+    let user = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+
+    let ix = ctx.program()
+        .accounts(/* ... */)
+        .args(/* ... */)
+        .instruction()
+        .unwrap();
+
+    // Build transaction manually if needed
+    let tx = Transaction::new_signed_with_payer(
+        &[ix],
+        Some(&ctx.payer().pubkey()),
+        &[ctx.payer(), &user],
+        ctx.latest_blockhash(),
+    );
+
+    // Note: takes &Transaction (reference)
+    ctx.send_and_confirm_transaction(&tx).unwrap();
+}
+```
+
+## Complete Example
+
+Here's a comprehensive example using the escrow pattern with `declare_program!`:
+
+```rust
+use anchor_litesvm::AnchorLiteSVM;
+use anchor_litesvm::{AssertionHelpers, TestHelpers};
+use anchor_lang::system_program;
+use solana_sdk::signature::{read_keypair_file, Signer};
+use spl_associated_token_account::get_associated_token_address;
+use litesvm_token::spl_token;
+
+anchor_lang::declare_program!(anchor_escrow);
+
+#[test]
+fn test_make_and_take() {
+    // 1. One-line setup
+    let program_keypair = read_keypair_file("target/deploy/anchor_escrow-keypair.json").unwrap();
+    let program_id = program_keypair.pubkey();
+
+    let mut ctx = AnchorLiteSVM::build_with_program(
+        program_id,
+        include_bytes!("../target/deploy/anchor_escrow.so"),
+    );
+
+    // 2. Create test accounts using TestHelpers on ctx.svm
+    let maker = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+    let taker = ctx.svm.create_funded_account(10_000_000_000).unwrap();
+
+    // 3. Create token mints and funded ATAs
+    let mint_a = ctx.svm.create_token_mint(&maker, 9).unwrap();
+    let mint_b = ctx.svm.create_token_mint(&maker, 9).unwrap();
+
+    let maker_ata_a = ctx.svm
+        .create_associated_token_account(&mint_a.pubkey(), &maker)
+        .unwrap();
+    ctx.svm.mint_to(&mint_a.pubkey(), &maker_ata_a, &maker, 1_000_000_000).unwrap();
+
+    let taker_ata_b = ctx.svm
+        .create_associated_token_account(&mint_b.pubkey(), &taker)
+        .unwrap();
+    ctx.svm.mint_to(&mint_b.pubkey(), &taker_ata_b, &maker, 500_000_000).unwrap();
+
+    // 4. Derive PDAs
+    let seed: u64 = 42;
+    let escrow_pda = ctx.svm.get_pda(
+        &[b"escrow", maker.pubkey().as_ref(), &seed.to_le_bytes()],
+        &program_id,
+    );
+    let vault = get_associated_token_address(&escrow_pda, &mint_a.pubkey());
+
+    // 5. Build and execute Make instruction using generated client types
+    let make_ix = ctx.program()
+        .accounts(anchor_escrow::client::accounts::Make {
+            maker: maker.pubkey(),
+            escrow: escrow_pda,
+            mint_a: mint_a.pubkey(),
+            mint_b: mint_b.pubkey(),
+            maker_ata_a,
+            vault,
+            associated_token_program: spl_associated_token_account::id(),
+            token_program: spl_token::id(),
+            system_program: system_program::ID,
+        })
+        .args(anchor_escrow::client::args::Make {
+            seed,
+            receive: 500_000_000,
+            amount: 1_000_000_000,
+        })
+        .instruction()
+        .unwrap();
+
+    ctx.execute_instruction(make_ix, &[&maker])
+        .unwrap()
+        .assert_success();
+
+    // 6. Assert state using AssertionHelpers on ctx.svm
+    assert!(ctx.account_exists(&escrow_pda));
+    ctx.svm.assert_token_balance(&vault, 1_000_000_000);
+    ctx.svm.assert_token_balance(&maker_ata_a, 0);
+
+    // 7. Execute Take
+    let taker_ata_a = get_associated_token_address(&taker.pubkey(), &mint_a.pubkey());
+    let maker_ata_b = get_associated_token_address(&maker.pubkey(), &mint_b.pubkey());
+
+    let take_ix = ctx.program()
+        .accounts(anchor_escrow::client::accounts::Take {
+            taker: taker.pubkey(),
+            maker: maker.pubkey(),
+            escrow: escrow_pda,
+            mint_a: mint_a.pubkey(),
+            mint_b: mint_b.pubkey(),
+            vault,
+            taker_ata_a,
+            taker_ata_b,
+            maker_ata_b,
+            associated_token_program: spl_associated_token_account::id(),
+            token_program: spl_token::id(),
+            system_program: system_program::ID,
+        })
+        .args(anchor_escrow::client::args::Take {})
+        .instruction()
+        .unwrap();
+
+    ctx.execute_instruction(take_ix, &[&taker])
+        .unwrap()
+        .assert_success();
+
+    // 8. Final assertions
+    ctx.svm.assert_account_closed(&escrow_pda);
+    ctx.svm.assert_account_closed(&vault);
+    ctx.svm.assert_token_balance(&taker_ata_a, 1_000_000_000);
+    ctx.svm.assert_token_balance(&maker_ata_b, 500_000_000);
+}
+```

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-loader/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-loader/index.mdx
@@ -1,0 +1,219 @@
+---
+title: Quick Start
+description:
+  Learn how to use the litesvm-loader crate for testing upgradeable program
+  deployment
+---
+
+<div className="flex items-center gap-3 mb-6">
+  <a
+    href="https://crates.io/crates/litesvm-loader"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-2 px-3 py-1.5 bg-fd-muted/50 hover:bg-fd-muted rounded-lg text-sm font-medium transition-colors border border-fd-border/50"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      className="w-4 h-4"
+      fill="currentColor"
+    >
+      <path d="M239.1 6.3l-208 78c-18.7 7-31.1 25-31.1 45v225.1c0 18.2 10.3 34.8 26.5 42.9l208 104c13.5 6.8 29.4 6.8 42.9 0l208-104c16.3-8.1 26.5-24.8 26.5-42.9V129.3c0-20-12.4-37.9-31.1-44.9l-208-78C262 2.2 250 2.2 239.1 6.3zM256 68.4l192 72v1.1l-192 78-192-78v-1.1l192-72zm32 356V275.5l160-65v133.9l-160 80z" />
+    </svg>
+    View <code>litesvm-loader</code> on crates.io
+  </a>
+</div>
+
+## Installation
+
+Make sure you have all the needed dependencies:
+
+```bash
+cargo add --dev litesvm litesvm-loader solana-keypair solana-signer
+```
+
+If your test invokes the deployed program directly, also add the Solana
+instruction and transaction crates used by your test:
+
+```bash
+cargo add --dev solana-instruction solana-message solana-transaction
+```
+
+## What is litesvm-loader?
+
+The `litesvm-loader` crate provides helpers for deploying programs through the
+BPF upgradeable loader inside LiteSVM. Use it when your test needs loader-owned
+program accounts, program data accounts, or upgrade authority behavior instead
+of directly inserting a program with `svm.add_program(...)`.
+
+<Steps>
+<Step>
+**Upgradeable Deployment**
+- Creates the loader buffer account
+- Writes program bytes in chunks
+- Deploys the final program account with the BPF upgradeable loader
+- Uses the provided program keypair as the program ID
+</Step>
+
+<Step>
+  **Upgrade Authority Management** - Changes the upgrade authority for an
+  already deployed program - Supports assigning a new authority - Supports
+  passing `None` to make the program immutable
+</Step>
+
+<Step>
+**Real Loader State**
+- Exercises the same loader account model your program sees on-chain
+- Lets tests inspect program and program data accounts
+- Helps catch mistakes hidden by direct program insertion
+</Step>
+</Steps>
+
+<Callout type="info">
+  For most tests, `svm.add_program(program_id, program_bytes)` is still the
+  fastest and simplest way to load a program. Use `litesvm-loader` when the
+  loader account layout or upgrade authority is part of what you need to test.
+</Callout>
+
+## Quick Example
+
+Here's a complete example that deploys a program through the upgradeable loader
+and then rotates its authority:
+
+```rust
+use litesvm::LiteSVM;
+use litesvm_loader::{deploy_upgradeable_program, set_upgrade_authority};
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+
+#[test]
+fn test_upgradeable_deployment() {
+    let mut svm = LiteSVM::new();
+
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10_000_000_000).unwrap();
+
+    // Use the keypair that should own the program ID.
+    // For Anchor programs, this is usually target/deploy/<program>-keypair.json.
+    let program = Keypair::new();
+    let program_bytes = include_bytes!("../target/deploy/my_program.so");
+
+    deploy_upgradeable_program(&mut svm, &payer, &program, program_bytes).unwrap();
+
+    let program_account = svm.get_account(&program.pubkey()).unwrap();
+    assert!(program_account.executable);
+
+    let new_authority = Keypair::new();
+    set_upgrade_authority(
+        &mut svm,
+        &payer,
+        &program.pubkey(),
+        &payer,
+        Some(&new_authority.pubkey()),
+    )
+    .unwrap();
+}
+```
+
+## Choosing the Program Keypair
+
+`deploy_upgradeable_program` uses the `program_kp` argument as the program
+address. If your program declares a fixed ID, load the generated deploy keypair
+instead of creating a random keypair:
+
+```rust
+use solana_keypair::read_keypair_file;
+
+let program = read_keypair_file("target/deploy/my_program-keypair.json").unwrap();
+deploy_upgradeable_program(&mut svm, &payer, &program, program_bytes).unwrap();
+```
+
+## Invoking the Deployed Program
+
+After deployment, call the program the same way you would call any
+LiteSVM-loaded program. Build an instruction for your program, sign the
+transaction, and send it through the same `LiteSVM` instance:
+
+```rust
+use solana_instruction::Instruction;
+use solana_message::Message;
+use solana_transaction::Transaction;
+
+let instruction = Instruction::new_with_bytes(
+    program.pubkey(),
+    &[],  // instruction data for your program
+    vec![], // account metas for your program
+);
+
+let message = Message::new(&[instruction], Some(&payer.pubkey()));
+let tx = Transaction::new(&[&payer], message, svm.latest_blockhash());
+
+svm.send_transaction(tx).unwrap();
+```
+
+## Key Components
+
+### deploy_upgradeable_program
+
+| Argument        | Description                                                   |
+| --------------- | ------------------------------------------------------------- |
+| `svm`           | Mutable `LiteSVM` instance that receives the deployed program |
+| `payer_kp`      | Fee payer and initial upgrade authority                       |
+| `program_kp`    | Keypair whose public key becomes the program ID               |
+| `program_bytes` | Compiled SBF program bytes, usually from `target/deploy/*.so` |
+
+`deploy_upgradeable_program` creates a loader buffer, writes the program bytes
+in 512-byte chunks, and deploys the program with room for future upgrades.
+
+### set_upgrade_authority
+
+| Argument                    | Description                                                    |
+| --------------------------- | -------------------------------------------------------------- |
+| `svm`                       | Mutable `LiteSVM` instance containing the deployed program     |
+| `from_keypair`              | Fee payer and signing authority for the transaction            |
+| `program_address`           | Program ID whose authority should change                       |
+| `current_authority_keypair` | Current upgrade authority keypair                              |
+| `new_authority_address`     | New authority address, or `None` to make the program immutable |
+
+<Callout type="warn">
+  In the current helper implementation, the generated transaction is signed by
+  `from_keypair`. Pass the current authority as `from_keypair`, or keep the
+  payer and current authority the same, when changing upgrade authority.
+</Callout>
+
+## Common Workflows
+
+### Deploy with the declared program ID
+
+```rust
+use solana_keypair::read_keypair_file;
+
+let program = read_keypair_file("target/deploy/my_program-keypair.json").unwrap();
+let program_bytes = include_bytes!("../target/deploy/my_program.so");
+
+deploy_upgradeable_program(&mut svm, &payer, &program, program_bytes).unwrap();
+```
+
+### Make a program immutable
+
+```rust
+set_upgrade_authority(
+    &mut svm,
+    &payer,
+    &program.pubkey(),
+    &payer,
+    None,
+)
+.unwrap();
+```
+
+## Troubleshooting
+
+### Common Errors
+
+| Error                                                                 | Cause                                                                          | Solution                                                                                              |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `ProgramAccountNotFound` or instruction failures against the wrong ID | The deployment used a random `Keypair` while the program expects a declared ID | Read `target/deploy/<program>-keypair.json` and pass that keypair to `deploy_upgradeable_program`     |
+| `InsufficientFunds`                                                   | The payer does not have enough lamports for loader buffer and program accounts | Airdrop more lamports before deployment                                                               |
+| `MissingRequiredSignature` when changing authority                    | The current authority did not sign the transaction                             | Pass the current authority as `from_keypair`, or keep payer and current authority as the same keypair |
+| Program deployment is slower than expected                            | Loader deployment writes bytes through real loader instructions                | Use `svm.add_program(...)` when you do not need loader state or upgrade authority behavior            |

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-loader/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-loader/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "litesvm-loader",
+  "pages": ["index"]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-utils/assertions.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-utils/assertions.mdx
@@ -1,0 +1,265 @@
+---
+title: Assertions
+description:
+  Verify account states, balances, and ownership with assertion helpers
+---
+
+## Account Existence
+
+Verify whether accounts exist or have been closed.
+
+### Assert Account Exists
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_assert_account_exists() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+
+    // This will pass - account exists
+    svm.assert_account_exists(&alice.pubkey());
+}
+```
+
+### Assert Account Closed
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Pubkey};
+
+#[test]
+fn test_assert_account_closed() {
+    let mut svm = LiteSVM::new();
+
+    // A random pubkey that was never created
+    let nonexistent = Pubkey::new_unique();
+
+    // This will pass - account doesn't exist
+    svm.assert_account_closed(&nonexistent);
+}
+```
+
+<Callout type="info">
+  `assert_account_closed` passes when an account either doesn't exist, has zero
+  lamports, or has empty data. Use this to verify cleanup after closing
+  accounts.
+</Callout>
+
+## Balance Assertions
+
+Verify SOL and token balances.
+
+### Assert SOL Balance
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_assert_sol_balance() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Verify Alice has 10 SOL
+    svm.assert_sol_balance(&alice.pubkey(), 10 * LAMPORTS_PER_SOL);
+}
+```
+
+### Assert Token Balance
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_assert_token_balance() {
+    let mut svm = LiteSVM::new();
+
+    let authority = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let user = svm.create_funded_account(5 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create mint and token account
+    let mint = svm.create_token_mint(&authority, 9).unwrap();
+    let user_ata = svm.create_associated_token_account(&mint.pubkey(), &user).unwrap();
+
+    // Mint tokens
+    svm.mint_to(&mint.pubkey(), &user_ata, &authority, 5000).unwrap();
+
+    // Verify balance
+    svm.assert_token_balance(&user_ata, 5000);
+}
+```
+
+### Assert Mint Supply
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_assert_mint_supply() {
+    let mut svm = LiteSVM::new();
+
+    let authority = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let user1 = svm.create_funded_account(5 * LAMPORTS_PER_SOL).unwrap();
+    let user2 = svm.create_funded_account(5 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create mint (returns Keypair)
+    let mint = svm.create_token_mint(&authority, 9).unwrap();
+
+    // Create ATAs and mint tokens
+    let user1_ata = svm.create_associated_token_account(&mint.pubkey(), &user1).unwrap();
+    let user2_ata = svm.create_associated_token_account(&mint.pubkey(), &user2).unwrap();
+
+    svm.mint_to(&mint.pubkey(), &user1_ata, &authority, 1000).unwrap();
+    svm.mint_to(&mint.pubkey(), &user2_ata, &authority, 2000).unwrap();
+
+    // Verify total supply
+    svm.assert_mint_supply(&mint.pubkey(), 3000);
+}
+```
+
+## Account Properties
+
+Verify account ownership and data properties.
+
+### Assert Account Owner
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_program};
+
+#[test]
+fn test_assert_account_owner() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Regular accounts are owned by the System Program
+    svm.assert_account_owner(&alice.pubkey(), &system_program::id());
+}
+```
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_assert_token_account_owner() {
+    let mut svm = LiteSVM::new();
+
+    let authority = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let user = svm.create_funded_account(5 * LAMPORTS_PER_SOL).unwrap();
+
+    let mint = svm.create_token_mint(&authority, 9).unwrap();
+    let user_ata = svm.create_associated_token_account(&mint.pubkey(), &user).unwrap();
+
+    // Token accounts are owned by the Token Program
+    svm.assert_account_owner(&user_ata, &spl_token::id());
+}
+```
+
+### Assert Account Data Length
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_assert_account_data_len() {
+    let mut svm = LiteSVM::new();
+
+    let authority = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let user = svm.create_funded_account(5 * LAMPORTS_PER_SOL).unwrap();
+
+    let mint = svm.create_token_mint(&authority, 9).unwrap();
+    let user_ata = svm.create_associated_token_account(&mint.pubkey(), &user).unwrap();
+
+    // Token mint accounts are 82 bytes
+    svm.assert_account_data_len(&mint.pubkey(), 82);
+
+    // Token accounts are 165 bytes
+    svm.assert_account_data_len(&user_ata, 165);
+}
+```
+
+<Callout type="info">
+  Common account sizes: - **Mint Account**: 82 bytes - **Token Account**: 165
+  bytes - **System Account**: 0 bytes (just lamports)
+</Callout>
+
+## Complete Example
+
+Here's a comprehensive test demonstrating multiple assertions:
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_comprehensive_assertions() {
+    let mut svm = LiteSVM::new();
+
+    // Setup
+    let admin = svm.create_funded_account(100 * LAMPORTS_PER_SOL).unwrap();
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+
+    // Verify initial SOL balances
+    svm.assert_sol_balance(&admin.pubkey(), 100 * LAMPORTS_PER_SOL);
+    svm.assert_sol_balance(&alice.pubkey(), 10 * LAMPORTS_PER_SOL);
+    svm.assert_sol_balance(&bob.pubkey(), 0);
+
+    // Transfer SOL from Alice to Bob
+    let transfer_ix = system_instruction::transfer(
+        &alice.pubkey(),
+        &bob.pubkey(),
+        5 * LAMPORTS_PER_SOL,
+    );
+    svm.send_instruction(transfer_ix, &[&alice]).unwrap().assert_success();
+
+    // Verify balances after transfer (Alice paid fees too)
+    svm.assert_sol_balance(&bob.pubkey(), 5 * LAMPORTS_PER_SOL);
+
+    // Create token infrastructure (mint returns Keypair, ATAs return Pubkey)
+    let mint = svm.create_token_mint(&admin, 6).unwrap();
+    let alice_ata = svm.create_associated_token_account(&mint.pubkey(), &alice).unwrap();
+    let bob_ata = svm.create_associated_token_account(&mint.pubkey(), &bob).unwrap();
+
+    // Verify account properties
+    svm.assert_account_exists(&mint.pubkey());
+    svm.assert_account_exists(&alice_ata);
+    svm.assert_account_owner(&mint.pubkey(), &spl_token::id());
+    svm.assert_account_data_len(&mint.pubkey(), 82);
+    svm.assert_account_data_len(&alice_ata, 165);
+
+    // Mint and verify
+    svm.mint_to(&mint.pubkey(), &alice_ata, &admin, 1_000_000).unwrap();
+    svm.mint_to(&mint.pubkey(), &bob_ata, &admin, 500_000).unwrap();
+
+    svm.assert_token_balance(&alice_ata, 1_000_000);
+    svm.assert_token_balance(&bob_ata, 500_000);
+    svm.assert_mint_supply(&mint.pubkey(), 1_500_000);
+
+    println!("All assertions passed!");
+}
+```
+
+## Handling Assertion Failures
+
+When an assertion fails, it will panic with a descriptive message:
+
+```rust
+// This will panic with a message like:
+// "Expected token balance 1000, but got 500"
+svm.assert_token_balance(&some_ata, 1000); // when balance is actually 500
+```
+
+<Callout type="warn">
+  Assertions are designed to fail fast with clear error messages. Use them
+  liberally throughout your tests to catch issues early.
+</Callout>

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-utils/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-utils/index.mdx
@@ -1,0 +1,189 @@
+---
+title: Quick Start
+description:
+  Learn how to use the litesvm-utils crate for streamlined Solana program
+  testing
+---
+
+<div className="flex items-center gap-3 mb-6">
+  <a
+    href="https://crates.io/crates/litesvm-utils"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-2 px-3 py-1.5 bg-fd-muted/50 hover:bg-fd-muted rounded-lg text-sm font-medium transition-colors border border-fd-border/50"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      className="w-4 h-4"
+      fill="currentColor"
+    >
+      <path d="M239.1 6.3l-208 78c-18.7 7-31.1 25-31.1 45v225.1c0 18.2 10.3 34.8 26.5 42.9l208 104c13.5 6.8 29.4 6.8 42.9 0l208-104c16.3-8.1 26.5-24.8 26.5-42.9V129.3c0-20-12.4-37.9-31.1-44.9l-208-78C262 2.2 250 2.2 239.1 6.3zM256 68.4l192 72v1.1l-192 78-192-78v-1.1l192-72zm32 356V275.5l160-65v133.9l-160 80z" />
+    </svg>
+    View <code>litesvm-utils</code> on crates.io
+  </a>
+</div>
+
+## Installation
+
+Make sure you have all the needed dependencies:
+
+```bash
+cargo add --dev litesvm litesvm-utils
+```
+
+## What is litesvm-utils?
+
+The `litesvm-utils` crate provides essential helper traits and utilities that
+simplify Solana program testing. It reduces common testing boilerplate from 30+
+lines to minimal, readable code through ergonomic APIs.
+
+<Steps>
+<Step>
+**TestHelpers Trait**
+- Create funded accounts with a single method call
+- Set up token mints and token accounts easily
+- Derive PDAs without boilerplate
+- Manage slots for time-based testing
+</Step>
+
+<Step>
+  **AssertionHelpers Trait** - Assert account states (exists, closed, owner) -
+  Verify token balances and mint supplies - Check SOL balances - Validate
+  account data lengths
+</Step>
+
+<Step>
+  **TransactionHelpers Trait** - Execute instructions with rich result handling
+  - Assert transaction success or failure - Check for specific error codes -
+  Inspect transaction logs and compute units
+</Step>
+
+<Step>
+**LiteSVMBuilder**
+- Fluent builder pattern for test environment setup
+- Deploy programs with method chaining
+- Convenient static factory methods
+</Step>
+</Steps>
+
+## Quick Example
+
+Here's a complete example showing the power of litesvm-utils:
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_with_utils() {
+    let mut svm = LiteSVM::new();
+
+    // Create funded accounts in one line
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+
+    // Create a token mint easily
+    let mint = svm.create_token_mint(&alice, 9).unwrap();
+
+    // Create associated token accounts (returns Pubkey)
+    let alice_ata = svm.create_associated_token_account(&mint.pubkey(), &alice).unwrap();
+    let bob_ata = svm.create_associated_token_account(&mint.pubkey(), &bob).unwrap();
+
+    // Mint tokens
+    svm.mint_to(&mint.pubkey(), &alice_ata, &alice, 1000).unwrap();
+
+    // Assert balances
+    svm.assert_token_balance(&alice_ata, 1000);
+    svm.assert_token_balance(&bob_ata, 0);
+
+    // Execute a SOL transfer with rich result handling
+    let transfer_ix = system_instruction::transfer(
+        &alice.pubkey(),
+        &bob.pubkey(),
+        LAMPORTS_PER_SOL,
+    );
+
+    let result = svm.send_instruction(transfer_ix, &[&alice]).unwrap();
+    result.assert_success();
+
+    // Verify the transfer
+    svm.assert_sol_balance(&bob.pubkey(), LAMPORTS_PER_SOL);
+}
+```
+
+## Key Benefits
+
+### Before litesvm-utils
+
+```rust
+// Creating a funded account manually
+let keypair = Keypair::new();
+let airdrop_tx = Transaction::new_signed_with_payer(
+    &[system_instruction::transfer(
+        &payer.pubkey(),
+        &keypair.pubkey(),
+        lamports,
+    )],
+    Some(&payer.pubkey()),
+    &[&payer],
+    svm.latest_blockhash(),
+);
+svm.send_transaction(airdrop_tx).unwrap();
+```
+
+### After litesvm-utils
+
+```rust
+// One line to create a funded account
+let keypair = svm.create_funded_account(lamports).unwrap();
+```
+
+## Trait Overview
+
+### TestHelpers
+
+| Method                                         | Returns                | Description                         |
+| ---------------------------------------------- | ---------------------- | ----------------------------------- |
+| `create_funded_account(lamports)`              | `Result<Keypair>`      | Creates a keypair and funds it      |
+| `create_funded_accounts(count, lamports)`      | `Result<Vec<Keypair>>` | Creates multiple funded keypairs    |
+| `create_token_mint(authority, decimals)`       | `Result<Keypair>`      | Creates an SPL token mint           |
+| `create_token_account(mint, owner)`            | `Result<Keypair>`      | Creates a regular token account     |
+| `create_associated_token_account(mint, owner)` | `Result<Pubkey>`       | Creates an ATA, returns its address |
+| `mint_to(mint, account, authority, amount)`    | `Result<()>`           | Mints tokens to an account          |
+| `derive_pda(seeds, program_id)`                | `(Pubkey, u8)`         | Derives a PDA with bump seed        |
+| `get_pda(seeds, program_id)`                   | `Pubkey`               | Gets just the PDA address           |
+| `get_pda_with_bump(seeds, program_id)`         | `(Pubkey, u8)`         | Alias for `derive_pda`              |
+| `get_current_slot()`                           | `u64`                  | Returns current slot                |
+| `advance_slot(slots)`                          | `()`                   | Advances time by N slots            |
+
+### AssertionHelpers
+
+| Method                                  | Description                                    |
+| --------------------------------------- | ---------------------------------------------- |
+| `assert_account_exists(pubkey)`         | Panics if account does not exist               |
+| `assert_account_closed(pubkey)`         | Panics if account exists and has data/lamports |
+| `assert_token_balance(account, amount)` | Verifies token balance                         |
+| `assert_sol_balance(pubkey, lamports)`  | Verifies SOL balance                           |
+| `assert_mint_supply(mint, supply)`      | Verifies mint total supply                     |
+| `assert_account_owner(pubkey, owner)`   | Verifies account owner                         |
+| `assert_account_data_len(pubkey, len)`  | Verifies data length                           |
+
+### TransactionHelpers
+
+| Method                            | Returns                                       | Description                           |
+| --------------------------------- | --------------------------------------------- | ------------------------------------- |
+| `send_instruction(ix, signers)`   | `Result<TransactionResult, TransactionError>` | Sends a single instruction            |
+| `send_instructions(ixs, signers)` | `Result<TransactionResult, TransactionError>` | Sends multiple instructions in one tx |
+| `send_transaction_result(tx)`     | `Result<TransactionResult, TransactionError>` | Sends a raw `Transaction`             |
+
+## Troubleshooting
+
+### Common Errors
+
+| Error               | Cause                                       | Solution                          |
+| ------------------- | ------------------------------------------- | --------------------------------- |
+| `AccountNotFound`   | Trying to use an account that doesn't exist | Use `create_funded_account` first |
+| `InsufficientFunds` | Not enough lamports for transaction         | Increase initial funding amount   |
+| `OwnerMismatch`     | Account owned by wrong program              | Verify correct program ID         |
+| `AssertionFailed`   | Balance or state doesn't match expected     | Check your test logic             |

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-utils/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-utils/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "litesvm-utils",
+  "pages": ["index", "test-helpers", "assertions", "transactions"]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-utils/test-helpers.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-utils/test-helpers.mdx
@@ -1,0 +1,261 @@
+---
+title: Test Helpers
+description:
+  Account creation, token operations, PDA derivation, and slot management
+  utilities
+---
+
+## Create Funded Accounts
+
+The most common testing need is creating accounts with SOL. The `TestHelpers`
+trait makes this trivial.
+
+### Single Account
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_create_funded_account() {
+    let mut svm = LiteSVM::new();
+
+    // Create a funded account with 10 SOL
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+
+    // The keypair is ready to use immediately
+    println!("Alice's pubkey: {}", alice.pubkey());
+}
+```
+
+### Multiple Accounts
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_create_multiple_accounts() {
+    let mut svm = LiteSVM::new();
+
+    // Create 5 funded accounts, each with 5 SOL
+    let accounts = svm.create_funded_accounts(5, 5 * LAMPORTS_PER_SOL).unwrap();
+
+    assert_eq!(accounts.len(), 5);
+
+    for (i, account) in accounts.iter().enumerate() {
+        println!("Account {}: {}", i, account.pubkey());
+    }
+}
+```
+
+## Token Operations
+
+Create token mints and accounts without the usual boilerplate.
+
+### Create a Token Mint
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_create_token_mint() {
+    let mut svm = LiteSVM::new();
+
+    // Create authority account
+    let authority = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create a token mint with 9 decimals (returns Keypair)
+    let mint = svm.create_token_mint(&authority, 9).unwrap();
+
+    println!("Mint address: {}", mint.pubkey());
+}
+```
+
+### Create Token Accounts
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_create_token_accounts() {
+    let mut svm = LiteSVM::new();
+
+    let authority = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let user = svm.create_funded_account(5 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create mint (returns Keypair)
+    let mint = svm.create_token_mint(&authority, 9).unwrap();
+
+    // Create a regular token account (returns Keypair)
+    let token_account = svm.create_token_account(&mint.pubkey(), &user).unwrap();
+
+    // Or create an Associated Token Account — ATA (returns Pubkey)
+    let ata = svm.create_associated_token_account(&mint.pubkey(), &user).unwrap();
+
+    println!("Token account: {}", token_account.pubkey());
+    println!("ATA: {}", ata);
+}
+```
+
+<Callout type="info">
+  **Use ATAs for most cases.** Associated Token Accounts are deterministic and
+  follow Solana conventions. Use regular token accounts only when you need
+  multiple accounts for the same mint/owner pair.
+</Callout>
+
+### Mint Tokens
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_mint_tokens() {
+    let mut svm = LiteSVM::new();
+
+    let authority = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let user = svm.create_funded_account(5 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create mint with authority
+    let mint = svm.create_token_mint(&authority, 9).unwrap();
+
+    // Create ATA for user (returns Pubkey)
+    let user_ata = svm.create_associated_token_account(&mint.pubkey(), &user).unwrap();
+
+    // Mint 1000 tokens to user's ATA
+    svm.mint_to(&mint.pubkey(), &user_ata, &authority, 1000).unwrap();
+
+    // Verify the balance
+    svm.assert_token_balance(&user_ata, 1000);
+}
+```
+
+## PDA Derivation
+
+Derive Program Derived Addresses easily for your tests.
+
+### Basic PDA Derivation
+
+```rust
+use litesvm_utils::{LiteSVM, Pubkey, TestHelpers};
+
+#[test]
+fn test_derive_pda() {
+    let mut svm = LiteSVM::new();
+
+    let program_id = Pubkey::new_unique();
+    let user = Pubkey::new_unique();
+
+    // Get PDA with bump
+    let (pda, bump) = svm.derive_pda(
+        &[b"user_account", user.as_ref()],
+        &program_id,
+    );
+
+    println!("PDA: {}, Bump: {}", pda, bump);
+}
+```
+
+### Get Just the PDA
+
+```rust
+use litesvm_utils::{LiteSVM, Pubkey, TestHelpers};
+
+#[test]
+fn test_get_pda() {
+    let mut svm = LiteSVM::new();
+
+    let program_id = Pubkey::new_unique();
+
+    // When you don't need the bump
+    let pda = svm.get_pda(&[b"config"], &program_id);
+
+    println!("Config PDA: {}", pda);
+}
+```
+
+<Callout type="info">
+  Use `derive_pda` when you need the bump seed (e.g., for CPI calls). Use
+  `get_pda` when you only need the address.
+</Callout>
+
+## Slot Management
+
+Control time progression for testing time-dependent logic.
+
+### Get Current Slot
+
+```rust
+use litesvm_utils::{LiteSVM, TestHelpers};
+
+#[test]
+fn test_get_current_slot() {
+    let mut svm = LiteSVM::new();
+
+    let slot = svm.get_current_slot();
+    println!("Current slot: {}", slot);
+}
+```
+
+### Advance Slots
+
+```rust
+use litesvm_utils::{LiteSVM, TestHelpers};
+
+#[test]
+fn test_advance_slots() {
+    let mut svm = LiteSVM::new();
+
+    let initial_slot = svm.get_current_slot();
+
+    // Advance by 100 slots
+    svm.advance_slot(100);
+
+    let new_slot = svm.get_current_slot();
+    assert_eq!(new_slot, initial_slot + 100);
+}
+```
+
+## Complete Example
+
+Here's a comprehensive example using multiple test helpers together:
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers};
+use solana_sdk::native_token::LAMPORTS_PER_SOL;
+
+#[test]
+fn test_complete_setup() {
+    let mut svm = LiteSVM::new();
+
+    // Create accounts
+    let admin = svm.create_funded_account(100 * LAMPORTS_PER_SOL).unwrap();
+    let users = svm.create_funded_accounts(3, 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create token infrastructure (returns Keypair)
+    let mint = svm.create_token_mint(&admin, 6).unwrap(); // 6 decimals like USDC
+
+    // Create ATAs and mint tokens to each user
+    for (i, user) in users.iter().enumerate() {
+        // create_associated_token_account returns Pubkey
+        let ata = svm.create_associated_token_account(&mint.pubkey(), user).unwrap();
+        let amount = (i as u64 + 1) * 1_000_000; // 1, 2, 3 tokens
+        svm.mint_to(&mint.pubkey(), &ata, &admin, amount).unwrap();
+
+        // Verify
+        svm.assert_token_balance(&ata, amount);
+    }
+
+    // Verify total supply
+    let total_supply = 1_000_000 + 2_000_000 + 3_000_000;
+    svm.assert_mint_supply(&mint.pubkey(), total_supply);
+
+    // Test time-based logic
+    let start_slot = svm.get_current_slot();
+    svm.advance_slot(1000);
+    assert!(svm.get_current_slot() > start_slot);
+}
+```

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-utils/transactions.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-litesvm-utils/transactions.mdx
@@ -1,0 +1,312 @@
+---
+title: Transaction Helpers
+description: Execute transactions and analyze results with rich error handling
+---
+
+## Sending Transactions
+
+The `TransactionHelpers` trait provides convenient methods for sending
+instructions and analyzing results.
+
+### Send a Single Instruction
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_send_instruction() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+
+    // Create a transfer instruction
+    let transfer_ix = system_instruction::transfer(
+        &alice.pubkey(),
+        &bob.pubkey(),
+        LAMPORTS_PER_SOL,
+    );
+
+    // Send and get result (returns Result<TransactionResult, TransactionError>)
+    let result = svm.send_instruction(transfer_ix, &[&alice]).unwrap();
+
+    // Assert it succeeded
+    result.assert_success();
+}
+```
+
+### Send Multiple Instructions
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_send_multiple_instructions() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+    let carol = svm.create_funded_account(0).unwrap();
+
+    // Create multiple transfer instructions
+    let instructions = vec![
+        system_instruction::transfer(&alice.pubkey(), &bob.pubkey(), LAMPORTS_PER_SOL),
+        system_instruction::transfer(&alice.pubkey(), &carol.pubkey(), LAMPORTS_PER_SOL),
+    ];
+
+    // Send all in one transaction
+    let result = svm.send_instructions(&instructions, &[&alice]).unwrap();
+    result.assert_success();
+}
+```
+
+## TransactionResult
+
+The `send_instruction` and `send_instructions` methods return a
+`TransactionResult` that wraps the transaction metadata with useful testing
+utilities.
+
+### Assert Success
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_assert_success() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+
+    let ix = system_instruction::transfer(&alice.pubkey(), &bob.pubkey(), LAMPORTS_PER_SOL);
+    let result = svm.send_instruction(ix, &[&alice]).unwrap();
+
+    // Panics with detailed logs if the transaction failed
+    result.assert_success();
+}
+```
+
+<Callout type="info">
+  `assert_success()` will panic with the full transaction logs if the
+  transaction failed, making debugging much easier.
+</Callout>
+
+### Assert Failure
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_assert_failure() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(1 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+
+    // Try to transfer more than Alice has
+    let ix = system_instruction::transfer(
+        &alice.pubkey(),
+        &bob.pubkey(),
+        100 * LAMPORTS_PER_SOL, // Alice only has 1 SOL
+    );
+    let result = svm.send_instruction(ix, &[&alice]).unwrap();
+
+    // This should fail
+    result.assert_failure();
+}
+```
+
+### Assert Specific Error
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_assert_error() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(1 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+
+    let ix = system_instruction::transfer(
+        &alice.pubkey(),
+        &bob.pubkey(),
+        100 * LAMPORTS_PER_SOL,
+    );
+    let result = svm.send_instruction(ix, &[&alice]).unwrap();
+
+    // Assert a specific error message is present
+    result.assert_error("insufficient lamports");
+}
+```
+
+### Assert Error Code
+
+For custom program errors, you can assert on the error code:
+
+```rust
+// Assert a specific custom error code
+result.assert_error_code(6000); // Custom error code from your program
+```
+
+### Assert Anchor Error
+
+For Anchor programs, assert on error names:
+
+```rust
+// Assert an Anchor-specific error
+result.assert_anchor_error("InsufficientFunds");
+```
+
+## Inspecting Transactions
+
+### Check Transaction Logs
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_check_logs() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+
+    let ix = system_instruction::transfer(&alice.pubkey(), &bob.pubkey(), LAMPORTS_PER_SOL);
+    let result = svm.send_instruction(ix, &[&alice]).unwrap();
+
+    // Check if a specific message is in the logs
+    if result.has_log("Transfer") {
+        println!("Found transfer log!");
+    }
+
+    // Find a log matching a pattern
+    if let Some(log) = result.find_log("Program") {
+        println!("Found log: {}", log);
+    }
+
+    // Get all logs
+    let logs = result.logs();
+    for log in logs {
+        println!("{}", log);
+    }
+}
+```
+
+### Print Logs for Debugging
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_print_logs() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+
+    let ix = system_instruction::transfer(&alice.pubkey(), &bob.pubkey(), LAMPORTS_PER_SOL);
+    let result = svm.send_instruction(ix, &[&alice]).unwrap();
+
+    // Print formatted logs for debugging
+    result.print_logs();
+}
+```
+
+### Check Compute Units
+
+```rust
+use litesvm_utils::{LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_compute_units() {
+    let mut svm = LiteSVM::new();
+
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+
+    let ix = system_instruction::transfer(&alice.pubkey(), &bob.pubkey(), LAMPORTS_PER_SOL);
+    let result = svm.send_instruction(ix, &[&alice]).unwrap();
+
+    let compute_units = result.compute_units();
+    println!("Compute units consumed: {}", compute_units);
+
+    // Assert compute usage is within expected bounds
+    assert!(compute_units < 10_000, "Transaction used too many compute units");
+}
+```
+
+<Callout type="info">
+  Monitoring compute units is useful for optimization. Solana limits
+  transactions to 1.4M compute units, and higher usage costs more.
+</Callout>
+
+## Complete Example
+
+Here's a comprehensive example demonstrating transaction helpers:
+
+```rust
+use litesvm_utils::{AssertionHelpers, LiteSVM, Signer, TestHelpers, TransactionHelpers};
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, system_instruction};
+
+#[test]
+fn test_transaction_workflow() {
+    let mut svm = LiteSVM::new();
+
+    // Setup accounts
+    let alice = svm.create_funded_account(10 * LAMPORTS_PER_SOL).unwrap();
+    let bob = svm.create_funded_account(0).unwrap();
+
+    // Test successful transfer
+    let transfer_ix = system_instruction::transfer(
+        &alice.pubkey(),
+        &bob.pubkey(),
+        2 * LAMPORTS_PER_SOL,
+    );
+
+    let result = svm.send_instruction(transfer_ix, &[&alice]).unwrap();
+
+    // Verify success
+    result.assert_success();
+
+    // Check compute usage
+    let cu = result.compute_units();
+    println!("Transfer used {} compute units", cu);
+
+    // Verify balances
+    svm.assert_sol_balance(&bob.pubkey(), 2 * LAMPORTS_PER_SOL);
+
+    // Test expected failure
+    let bad_transfer = system_instruction::transfer(
+        &alice.pubkey(),
+        &bob.pubkey(),
+        100 * LAMPORTS_PER_SOL, // More than Alice has
+    );
+
+    let fail_result = svm.send_instruction(bad_transfer, &[&alice]).unwrap();
+    fail_result.assert_failure();
+
+    // Print logs for debugging
+    fail_result.print_logs();
+
+    println!("Transaction workflow test passed!");
+}
+```
+
+## Error Types
+
+The `TransactionError` enum provides structured error information:
+
+| Variant                   | Description                               |
+| ------------------------- | ----------------------------------------- |
+| `ExecutionFailed(String)` | Transaction execution failed with message |
+| `BuildError(String)`      | Failed to build the transaction           |
+| `AssertionFailed(String)` | An assertion on the result failed         |

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-spl-tokens/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-spl-tokens/index.mdx
@@ -1,0 +1,279 @@
+---
+title: Quick Start
+description:
+  Learn how to use the litesvm-token crate for testing with SPL tokens
+---
+
+<div className="flex items-center gap-3 mb-6">
+  <a
+    href="https://crates.io/crates/litesvm-token"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-2 px-3 py-1.5 bg-fd-muted/50 hover:bg-fd-muted rounded-lg text-sm font-medium transition-colors border border-fd-border/50"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      className="w-4 h-4"
+      fill="currentColor"
+    >
+      <path d="M239.1 6.3l-208 78c-18.7 7-31.1 25-31.1 45v225.1c0 18.2 10.3 34.8 26.5 42.9l208 104c13.5 6.8 29.4 6.8 42.9 0l208-104c16.3-8.1 26.5-24.8 26.5-42.9V129.3c0-20-12.4-37.9-31.1-44.9l-208-78C262 2.2 250 2.2 239.1 6.3zM256 68.4l192 72v1.1l-192 78-192-78v-1.1l192-72zm32 356V275.5l160-65v133.9l-160 80z" />
+    </svg>
+    View <code>litesvm-token</code> on crates.io
+  </a>
+</div>
+
+## Installation
+
+Make sure you have all the needed dependencies:
+
+```bash
+cargo add --dev litesvm litesvm-token solana-sdk spl-token spl-associated-token-account
+```
+
+## SPL Token Basics
+
+In Solana, creating a token account is a two step process.
+
+<Steps>
+<Step>
+**Create a `Mint Account`**
+- Has no token balance 
+- Holds all the global information of the token, like the total supply, decimals, authority, etc.
+- There is one Mint Account per token
+- The Owner is the Token Program (TokenKeg or Token 2022)
+</Step>
+
+<Step>
+**Create a `Token Account`**
+- Stores the balance for a specific SPL token 
+- Holds the Mint Account to define which SPL token is in this account 
+- There can be several token accounts for one Mint Account 
+- The owner is who has control over the tokens inside this account 
+</Step>
+</Steps>
+
+## Types of Token Accounts
+
+### Regular Token Account
+
+A token account stores your balance for a specific SPL token:
+
+```rust
+// Can create token accounts at ANY address
+let token_account = Keypair::new();  // Random address
+let create_ix = system_instruction::create_account(
+    &payer.pubkey(),
+    &token_account.pubkey(),  // Any address you want
+    rent,
+    165,  // Token account size
+    &spl_token::id(),
+);
+let init_ix = spl_token::instruction::initialize_account(
+    &spl_token::id(),
+    &token_account.pubkey(),
+    &mint,
+    &owner.pubkey(),
+)?;
+```
+
+<div className="grid grid-cols-1 md:grid-cols-2 gap-2 my-3">
+  <div className="bg-gray-50 dark:bg-gray-950/20 border border-gray-200 dark:border-gray-800 rounded-lg px-2 pt-0.5 pb-2">
+    <h4 className="text-xs font-semibold text-gray-800 dark:text-gray-300 mb-1.5 flex items-center gap-1.5">
+      <span className="text-sm">✓</span> Pros
+    </h4>
+    <ul className="space-y-1 text-xs text-gray-900 dark:text-gray-200">
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Can create multiple accounts for same mint/owner</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Flexible - can use any address</span>
+      </li>
+    </ul>
+  </div>
+
+  <div className="bg-gray-50 dark:bg-gray-950/20 border border-gray-200 dark:border-gray-800 rounded-lg px-2 pt-0.5 pb-2">
+    <h4 className="text-xs font-semibold text-gray-800 dark:text-gray-300 mb-1.5 flex items-center gap-1.5">
+      <span className="text-sm">✗</span> Cons
+    </h4>
+    <ul className="space-y-1 text-xs text-gray-900 dark:text-gray-200">
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Not deterministic - need to track addresses manually</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Recipient must tell you which account to send to</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Creates confusion with multiple accounts</span>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<Callout type="info">
+  **When to use:** Temporary/escrow accounts, program-owned accounts with custom
+  logic, when you need multiple accounts for the same token, advanced DeFi
+  strategies.
+</Callout>
+
+### Associated Token Account (ATA)
+
+An ATA is a token account at a deterministic PDA address:
+
+```rust
+// ATA address is ALWAYS the same for owner + mint
+let ata = get_associated_token_address(&owner.pubkey(), &mint);
+// Address derived from: [owner_pubkey, token_program_id, mint]
+```
+
+How the ATA address is derived:
+
+```rust
+// ATA is a PDA owned by the Associated Token Program
+let (ata, bump) = Pubkey::find_program_address(
+    &[
+        owner.as_ref(),
+        spl_token::id().as_ref(),
+        mint.as_ref(),
+    ],
+    &spl_associated_token_account::id(),  // ATA program
+);
+```
+
+<div className="grid grid-cols-1 md:grid-cols-2 gap-2 my-3">
+  <div className="bg-gray-50 dark:bg-gray-950/20 border border-gray-200 dark:border-gray-800 rounded-lg px-2 pt-0.5 pb-2">
+    <h4 className="text-xs font-semibold text-gray-800 dark:text-gray-300 mb-1.5 flex items-center gap-1.5">
+      <span className="text-sm">✓</span> Pros
+    </h4>
+    <ul className="space-y-1 text-xs text-gray-900 dark:text-gray-200">
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>One canonical account per owner/mint pair</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Deterministic - anyone can calculate the address</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Simplifies payments - just need wallet address + mint</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Standard convention across all Solana apps</span>
+      </li>
+    </ul>
+  </div>
+
+  <div className="bg-gray-50 dark:bg-gray-950/20 border border-gray-200 dark:border-gray-800 rounded-lg px-2 pt-0.5 pb-2">
+    <h4 className="text-xs font-semibold text-gray-800 dark:text-gray-300 mb-1.5 flex items-center gap-1.5">
+      <span className="text-sm">✗</span> Cons
+    </h4>
+    <ul className="space-y-1 text-xs text-gray-900 dark:text-gray-200">
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Can only have ONE ATA per owner/mint (by design)</span>
+      </li>
+    </ul>
+  </div>
+</div>
+
+<Callout type="info">
+  **Recommended for most cases:** Wallet applications, DeFi protocols, NFT
+  holdings, payment systems, and any user-facing token transfers.
+</Callout>
+
+## Quick Example
+
+Here's a complete example of creating a token mint and minting tokens:
+
+```rust
+use litesvm::LiteSVM;
+use litesvm_token::{
+    get_spl_account,
+    spl_token::{native_mint::DECIMALS, state::Account as TokenAccount},
+    CreateAccount, CreateMint, MintTo, Transfer,
+};
+use solana_sdk::{
+    native_token::LAMPORTS_PER_SOL,
+    signature::{Keypair, Signer},
+};
+
+#[test]
+fn test_create_and_mint_tokens() {
+    let mut svm = LiteSVM::new();
+
+    // Create payer account and fund it
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create a new SPL token mint with the payer as the mint authority
+    let mint = CreateMint::new(&mut svm, &payer)
+        .authority(&payer.pubkey())
+        .decimals(DECIMALS)
+        .send()
+        .unwrap();
+
+    // Create a token account for the payer
+    let token_account = CreateAccount::new(&mut svm, &payer, &mint)
+        .owner(&payer.pubkey())
+        .send()
+        .unwrap();
+
+    // Mint tokens into the payer's token account
+    MintTo::new(&mut svm, &payer, &mint, &token_account, 1000)
+        .owner(&payer)
+        .send()
+        .unwrap();
+
+    // Verify balance
+    let token_account: TokenAccount = get_spl_account(&svm, &token_account).unwrap();
+    let account_balance = token_account.amount;
+    assert_eq!(account_balance, 1000)
+}
+```
+
+## Key Concepts
+
+### Token Decimals
+
+Most tokens use decimals to represent fractional amounts:
+
+```rust
+// SOL has 9 decimals
+let one_sol = 10_u64.pow(9);  // 1_000_000_000 lamports
+
+// USDC has 6 decimals
+let one_usdc = 10_u64.pow(6); // 1_000_000 micro-USDC
+
+// Always account for decimals in calculations
+let amount_tokens = 100;
+let amount_raw = amount_tokens * 10_u64.pow(decimals as u32);
+```
+
+### Account Relationships
+
+Understanding the relationships between accounts is crucial:
+
+- **Mint Account**: Defines the token (supply, decimals, authorities)
+- **Token Account**: Holds tokens for a specific owner
+- **Associated Token Account**: Deterministic token account for an owner+mint
+  pair
+- **Mint Authority**: Can create new tokens
+- **Freeze Authority**: Can freeze token accounts (optional)
+
+## Troubleshooting
+
+### Common Errors
+
+| Error                       | Cause                                               | Solution                                |
+| --------------------------- | --------------------------------------------------- | --------------------------------------- |
+| `AccountNotFound`           | Trying to use an account that doesn't exist         | Ensure account is created before use    |
+| `AccountAlreadyInitialized` | Trying to initialize an already initialized account | Check if account exists before creating |
+| `InsufficientFunds`         | Not enough lamports for rent or tokens for transfer | Ensure sufficient funding/minting       |
+| `OwnerMismatch`             | Account owned by wrong program                      | Verify correct program ID when creating |

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-spl-tokens/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-spl-tokens/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "litesvm-token",
+  "pages": ["index", "token-operations"]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-spl-tokens/token-operations.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/additional-crates/testing-with-spl-tokens/token-operations.mdx
@@ -1,0 +1,266 @@
+---
+title: Token Operations
+description:
+  Working with token operations - minting, transfers, and account management
+---
+
+## Create a Token Mint
+
+A mint is the foundation of any SPL token. It defines the token's properties and
+controls who can mint new tokens.
+
+```rust
+use litesvm::LiteSVM;
+use litesvm_token::{
+    spl_token::native_mint::DECIMALS,
+    CreateMint,
+};
+use solana_sdk::{
+    native_token::LAMPORTS_PER_SOL,
+    signature::{Keypair, Signer},
+};
+
+#[test]
+fn test_create_mint() {
+    let mut svm = LiteSVM::new();
+
+    // Create payer account and fund it
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create a new SPL token mint with the payer as the mint authority
+    let mint = CreateMint::new(&mut svm, &payer)
+        .authority(&payer.pubkey())
+        .decimals(DECIMALS)
+        .send()
+        .unwrap();
+}
+```
+
+## Create a Token Account
+
+A token account holds the balance of a specific spl-token for a specific user.
+To understand the difference between this and an ATA, read
+[this section](/docs/tools/litesvm/additional-crates/testing-with-spl-tokens#types-of-token-accounts).
+
+```rust
+use litesvm::LiteSVM;
+use litesvm_token::{
+    spl_token::native_mint::DECIMALS,
+    CreateMint, CreateAccount,
+};
+use solana_sdk::{
+    native_token::LAMPORTS_PER_SOL,
+    signature::{Keypair, Signer},
+};
+
+#[test]
+fn test_create_mint() {
+    let mut svm = LiteSVM::new();
+
+    // Create payer account and fund it
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create a new SPL token mint with the payer as the mint authority
+    let mint = CreateMint::new(&mut svm, &payer)
+        .authority(&payer.pubkey())
+        .decimals(DECIMALS)
+        .send()
+        .unwrap();
+
+    // Create a token account for the payer
+    // You must have created a Mint Account to be able to create a Token Account
+    let token_account = CreateAccount::new(&mut svm, &payer, &mint)
+        .owner(&payer.pubkey())
+        .send()
+        .unwrap();
+}
+```
+
+## Create an Associated Token Account
+
+Associated Token Accounts (ATAs) are deterministic addresses for holding tokens
+for a specific user. To understand the difference between this and an ATA, read
+[this section](/docs/tools/litesvm/additional-crates/testing-with-spl-tokens#types-of-token-accounts).
+
+```rust
+use litesvm::LiteSVM;
+use litesvm_token::{
+    spl_token::native_mint::DECIMALS,
+    CreateMint, CreateAssociatedTokenAccount,
+};
+use solana_sdk::{
+    native_token::LAMPORTS_PER_SOL,
+    signature::{Keypair, Signer},
+};
+
+#[test]
+fn test_create_mint() {
+    let mut svm = LiteSVM::new();
+
+    // Create payer account and fund it
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create a new SPL token mint with the payer as the mint authority
+    let mint = CreateMint::new(&mut svm, &payer)
+        .authority(&payer.pubkey())
+        .decimals(DECIMALS)
+        .send()
+        .unwrap();
+
+    // Create an ATA for the payer
+    // You must have created a Mint Account to be able to create a Token Account
+    let associated_token_account = CreateAssociatedTokenAccount::new(&mut svm, &payer, &mint)
+        .owner(&payer.pubkey())
+        .send()
+        .unwrap();
+}
+
+```
+
+## Mint Tokens into a Token Account
+
+Once you have a mint and token accounts, you can mint tokens to those accounts.
+
+```rust
+use litesvm::LiteSVM;
+use litesvm_token::{
+    get_spl_account,
+    spl_token::{native_mint::DECIMALS, state::Account as TokenAccount},
+    CreateAssociatedTokenAccount, CreateMint, MintTo,
+};
+use solana_sdk::{
+    native_token::LAMPORTS_PER_SOL,
+    signature::{Keypair, Signer},
+};
+
+#[test]
+fn test_mint_tokens() {
+    let mut svm = LiteSVM::new();
+
+    // Create payer account and fund it
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create two users
+    let alice = Keypair::new();
+
+    // Create a new SPL token mint with alice as the mint authority
+    let mint = CreateMint::new(&mut svm, &payer)
+        .authority(&alice.pubkey())
+        .decimals(DECIMALS)
+        .send()
+        .unwrap();
+
+    // Create associated token accounts (ATAs) for alice and bob
+    let alice_token_account = CreateAssociatedTokenAccount::new(&mut svm, &payer, &mint)
+        .owner(&alice.pubkey())
+        .send()
+        .unwrap();
+
+    // Mint 1000 tokens to Alice's account
+    MintTo::new(&mut svm, &payer, &mint, &alice_token_account, 1000)
+        .owner(&alice)
+        .send()
+        .unwrap();
+
+    // Verify balance
+    let alice_account: TokenAccount = get_spl_account(&svm, &alice_token_account).unwrap();
+    let alice_balance = alice_account.amount;
+    assert_eq!(alice_balance, 1000);
+}
+```
+
+## Make a Token Transfer
+
+Transfer tokens between accounts using the Transfer instruction.
+
+```rust
+use litesvm::LiteSVM;
+use litesvm_token::{
+    get_spl_account,
+    spl_token::{native_mint::DECIMALS, state::Account as TokenAccount},
+    CreateAssociatedTokenAccount, CreateMint, MintTo, Transfer,
+};
+use solana_sdk::{
+    native_token::LAMPORTS_PER_SOL,
+    signature::{Keypair, Signer},
+};
+
+#[test]
+fn test_token_transfer() {
+        let mut svm = LiteSVM::new();
+
+    // Create payer account and fund it
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create two users
+    let alice = Keypair::new();
+    let bob = Keypair::new();
+
+    // Create a new SPL token mint with alice as the mint authority
+    let mint = CreateMint::new(&mut svm, &payer)
+        .authority(&alice.pubkey())
+        .decimals(DECIMALS)
+        .send()
+        .unwrap();
+
+    // Create associated token accounts (ATAs) for alice and bob
+    let alice_token_account = CreateAssociatedTokenAccount::new(&mut svm, &payer, &mint)
+        .owner(&alice.pubkey())
+        .send()
+        .unwrap();
+
+    let bob_token_account = CreateAssociatedTokenAccount::new(&mut svm, &payer, &mint)
+        .owner(&bob.pubkey())
+        .send()
+        .unwrap();
+
+    // Mint 1000 tokens to Alice's account
+    MintTo::new(&mut svm, &payer, &mint, &alice_token_account, 1000)
+        .owner(&alice)
+        .send()
+        .unwrap();
+
+    // Transfer 400 tokens from Alice to Bob
+    Transfer::new(&mut svm, &payer, &mint, &bob_token_account, 400)
+        .source(&alice_token_account)
+        .owner(&alice)
+        .send()
+        .unwrap();
+
+    // Verify balances
+    let alice_account: TokenAccount = get_spl_account(&svm, &alice_token_account).unwrap();
+    let bob_account: TokenAccount = get_spl_account(&svm, &bob_token_account).unwrap();
+
+    let alice_balance = alice_account.amount;
+    let bob_balance = bob_account.amount;
+
+    assert_eq!(alice_balance, 600);
+    assert_eq!(bob_balance, 400);
+
+    println!("SPL token transfer successful!");
+}
+```
+
+## Working with Decimals
+
+Most tokens use decimals to represent fractional amounts. Here's how to handle
+them correctly:
+
+```rust
+// For a token with 6 decimals (like USDC)
+let decimals = 6;
+let one_token = 10_u64.pow(decimals as u32);
+let amount_tokens = 100; // Want to send 100 tokens
+let amount_raw = amount_tokens * one_token; // 100,000,000 raw units
+
+// For a token with 9 decimals (like SOL)
+let decimals = 9;
+let one_sol = 10_u64.pow(decimals as u32);
+let amount_sol = 1.5; // Want to send 1.5 SOL
+let amount_lamports = (amount_sol * one_sol as f64) as u64; // 1,500,000,000 lamports
+```

--- a/apps/docs/content/docs/en/tools/litesvm/api-reference/account-management.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/api-reference/account-management.mdx
@@ -1,0 +1,156 @@
+---
+title: Account Management
+description: Methods for managing accounts, balances, and rent
+---
+
+## airdrop
+
+```rust
+pub fn airdrop(&mut self, address: &Address, lamports: u64) -> TransactionResult
+```
+
+Where `TransactionResult` is
+`Result<TransactionMetadata, FailedTransactionMetadata>`.
+
+Fund an account with lamports. Returns transaction metadata on success.
+
+```rust
+let keypair = Keypair::new();
+
+// Option 1: Ignore result if you don't care about tx details
+svm.airdrop(&keypair.pubkey(), 10_000_000_000).unwrap();
+
+// Option 2: Check transaction metadata
+match svm.airdrop(&keypair.pubkey(), 10_000_000_000) {
+    Ok(meta) => {
+        println!("Airdrop successful");
+        println!("Compute units: {}", meta.compute_units_consumed);
+    }
+    Err(e) => {
+        println!("Airdrop failed: {:?}", e.err);
+    }
+}
+```
+
+## get_account
+
+```rust
+pub fn get_account(&self, address: &Address) -> Option<Account>
+```
+
+Retrieve account data.
+
+```rust
+let account = svm.get_account(&pubkey)?;
+println!("Lamports: {}", account.lamports);
+println!("Owner: {}", account.owner);
+println!("Data length: {}", account.data.len());
+```
+
+## set_account
+
+```rust
+pub fn set_account(&mut self, address: Address, account: Account) -> Result<(), LiteSVMError>
+```
+
+Directly set account state.
+
+```rust
+use solana_account::Account;
+
+svm.set_account(pubkey, Account {
+    lamports: 1_000_000,
+    data: vec![0; 100],
+    owner: program_id,
+    executable: false,
+    rent_epoch: 0,
+}).unwrap();
+```
+
+## get_balance
+
+```rust
+pub fn get_balance(&self, address: &Address) -> Option<u64>
+```
+
+Get account lamport balance. Returns `None` if account doesn't exist.
+
+```rust
+// Check if account exists and get balance
+if let Some(balance) = svm.get_balance(&pubkey) {
+    println!("Balance: {} lamports", balance);
+} else {
+    println!("Account doesn't exist");
+}
+
+// Or use unwrap_or for default
+let balance = svm.get_balance(&pubkey).unwrap_or(0);
+println!("Balance: {} lamports", balance);
+```
+
+## minimum_balance_for_rent_exemption
+
+```rust
+pub fn minimum_balance_for_rent_exemption(&self, data_len: usize) -> u64
+```
+
+Calculate minimum lamports needed for rent exemption.
+
+```rust
+let data_len = 100;
+let min_balance = svm.minimum_balance_for_rent_exemption(data_len);
+
+use solana_account::Account;
+
+svm.set_account(pubkey, Account {
+    lamports: min_balance,
+    data: vec![0; data_len],
+    owner: program_id,
+    executable: false,
+    rent_epoch: 0,
+}).unwrap();
+```
+
+## Performance Tips
+
+### Batch Account Creation
+
+```rust
+// Slow - individual operations
+for i in 0..100 {
+    let account = Keypair::new();
+    svm.airdrop(&account.pubkey(), 1_000_000_000).unwrap();
+}
+
+// Fast - batch with set_account
+let accounts: Vec<_> = (0..100)
+    .map(|_| {
+        let keypair = Keypair::new();
+        svm.set_account(keypair.pubkey(), Account {
+            lamports: 1_000_000_000,
+            data: vec![],
+            owner: solana_sdk::system_program::id(),
+            executable: false,
+            rent_epoch: 0,
+        }).unwrap();
+        keypair
+    })
+    .collect();
+```
+
+### Account State Inspection
+
+```rust
+// Before transaction
+let before = svm.get_account(&pubkey).unwrap();
+
+// Execute
+svm.send_transaction(tx).unwrap();
+
+// After transaction
+let after = svm.get_account(&pubkey).unwrap();
+
+// Compare
+assert_ne!(before.lamports, after.lamports);
+assert_ne!(before.data, after.data);
+```

--- a/apps/docs/content/docs/en/tools/litesvm/api-reference/configuration.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/api-reference/configuration.mdx
@@ -1,0 +1,249 @@
+---
+title: Environment Configuration
+description: Builder pattern methods for configuring LiteSVM test environments
+---
+
+All configuration methods use the builder pattern with `LiteSVM::default()`.
+
+## with_compute_budget
+
+```rust
+pub fn with_compute_budget(self, compute_budget: ComputeBudget) -> Self
+```
+
+Set compute unit limits and heap size.
+
+```rust
+use solana_compute_budget::compute_budget::ComputeBudget;
+
+let mut svm = LiteSVM::default()
+    .with_compute_budget(ComputeBudget {
+        compute_unit_limit: 1_400_000,
+        heap_size: 256 * 1024,
+        ..ComputeBudget::default()
+    });
+```
+
+## with_sigverify
+
+```rust
+pub fn with_sigverify(self, sigverify: bool) -> Self
+```
+
+Enable or disable signature verification. Default: `true`.
+
+```rust
+// Disable for faster tests
+let mut svm = LiteSVM::default()
+    .with_sigverify(false);
+```
+
+## with_blockhash_check
+
+```rust
+pub fn with_blockhash_check(self, check: bool) -> Self
+```
+
+Enable or disable blockhash validation. Default: `true`.
+
+```rust
+// Disable to use any blockhash
+let mut svm = LiteSVM::default()
+    .with_blockhash_check(false);
+```
+
+## with_transaction_history
+
+```rust
+pub fn with_transaction_history(self, capacity: usize) -> Self
+```
+
+Set number of transactions to keep in history. Default: `0`.
+
+```rust
+// Keep last 100 transactions
+let mut svm = LiteSVM::default()
+    .with_transaction_history(100);
+```
+
+## with_log_bytes_limit
+
+```rust
+pub fn with_log_bytes_limit(self, limit: Option<usize>) -> Self
+```
+
+Set maximum bytes for transaction logs. Default: `Some(10_000)`.
+
+```rust
+// Unlimited logs
+let mut svm = LiteSVM::default()
+    .with_log_bytes_limit(None);
+
+// Custom limit (50KB)
+let mut svm = LiteSVM::default()
+    .with_log_bytes_limit(Some(50_000));
+```
+
+## with_lamports
+
+```rust
+pub fn with_lamports(self, lamports: u64) -> Self
+```
+
+Set initial lamports for fee collection. Default: `1_000_000_000`.
+
+```rust
+let mut svm = LiteSVM::default()
+    .with_lamports(10_000_000_000);
+```
+
+## with_default_programs
+
+```rust
+pub fn with_default_programs(self) -> Self
+```
+
+Include default SPL programs (Token, Associated Token, etc.).
+
+```rust
+let mut svm = LiteSVM::default()
+    .with_default_programs();
+```
+
+## with_sysvars
+
+```rust
+pub fn with_sysvars(self) -> Self
+```
+
+Includes default sysvars (Clock, Rent, EpochSchedule, SlotHashes, StakeHistory,
+etc.).
+
+```rust
+let mut svm = LiteSVM::default()
+    .with_sysvars();
+```
+
+## with_feature_set
+
+```rust
+pub fn with_feature_set(self, feature_set: FeatureSet) -> Self
+```
+
+Configure Solana feature set for testing specific runtime features.
+
+```rust
+use agave_feature_set::FeatureSet;
+
+let mut svm = LiteSVM::default()
+    .with_feature_set(FeatureSet::all_enabled());
+```
+
+## with_precompiles
+
+```rust
+#[cfg(feature = "precompiles")]
+pub fn with_precompiles(self) -> Self
+```
+
+Includes standard precompile programs (ed25519, secp256k1, secp256r1).
+
+```rust
+let mut svm = LiteSVM::default()
+    .with_precompiles();
+```
+
+<Callout type="info">
+  Requires the `precompiles` feature flag:
+
+```toml
+[dev-dependencies]
+litesvm = { version = "0.11", features = ["precompiles"] }
+```
+
+</Callout>
+
+## with_feature_accounts
+
+```rust
+pub fn with_feature_accounts(self) -> Self
+```
+
+Include feature gate accounts in the test environment. This ensures
+feature-gated Solana runtime behavior is accurately reflected in your tests.
+
+```rust
+let mut svm = LiteSVM::default()
+    .with_feature_accounts();
+```
+
+## register-tracing feature
+
+The `register-tracing` feature enables detailed SBF register tracing during
+transaction execution. It implies the `invocation-inspect-callback` feature.
+
+```toml
+[dev-dependencies]
+litesvm = { version = "0.11", features = ["register-tracing"] }
+```
+
+Use `LiteSVM::new_debuggable(true)` to create an instance with register tracing
+enabled:
+
+```rust
+#[cfg(feature = "register-tracing")]
+let mut svm = LiteSVM::new_debuggable(true);
+```
+
+When enabled, set the `SBF_TRACE_DISASSEMBLE` environment variable to also dump
+disassembly output alongside register traces:
+
+```bash
+SBF_TRACE_DISASSEMBLE=1 cargo test
+```
+
+## set_invocation_inspect_callback
+
+```rust
+pub fn set_invocation_inspect_callback<C: InvocationInspectCallback + 'static>(&mut self, callback: C)
+```
+
+Register a callback that fires before and after each program invocation.
+Requires the `invocation-inspect-callback` feature.
+
+```toml
+[dev-dependencies]
+litesvm = { version = "0.11", features = ["invocation-inspect-callback"] }
+```
+
+```rust
+use litesvm::{LiteSVM, types::InvocationInspectCallback};
+use solana_svm::invoke_context::InvokeContext;
+use solana_svm_transaction::svm_message::SVMMessage;
+
+struct MyInspector;
+
+impl InvocationInspectCallback for MyInspector {
+    fn before_invocation(
+        &self,
+        _svm: &LiteSVM,
+        _tx: &impl SVMMessage,
+        _program_indices: &[u16],
+        _invoke_context: &InvokeContext,
+    ) {
+        println!("Before program invocation");
+    }
+
+    fn after_invocation(
+        &self,
+        _svm: &LiteSVM,
+        _invoke_context: &InvokeContext,
+        _enable_register_tracing: bool,
+    ) {
+        println!("After program invocation");
+    }
+}
+
+let mut svm = LiteSVM::new();
+svm.set_invocation_inspect_callback(MyInspector);
+```

--- a/apps/docs/content/docs/en/tools/litesvm/api-reference/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/api-reference/index.mdx
@@ -1,0 +1,35 @@
+---
+title: API Reference
+description:
+  Complete API reference for LiteSVM methods and configuration options
+---
+
+## API Sections
+
+<Cards>
+  <Card
+    title="Quick Reference"
+    description="Quick reference table and getting started guide"
+    href="/docs/tools/litesvm/api-reference/quick-reference"
+  />
+  <Card
+    title="Account Management"
+    description="Methods for managing accounts, balances, and rent"
+    href="/docs/tools/litesvm/api-reference/account-management"
+  />
+  <Card
+    title="Transactions"
+    description="Execute and simulate transactions"
+    href="/docs/tools/litesvm/api-reference/transactions"
+  />
+  <Card
+    title="Configuration"
+    description="Builder pattern methods for configuring LiteSVM"
+    href="/docs/tools/litesvm/api-reference/configuration"
+  />
+  <Card
+    title="Time & Sysvars"
+    description="Manipulate time and system variables"
+    href="/docs/tools/litesvm/api-reference/time-and-sysvars"
+  />
+</Cards>

--- a/apps/docs/content/docs/en/tools/litesvm/api-reference/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/api-reference/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "API Reference",
+  "pages": [
+    "quick-reference",
+    "configuration",
+    "account-management",
+    "transactions",
+    "time-and-sysvars"
+  ]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/api-reference/quick-reference.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/api-reference/quick-reference.mdx
@@ -1,0 +1,28 @@
+---
+title: Quick Reference
+description: Quick reference table and getting started guide
+---
+
+## Quick Reference
+
+| Method                                         | Description                                                                                |
+| ---------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `LiteSVM::new()`                               | Create new LiteSVM basic test environment                                                  |
+| `LiteSVM::default()`                           | Returns the "default value" for a type                                                     |
+| `airdrop(&Address, lamports)`                  | Funds the account with the lamports specified                                              |
+| `get_account(&Address)`                        | Returns all information associated with the account of the provided address                |
+| `set_account(Address, Account)`                | Sets all information associated with the account of the provided address                   |
+| `get_balance(&Address)`                        | Gets the lamport balance of the provided account address                                   |
+| `minimum_balance_for_rent_exemption(data_len)` | Returns minimum balance required to make an account with specified data length rent exempt |
+| `add_program(program_id, &bytes)`              | Adds an SBF program to the test environment                                                |
+| `add_program_from_file(program_id, path)`      | Adds an SBF program to the test environment from the file specified                        |
+| `send_transaction(tx)`                         | Submits a signed transaction                                                               |
+| `simulate_transaction(tx)`                     | Simulates a transaction without modifying state                                            |
+| `get_transaction(&signature)`                  | Gets a transaction from history                                                            |
+| `latest_blockhash()`                           | Gets current blockhash                                                                     |
+| `expire_blockhash()`                           | Force blockhash expiration on the current blockhash                                        |
+| `warp_to_slot(slot)`                           | Warps the clock to the specified slot                                                      |
+| `get_sysvar<T>()`                              | Gets a sysvar from the test environment                                                    |
+| `set_sysvar<T>(&value)`                        | Sets the sysvar to the test environment                                                    |
+| `with_feature_accounts()`                      | Includes feature gate accounts in the test environment                                     |
+| `set_invocation_inspect_callback(callback)`    | Registers a pre/post invocation callback (requires `invocation-inspect-callback` feature)  |

--- a/apps/docs/content/docs/en/tools/litesvm/api-reference/time-and-sysvars.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/api-reference/time-and-sysvars.mdx
@@ -1,0 +1,215 @@
+---
+title: Time & Sysvars
+description: Methods for manipulating time and system variables
+---
+
+## Time Manipulation
+
+### warp_to_slot
+
+```rust
+pub fn warp_to_slot(&mut self, slot: u64)
+```
+
+Jump to a specific slot. Only forward time travel is supported.
+
+```rust
+// Get current slot
+let clock: Clock = svm.get_sysvar();
+let current_slot = clock.slot;
+
+// Jump forward 100 slots
+svm.warp_to_slot(current_slot + 100);
+
+// Verify
+let new_clock: Clock = svm.get_sysvar();
+assert_eq!(new_clock.slot, current_slot + 100);
+```
+
+### Manual Clock Manipulation
+
+```rust
+use solana_sdk::clock::Clock;
+
+// Read clock
+let mut clock: Clock = svm.get_sysvar();
+
+// Modify fields
+clock.slot = 1000;
+clock.epoch = 10;
+clock.unix_timestamp = 1735689600;
+
+// Write back
+svm.set_sysvar(&clock);
+```
+
+<Callout type="info">
+  Use `warp_to_slot()` for most time manipulation. Use manual clock modification
+  only when you need precise control over multiple fields.
+</Callout>
+
+## Sysvars
+
+### get_sysvar
+
+```rust
+pub fn get_sysvar<T: Sysvar>(&self) -> T
+```
+
+Read sysvar value.
+
+```rust
+use solana_sdk::clock::Clock;
+use solana_sdk::rent::Rent;
+use solana_sdk::epoch_schedule::EpochSchedule;
+
+let clock: Clock = svm.get_sysvar();
+let rent: Rent = svm.get_sysvar();
+let epoch_schedule: EpochSchedule = svm.get_sysvar();
+```
+
+### set_sysvar
+
+```rust
+pub fn set_sysvar<T: Sysvar>(&mut self, sysvar: &T)
+```
+
+Write sysvar value.
+
+```rust
+use solana_sdk::rent::Rent;
+
+let rent = Rent {
+    lamports_per_byte_year: 3480,
+    exemption_threshold: 2.0,
+    burn_percent: 50,
+};
+
+svm.set_sysvar(&rent);
+```
+
+## Common Sysvars
+
+### Clock
+
+```rust
+use solana_sdk::clock::Clock;
+
+let clock: Clock = svm.get_sysvar();
+println!("Slot: {}", clock.slot);
+println!("Timestamp: {}", clock.unix_timestamp);
+println!("Epoch: {}", clock.epoch);
+```
+
+### Rent
+
+```rust
+use solana_sdk::rent::Rent;
+
+let rent: Rent = svm.get_sysvar();
+let min_balance = rent.minimum_balance(data_len);
+```
+
+### Epoch Schedule
+
+```rust
+use solana_sdk::epoch_schedule::EpochSchedule;
+
+let schedule: EpochSchedule = svm.get_sysvar();
+println!("Slots per epoch: {}", schedule.slots_per_epoch);
+```
+
+### Stake History
+
+```rust
+use solana_sdk::stake_history::{StakeHistory, StakeHistoryEntry};
+
+let mut stake_history = StakeHistory::default();
+stake_history.add(
+    0, // epoch
+    StakeHistoryEntry {
+        effective: 1_000_000,
+        activating: 0,
+        deactivating: 0,
+    },
+);
+
+svm.set_sysvar(&stake_history);
+```
+
+## Time-Based Testing Patterns
+
+### Test Slot-Based Features
+
+```rust
+let mut svm = LiteSVM::new();
+
+// Get starting slot
+let start_slot = svm.get_sysvar::<Clock>().slot;
+
+// Try action before unlock slot (should fail)
+let result = call_locked_program(&mut svm);
+assert!(result.is_err());
+
+// Warp to unlock slot
+svm.warp_to_slot(start_slot + 1000);
+
+// Now it should succeed
+let result = call_locked_program(&mut svm);
+assert!(result.is_ok());
+```
+
+### Test Timestamp-Based Features
+
+```rust
+let mut svm = LiteSVM::new();
+
+// Get current timestamp
+let clock: Clock = svm.get_sysvar();
+let current_time = clock.unix_timestamp;
+
+// Warp forward 1 hour (3600 seconds)
+// Slots roughly correspond to ~0.4 seconds on Solana
+let target_slot = clock.slot + (3600.0 / 0.4) as u64;
+svm.warp_to_slot(target_slot);
+
+// Verify timestamp increased
+let new_clock: Clock = svm.get_sysvar();
+assert!(new_clock.unix_timestamp >= current_time + 3600);
+```
+
+### Test Vesting Schedules
+
+```rust
+// Setup vesting with 100 slot period
+let vesting_period = 100;
+let start_slot = svm.get_sysvar::<Clock>().slot;
+
+// Test before vesting completes
+let result = claim_vested_tokens(&mut svm);
+assert!(result.is_err()); // Too early
+
+// Warp past vesting period
+svm.warp_to_slot(start_slot + vesting_period + 1);
+
+// Now claim should succeed
+let result = claim_vested_tokens(&mut svm);
+assert!(result.is_ok());
+```
+
+## Common Use Cases
+
+- Vesting schedules
+- Time-locked withdrawals
+- Stake/unstake cooldown periods
+- Auction end times
+- Rental periods
+- Epoch-based rewards
+
+## Important Notes
+
+1. **Forward only** - You can only warp forward in time, not backward
+2. **Slot to time** - Slots roughly correspond to ~0.4 seconds on Solana mainnet
+3. **Clock sysvar** - Always updated when using `warp_to_slot()`
+4. **No automatic updates** - Unlike real validators, time doesn't advance
+   automatically between transactions

--- a/apps/docs/content/docs/en/tools/litesvm/api-reference/transactions.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/api-reference/transactions.mdx
@@ -1,0 +1,277 @@
+---
+title: Transactions
+description: Methods for handling transactions
+---
+
+## send_transaction
+
+```rust
+pub fn send_transaction(&mut self, tx: impl Into<VersionedTransaction>) -> Result<TransactionMetadata, FailedTransactionMetadata>
+```
+
+Execute transaction and modify state.
+
+```rust
+let tx = Transaction::new_signed_with_payer(
+    &[instruction],
+    Some(&payer.pubkey()),
+    &[&payer],
+    svm.latest_blockhash(),
+);
+
+match svm.send_transaction(tx) {
+    Ok(meta) => {
+        println!("Success! Signature: {}", meta.signature);
+        println!("Compute units: {}", meta.compute_units_consumed);
+        println!("Fee: {} lamports", meta.fee);
+    }
+    Err(e) => {
+        println!("Failed: {:?}", e.err);
+        println!("Logs: {:?}", e.meta.logs);
+    }
+}
+```
+
+## simulate_transaction
+
+```rust
+pub fn simulate_transaction(&self, tx: impl Into<VersionedTransaction>) -> Result<SimulatedTransactionInfo, FailedTransactionMetadata>
+```
+
+Simulate transaction without modifying state.
+
+Returns `SimulatedTransactionInfo` which contains:
+
+- `meta`: Transaction metadata (logs, compute units, signature, etc.)
+- `post_accounts`: Account states after simulation
+
+```rust
+// State before simulation
+let balance_before = svm.get_balance(&pubkey).unwrap_or(0);
+
+// Simulate transaction
+let result = svm.simulate_transaction(tx.clone());
+
+// State unchanged
+assert_eq!(svm.get_balance(&pubkey).unwrap_or(0), balance_before);
+
+// Check simulation result
+if let Ok(sim_info) = result {
+    println!("Would succeed");
+    println!("Compute units: {}", sim_info.meta.compute_units_consumed);
+
+    // Can inspect post_accounts to see what would change
+    for (pubkey, account) in sim_info.post_accounts {
+        println!("Account {} would have {} lamports", pubkey, account.lamports());
+    }
+
+    // Safe to send
+    svm.send_transaction(tx).unwrap();
+}
+```
+
+## When to Use Simulation
+
+Use `simulate_transaction()` to:
+
+- Test transaction validity without modifying state
+- Check compute unit consumption
+- Verify transaction logs without commitment
+- Test error handling paths
+
+```rust
+// Test if transaction would succeed
+let result = svm.simulate_transaction(tx.clone());
+
+match result {
+    Ok(sim_info) => {
+        println!("Would succeed");
+        println!("Compute units: {}", sim_info.meta.compute_units_consumed);
+
+        // Now execute for real
+        svm.send_transaction(tx).unwrap();
+    }
+    Err(e) => {
+        println!("Would fail: {:?}", e.err);
+        // Don't send transaction
+    }
+}
+```
+
+## Testing Error Cases
+
+```rust
+// Simulate expected failure
+let result = svm.simulate_transaction(invalid_tx);
+assert!(result.is_err());
+
+match result.unwrap_err().err {
+    TransactionError::InsufficientFundsForFee => {
+        println!("Expected error occurred");
+    }
+    _ => panic!("Unexpected error"),
+}
+```
+
+## State Remains Unchanged
+
+```rust
+let balance_before = svm.get_balance(&pubkey).unwrap_or(0);
+
+// Simulate multiple times
+for _ in 0..10 {
+    svm.simulate_transaction(tx.clone()).unwrap();
+}
+
+// Balance unchanged
+assert_eq!(svm.get_balance(&pubkey).unwrap_or(0), balance_before);
+```
+
+## Transaction Metadata
+
+`send_transaction()` returns `TransactionMetadata` directly, while
+`simulate_transaction()` returns `SimulatedTransactionInfo` which contains
+`meta: TransactionMetadata`:
+
+```rust
+pub struct TransactionMetadata {
+    pub signature: Signature,
+    pub logs: Vec<String>,
+    pub inner_instructions: InnerInstructionsList,
+    pub compute_units_consumed: u64,
+    pub return_data: TransactionReturnData,
+    pub fee: u64,
+}
+```
+
+### Accessing Transaction Data
+
+```rust
+let result = svm.send_transaction(tx).unwrap();
+
+// Signature
+println!("Signature: {}", result.signature);
+
+// Logs
+for log in &result.logs {
+    println!("{}", log);
+}
+
+// Compute units
+println!("CU consumed: {}", result.compute_units_consumed);
+
+// Return data
+if let Some(data) = result.return_data.data {
+    println!("Program returned: {:?}", data);
+}
+
+// Inner instructions (CPIs)
+for inner in &result.inner_instructions {
+    println!("CPI: {:?}", inner);
+}
+
+// Transaction fee paid by fee payer
+println!("Fee paid: {} lamports", result.fee);
+```
+
+## get_transaction
+
+```rust
+pub fn get_transaction(&self, signature: &Signature) -> Option<&TransactionResult>
+```
+
+Where
+`TransactionResult = Result<TransactionMetadata, FailedTransactionMetadata>`.
+
+Query transaction from history. Requires `with_transaction_history()` to be set.
+
+```rust
+let mut svm = LiteSVM::default()
+    .with_transaction_history(100);
+
+let result = svm.send_transaction(tx).unwrap();
+let signature = result.signature;
+
+// Query later
+if let Some(tx_result) = svm.get_transaction(&signature) {
+    match tx_result {
+        Ok(meta) => println!("Found: {:?}", meta),
+        Err(e) => println!("Failed: {:?}", e.err),
+    }
+}
+```
+
+## latest_blockhash
+
+```rust
+pub fn latest_blockhash(&self) -> Hash
+```
+
+Get current blockhash for transactions.
+
+```rust
+let blockhash = svm.latest_blockhash();
+
+let tx = Transaction::new_signed_with_payer(
+    &[instruction],
+    Some(&payer.pubkey()),
+    &[&payer],
+    blockhash,
+);
+```
+
+## expire_blockhash
+
+```rust
+pub fn expire_blockhash(&mut self)
+```
+
+Force current blockhash to expire.
+
+```rust
+let old_hash = svm.latest_blockhash();
+svm.expire_blockhash();
+let new_hash = svm.latest_blockhash();
+
+assert_ne!(old_hash, new_hash);
+
+// Transactions with old_hash will now fail
+```
+
+## Common Patterns
+
+### Validate Before Executing
+
+```rust
+// Simulate first to check validity
+if svm.simulate_transaction(tx.clone()).is_ok() {
+    // Execute if simulation passes
+    svm.send_transaction(tx).unwrap();
+} else {
+    println!("Transaction would fail, skipping execution");
+}
+```
+
+### Track Compute Units
+
+```rust
+let result = svm.send_transaction(tx).unwrap();
+
+// Assert within budget
+assert!(
+    result.compute_units_consumed < 100_000,
+    "Transaction used too many compute units: {}",
+    result.compute_units_consumed
+);
+```
+
+### Check Transaction Logs
+
+```rust
+let result = svm.send_transaction(tx).unwrap();
+
+// Check for specific log messages
+assert!(result.logs.iter().any(|log|
+    log.contains("Transfer successful")
+));
+```

--- a/apps/docs/content/docs/en/tools/litesvm/core-concepts.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/core-concepts.mdx
@@ -1,0 +1,233 @@
+---
+title: Why LiteSVM
+description: Understand how LiteSVM works and why it's different
+---
+
+## Overview
+
+Think of LiteSVM as a Solana VM running inside your test function. Not as a
+separate process, not as a network service - it's just a library call in your
+code.
+
+### Traditional Testing
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+```rust
+// Traditional approach - slow and complex
+let validator = TestValidator::new().await; // Starts separate process
+let client = RpcClient::new(validator.url()); // Network connection
+
+// Every operation is async and goes over network
+let balance = client.get_balance(&pubkey).await?;
+tokio::time::sleep(Duration::from_secs(1)).await; // Wait for confirmation
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```typescript
+// Traditional approach - slow and complex
+const validator = await startTestValidator(); // Starts separate process
+const rpc = createSolanaRpc(validator.url);
+
+// Every operation is async and goes over network
+const balance = await rpc.getBalance(address).send();
+```
+
+</Tab>
+</Tabs>
+
+### LiteSVM Testing
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+```rust
+// LiteSVM - fast and simple
+let mut svm = LiteSVM::new(); // Just a struct in memory
+
+// Everything is synchronous and immediate
+let balance = svm.get_balance(&pubkey).unwrap_or(0);
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```typescript
+import { createClient, generateKeyPairSigner } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+// LiteSVM - fast and simple
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
+// Everything is synchronous and immediate
+const balance = client.svm.getBalance(pubkey) ?? 0n;
+```
+
+</Tab>
+</Tabs>
+
+## Key Principles
+
+### 1. Everything is Synchronous
+
+No `async`, no `await`, no delays:
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+```rust
+// Send transaction and check result immediately
+svm.send_transaction(tx).unwrap();
+let balance = svm.get_balance(&account).unwrap(); // Already updated!
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```typescript
+// Send transaction and check result immediately
+client.svm.sendTransaction(signedTx);
+const balance = client.svm.getBalance(account); // Already updated!
+```
+
+</Tab>
+</Tabs>
+
+### 2. Direct State Manipulation
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+```rust
+// Create any account with any data
+svm.set_account(pubkey, Account {
+    lamports: 1_000_000_000,
+    data: vec![1, 2, 3, 4],
+    owner: program_id,
+    executable: false,
+    rent_epoch: 0,
+}).unwrap();
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```typescript
+// Create any account with any data
+client.svm.setAccount(pubkey, {
+  lamports: 1_000_000_000n,
+  data: new Uint8Array([1, 2, 3, 4]),
+  owner: programId,
+  executable: false,
+  rentEpoch: 0n
+});
+```
+
+</Tab>
+</Tabs>
+
+### 3. Time is Under Your Control
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+```rust
+// Jump to any slot instantly
+svm.warp_to_slot(1000);
+
+// Expire blockhashes on demand
+svm.expire_blockhash();
+
+// Set any sysvar
+let mut clock = svm.get_sysvar::<Clock>();
+clock.unix_timestamp = 1735689600; // Jan 1, 2025
+svm.set_sysvar(&clock);
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```typescript
+// Jump to any slot instantly
+client.svm.warpToSlot(1000n);
+
+// Expire blockhashes on demand
+client.svm.expireBlockhash();
+
+// Set the clock sysvar
+client.svm.setClock({
+  slot: 1000n,
+  epochStartTimestamp: 0n,
+  epoch: 0n,
+  leaderScheduleEpoch: 0n,
+  unixTimestamp: 1735689600n // Jan 1, 2025
+});
+```
+
+</Tab>
+</Tabs>
+
+### 4. Errors are Immediate and Clear
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+```rust
+match svm.send_transaction(tx) {
+    Ok(meta) => {
+        // Transaction succeeded
+        println!("Compute units: {}", meta.compute_units_consumed);
+    }
+    Err(e) => {
+        // Error with full details
+        println!("Error: {:?}", e.err);
+        println!("Logs: {:?}", e.meta.logs);
+    }
+}
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```typescript
+const result = client.svm.sendTransaction(signedTx);
+
+if ("err" in result && result.err()) {
+  // Error with full details
+  console.log("Error:", result.err());
+  console.log("Logs:", result.logs());
+} else {
+  // Transaction succeeded
+  console.log("Compute units:", result.computeUnitsConsumed());
+}
+```
+
+</Tab>
+</Tabs>
+
+## Next Steps
+
+<Tabs items={["Rust", "TypeScript"]} groupId="litesvm-lang">
+  <Tab value="Rust">
+    - **[Testing Your Program →](/docs/tools/litesvm/testing-your-program)**
+    Learn how to test your own Solana program - **[Examples
+    →](/docs/tools/litesvm/examples)** View copy-paste solutions for common
+    scenarios and full repository examples - **[API Reference
+    →](/docs/tools/litesvm/api-reference)** Learn advanced features and custom
+    configurations
+  </Tab>
+  <Tab value="TypeScript">
+    - **[Testing Your Program
+    →](/docs/tools/litesvm/typescript/getting-started)** Learn how to test your
+    own Solana program using LiteSVM for TypeScript - **[Examples
+    →](/docs/tools/litesvm/typescript/examples)** View copy-paste solutions for
+    common scenarios - **[API Reference
+    →](/docs/tools/litesvm/typescript/api-reference)** Learn advanced features
+    and custom configurations
+  </Tab>
+</Tabs>

--- a/apps/docs/content/docs/en/tools/litesvm/core-concepts.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/core-concepts.mdx
@@ -214,19 +214,18 @@ if ("err" in result && result.err()) {
 
 <Tabs items={["Rust", "TypeScript"]} groupId="litesvm-lang">
   <Tab value="Rust">
-    - **[Testing Your Program →](/docs/tools/litesvm/testing-your-program)**
-    Learn how to test your own Solana program - **[Examples
+    **[Testing Your Program →](/docs/tools/litesvm/testing-your-program)** Learn
+    how to test your own Solana program <br /> **[Examples
     →](/docs/tools/litesvm/examples)** View copy-paste solutions for common
-    scenarios and full repository examples - **[API Reference
+    scenarios and full repository examples <br /> **[API Reference
     →](/docs/tools/litesvm/api-reference)** Learn advanced features and custom
     configurations
   </Tab>
   <Tab value="TypeScript">
-    - **[Testing Your Program
-    →](/docs/tools/litesvm/typescript/getting-started)** Learn how to test your
-    own Solana program using LiteSVM for TypeScript - **[Examples
-    →](/docs/tools/litesvm/typescript/examples)** View copy-paste solutions for
-    common scenarios - **[API Reference
+    **[Testing Your Program →](/docs/tools/litesvm/typescript/getting-started)**
+    Learn how to test your own Solana program using LiteSVM for TypeScript{" "}
+    <br /> **[Examples →](/docs/tools/litesvm/typescript/examples)** View
+    copy-paste solutions for common scenarios <br /> **[API Reference
     →](/docs/tools/litesvm/typescript/api-reference)** Learn advanced features
     and custom configurations
   </Tab>

--- a/apps/docs/content/docs/en/tools/litesvm/examples/complete-examples.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/examples/complete-examples.mdx
@@ -1,0 +1,26 @@
+---
+title: Anchor Program Examples
+description:
+  View linked projects that showcase how to use litesvm for anchor program
+  testing
+---
+
+### `litesvm` crate examples
+
+<Cards>
+  <Card
+    title="Anchor CRUD App"
+    description="Example for handling data"
+    href="https://github.com/brimigs/anchor-crud-litesvm"
+  />
+</Cards>
+
+### `litesvm-token` crate examples
+
+<Cards>
+  <Card
+    title="Anchor Escrow App"
+    description="Example for handling tokens"
+    href="https://github.com/brimigs/anchor-escrow-with-litesvm"
+  />
+</Cards>

--- a/apps/docs/content/docs/en/tools/litesvm/examples/cpi.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/examples/cpi.mdx
@@ -1,0 +1,101 @@
+---
+title: Cross-Program Invocation
+description: How to test programs calling other programs
+---
+
+## Complete Test
+
+```rust title="tests/cpi_test.rs"
+use litesvm::LiteSVM;
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+    system_program,
+};
+
+#[test]
+fn test_cross_program_invocation() {
+    let mut svm = LiteSVM::new();
+
+    // Deploy both programs
+    let caller_program = Pubkey::new_unique();
+    let callee_program = Pubkey::new_unique();
+
+    svm.add_program(
+        caller_program,
+        include_bytes!("../target/deploy/caller.so")
+    ).unwrap();
+
+    svm.add_program(
+        callee_program,
+        include_bytes!("../target/deploy/callee.so")
+    ).unwrap();
+
+    // Setup accounts
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10_000_000_000).unwrap();
+
+    // Create instruction that will trigger CPI
+    let instruction = Instruction {
+        program_id: caller_program,
+        accounts: vec![
+            AccountMeta::new(payer.pubkey(), true),
+            AccountMeta::new_readonly(callee_program, false),
+            AccountMeta::new_readonly(system_program::id(), false),
+        ],
+        data: vec![1], // Instruction to trigger CPI
+    };
+
+    let tx = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer.pubkey()),
+        &[&payer],
+        svm.latest_blockhash(),
+    );
+
+    let result = svm.send_transaction(tx).unwrap();
+
+    // Verify both programs were invoked
+    assert!(result.logs.iter().any(|log|
+        log.contains(&format!("Program {} invoke", caller_program))
+    ));
+    assert!(result.logs.iter().any(|log|
+        log.contains(&format!("Program {} invoke", callee_program))
+    ));
+
+    println!("CPI successful!");
+    println!("Logs showing both programs:");
+    for log in &result.logs {
+        if log.contains("invoke") {
+            println!("   {}", log);
+        }
+    }
+}
+```
+
+## Key Points
+
+1. **Multiple Programs**: Deploy all programs involved in the CPI chain
+2. **Program IDs**: Pass the callee program ID as an account in the instruction
+3. **System Program**: Often needed for CPI operations (transfers, account
+   creation, etc.)
+4. **Log Verification**: Check logs to verify all programs in the call chain
+   executed
+
+For more detailed deployment information, read
+[this section](/docs/tools/litesvm/testing-your-program/deploy).
+
+## Understanding CPI Logs
+
+When a CPI occurs, you'll see logs like:
+
+```
+Program A invoke [1]
+Program B invoke [2]
+Program B success
+Program A success
+```
+
+The numbers in brackets indicate the call depth.

--- a/apps/docs/content/docs/en/tools/litesvm/examples/error-handling.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/examples/error-handling.mdx
@@ -1,0 +1,101 @@
+---
+title: Error Handling
+description: How to test error conditions and edge cases
+---
+
+## Complete Test
+
+```rust title="tests/error_test.rs"
+use litesvm::LiteSVM;
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    system_instruction,
+    transaction::Transaction,
+};
+use solana_transaction_error::TransactionError;
+
+#[test]
+fn test_insufficient_funds_error() {
+    let mut svm = LiteSVM::new();
+
+    let alice = Keypair::new();
+    let bob = Keypair::new();
+
+    // Give Alice only 0.5 SOL
+    svm.airdrop(&alice.pubkey(), 500_000_000).unwrap();
+
+    // Try to transfer 1 SOL (should fail)
+    let transfer_ix = system_instruction::transfer(
+        &alice.pubkey(),
+        &bob.pubkey(),
+        1_000_000_000, // More than Alice has
+    );
+
+    let tx = Transaction::new_signed_with_payer(
+        &[transfer_ix],
+        Some(&alice.pubkey()),
+        &[&alice],
+        svm.latest_blockhash(),
+    );
+
+    // Verify it fails with expected error
+    let result = svm.send_transaction(tx);
+    assert!(result.is_err());
+
+    let err = result.unwrap_err();
+    match err.err {
+        TransactionError::InstructionError(0, _) => {
+            println!("Got expected error: InstructionError (insufficient funds)");
+        }
+        _ => panic!("Got unexpected error: {:?}", err.err),
+    }
+
+    // Verify no funds were transferred
+    assert_eq!(svm.get_balance(&bob.pubkey()).unwrap_or(0), 0);
+}
+```
+
+## Testing Different Error Types
+
+### Invalid Account
+
+```rust
+#[test]
+fn test_account_not_found() {
+    let mut svm = LiteSVM::new();
+    let non_existent = Pubkey::new_unique();
+
+    // This should return None
+    assert!(svm.get_account(&non_existent).is_none());
+}
+```
+
+### Custom Program Errors
+
+```rust
+#[test]
+fn test_custom_program_error() {
+    let mut svm = LiteSVM::new();
+
+    // Deploy program and trigger custom error
+    let result = svm.send_transaction(tx);
+
+    if let Err(e) = result {
+        match e.err {
+            TransactionError::InstructionError(_, InstructionError::Custom(code)) => {
+                assert_eq!(code, YOUR_ERROR_CODE);
+            }
+            _ => panic!("Expected custom error"),
+        }
+    }
+}
+```
+
+## Key Points
+
+1. **Error Assertions**: Use `assert!(result.is_err())` to verify errors occur
+2. **Error Matching**: Match on specific error types to ensure correct error
+   handling
+3. **State Verification**: Verify state didn't change when errors occur
+4. **Custom Errors**: Test your program's custom error codes
+5. **Edge Cases**: Test boundary conditions and invalid inputs

--- a/apps/docs/content/docs/en/tools/litesvm/examples/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/examples/index.mdx
@@ -1,0 +1,54 @@
+---
+title: Examples
+description: Complete test examples for common Solana testing scenarios
+---
+
+## Overview
+
+This section provides complete, ready-to-use examples for common Solana testing
+scenarios with LiteSVM. Each example includes full code with explanations.
+
+## Available Examples
+
+<Cards>
+  <Card
+    title="SOL Transfer"
+    description="Test transferring SOL between accounts"
+    href="/docs/tools/litesvm/examples/sol-transfer"
+  />
+  <Card
+    title="Program Deployment"
+    description="Deploy and call a simple program"
+    href="/docs/tools/litesvm/examples/program-deployment"
+  />
+  <Card
+    title="PDA Creation"
+    description="Create and interact with Program Derived Addresses"
+    href="/docs/tools/litesvm/examples/pda-creation"
+  />
+  <Card
+    title="Error Handling"
+    description="Test error conditions and edge cases"
+    href="/docs/tools/litesvm/examples/error-handling"
+  />
+  <Card
+    title="SPL Token Operations"
+    description="Create mints, token accounts, and transfer tokens"
+    href="/docs/tools/litesvm/examples/spl-tokens"
+  />
+  <Card
+    title="Cross-Program Invocation"
+    description="Test programs calling other programs"
+    href="/docs/tools/litesvm/examples/cpi"
+  />
+  <Card
+    title="Time-Based Testing"
+    description="Test features that depend on slots or timestamps"
+    href="/docs/tools/litesvm/examples/time-based"
+  />
+  <Card
+    title="Github Examples"
+    description="View several linked projects using LiteSVM tests"
+    href="/docs/tools/litesvm/examples/complete-examples"
+  />
+</Cards>

--- a/apps/docs/content/docs/en/tools/litesvm/examples/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/examples/meta.json
@@ -1,0 +1,13 @@
+{
+  "title": "Examples",
+  "pages": [
+    "sol-transfer",
+    "program-deployment",
+    "pda-creation",
+    "error-handling",
+    "spl-tokens",
+    "cpi",
+    "time-based",
+    "complete-examples"
+  ]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/examples/pda-creation.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/examples/pda-creation.mdx
@@ -1,0 +1,56 @@
+---
+title: PDA Creation
+description: How to create and interact with Program Derived Addresses
+---
+
+## Complete Test
+
+```rust title="tests/pda_test.rs"
+use litesvm::LiteSVM;
+use solana_account::Account;
+use solana_sdk::pubkey::Pubkey;
+
+#[test]
+fn test_pda_creation() {
+    let mut svm = LiteSVM::new();
+
+    // Program that owns the PDA
+    let program_id = Pubkey::new_unique();
+
+    // Derive PDA address
+    let seed = b"my_pda";
+    let (pda, bump) = Pubkey::find_program_address(
+        &[seed],
+        &program_id
+    );
+
+    println!("PDA: {}", pda);
+    println!("Bump: {}", bump);
+
+    // Create PDA account manually (for testing)
+    svm.set_account(pda, Account {
+        lamports: 1_000_000,
+        data: vec![bump], // Store bump seed in data
+        owner: program_id,
+        executable: false,
+        rent_epoch: 0,
+    }).unwrap();
+
+    // Verify PDA was created
+    let account = svm.get_account(&pda).unwrap();
+    assert_eq!(account.owner, program_id);
+    assert_eq!(account.data[0], bump);
+
+    println!("PDA created successfully!");
+}
+```
+
+## Key Points
+
+1. **PDA Derivation**: Use `Pubkey::find_program_address()` to derive PDA
+   addresses
+2. **Seeds**: PDAs are derived from seeds and the program ID
+3. **Bump Seed**: The bump seed ensures the address is off the ed25519 curve
+4. **Account Creation**: Use `set_account()` to manually create accounts for
+   testing
+5. **Ownership**: PDAs must be owned by the program that derived them

--- a/apps/docs/content/docs/en/tools/litesvm/examples/program-deployment.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/examples/program-deployment.mdx
@@ -1,0 +1,69 @@
+---
+title: Program Deployment
+description: How to deploy and call a simple program
+---
+
+## Complete Test
+
+```rust title="tests/program_test.rs"
+use litesvm::LiteSVM;
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+#[test]
+fn test_program_deployment() {
+    let mut svm = LiteSVM::new();
+
+    // Deploy the program
+    let program_id = Pubkey::new_unique();
+    let program_bytes = include_bytes!("../target/deploy/hello_world.so");
+    svm.add_program(program_id, program_bytes).unwrap();
+
+    // Create payer account
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10_000_000_000).unwrap();
+
+    // Create instruction to call program
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(payer.pubkey(), true),
+        ],
+        data: vec![], // Program-specific data
+    };
+
+    // Send transaction
+    let tx = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer.pubkey()),
+        &[&payer],
+        svm.latest_blockhash(),
+    );
+
+    let result = svm.send_transaction(tx).unwrap();
+
+    // Verify program was called
+    assert!(result.logs.iter().any(|log|
+        log.contains(&format!("Program {} invoke", program_id))
+    ));
+
+    println!("Program called successfully!");
+    println!("Logs:\n{}", result.pretty_logs());
+}
+```
+
+## Key Points
+
+1. **Program Deployment**: Use `add_program()` to deploy a program from bytes
+2. **include_bytes!**: Embeds the compiled program at compile time
+3. **Program ID**: Use the keypair from `target/deploy/`
+4. **Instructions**: Create custom instructions with program ID, accounts, and
+   data
+5. **Log Verification**: Check transaction logs to verify program execution
+
+For more detailed deployment information, read
+[this section](/docs/tools/litesvm/testing-your-program/deploy).

--- a/apps/docs/content/docs/en/tools/litesvm/examples/sol-transfer.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/examples/sol-transfer.mdx
@@ -1,0 +1,64 @@
+---
+title: SOL Transfer
+description: How to transfer SOL between accounts
+---
+
+## Complete Test
+
+```rust title="tests/transfer_test.rs"
+use litesvm::LiteSVM;
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    system_instruction,
+    transaction::Transaction,
+};
+
+#[test]
+fn test_sol_transfer() {
+    let mut svm = LiteSVM::new();
+
+    // Create accounts
+    let alice = Keypair::new();
+    let bob = Keypair::new();
+
+    // Fund alice with 10 SOL
+    svm.airdrop(&alice.pubkey(), 10_000_000_000).unwrap();
+
+    // Create transfer instruction
+    let transfer_ix = system_instruction::transfer(
+        &alice.pubkey(),
+        &bob.pubkey(),
+        1_000_000_000, // 1 SOL
+    );
+
+    // Build transaction
+    let tx = Transaction::new_signed_with_payer(
+        &[transfer_ix],
+        Some(&alice.pubkey()),
+        &[&alice],
+        svm.latest_blockhash(),
+    );
+
+    // Send and verify
+    let result = svm.send_transaction(tx).unwrap();
+
+    // Check balances
+    assert_eq!(svm.get_balance(&bob.pubkey()).unwrap(), 1_000_000_000);
+    assert!(svm.get_balance(&alice.pubkey()).unwrap() < 9_000_000_000);
+
+    println!("Transfer successful!");
+    println!("Compute units used: {}", result.compute_units_consumed);
+    println!("Transaction logs:\n{}", result.pretty_logs());
+}
+```
+
+## Key Points
+
+1. **Account Creation**: Use `Keypair::new()` to create test accounts
+2. **Funding**: Use `airdrop()` to fund accounts with SOL
+3. **System Instructions**: Use `system_instruction::transfer()` for SOL
+   transfers
+4. **Balance Verification**: Check balances after transaction to verify the
+   transfer
+5. **Transaction Fees**: Alice's balance will be slightly less than 9 SOL due to
+   transaction fees

--- a/apps/docs/content/docs/en/tools/litesvm/examples/spl-tokens.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/examples/spl-tokens.mdx
@@ -1,0 +1,92 @@
+---
+title: SPL Token Operations
+description: How write tests with SPL tokens using `litesvm-token`
+---
+
+<Callout>Requires `cargo add --dev litesvm-token spl-token`</Callout>
+
+## Complete Test
+
+```rust title="tests/spl_token_test.rs"
+use litesvm::LiteSVM;
+use litesvm_token::{
+    get_spl_account,
+    spl_token::{native_mint::DECIMALS, state::Account as TokenAccount},
+    CreateAssociatedTokenAccount, CreateMint, MintTo, Transfer,
+};
+use solana_sdk::{
+    native_token::LAMPORTS_PER_SOL,
+    signature::{Keypair, Signer},
+};
+
+#[test]
+fn test_token_transfer() {
+        let mut svm = LiteSVM::new();
+
+    // Create payer account and fund it
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10 * LAMPORTS_PER_SOL).unwrap();
+
+    // Create two users
+    let alice = Keypair::new();
+    let bob = Keypair::new();
+
+    // Create a new SPL token mint with alice as the mint authority
+    let mint = CreateMint::new(&mut svm, &payer)
+        .authority(&alice.pubkey())
+        .decimals(DECIMALS)
+        .send()
+        .unwrap();
+
+    // Create associated token accounts (ATAs) for alice and bob
+    let alice_token_account = CreateAssociatedTokenAccount::new(&mut svm, &payer, &mint)
+        .owner(&alice.pubkey())
+        .send()
+        .unwrap();
+
+    let bob_token_account = CreateAssociatedTokenAccount::new(&mut svm, &payer, &mint)
+        .owner(&bob.pubkey())
+        .send()
+        .unwrap();
+
+    // Mint 1000 tokens to Alice's account
+    MintTo::new(&mut svm, &payer, &mint, &alice_token_account, 1000)
+        .owner(&alice)
+        .send()
+        .unwrap();
+
+    // Transfer 400 tokens from Alice to Bob
+    Transfer::new(&mut svm, &payer, &mint, &bob_token_account, 400)
+        .source(&alice_token_account)
+        .owner(&alice)
+        .send()
+        .unwrap();
+
+    // Verify balances
+    let alice_account: TokenAccount = get_spl_account(&svm, &alice_token_account).unwrap();
+    let bob_account: TokenAccount = get_spl_account(&svm, &bob_token_account).unwrap();
+
+    let alice_balance = alice_account.amount;
+    let bob_balance = bob_account.amount;
+
+    assert_eq!(alice_balance, 600);
+    assert_eq!(bob_balance, 400);
+
+    println!("SPL token transfer successful!");
+}
+```
+
+## Key Points
+
+1. **litesvm-token**: Helper crate that simplifies SPL token testing
+2. **Mint Creation**: Create a mint with specified decimals and authorities
+3. **Token Accounts**: Create token accounts to hold tokens for users
+   - To understand the difference between this and an ATA, read
+     [this section](/docs/tools/litesvm/additional-crates/testing-with-spl-tokens#types-of-token-accounts).
+4. **Minting**: Mint tokens to token accounts using the mint authority
+5. **Decimals**: Remember to account for decimals when specifying amounts
+
+## See Also
+
+- [Testing with SPL Tokens](/docs/tools/litesvm/additional-crates/testing-with-spl-tokens) -
+  Comprehensive guide to SPL token testing

--- a/apps/docs/content/docs/en/tools/litesvm/examples/time-based.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/examples/time-based.mdx
@@ -1,0 +1,105 @@
+---
+title: Time-Based Testing
+description: Test features that depend on slots or timestamps
+---
+
+## Overview
+
+This example shows how to test time-dependent features by manipulating slots and
+timestamps in LiteSVM.
+
+## Complete Test
+
+```rust title="tests/time_test.rs"
+use litesvm::LiteSVM;
+use solana_sdk::clock::Clock;
+
+#[test]
+fn test_time_locked_feature() {
+    let mut svm = LiteSVM::new();
+
+    // Get current time
+    let clock: Clock = svm.get_sysvar();
+    println!("Starting slot: {}", clock.slot);
+    println!("Starting timestamp: {}", clock.unix_timestamp);
+
+    // Test something at current time
+    // ... your test logic ...
+
+    // Jump forward 100 slots
+    svm.warp_to_slot(clock.slot + 100);
+
+    // Verify time changed
+    let new_clock: Clock = svm.get_sysvar();
+    assert_eq!(new_clock.slot, clock.slot + 100);
+
+    // Test time-locked feature is now available
+    // ... your test logic ...
+
+    println!("Time travel successful!");
+}
+```
+
+## Testing Slot-Based Features
+
+```rust
+#[test]
+fn test_slot_based_unlock() {
+    let mut svm = LiteSVM::new();
+
+    // Get starting slot
+    let start_slot = svm.get_sysvar::<Clock>().slot;
+
+    // Deploy program with slot-based lock
+    let program_id = deploy_locked_program(&mut svm);
+
+    // Try to call before unlock slot (should fail)
+    let result = call_program(&mut svm, program_id);
+    assert!(result.is_err());
+
+    // Warp to unlock slot
+    svm.warp_to_slot(start_slot + 1000);
+
+    // Now it should succeed
+    let result = call_program(&mut svm, program_id);
+    assert!(result.is_ok());
+}
+```
+
+## Testing Timestamp-Based Features
+
+```rust
+#[test]
+fn test_timestamp_based_feature() {
+    let mut svm = LiteSVM::new();
+
+    // Get current timestamp
+    let clock: Clock = svm.get_sysvar();
+    let current_time = clock.unix_timestamp;
+
+    // Warp forward 1 hour (3600 seconds)
+    let target_slot = clock.slot + (3600.0 / 0.4) as u64; // ~0.4s per slot
+    svm.warp_to_slot(target_slot);
+
+    // Verify timestamp increased
+    let new_clock: Clock = svm.get_sysvar();
+    assert!(new_clock.unix_timestamp >= current_time + 3600);
+}
+```
+
+## Key Points
+
+1. **Clock Sysvar**: Use `svm.get_sysvar::<Clock>()` to get current time
+2. **Slot Warping**: Use `warp_to_slot()` to jump forward in time
+3. **Timestamp Calculation**: Slots roughly correspond to ~0.4 seconds on Solana
+4. **Testing Unlocks**: Test time-locked features by warping past the unlock
+   time
+5. **No Going Back**: You can only warp forward, not backward in time
+
+## Common Use Cases
+
+- Vesting schedules
+- Time-locked withdrawals
+- Stake/unstake cooldown periods
+- Auction end times
+- Rental periods

--- a/apps/docs/content/docs/en/tools/litesvm/getting-started.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/getting-started.mdx
@@ -381,19 +381,18 @@ to use LiteSVM for testing
 
 <Tabs items={["Rust", "TypeScript"]} groupId="litesvm-lang">
   <Tab value="Rust">
-    - **[Testing Your Program →](/docs/tools/litesvm/testing-your-program)**
-    Learn how to test your own Solana program - **[Examples
+    **[Testing Your Program →](/docs/tools/litesvm/testing-your-program)** Learn
+    how to test your own Solana program <br /> **[Examples
     →](/docs/tools/litesvm/examples)** View copy-paste solutions for common
-    scenarios and full repository examples - **[API Reference
+    scenarios and full repository examples <br /> **[API Reference
     →](/docs/tools/litesvm/api-reference)** Learn advanced features and custom
     configurations
   </Tab>
   <Tab value="TypeScript">
-    - **[Testing Your Program
-    →](/docs/tools/litesvm/typescript/getting-started)** Learn how to test your
-    own Solana program using LiteSVM for TypeScript - **[Examples
-    →](/docs/tools/litesvm/typescript/examples)** View copy-paste solutions for
-    common scenarios - **[API Reference
+    **[Testing Your Program →](/docs/tools/litesvm/typescript/getting-started)**
+    Learn how to test your own Solana program using LiteSVM for TypeScript{" "}
+    <br /> **[Examples →](/docs/tools/litesvm/typescript/examples)** View
+    copy-paste solutions for common scenarios <br /> **[API Reference
     →](/docs/tools/litesvm/typescript/api-reference)** Learn advanced features
     and custom configurations
   </Tab>

--- a/apps/docs/content/docs/en/tools/litesvm/getting-started.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/getting-started.mdx
@@ -1,0 +1,400 @@
+---
+title: Getting Started
+description: Install LiteSVM and write your first tests.
+---
+
+# Quick Start Guide
+
+This guide covers the basics: how to create an account, fund an account, and
+send a transaction.
+
+<Steps>
+
+<Step>
+### Install Dependencies
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+Add LiteSVM to your dev dependencies:
+
+```bash
+cargo add --dev litesvm
+```
+
+Several Solana crates enhance the testing experience by providing essential
+types and utilities. You can use the `solana-sdk` convenience crate or the
+individual component crates:
+
+```bash
+cargo add --dev solana-sdk
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']}>
+<Tab value="pnpm">
+
+```bash
+pnpm add @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/system
+```
+
+</Tab>
+<Tab value="npm">
+
+```bash
+npm install @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/system
+```
+
+</Tab>
+<Tab value="yarn">
+
+```bash
+yarn add @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/system
+```
+
+</Tab>
+<Tab value="bun">
+
+```bash
+bun add @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/system
+```
+
+</Tab>
+</Tabs>
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step>
+### Create Test File
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+Inside your workspace, create a folder for `tests`.
+
+```bash
+mkdir tests
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+Create a new TypeScript file for your test.
+
+```bash
+touch basic-test.ts
+```
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step>
+### Create and Fund an Account
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+Let's write your first LiteSVM test.
+
+Inside your `tests` folder, create a new file and copy this code:
+
+```rust title="tests/create_account.rs"
+use litesvm::LiteSVM;
+use solana_sdk::signature::{Keypair, Signer};
+
+#[test]
+fn create_account() {
+    // Create the test environment
+    let mut svm = LiteSVM::new();
+
+    // Create a test account
+    let user = Keypair::new();
+
+    // Fund the account with SOL
+    svm.airdrop(&user.pubkey(), 1_000_000_000).unwrap();
+
+    // Check the balance
+    let balance = svm.get_balance(&user.pubkey()).unwrap();
+    assert_eq!(balance, 1_000_000_000);
+
+    println!("Account funded with {} SOL", balance as f64 / 1e9);
+}
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+Copy this code into your test file:
+
+```typescript title="basic-test.ts"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+// Payer first, then the LiteSVM transport.
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
+// Fund the payer and check balance
+client.svm.airdrop(client.payer.address, lamports(5_000_000_000n));
+const balance = client.svm.getBalance(client.payer.address);
+console.log("Balance:", balance, "lamports");
+```
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step>
+### Run Your Test
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+```bash
+cargo test create_account -- --show-output
+```
+
+You should see:
+
+```
+running 1 test
+test create_account ... ok
+
+successes:
+
+---- create_account stdout ----
+Account funded with 1 SOL
+
+
+successes:
+    create_account
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```bash
+npx tsx basic-test.ts
+```
+
+You should see:
+
+```
+Balance: 5000000000n lamports
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="info">
+  **That's it!** You just made your first litesvm test, that covers creating an
+  account and funding it.
+</Callout>
+
+</Step>
+
+<Step>
+### Execute a Transaction
+
+Now let's create a transfer transaction.
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+Create a new test file and copy this code:
+
+```rust title="tests/transfer_test.rs"
+use litesvm::LiteSVM;
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    system_instruction,
+    transaction::Transaction,
+};
+
+#[test]
+fn test_transfer() {
+    let mut svm = LiteSVM::new();
+
+    // Create two accounts
+    let alice = Keypair::new();
+    let bob = Keypair::new();
+
+    // Fund Alice
+    svm.airdrop(&alice.pubkey(), 2_000_000_000).unwrap();
+
+    // Create transfer instruction
+    let transfer = system_instruction::transfer(
+        &alice.pubkey(),
+        &bob.pubkey(),
+        1_000_000_000, // 1 SOL
+    );
+
+    // Build and sign transaction
+    let tx = Transaction::new_signed_with_payer(
+        &[transfer],
+        Some(&alice.pubkey()),
+        &[&alice],
+        svm.latest_blockhash(),
+    );
+
+    // Send it (execution happens immediately)
+    svm.send_transaction(tx).unwrap();
+
+    // Check new balances
+    assert_eq!(svm.get_balance(&bob.pubkey()).unwrap(), 1_000_000_000);
+    assert!(svm.get_balance(&alice.pubkey()).unwrap() < 1_000_000_000);
+
+    println!("Transfer successful!");
+}
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+Create a new file and copy this code:
+
+```typescript title="transfer-test.ts"
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+import { systemProgram } from "@solana-program/system";
+
+// Payer first, then the LiteSVM transport, then program plugins.
+const mySigner = await generateKeyPairSigner();
+const client = createClient()
+  .use(signer(mySigner))
+  .use(litesvm())
+  .use(systemProgram());
+const recipient = await generateKeyPairSigner();
+
+// Airdrop SOL to the payer
+client.svm.airdrop(client.payer.address, lamports(2_000_000_000n));
+
+// Build and send the transfer
+await client.system.instructions
+  .transferSol({
+    source: client.payer,
+    destination: recipient.address,
+    amount: lamports(1_000_000_000n) // 1 SOL
+  })
+  .sendTransaction();
+
+// Check new balances
+const recipientBalance = client.svm.getBalance(recipient.address) ?? 0n;
+console.log("Recipient balance:", Number(recipientBalance) / 1e9, "SOL");
+console.log("Transfer successful!");
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="info">
+  **Test complete!** This test covers executing the transfer instruction from
+  the system program.
+</Callout>
+
+</Step>
+
+<Step>
+### Run All Tests
+
+<Tabs items={['Rust', 'TypeScript']} groupId="litesvm-lang">
+<Tab value="Rust">
+
+```bash
+cargo test -- --show-output
+```
+
+You should see:
+
+```
+running 1 test
+test create_account ... ok
+
+successes:
+
+---- create_account stdout ----
+Account funded with 1 SOL
+
+
+successes:
+    create_account
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+
+     Running tests/test_transfer.rs (target/debug/deps/test_transfer-f174954e7483f36b)
+
+running 1 test
+test test_transfer ... ok
+
+successes:
+
+---- test_transfer stdout ----
+Transfer successful!
+
+
+successes:
+    test_transfer
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
+
+```
+
+</Tab>
+<Tab value="TypeScript">
+
+```bash
+npx tsx basic-test.ts && npx tsx transfer-test.ts
+```
+
+You should see:
+
+```
+Balance: 5000000000n lamports
+Recipient balance: 1 SOL
+Transfer successful!
+```
+
+</Tab>
+</Tabs>
+
+<Callout type="info">
+  **That's it!** Now you've successfully made litesvm tests that create and fund accounts and execute transactions.
+</Callout>
+</Step>
+
+</Steps>
+
+## Next Steps
+
+**[Why LiteSVM →](/docs/tools/litesvm/core-concepts)** Learn why you would want
+to use LiteSVM for testing
+
+<Tabs items={["Rust", "TypeScript"]} groupId="litesvm-lang">
+  <Tab value="Rust">
+    - **[Testing Your Program →](/docs/tools/litesvm/testing-your-program)**
+    Learn how to test your own Solana program - **[Examples
+    →](/docs/tools/litesvm/examples)** View copy-paste solutions for common
+    scenarios and full repository examples - **[API Reference
+    →](/docs/tools/litesvm/api-reference)** Learn advanced features and custom
+    configurations
+  </Tab>
+  <Tab value="TypeScript">
+    - **[Testing Your Program
+    →](/docs/tools/litesvm/typescript/getting-started)** Learn how to test your
+    own Solana program using LiteSVM for TypeScript - **[Examples
+    →](/docs/tools/litesvm/typescript/examples)** View copy-paste solutions for
+    common scenarios - **[API Reference
+    →](/docs/tools/litesvm/typescript/api-reference)** Learn advanced features
+    and custom configurations
+  </Tab>
+</Tabs>

--- a/apps/docs/content/docs/en/tools/litesvm/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/index.mdx
@@ -1,0 +1,85 @@
+---
+title: LiteSVM
+description:
+  Lightning-fast Solana program testing with an in-process VM. Test your
+  programs faster without network overhead or validator processes.
+---
+
+LiteSVM is a lightweight library for testing Solana programs that works by
+creating an in-process Solana VM optimized for program developers. Unlike other
+testing approaches that spin up separate validator processes, LiteSVM embeds the
+VM inside your tests, making them execute much faster. In a further break from
+tradition, it has an ergonomic API with sane defaults and extensive
+configurability for those who want it.
+
+## Getting Started
+
+<Cards>
+  <Card
+    title="Getting Started"
+    href="/docs/tools/litesvm/getting-started"
+    description="Install LiteSVM and write your first tests."
+  />
+  <Card
+    title="Why LiteSVM"
+    href="/docs/tools/litesvm/core-concepts"
+    description="Learn why you would want to use LiteSVM for testing."
+  />
+</Cards>
+
+## Rust
+
+<Cards>
+  <Card
+    title="Testing Your Program"
+    href="/docs/tools/litesvm/testing-your-program"
+    description="Learn how to test your own Solana program."
+  />
+  <Card
+    title="Examples"
+    href="/docs/tools/litesvm/examples"
+    description="Copy-paste solutions for common scenarios and full repository examples."
+  />
+  <Card
+    title="API Reference"
+    href="/docs/tools/litesvm/api-reference"
+    description="Learn advanced features and custom configurations."
+  />
+  <Card
+    title="Additional Crates"
+    href="/docs/tools/litesvm/additional-crates/testing-with-litesvm-utils"
+    description="Helper crates for utils, SPL tokens, the loader, and Anchor testing."
+  />
+</Cards>
+
+## TypeScript
+
+<Cards>
+  <Card
+    title="Getting Started"
+    href="/docs/tools/litesvm/typescript/getting-started"
+    description="Use LiteSVM through @solana/kit in your TypeScript tests."
+  />
+  <Card
+    title="Token Testing"
+    href="/docs/tools/litesvm/typescript/tokens"
+    description="Test SPL tokens with the tokenProgram() plugin."
+  />
+  <Card
+    title="API Reference"
+    href="/docs/tools/litesvm/typescript/api-reference"
+    description="Learn advanced features and custom configurations."
+  />
+  <Card
+    title="Examples"
+    href="/docs/tools/litesvm/typescript/examples"
+    description="Copy-paste solutions for common scenarios."
+  />
+</Cards>
+
+## Resources
+
+- [crates.io](https://crates.io/crates/litesvm) - The LiteSVM Rust crate
+- [npm](https://www.npmjs.com/package/@solana/kit-plugin-litesvm) - The
+  @solana/kit LiteSVM plugin
+- [GitHub](https://github.com/LiteSVM/litesvm) - View the source code

--- a/apps/docs/content/docs/en/tools/litesvm/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/meta.json
@@ -13,6 +13,7 @@
     "typescript/tokens",
     "typescript/api-reference",
     "typescript/examples",
-    "--- ---"
+    "--- ---",
+    "[GitHub](https://github.com/LiteSVM/litesvm)"
   ]
 }

--- a/apps/docs/content/docs/en/tools/litesvm/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/meta.json
@@ -1,0 +1,17 @@
+{
+  "title": "LiteSVM",
+  "pages": [
+    "getting-started",
+    "core-concepts",
+    "---Rust---",
+    "testing-your-program",
+    "examples",
+    "api-reference",
+    "additional-crates",
+    "---TypeScript---",
+    "typescript/getting-started",
+    "typescript/tokens",
+    "typescript/api-reference",
+    "typescript/examples"
+  ]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/meta.json
@@ -12,6 +12,7 @@
     "typescript/getting-started",
     "typescript/tokens",
     "typescript/api-reference",
-    "typescript/examples"
+    "typescript/examples",
+    "--- ---"
   ]
 }

--- a/apps/docs/content/docs/en/tools/litesvm/testing-your-program/deploy.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/testing-your-program/deploy.mdx
@@ -1,0 +1,350 @@
+---
+title: Deploying Programs
+description: Learn how to deploy programs to a LiteSVM test instance
+---
+
+## Getting Started
+
+```rust
+let mut svm = LiteSVM::new();
+```
+
+This creates the basic litesvm test instance, which includes all runtime
+features enabled, default sysvars, precompiles, spl programs, sigverify, and all
+built in programs like the system program.
+
+To interact with any other program in your tests, you must deploy that program
+to your test environment.
+
+1. Build and deploy the program you want to test
+
+2. Find all programs that the above program makes CPI calls to and deploy those
+   programs
+
+<Callout type="info">
+  **Example:** If your program is using data feeds from Pyth, you will need to
+  have the Pyth program deployed to your test instance.
+</Callout>
+
+## Basic Program Deployment
+
+### Method 1: Deploy from Bytes
+
+Deploy programs directly from byte arrays for fastest test execution:
+
+```rust
+use litesvm::LiteSVM;
+use solana_sdk::signature::{read_keypair_file, Signer};
+
+let mut svm = LiteSVM::new();
+
+// Read the program's keypair to get correct ID
+let program_keypair = read_keypair_file("target/deploy/my_program-keypair.json")
+    .expect("Program keypair file not found");
+let program_id = program_keypair.pubkey();
+
+// Include bytes at compile time
+let program_bytes = include_bytes!("../target/deploy/my_program.so");
+
+// Deploy from bytes
+svm.add_program(program_id, program_bytes)
+    .expect("Failed to deploy program");
+
+// Verify deployment
+assert!(svm.get_account(&program_id).is_some(), "Program account not created");
+assert!(svm.get_account(&program_id).unwrap().executable, "Program not executable");
+```
+
+`include_bytes!` embeds the binary directly into the test executable at compile
+time, eliminating I/O during test execution.
+
+<div className="grid grid-cols-1 md:grid-cols-2 gap-2 my-3">
+  <div className="bg-gray-50 dark:bg-gray-950/20 border border-gray-200 dark:border-gray-800 rounded-lg px-2 pt-0.5 pb-2">
+    <h4 className="text-xs font-semibold text-gray-800 dark:text-gray-300 mb-1.5 flex items-center gap-1.5">
+      <span className="text-sm">✓</span> Pros
+    </h4>
+    <ul className="space-y-1 text-xs text-gray-900 dark:text-gray-200">
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Faster at runtime (no disk reads)</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Self-contained test binary</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Works even if .so file is deleted after compilation</span>
+      </li>
+    </ul>
+  </div>
+
+  <div className="bg-gray-50 dark:bg-gray-950/20 border border-gray-200 dark:border-gray-800 rounded-lg px-2 pt-0.5 pb-2">
+    <h4 className="text-xs font-semibold text-gray-800 dark:text-gray-300 mb-1.5 flex items-center gap-1.5">
+      <span className="text-sm">✗</span> Cons
+    </h4>
+    <ul className="space-y-1 text-xs text-gray-900 dark:text-gray-200">
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Larger test binary size</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Must recompile tests when .so changes</span>
+      </li>
+    </ul>
+  </div>
+</div>
+
+### Method 2: Deploy from File (.so)
+
+Load programs from the file system when they change frequently:
+
+```rust
+use litesvm::LiteSVM;
+use solana_sdk::signature::{read_keypair_file, Signer};
+
+let mut svm = LiteSVM::new();
+
+// Read keypair for correct program ID
+let program_keypair = read_keypair_file("target/deploy/program-keypair.json").unwrap();
+let program_id = program_keypair.pubkey();
+
+// Deploy from file
+svm.add_program_from_file(program_id, "target/deploy/program.so")
+    .expect("Failed to deploy program from file");
+
+// Always verify
+assert!(svm.get_account(&program_id).unwrap().executable);
+```
+
+<div className="grid grid-cols-1 md:grid-cols-2 gap-2 my-3">
+  <div className="bg-gray-50 dark:bg-gray-950/20 border border-gray-200 dark:border-gray-800 rounded-lg px-2 pt-0.5 pb-2">
+    <h4 className="text-xs font-semibold text-gray-800 dark:text-gray-300 mb-1.5 flex items-center gap-1.5">
+      <span className="text-sm">✓</span> Pros
+    </h4>
+    <ul className="space-y-1 text-xs text-gray-900 dark:text-gray-200">
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Smaller test binary</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Can pick up .so changes without recompiling tests</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>More flexible for CI/CD pipelines</span>
+      </li>
+    </ul>
+  </div>
+
+  <div className="bg-gray-50 dark:bg-gray-950/20 border border-gray-200 dark:border-gray-800 rounded-lg px-2 pt-0.5 pb-2">
+    <h4 className="text-xs font-semibold text-gray-800 dark:text-gray-300 mb-1.5 flex items-center gap-1.5">
+      <span className="text-sm">✗</span> Cons
+    </h4>
+    <ul className="space-y-1 text-xs text-gray-900 dark:text-gray-200">
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Slower (disk I/O at runtime)</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>Requires .so file to exist at test execution time</span>
+      </li>
+      <li className="flex items-start gap-1.5">
+        <span className="text-gray-600 dark:text-gray-400 mt-0.5">•</span>
+        <span>File path must be correct relative to test execution directory</span>
+      </li>
+    </ul>
+  </div>
+</div>
+
+## Pulling Programs from Mainnet/Devnet
+
+When you need a program that you don't have the code for, use the Solana CLI to
+dump programs from live clusters and use them in tests:
+
+```bash
+# Dump a program from mainnet
+solana program dump gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s pyth.so --url mainnet-beta
+
+# Dump from devnet
+solana program dump YourProgramID program.so --url devnet
+```
+
+Then load it in your tests:
+
+```rust
+svm.add_program_from_file(
+    pubkey!("gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s"),
+    "pyth.so"
+).unwrap();
+```
+
+## Best Practices
+
+### 1. Choose the Right Deployment Method
+
+- **Use `add_program()`** when:
+  - Programs are embedded in your test binary at compile time
+  - You want faster test execution (no runtime I/O)
+  - Self-contained tests
+
+- **Use `add_program_from_file()`** when:
+  - Programs are built separately (i.e. pulling from devnet)
+  - Program change frequently during development (can rerun tests without
+    recompiling)
+  - You have CI/CD environments where .so files are artifacts
+
+### Understanding Program Keypairs
+
+When you build a Solana program:
+
+1. **Anchor** creates `target/deploy/program-keypair.json`
+2. **Native** builds create a keypair file alongside the `.so` file
+3. The program's **on-chain address** is this keypair's public key, which is
+   also known as the program ID.
+4. For **PDAs**,`find_program_address()` requires the program ID as a seed
+5. For **CPIs**, the program ID is used to call other programs
+
+## Common Issues and Solutions
+
+### Silent Deployment Failures
+
+**Problem**: Program appears to deploy but transactions fail with
+"InvalidProgramForExecution".
+
+**Cause**: Program ID doesn't match the keypair.
+
+**Solution**:
+
+```rust
+// Always use the keypair-derived ID
+let keypair = read_keypair_file("target/deploy/program-keypair.json").unwrap();
+let program_id = keypair.pubkey();
+
+svm.add_program(program_id, &program_bytes).unwrap();
+
+// Verify with detailed checks
+let account = svm.get_account(&program_id)
+    .expect("Program account doesn't exist");
+
+assert!(account.executable, "Program not executable");
+assert_eq!(account.owner, solana_sdk::bpf_loader::id(), "Wrong owner");
+assert!(!account.data.is_empty(), "Program data is empty");
+
+println!("✅ Program verified at {}", program_id);
+```
+
+### Program Not Found Error
+
+**Error**: `TransactionError::InvalidProgramForExecution`
+
+**Common Causes**:
+
+1. Program not deployed
+2. Wrong program ID used in instruction
+3. Program ID mismatch with keypair
+
+**Debugging Steps**:
+
+```rust
+// Step 1: Check if program exists
+if let Some(account) = svm.get_account(&program_id) {
+    println!("Program exists");
+    println!("  Executable: {}", account.executable);
+    println!("  Owner: {}", account.owner);
+    println!("  Data length: {}", account.data.len());
+} else {
+    println!("Program does not exist at {}", program_id);
+}
+
+// Step 2: Verify the ID matches keypair
+let expected_keypair = read_keypair_file("target/deploy/program-keypair.json").unwrap();
+let expected_id = expected_keypair.pubkey();
+
+if program_id != expected_id {
+    println!("  ID mismatch!");
+    println!("  Used: {}", program_id);
+    println!("  Expected: {}", expected_id);
+}
+
+// Step 3: Check instruction program ID
+println!("Instruction program_id: {}", instruction.program_id);
+assert_eq!(instruction.program_id, program_id, "Instruction uses wrong program ID");
+```
+
+### CPI to Undeployed Programs
+
+**Problem**: Your program makes a CPI call to a program that is not deployed.
+
+**Solution**: Deploy all dependency programs:
+
+```rust
+// Find all dependency programs and make sure they are deployed
+svm.add_program_from_file(
+    pubkey!("gSbePebfvPy7tRqimPoVecS2UsBvYv46ynrzWocc92s"),
+    "pyth.so"
+).unwrap();
+
+```
+
+If you need to pull the program from a cluster, review
+[this section](#pulling-programs-from-mainnetdevnet).
+
+### Insufficient Lamports for Deployment
+
+**Note**: LiteSVM automatically handles rent-exempt balance for programs.
+
+```rust
+// No need to manually fund - LiteSVM handles this
+svm.add_program(program_id, &program_bytes).unwrap();
+
+// But you can check the rent if needed
+let program_len = program_bytes.len();
+let required_lamports = svm.minimum_balance_for_rent_exemption(program_len);
+println!("Program requires {} lamports for rent exemption", required_lamports);
+```
+
+## Deployment Verification Checklist
+
+<Steps>
+<Step>
+**Read the program keypair**
+
+```rust
+let keypair = read_keypair_file("target/deploy/program-keypair.json").unwrap();
+let program_id = keypair.pubkey();
+```
+
+</Step>
+
+<Step>
+**Deploy with matching ID**
+
+```rust
+svm.add_program(program_id, &program_bytes).unwrap();
+```
+
+</Step>
+
+<Step>
+**Verify deployment**
+
+```rust
+assert!(svm.get_account(&program_id).unwrap().executable);
+```
+
+</Step>
+
+<Step>
+Deploy any programs your program calls via CPI to the litesvm test instance
+
+</Step>
+</Steps>
+
+## Next Steps
+
+In the next section, we'll learn how to execute program instructions and handle
+complex transaction patterns.

--- a/apps/docs/content/docs/en/tools/litesvm/testing-your-program/executing-instructions.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/testing-your-program/executing-instructions.mdx
@@ -1,0 +1,324 @@
+---
+title: Executing Instructions
+description: Learn how to call an instruction from a Solana program in your test
+---
+
+## Overview
+
+After deploying a program to LiteSVM, you'll need to execute instructions to
+interact with the deployed program.
+
+LiteSVM provides a simple API for creating, sending, and simulating transactions
+that is fully compatible with Solana's transaction model.
+
+## Basic Transaction Flow
+
+The typical flow for executing an instruction is:
+
+1. **Create an Instruction** - Define what program to call and with what data
+2. **Build a Message** - Combine one or more instructions
+3. **Create a Transaction** - Sign the message with required signers
+4. **Send or Simulate** - Execute the transaction and handle results
+
+## Creating Instructions
+
+### Basic Instruction Structure
+
+```rust
+use solana_instruction::{Instruction, AccountMeta};
+use solana_pubkey::Pubkey;
+
+let instruction = Instruction {
+    program_id: Pubkey::new_unique(),  // The program to call
+    accounts: vec![                     // Accounts the program needs
+        AccountMeta::new(account_pubkey, false),        // Writable, not signer
+        AccountMeta::new_readonly(readonly_pubkey, false), // Read-only, not signer
+        AccountMeta::new(signer_pubkey, true),          // Writable, signer
+    ],
+    data: vec![0, 1, 2, 3],             // Instruction data (program-specific)
+};
+```
+
+## Building and Sending Transactions
+
+### Method 1: Basic Transaction
+
+```rust
+use litesvm::LiteSVM;
+use solana_keypair::Keypair;
+use solana_message::Message;
+use solana_transaction::Transaction;
+use solana_signer::Signer;
+
+let mut svm = LiteSVM::new();
+let payer = Keypair::new();
+
+// Airdrop SOL for fees
+svm.airdrop(&payer.pubkey(), 1_000_000_000).unwrap();
+
+// Create instruction
+let instruction = /* your instruction */;
+
+// Build message with payer
+let message = Message::new(&[instruction], Some(&payer.pubkey()));
+
+// Create and sign transaction
+let tx = Transaction::new_signed_with_payer(
+    &[instruction],                 // Your instructions
+    Some(&payer.pubkey()),          // Who pays transaction fees
+    &[&payer],                      // All required signers
+    svm.latest_blockhash(),         // Recent blockhash
+);
+
+
+// Send transaction
+let result = svm.send_transaction(tx);
+```
+
+<div className="ml-4 my-2">
+  <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+    What `new_signed_with_payer` does:
+  </p>
+  <ul className="space-y-0.5 ml-4 list-disc text-sm text-gray-600 dark:text-gray-400">
+    <li>Automatically builds a Message from your instructions</li>
+    <li>Automatically signs the transaction with all provided keypairs</li>
+    <li>Returns a fully signed, ready-to-send transaction</li>
+  </ul>
+</div>
+
+### Method 2: Custom Message Transaction
+
+```rust
+let payer = Keypair::new();
+
+// Manually construct message
+let message = Message::new(&[instruction], Some(&payer.pubkey()));
+
+// Create transaction with signers, message, and blockhash
+let tx = Transaction::new(
+    &[&payer],
+    message,
+    svm.latest_blockhash(),
+);
+
+let result = svm.send_transaction(tx);
+```
+
+<div className="ml-4 my-2">
+  <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+    Use this method when you need control over the `Message` like:
+  </p>
+  <ul className="space-y-0.5 ml-4 list-disc text-sm text-gray-600 dark:text-gray-400">
+    <li>Versioned transactions (v0 with lookup tables)</li>
+    <li>Partial/multi-sig workflows</li>
+    <li>Durable nonces</li>
+    <li>Pre-signature simulation or inspection</li>
+    <li>Custom fee payer logic</li>
+    <li>Transaction size optimization</li>
+  </ul>
+</div>
+
+## Versioned Transactions
+
+LiteSVM supports both legacy and versioned transactions:
+
+```rust
+use solana_transaction::versioned::VersionedTransaction;
+use solana_message::VersionedMessage;
+
+// Legacy transaction (most common)
+let legacy_msg = Message::new(&[instruction], Some(&payer.pubkey()));
+let versioned_tx = VersionedTransaction::try_new(
+    VersionedMessage::Legacy(legacy_msg),
+    &[&payer]
+).unwrap();
+
+// Send versioned transaction
+let result = svm.send_transaction(versioned_tx);
+```
+
+## Transaction Results
+
+### Successful Transaction
+
+```rust
+match svm.send_transaction(tx) {
+    Ok(meta) => {
+        println!("Signature: {}", meta.signature);
+        println!("Compute units: {}", meta.compute_units_consumed);
+        println!("Logs:");
+        for log in &meta.logs {
+            println!("  {}", log);
+        }
+    }
+    Err(err) => {
+        println!("Transaction failed: {:?}", err.err);
+        // Logs are still available on failure
+        println!("Failure logs: {:?}", err.meta.logs);
+    }
+}
+```
+
+### Transaction Metadata Fields
+
+```rust
+pub struct TransactionMetadata {
+    pub signature: Signature,
+    pub logs: Vec<String>,
+    pub inner_instructions: InnerInstructionsList,
+    pub compute_units_consumed: u64,
+    pub return_data: TransactionReturnData,
+    pub fee: u64,
+}
+```
+
+## Simulating Transactions
+
+Simulate transaction lets you test transactions without changing state:
+
+```rust
+// Simulate instead of sending
+match svm.simulate_transaction(tx) {
+    Ok(sim_result) => {
+        println!("Simulation successful!");
+        println!("Logs: {:?}", sim_result.meta.logs);
+        println!("Compute units: {}", sim_result.meta.compute_units_consumed);
+    }
+    Err(err) => {
+        println!("Simulation failed: {:?}", err.err);
+    }
+}
+```
+
+## Error Handling
+
+### Common Transaction Errors
+
+```rust
+use solana_transaction_error::TransactionError;
+use solana_instruction::error::InstructionError;
+
+match svm.send_transaction(tx) {
+    Err(failed_tx) => {
+        match failed_tx.err {
+            TransactionError::InsufficientFundsForFee => {
+                println!("Not enough SOL for fees");
+            }
+            TransactionError::InvalidProgramForExecution => {
+                println!("Program doesn't exist or isn't executable");
+            }
+            TransactionError::InstructionError(index, err) => {
+                println!("Instruction {} failed: {:?}", index, err);
+                match err {
+                    InstructionError::Custom(code) => {
+                        println!("Custom error code: {}", code);
+                    }
+                    InstructionError::AccountNotFound => {
+                        println!("An account doesn't exist");
+                    }
+                    _ => {}
+                }
+            }
+            TransactionError::BlockhashNotFound => {
+                println!("Blockhash expired or invalid");
+            }
+            _ => println!("Other error: {:?}", failed_tx.err),
+        }
+    }
+    Ok(_) => {}
+}
+```
+
+## Working with Program Logs
+
+### Accessing Logs
+
+```rust
+let result = svm.send_transaction(tx).unwrap();
+
+// All logs (including system logs)
+for log in &result.logs {
+    println!("{}", log);
+}
+
+// Pretty-printed logs (formatted)
+println!("{}", result.pretty_logs());
+```
+
+### Log Output Example
+
+```
+Program 11111111111111111111111111111111 invoke [1]
+Program log: Processing instruction
+Program 11111111111111111111111111111111 consumed 2000 compute units
+Program 11111111111111111111111111111111 success
+```
+
+## Compute Budget Configuration
+
+### Setting Global Compute Budget
+
+```rust
+use solana_compute_budget::compute_budget::ComputeBudget;
+
+let mut svm = LiteSVM::new()
+    .with_compute_budget(ComputeBudget {
+        compute_unit_limit: 200_000,
+        ..Default::default()
+    });
+```
+
+### Per-Transaction Compute Budget
+
+```rust
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+
+let instructions = vec![
+    // Set compute budget for this transaction
+    ComputeBudgetInstruction::set_compute_unit_limit(400_000),
+    ComputeBudgetInstruction::set_compute_unit_price(1),
+
+    // Your actual instruction
+    your_instruction,
+];
+```
+
+## System Program Instructions
+
+LiteSVM includes system program support:
+
+```rust
+use solana_keypair::Keypair;
+use solana_signer::Signer;
+use solana_system_interface::instruction as system_instruction;
+use solana_transaction::Transaction;
+
+
+// Transfer SOL
+let transfer_ix = system_instruction::transfer(
+    &alice.pubkey(),
+    &bob.pubkey(),
+    1_000_000_000, // 1 SOL
+);
+
+// Create new account
+let create_ix = system_instruction::create_account(
+    &payer_pubkey,
+    &new_account_pubkey,
+    lamports,
+    space as u64,
+    &owner_program_id,
+);
+```
+
+## Summary
+
+Executing instructions in LiteSVM follows the standard Solana transaction model:
+
+1. Create `Instruction` objects with program ID, accounts, and data
+2. Build a `Transaction` with the instruction and required signers
+3. Use `send_transaction()` to execute or `simulate_transaction()` to test
+4. Handle results by checking the `TransactionMetadata` or error details
+
+LiteSVM provides instant execution with detailed logs and debugging information,
+making it ideal for testing Solana programs efficiently.

--- a/apps/docs/content/docs/en/tools/litesvm/testing-your-program/executing-instructions.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/testing-your-program/executing-instructions.mdx
@@ -76,9 +76,9 @@ let result = svm.send_transaction(tx);
 ```
 
 <div className="ml-4 my-2">
-  <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+  <div className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
     What `new_signed_with_payer` does:
-  </p>
+  </div>
   <ul className="space-y-0.5 ml-4 list-disc text-sm text-gray-600 dark:text-gray-400">
     <li>Automatically builds a Message from your instructions</li>
     <li>Automatically signs the transaction with all provided keypairs</li>
@@ -105,9 +105,9 @@ let result = svm.send_transaction(tx);
 ```
 
 <div className="ml-4 my-2">
-  <p className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
+  <div className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1">
     Use this method when you need control over the `Message` like:
-  </p>
+  </div>
   <ul className="space-y-0.5 ml-4 list-disc text-sm text-gray-600 dark:text-gray-400">
     <li>Versioned transactions (v0 with lookup tables)</li>
     <li>Partial/multi-sig workflows</li>

--- a/apps/docs/content/docs/en/tools/litesvm/testing-your-program/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/testing-your-program/index.mdx
@@ -8,7 +8,7 @@ description: Learn how to test your Solana program with LiteSVM
 Before testing your program, ensure you:
 
 1. Build your program to generate the `.so` file
-2. Add `litesvm` as a dev dependencies to the `Cargo.toml` file
+2. Add `litesvm` as a dev dependency to the `Cargo.toml` file
 3. Add any additional dev dependencies that may be needed, like `solana-sdk` and
    `litesvm-token`
 4. Create a test file in your `tests` directory

--- a/apps/docs/content/docs/en/tools/litesvm/testing-your-program/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/testing-your-program/index.mdx
@@ -1,0 +1,85 @@
+---
+title: Quick Start
+description: Learn how to test your Solana program with LiteSVM
+---
+
+## Setup
+
+Before testing your program, ensure you:
+
+1. Build your program to generate the `.so` file
+2. Add `litesvm` as a dev dependencies to the `Cargo.toml` file
+3. Add any additional dev dependencies that may be needed, like `solana-sdk` and
+   `litesvm-token`
+4. Create a test file in your `tests` directory
+
+## Basic Program Test Layout
+
+Here are all the basic steps needed to call and execute an instruction in a
+Solana program.
+
+```rust title="tests/program_test.rs"
+use litesvm::LiteSVM;
+use solana_sdk::{
+    instruction::{AccountMeta, Instruction},
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+
+use my_program;
+
+#[test]
+fn test_my_program() {
+    // Initialize the test environment
+    let mut svm = LiteSVM::new();
+
+    // Deploy your program to the test environment
+    let program_id = Pubkey::from(my_program::ID);
+    let program_bytes = include_bytes!("../../../target/deploy/my_program.so");
+    svm.add_program(program_id, program_bytes);
+
+    // Create and fund test accounts
+    let payer = Keypair::new();
+    svm.airdrop(&payer.pubkey(), 10_000_000_000).unwrap();
+
+    // Create your instruction
+    let instruction = Instruction {
+        program_id,
+        accounts: vec![
+            AccountMeta::new(payer.pubkey(), true),
+        ],
+        data: vec![],
+    };
+
+    // Build transaction
+    let tx = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&payer.pubkey()),
+        &[&payer],
+        svm.latest_blockhash(),
+    );
+
+    // Send transaction
+    let result = svm.send_transaction(tx).unwrap();
+
+    // Check transaction succeeded
+    println!("Transaction logs: {:?}", result.logs);
+
+    println!("Program executed successfully!");
+}
+```
+
+The default test environment that is generated with `LiteSVM::new()` includes
+all runtime features enabled, default sysvars, precompiles, spl programs,
+sigverify, and all built in programs, like the system program.
+
+<Callout type="info">
+  If you want to interact with any program that is not included in the default
+  test environment, you must deploy that program to the test environment.
+</Callout>
+
+## Next Steps
+
+In the next section, we'll learn all about deploying programs to the litesvm
+test environment.

--- a/apps/docs/content/docs/en/tools/litesvm/testing-your-program/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/testing-your-program/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Testing Your Program",
+  "pages": ["index", "deploy", "executing-instructions"]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/account-management.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/account-management.mdx
@@ -1,0 +1,188 @@
+---
+title: Account Management
+description: Methods for managing accounts, balances, and rent in TypeScript
+---
+
+# Account Management
+
+Methods for managing accounts, balances, and setting account state.
+
+## airdrop
+
+```typescript
+airdrop(address: Address, lamports: Lamports): TransactionMetadata | FailedTransactionMetadata | null
+```
+
+Fund an account with lamports.
+
+```typescript
+import { lamports } from "@solana/kit";
+
+// Airdrop 5 SOL
+const result = client.svm.airdrop(account.address, lamports(5_000_000_000n));
+
+if (result) {
+  // Note: Result properties are getter functions
+  console.log("Compute units:", result.computeUnitsConsumed());
+}
+```
+
+## setAccount
+
+```typescript
+setAccount(account: EncodedAccount): LiteSVM
+```
+
+Directly set account state without a transaction.
+
+```typescript
+import { address, lamports } from "@solana/kit";
+
+client.svm.setAccount({
+  address: myAddress,
+  data: new Uint8Array([1, 2, 3, 4]),
+  executable: false,
+  lamports: lamports(1_000_000n),
+  programAddress: address("11111111111111111111111111111111"),
+  space: 4n
+});
+```
+
+### EncodedAccount Properties
+
+| Property         | Type         | Description                   |
+| ---------------- | ------------ | ----------------------------- |
+| `address`        | `Address`    | Account public key            |
+| `data`           | `Uint8Array` | Account data bytes            |
+| `executable`     | `boolean`    | Whether account is executable |
+| `lamports`       | `Lamports`   | SOL balance                   |
+| `programAddress` | `Address`    | Owner program                 |
+| `space`          | `bigint`     | Data size in bytes            |
+
+## getAccount
+
+```typescript
+getAccount(address: Address): MaybeEncodedAccount
+```
+
+Retrieve account data.
+
+```typescript
+const account = client.svm.getAccount(myAddress);
+
+if (account.exists) {
+  console.log("Address:", account.address);
+  console.log("Lamports:", account.lamports);
+  console.log("Owner:", account.programAddress);
+  console.log("Data:", account.data);
+  console.log("Executable:", account.executable);
+}
+```
+
+## getBalance
+
+```typescript
+getBalance(address: Address): Lamports | null
+```
+
+Get account SOL balance. Returns `null` if account doesn't exist.
+
+```typescript
+const balance = client.svm.getBalance(account.address);
+
+if (balance !== null) {
+  console.log("Balance:", balance, "lamports");
+  console.log("Balance:", Number(balance) / 1e9, "SOL");
+} else {
+  console.log("Account does not exist");
+}
+```
+
+## minimumBalanceForRentExemption
+
+```typescript
+minimumBalanceForRentExemption(dataLen: bigint): bigint
+```
+
+Calculate the minimum lamports needed for rent exemption.
+
+```typescript
+const dataSize = 100n;
+const minBalance = client.svm.minimumBalanceForRentExemption(dataSize);
+
+console.log(
+  `Rent-exempt minimum for ${dataSize} bytes:`,
+  minBalance,
+  "lamports"
+);
+
+// Use when setting up accounts
+client.svm.setAccount({
+  address: myAddress,
+  data: new Uint8Array(Number(dataSize)),
+  executable: false,
+  lamports: lamports(minBalance),
+  programAddress: programId,
+  space: dataSize
+});
+```
+
+## Program Management
+
+### addProgram
+
+```typescript
+addProgram(programId: Address, programBytes: Uint8Array): LiteSVM
+```
+
+Load a program from bytes.
+
+```typescript
+const programBytes = fs.readFileSync("path/to/program.so");
+client.svm.addProgram(programId, programBytes);
+```
+
+### addProgramFromFile
+
+```typescript
+addProgramFromFile(programId: Address, path: string): LiteSVM
+```
+
+Load a program from a `.so` file path.
+
+```typescript
+import { generateKeyPairSigner } from "@solana/kit";
+
+const programId = await generateKeyPairSigner().then((s) => s.address);
+client.svm.addProgramFromFile(
+  programId,
+  "/path/to/target/deploy/my_program.so"
+);
+```
+
+## Batch Account Setup
+
+For testing, you can set up multiple accounts efficiently:
+
+```typescript
+// Set up multiple test accounts
+const accounts = await Promise.all(
+  Array.from({ length: 10 }, () => generateKeyPairSigner())
+);
+
+for (const [index, account] of accounts.entries()) {
+  client.svm.setAccount({
+    address: account.address,
+    data: new Uint8Array([index]),
+    executable: false,
+    lamports: lamports(1_000_000n),
+    programAddress: address("11111111111111111111111111111111"),
+    space: 1n
+  });
+}
+```
+
+<Callout type="info">
+  Using `setAccount` is faster than `airdrop` for bulk account setup since it
+  doesn't execute transactions.
+</Callout>

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/configuration.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/configuration.mdx
@@ -1,0 +1,165 @@
+---
+title: Configuration
+description: Builder methods for configuring LiteSVM in TypeScript
+---
+
+# Configuration
+
+LiteSVM uses a builder pattern for configuration. All methods return `LiteSVM`
+for chaining.
+
+## Typical Test Setup
+
+```typescript
+import { createClient, generateKeyPairSigner } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
+client.svm
+  .withSigverify(false) // Skip signature verification (faster)
+  .withBlockhashCheck(false) // Skip blockhash validation (simpler)
+  .withSysvars() // Enable Clock, Rent, etc.
+  .withBuiltins() // Enable ed25519, secp256k1
+  .withTransactionHistory(100n); // Store last 100 transactions
+```
+
+## Signature & Blockhash
+
+### withSigverify
+
+```typescript
+withSigverify(sigverify: boolean): LiteSVM
+```
+
+Enable or disable signature verification.
+
+```typescript
+// Disable for faster tests (default is enabled)
+client.svm.withSigverify(false);
+
+// Enable for production-like testing
+client.svm.withSigverify(true);
+```
+
+<Callout type="info">
+  Disabling signature verification makes tests faster but less realistic.
+</Callout>
+
+### withBlockhashCheck
+
+```typescript
+withBlockhashCheck(check: boolean): LiteSVM
+```
+
+Enable or disable blockhash expiration checking.
+
+```typescript
+// Disable for simpler tests
+client.svm.withBlockhashCheck(false);
+```
+
+## Programs & Sysvars
+
+### withSysvars
+
+```typescript
+withSysvars(): LiteSVM
+```
+
+Enable sysvar accounts (Clock, Rent, EpochSchedule, etc.).
+
+```typescript
+client.svm.withSysvars();
+
+// Now you can access sysvars
+const clock = client.svm.getClock();
+const rent = client.svm.getRent();
+```
+
+### withBuiltins
+
+```typescript
+withBuiltins(): LiteSVM
+```
+
+Enable built-in programs (ed25519, secp256k1 signature verification).
+
+```typescript
+client.svm.withBuiltins();
+```
+
+### withPrecompiles
+
+```typescript
+withPrecompiles(): LiteSVM
+```
+
+Enable precompiled programs.
+
+```typescript
+client.svm.withPrecompiles();
+```
+
+### withDefaultPrograms
+
+```typescript
+withDefaultPrograms(): LiteSVM
+```
+
+Add default programs (System Program, BPF Loader, etc.).
+
+```typescript
+client.svm.withDefaultPrograms();
+```
+
+## Resource Limits
+
+### withLamports
+
+```typescript
+withLamports(lamports: bigint): LiteSVM
+```
+
+Set default lamports for accounts.
+
+```typescript
+client.svm.withLamports(1_000_000_000n); // 1 SOL
+```
+
+### withLogBytesLimit
+
+```typescript
+withLogBytesLimit(limit?: bigint): LiteSVM
+```
+
+Set the log output byte limit.
+
+```typescript
+client.svm.withLogBytesLimit(10000n);
+```
+
+### withTransactionHistory
+
+```typescript
+withTransactionHistory(capacity: bigint): LiteSVM
+```
+
+Enable transaction history storage.
+
+```typescript
+// Store last 100 transactions
+client.svm.withTransactionHistory(100n);
+```
+
+## Feature Sets
+
+### withFeatureSet
+
+```typescript
+withFeatureSet(featureSet: FeatureSet): LiteSVM
+```
+
+Configure the feature set for testing specific Solana versions.

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/index.mdx
@@ -1,0 +1,108 @@
+---
+title: API Reference
+description: Complete TypeScript API reference for LiteSVM
+---
+
+# TypeScript API Reference
+
+Complete API documentation for using LiteSVM with `@solana/kit` and its plugin
+ecosystem.
+
+## API Sections
+
+<Cards>
+  <Card
+    title="Account Management"
+    description="setAccount, getAccount, airdrop, getBalance"
+    href="/docs/tools/litesvm/typescript/api-reference/account-management"
+  />
+  <Card
+    title="Transactions"
+    description="sendTransaction, simulateTransaction, blockhash management"
+    href="/docs/tools/litesvm/typescript/api-reference/transactions"
+  />
+  <Card
+    title="Configuration"
+    description="Builder methods for configuring LiteSVM"
+    href="/docs/tools/litesvm/typescript/api-reference/configuration"
+  />
+  <Card
+    title="Time & Sysvars"
+    description="Clock manipulation and sysvar access"
+    href="/docs/tools/litesvm/typescript/api-reference/time-and-sysvars"
+  />
+</Cards>
+
+## Quick Reference
+
+### Plugin Setup
+
+```typescript
+import { createClient, generateKeyPairSigner } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+// client.svm: LiteSVM instance
+// client.rpc: RPC compatibility layer
+```
+
+### Account Management (client.svm)
+
+| Method                                 | Description                   |
+| -------------------------------------- | ----------------------------- |
+| `setAccount(account)`                  | Set account state directly    |
+| `getAccount(address)`                  | Retrieve account data         |
+| `getBalance(address)`                  | Get SOL balance               |
+| `airdrop(address, lamports)`           | Fund an account               |
+| `minimumBalanceForRentExemption(size)` | Calculate rent-exempt minimum |
+
+### Program Management (client.svm)
+
+| Method                                | Description                |
+| ------------------------------------- | -------------------------- |
+| `addProgram(programId, bytes)`        | Load program from bytes    |
+| `addProgramFromFile(programId, path)` | Load program from .so file |
+
+### Transactions (client.svm)
+
+| Method                    | Description                    |
+| ------------------------- | ------------------------------ |
+| `sendTransaction(tx)`     | Execute a transaction          |
+| `simulateTransaction(tx)` | Simulate without state changes |
+| `latestBlockhash()`       | Get current blockhash          |
+| `expireBlockhash()`       | Advance to new blockhash       |
+
+### Configuration (client.svm)
+
+| Method                      | Description                           |
+| --------------------------- | ------------------------------------- |
+| `withSigverify(bool)`       | Enable/disable signature verification |
+| `withBlockhashCheck(bool)`  | Enable/disable blockhash validation   |
+| `withSysvars()`             | Enable sysvar accounts                |
+| `withBuiltins()`            | Enable built-in programs              |
+| `withPrecompiles()`         | Enable precompiled programs           |
+| `withTransactionHistory(n)` | Store last n transactions             |
+| `withComputeBudget(budget)` | Set compute limits                    |
+| `withLamports(amount)`      | Set default lamports                  |
+| `withLogBytesLimit(n)`      | Set log output limit                  |
+
+### Time & Sysvars (client.svm)
+
+| Method                     | Description           |
+| -------------------------- | --------------------- |
+| `warpToSlot(slot)`         | Jump to specific slot |
+| `getClock()`               | Get clock sysvar      |
+| `getRent()`                | Get rent sysvar       |
+| `getEpochSchedule()`       | Get epoch schedule    |
+| `getLastRestartSlot()`     | Get last restart slot |
+| `setLastRestartSlot(slot)` | Set last restart slot |
+
+### RPC (client.rpc)
+
+| Method                           | Description                        |
+| -------------------------------- | ---------------------------------- |
+| `getAccountInfo(address)`        | Fetch single account (base64 only) |
+| `getMultipleAccounts(addresses)` | Fetch multiple accounts            |
+| `getLatestBlockhash()`           | Get current blockhash              |

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "API Reference",
+  "pages": [
+    "index",
+    "account-management",
+    "transactions",
+    "configuration",
+    "time-and-sysvars"
+  ]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/time-and-sysvars.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/time-and-sysvars.mdx
@@ -1,0 +1,270 @@
+---
+title: Time & Sysvars
+description: Clock manipulation and sysvar access in TypeScript
+---
+
+# Time & Sysvars
+
+Methods for manipulating time and accessing system variables.
+
+<Callout type="warn">
+  Enable sysvars first with `client.svm.withSysvars()` before accessing sysvar
+  methods.
+</Callout>
+
+## Clock Manipulation
+
+### warpToSlot
+
+```typescript
+warpToSlot(slot: bigint): LiteSVM
+```
+
+Advance the clock to a specific slot.
+
+```typescript
+client.svm.withSysvars();
+
+// Check current slot
+const before = client.svm.getClock();
+console.log("Current slot:", before.slot);
+
+// Warp forward
+client.svm.warpToSlot(10000n);
+
+const after = client.svm.getClock();
+console.log("New slot:", after.slot);
+```
+
+### getClock
+
+```typescript
+getClock(): Clock
+```
+
+Get the current clock sysvar values.
+
+```typescript
+const clock = client.svm.getClock();
+
+console.log("Slot:", clock.slot);
+console.log("Epoch:", clock.epoch);
+console.log("Unix timestamp:", clock.unixTimestamp);
+console.log("Epoch start timestamp:", clock.epochStartTimestamp);
+console.log("Leader schedule epoch:", clock.leaderScheduleEpoch);
+```
+
+### setClock
+
+```typescript
+setClock(clock: Clock): LiteSVM
+```
+
+Overwrite the clock sysvar. Get the clock, mutate its fields, then write it
+back. Use this when you need precise control over multiple clock fields — for
+example, setting the epoch or unix timestamp, which `warpToSlot` does not
+update.
+
+```typescript
+const clock = client.svm.getClock();
+clock.slot = 1000n;
+clock.epoch = 10n;
+clock.unixTimestamp = 1735689600n;
+client.svm.setClock(clock);
+```
+
+<Callout type="info">
+  `warpToSlot` only updates `slot`. Use `setClock` when your program reads
+  `epoch` or `unix_timestamp` from the Clock sysvar.
+</Callout>
+
+### Clock Properties
+
+| Property              | Type     | Description               |
+| --------------------- | -------- | ------------------------- |
+| `slot`                | `bigint` | Current slot number       |
+| `epoch`               | `bigint` | Current epoch number      |
+| `unixTimestamp`       | `bigint` | Unix timestamp in seconds |
+| `epochStartTimestamp` | `bigint` | Start of current epoch    |
+| `leaderScheduleEpoch` | `bigint` | Leader schedule epoch     |
+
+## Rent
+
+### getRent
+
+```typescript
+getRent(): Rent
+```
+
+Get the rent sysvar.
+
+```typescript
+const rent = client.svm.getRent();
+
+console.log("Lamports per byte-year:", rent.lamportsPerByteYear);
+console.log("Exemption threshold:", rent.exemptionThreshold);
+console.log("Burn percent:", rent.burnPercent);
+```
+
+### minimumBalanceForRentExemption
+
+```typescript
+minimumBalanceForRentExemption(dataLen: bigint): bigint
+```
+
+Calculate the minimum lamports needed for rent exemption.
+
+```typescript
+// Calculate for different data sizes
+for (const size of [0n, 100n, 1000n]) {
+  const min = client.svm.minimumBalanceForRentExemption(size);
+  console.log(`${size} bytes: ${min} lamports`);
+}
+```
+
+## Epoch Schedule
+
+### getEpochSchedule
+
+```typescript
+getEpochSchedule(): EpochSchedule
+```
+
+Get the epoch schedule sysvar.
+
+```typescript
+const epochSchedule = client.svm.getEpochSchedule();
+
+console.log("Slots per epoch:", epochSchedule.slotsPerEpoch);
+console.log(
+  "Leader schedule slot offset:",
+  epochSchedule.leaderScheduleSlotOffset
+);
+console.log("Warmup:", epochSchedule.warmup);
+console.log("First normal epoch:", epochSchedule.firstNormalEpoch);
+console.log("First normal slot:", epochSchedule.firstNormalSlot);
+```
+
+## Epoch Rewards
+
+### getEpochRewards
+
+```typescript
+getEpochRewards(): EpochRewards
+```
+
+Get the epoch rewards sysvar.
+
+```typescript
+const rewards = client.svm.getEpochRewards();
+
+console.log("Active:", rewards.active);
+console.log("Total rewards:", rewards.totalRewards);
+console.log("Distributed rewards:", rewards.distributedRewards);
+console.log("Total points:", rewards.totalPoints);
+console.log("Num partitions:", rewards.numPartitions);
+console.log(
+  "Distribution starting block height:",
+  rewards.distributionStartingBlockHeight
+);
+```
+
+## Slot Information
+
+### getSlotHashes
+
+```typescript
+getSlotHashes(): SlotHash[]
+```
+
+Get recent slot hashes.
+
+```typescript
+const slotHashes = client.svm.getSlotHashes();
+
+console.log("Slot hashes count:", slotHashes.length);
+if (slotHashes.length > 0) {
+  console.log("First hash:", {
+    slot: slotHashes[0].slot,
+    hash: slotHashes[0].hash
+  });
+}
+```
+
+### getSlotHistory
+
+```typescript
+getSlotHistory(): SlotHistory
+```
+
+Get the slot history.
+
+```typescript
+const slotHistory = client.svm.getSlotHistory();
+console.log("Next slot:", slotHistory.nextSlot);
+```
+
+### getLastRestartSlot / setLastRestartSlot
+
+```typescript
+getLastRestartSlot(): bigint
+setLastRestartSlot(slot: bigint): LiteSVM
+```
+
+Get or set the last restart slot.
+
+```typescript
+const lastRestart = client.svm.getLastRestartSlot();
+console.log("Last restart slot:", lastRestart);
+
+client.svm.setLastRestartSlot(500n);
+```
+
+## Stake History
+
+### getStakeHistory
+
+```typescript
+getStakeHistory(): StakeHistory
+```
+
+Get the stake history.
+
+```typescript
+const stakeHistory = client.svm.getStakeHistory();
+// Returns array of { epoch, entry: { effective, activating, deactivating } }
+```
+
+## Testing Time-Dependent Logic
+
+Use `warpToSlot` to test time-dependent program behavior:
+
+```typescript
+import { createClient, generateKeyPairSigner } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+async function testTimeLockedVault() {
+  const mySigner = await generateKeyPairSigner();
+  const client = createClient().use(signer(mySigner)).use(litesvm());
+  client.svm.withSysvars();
+
+  const unlockSlot = 10000n;
+
+  // Setup: Create time-locked account
+  // ... set up your account state ...
+
+  // Test 1: Try to withdraw before unlock (should fail)
+  const beforeClock = client.svm.getClock();
+  console.log("Current slot:", beforeClock.slot);
+  // ... attempt withdrawal, expect failure ...
+
+  // Warp time forward past unlock slot
+  client.svm.warpToSlot(unlockSlot + 1n);
+
+  // Test 2: Try to withdraw after unlock (should succeed)
+  const afterClock = client.svm.getClock();
+  console.log("New slot:", afterClock.slot);
+  // ... attempt withdrawal, expect success ...
+}
+```

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/transactions.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/transactions.mdx
@@ -1,0 +1,153 @@
+---
+title: Transactions
+description: Execute and simulate transactions with LiteSVM in TypeScript
+---
+
+# Transactions
+
+Methods for sending, simulating, and managing transactions.
+
+## sendTransaction
+
+```typescript
+sendTransaction(tx: Transaction): TransactionMetadata | FailedTransactionMetadata
+```
+
+Execute a transaction. Returns metadata on success or failure details on error.
+
+```typescript
+const result = client.svm.sendTransaction(signedTx);
+
+// Check for errors
+if ("err" in result && result.err()) {
+  console.error("Transaction failed:", result.err());
+  return;
+}
+
+// Access result properties (note: these are getter functions)
+console.log("Signature:", result.signature());
+console.log("Compute units:", result.computeUnitsConsumed());
+console.log("Logs:", result.logs());
+```
+
+<Callout type="warn">
+  Transaction result properties like `err()`, `computeUnitsConsumed()`,
+  `logs()`, and `signature()` are **getter functions**, not properties. Always
+  call them with parentheses.
+</Callout>
+
+### TransactionMetadata Methods
+
+| Method                   | Returns                 | Description                 |
+| ------------------------ | ----------------------- | --------------------------- |
+| `signature()`            | `Uint8Array`            | Transaction signature bytes |
+| `computeUnitsConsumed()` | `bigint`                | Compute units used          |
+| `logs()`                 | `string[]`              | Program logs                |
+| `innerInstructions()`    | `InnerInstruction[]`    | Inner (CPI) instructions    |
+| `returnData()`           | `TransactionReturnData` | Return data from programs   |
+| `prettyLogs()`           | `string`                | Formatted logs with colors  |
+
+## simulateTransaction
+
+```typescript
+simulateTransaction(tx: Transaction): SimulatedTransactionInfo | FailedTransactionMetadata
+```
+
+Simulate a transaction without modifying state.
+
+```typescript
+const simResult = client.svm.simulateTransaction(signedTx);
+
+if ("err" in simResult && simResult.err()) {
+  console.error("Simulation failed:", simResult.err());
+  return;
+}
+
+// Use .meta() to get TransactionMetadata
+const meta = simResult.meta();
+console.log("Would use", meta.computeUnitsConsumed(), "compute units");
+console.log("Logs:", meta.logs());
+
+// Get post-execution account states
+const postAccounts = simResult.postAccounts();
+console.log("Post-state accounts:", postAccounts);
+```
+
+<Callout type="info">
+  Simulation doesn't change state. Use it to check transactions before sending.
+</Callout>
+
+## Blockhash Management
+
+### latestBlockhash
+
+```typescript
+latestBlockhash(): Blockhash
+```
+
+Get the current blockhash.
+
+```typescript
+const blockhash = client.svm.latestBlockhash();
+console.log("Blockhash:", blockhash);
+```
+
+### getLatestBlockhash (via client.rpc)
+
+Get the blockhash with lifetime information for building transactions manually.
+Use the RPC helper since it returns both `blockhash` and `lastValidBlockHeight`.
+
+```typescript
+import {
+  createTransactionMessage,
+  setTransactionMessageLifetimeUsingBlockhash
+} from "@solana/kit";
+
+const { value: blockhashLifetime } = await client.rpc
+  .getLatestBlockhash()
+  .send();
+
+const tx = setTransactionMessageLifetimeUsingBlockhash(
+  blockhashLifetime,
+  createTransactionMessage({ version: 0 })
+);
+```
+
+<Callout type="info">
+  When using program plugins like `systemProgram()` or `tokenProgram()`, you
+  never need to fetch the blockhash yourself — `client.sendTransaction()` (and
+  the `.sendTransaction()` helper on instruction chains) handle it for you.
+</Callout>
+
+### expireBlockhash
+
+```typescript
+expireBlockhash(): LiteSVM
+```
+
+Advance to a new blockhash. Useful for testing blockhash expiration scenarios.
+
+```typescript
+const oldBlockhash = client.svm.latestBlockhash();
+client.svm.expireBlockhash();
+const newBlockhash = client.svm.latestBlockhash();
+
+console.log("Old:", oldBlockhash);
+console.log("New:", newBlockhash);
+// Blockhashes will be different
+```
+
+## Transaction History
+
+Enable transaction history to retrieve transactions after sending:
+
+```typescript
+// Enable history storage (stores last N transactions)
+client.svm.withTransactionHistory(100n);
+
+// Send a transaction
+const result = client.svm.sendTransaction(signedTx);
+
+// Later, retrieve it by signature (base58 string)
+// Note: getTransaction expects a base58-encoded signature string
+```

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/account-setup.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/account-setup.mdx
@@ -1,0 +1,183 @@
+---
+title: Account Setup
+description: Set up test accounts and state with LiteSVM
+---
+
+# Account Setup Example
+
+Demonstrates setting up test account state directly without transactions.
+
+## Basic Account Setup
+
+```typescript
+import {
+  createClient,
+  address,
+  generateKeyPairSigner,
+  lamports
+} from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
+// Calculate minimum balance for rent exemption
+const dataSize = 100n;
+const minBalance = client.svm.minimumBalanceForRentExemption(dataSize);
+console.log(`Minimum balance for ${dataSize} bytes:`, minBalance, "lamports");
+
+// Set account state directly (no transaction needed)
+const programId = address("11111111111111111111111111111111");
+const accountData = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+
+const testAddress = address("REPLACE_WITH_TEST_ADDRESS"); // or use generateKeyPairSigner()
+
+client.svm.setAccount({
+  address: testAddress,
+  data: accountData,
+  executable: false,
+  lamports: lamports(minBalance),
+  programAddress: programId,
+  space: BigInt(accountData.length)
+});
+
+console.log("Account state set successfully");
+
+// Retrieve the account data
+const retrieved = client.svm.getAccount(testAddress);
+
+if (retrieved.exists) {
+  console.log("Retrieved account:");
+  console.log("  Address:", retrieved.address);
+  console.log("  Lamports:", retrieved.lamports);
+  console.log("  Owner:", retrieved.programAddress);
+  console.log("  Executable:", retrieved.executable);
+  console.log("  Data:", Array.from(retrieved.data));
+}
+
+// Get balance separately
+const balance = client.svm.getBalance(testAddress);
+console.log("Balance:", balance, "lamports");
+```
+
+## Setting Up Multiple Accounts
+
+```typescript
+import {
+  createClient,
+  address,
+  generateKeyPairSigner,
+  lamports
+} from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+const programId = address("11111111111111111111111111111111");
+
+// Set up multiple accounts with different data
+const account1 = address("Account111111111111111111111111111"); // replace or generateKeyPairSigner()
+const account2 = address("Account211111111111111111111111111"); // replace or generateKeyPairSigner()
+const account3 = address("Account311111111111111111111111111"); // replace or generateKeyPairSigner()
+const account4 = address("Account411111111111111111111111111"); // replace or generateKeyPairSigner()
+const account5 = address("Account511111111111111111111111111"); // replace or generateKeyPairSigner()
+const accounts = [account1, account2, account3, account4, account5];
+
+for (const [index, accountAddress] of accounts.entries()) {
+  const customData = new Uint8Array([index, index + 1, index + 2]);
+
+  client.svm.setAccount({
+    address: accountAddress,
+    data: customData,
+    executable: false,
+    lamports: lamports(1_000_000n),
+    programAddress: programId,
+    space: BigInt(customData.length)
+  });
+
+  console.log(`Account ${index}: ${accountAddress}`);
+}
+
+// Verify accounts via RPC
+console.log("\nVerifying via RPC:");
+const { value: rpcAccounts } = await client.rpc
+  .getMultipleAccounts(accounts)
+  .send();
+
+rpcAccounts.forEach((acc, i) => {
+  if (acc) {
+    console.log(
+      `  Account ${i}: ${acc.lamports} lamports, data: ${acc.data[0]}`
+    );
+  }
+});
+```
+
+## Program Data Account Setup
+
+Set up a program-owned data account:
+
+```typescript
+import {
+  createClient,
+  address,
+  generateKeyPairSigner,
+  lamports
+} from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
+// Your program ID
+const programId = address("YourProgramId111111111111111111111111111"); // replace or generateKeyPairSigner()
+const dataAccountAddress = address("DataAccount111111111111111111111111111"); // replace or generateKeyPairSigner()
+
+// Serialize your account data structure
+// This example uses a simple layout: [u8 discriminator, u64 counter, pubkey owner]
+const data = new Uint8Array(1 + 8 + 32);
+const view = new DataView(data.buffer);
+
+// Set discriminator
+data[0] = 0x01;
+
+// Set counter (u64 little-endian)
+view.setBigUint64(1, 100n, true);
+
+// Set owner pubkey (32 bytes)
+// In practice, you'd decode a real address here
+
+// Calculate rent-exempt minimum
+const minBalance = client.svm.minimumBalanceForRentExemption(
+  BigInt(data.length)
+);
+
+// Set the account
+client.svm.setAccount({
+  address: dataAccountAddress,
+  data,
+  executable: false,
+  lamports: lamports(minBalance),
+  programAddress: programId,
+  space: BigInt(data.length)
+});
+
+console.log("Program data account set up:", dataAccountAddress);
+```
+
+<Callout type="info">
+  Using `setAccount` is faster than executing transactions for bulk account
+  setup.
+</Callout>
+
+## Key Points
+
+1. **Direct State**: `setAccount` sets account state without transactions
+2. **Rent Exemption**: Use `minimumBalanceForRentExemption` to calculate
+   required lamports
+3. **Account Structure**: Provide all required fields: address, data,
+   executable, lamports, programAddress, space
+4. **Verification**: Use `getAccount` or `client.rpc.getAccountInfo` to verify

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/index.mdx
@@ -1,0 +1,44 @@
+---
+title: Examples
+description: Complete TypeScript examples for LiteSVM
+---
+
+# TypeScript Examples
+
+Complete, runnable examples demonstrating LiteSVM usage with `@solana/kit`.
+
+<Cards>
+  <Card
+    title="SOL Transfer"
+    description="Build and send a SOL transfer transaction"
+    href="/docs/tools/litesvm/typescript/examples/sol-transfer"
+  />
+  <Card
+    title="Account Setup"
+    description="Set up test accounts and state"
+    href="/docs/tools/litesvm/typescript/examples/account-setup"
+  />
+  <Card
+    title="Program Testing"
+    description="Load and test custom programs"
+    href="/docs/tools/litesvm/typescript/examples/program-testing"
+  />
+  <Card
+    title="Time-Based Testing"
+    description="Test time-dependent logic"
+    href="/docs/tools/litesvm/typescript/examples/time-based"
+  />
+</Cards>
+
+## Running Examples
+
+All examples can be run with `tsx` though some addresses/variables require
+replacing place holders with actual values.
+
+```bash
+# Install dependencies
+pnpm add @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/system
+
+# Run an example
+npx tsx example.ts
+```

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Examples",
+  "pages": [
+    "index",
+    "sol-transfer",
+    "account-setup",
+    "program-testing",
+    "time-based"
+  ]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/program-testing.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/program-testing.mdx
@@ -1,0 +1,140 @@
+---
+title: Program Testing
+description: Load and test custom Solana programs with LiteSVM
+---
+
+# Program Testing Example
+
+Testing a custom Solana program means loading its compiled `.so` file into the
+SVM, setting up the accounts it expects, and sending instructions against it.
+LiteSVM handles all of this in-process — no validator needed. We recommend
+generating program clients with the
+[Codama JS Renderer](https://github.com/codama-idl/renderers-js) so you can have
+access to a compatible Kit Plugin.
+
+## Loading a Program
+
+```typescript
+import { createClient, address, generateKeyPairSigner } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+import { myProgramPlugin } from "@my-program/sdk";
+import * as fs from "node:fs";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient()
+  .use(signer(mySigner))
+  .use(litesvm())
+  .use(myProgramPlugin());
+
+// Configure for program testing
+client.svm
+  .withSigverify(false)
+  .withBlockhashCheck(false)
+  .withSysvars()
+  .withBuiltins();
+
+// Load program from .so file
+const programId = address("YourProgramId111111111111111111111111111");
+const soPath = "/path/to/target/deploy/my_program.so";
+
+if (fs.existsSync(soPath)) {
+  client.svm.addProgramFromFile(programId, soPath);
+  console.log("Program loaded:", programId);
+
+  // Verify program account
+  const programAccount = client.svm.getAccount(programId);
+  if (programAccount.exists) {
+    console.log("  Executable:", programAccount.executable);
+    console.log("  Data size:", programAccount.data.length, "bytes");
+  }
+} else {
+  console.log("Program file not found:", soPath);
+  console.log("Build with: cargo build-sbf");
+}
+```
+
+## Complete Program Test Setup
+
+```typescript
+import { createClient, address, generateKeyPairSigner, lamports } from '@solana/kit';
+import { litesvm } from '@solana/kit-plugin-litesvm';
+import { signer } from '@solana/kit-plugin-signer';
+import { myProgramPlugin } from '@my-program/sdk';
+import * as fs from 'node:fs';
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient()
+    .use(signer(mySigner))
+    .use(litesvm())
+    .use(myProgramPlugin());
+
+client.svm
+    .withSigverify(false)
+    .withBlockhashCheck(false)
+    .withSysvars()
+    .withBuiltins()
+    .withPrecompiles()
+    .withTransactionHistory(100n);
+
+// Load program
+const programId = address('YourProgramId111111111111111111111111111');
+const soPath = '/path/to/target/deploy/my_program.so';
+
+if (fs.existsSync(soPath)) {
+    client.svm.addProgramFromFile(programId, soPath);
+}
+
+// Set up any required data accounts
+const dataAccountAddress = address('DataAccount111111111111111111111111111');
+const minBalance = client.svm.minimumBalanceForRentExemption(100n);
+client.svm.setAccount({
+    address: dataAccountAddress,
+    data: new Uint8Array(100),
+    executable: false,
+    lamports: lamports(minBalance),
+    programAddress: programId,
+    space: 100n,
+});
+
+// Send the transaction
+await client.myProgram.testInstruction({..}).sendTransaction();
+
+// Verify state changes
+const updatedAccount = client.myProgram.myAccount.fetch(dataAccountAddress);
+// assert on decoded account
+```
+
+## Using Default Programs
+
+For testing that requires standard programs:
+
+```typescript
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
+// Add all default programs (System, BPF Loader, etc.)
+client.svm.withDefaultPrograms();
+
+// Or add specific programs you need
+// The Token program, Associated Token program, etc. would need
+// to be added manually via addProgramFromFile if needed
+```
+
+<Callout type="info">
+  Build your Solana program with `cargo build-sbf` to generate the `.so` file.
+</Callout>
+
+The pattern is always the same:
+
+1. **Program Loading**: Use `addProgramFromFile` to load compiled programs and
+   import myProgramPlugin() from your client
+2. **Configuration**: Enable sysvars, builtins, and precompiles as needed
+3. **Account Setup**: Pre-populate data accounts with `setAccount`
+4. **Sending**: Use `client.myProgram.testInstruction({..}).sendTransaction()` —
+   no manual transaction building
+5. **Verification**: Check account state after execution
+   (`client.myProgram.myAccount.fetch`)
+
+Once you have this skeleton working, you can build out a full test suite by
+adding more instructions and assertions.

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/sol-transfer.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/sol-transfer.mdx
@@ -1,0 +1,67 @@
+---
+title: SOL Transfer
+description: Build and send a SOL transfer transaction with LiteSVM
+---
+
+# SOL Transfer Example
+
+The most basic Solana transaction: move SOL from one account to another. This is
+a good first test to verify your LiteSVM setup works before testing more complex
+program logic.
+
+## Full Example
+
+```typescript
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+import { systemProgram } from "@solana-program/system";
+
+// Payer first, then the LiteSVM transport, then program plugins.
+const mySigner = await generateKeyPairSigner();
+const client = createClient()
+  .use(signer(mySigner))
+  .use(litesvm())
+  .use(systemProgram());
+const recipient = await generateKeyPairSigner();
+
+// Airdrop SOL to the payer
+client.svm.airdrop(client.payer.address, lamports(10_000_000_000n));
+
+// Check initial balance
+const senderInitial = client.svm.getBalance(client.payer.address) ?? 0n;
+console.log("Sender initial:", Number(senderInitial) / 1e9, "SOL");
+
+// Build and send the transfer
+await client.system.instructions
+  .transferSol({
+    source: client.payer,
+    destination: recipient.address,
+    amount: lamports(1_000_000_000n) // 1 SOL
+  })
+  .sendTransaction();
+
+// Check final balances
+const senderFinal = client.svm.getBalance(client.payer.address) ?? 0n;
+const recipientFinal = client.svm.getBalance(recipient.address) ?? 0n;
+console.log("Sender final:", Number(senderFinal) / 1e9, "SOL");
+console.log("Recipient final:", Number(recipientFinal) / 1e9, "SOL");
+```
+
+## Expected Output
+
+```
+Sender initial: 10 SOL
+Sender final: 8.999995 SOL
+Recipient final: 1 SOL
+```
+
+<Callout type="info">
+  The sender's final balance is slightly less than 9 SOL due to transaction fees
+  (5,000 lamports per signature).
+</Callout>
+
+This covers the simplest transaction type. For testing with custom programs, see
+[Program Testing](/docs/tools/litesvm/typescript/examples/program-testing). For
+token transfers (mints, ATAs), see
+[Token Testing](/docs/tools/litesvm/typescript/tokens).

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/time-based.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/time-based.mdx
@@ -1,0 +1,208 @@
+---
+title: Time-Based Testing
+description: Test time-dependent logic with LiteSVM clock manipulation
+---
+
+# Time-Based Testing Example
+
+Demonstrates using `warpToSlot` to test time-dependent program logic.
+
+## Basic Clock Manipulation
+
+```typescript
+import { createClient, generateKeyPairSigner } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
+// Enable sysvars for clock access
+client.svm.withSysvars();
+
+// Check initial clock
+const initialClock = client.svm.getClock();
+console.log("Initial state:");
+console.log("  Slot:", initialClock.slot);
+console.log("  Epoch:", initialClock.epoch);
+console.log("  Unix timestamp:", initialClock.unixTimestamp);
+
+// Warp to slot 1000
+client.svm.warpToSlot(1000n);
+
+const afterWarp = client.svm.getClock();
+console.log("\nAfter warpToSlot(1000):");
+console.log("  Slot:", afterWarp.slot);
+console.log("  Epoch:", afterWarp.epoch);
+
+// Warp further
+client.svm.warpToSlot(100000n);
+
+const afterWarp2 = client.svm.getClock();
+console.log("\nAfter warpToSlot(100000):");
+console.log("  Slot:", afterWarp2.slot);
+console.log("  Epoch:", afterWarp2.epoch);
+```
+
+## Testing Time-Locked Logic
+
+Example pattern for testing time-locked functionality:
+
+```typescript
+import {
+  createClient,
+  address,
+  generateKeyPairSigner,
+  lamports
+} from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
+client.svm.withSigverify(false).withBlockhashCheck(false).withSysvars();
+
+// Fund payer
+client.svm.airdrop(client.payer.address, lamports(10_000_000_000n));
+
+// Set up a time-locked vault account
+// Structure: [u8 discriminator, u64 unlock_slot, u64 amount]
+const unlockSlot = 10000n;
+const lockedAmount = 5_000_000_000n;
+
+const vaultData = new Uint8Array(1 + 8 + 8);
+const view = new DataView(vaultData.buffer);
+vaultData[0] = 0x01; // discriminator
+view.setBigUint64(1, unlockSlot, true); // unlock_slot
+view.setBigUint64(9, lockedAmount, true); // amount
+
+const programId = address("TimeLockedVault11111111111111111111111"); // replace or generateKeyPairSigner()
+const vaultAddress = address("Vault111111111111111111111111111"); // replace or generateKeyPairSigner()
+const minBalance = client.svm.minimumBalanceForRentExemption(
+  BigInt(vaultData.length)
+);
+
+client.svm.setAccount({
+  address: vaultAddress,
+  data: vaultData,
+  executable: false,
+  lamports: lamports(minBalance + lockedAmount),
+  programAddress: programId,
+  space: BigInt(vaultData.length)
+});
+
+console.log("Vault created with unlock slot:", unlockSlot);
+console.log("Locked amount:", Number(lockedAmount) / 1e9, "SOL");
+
+// Test 1: Try to withdraw before unlock (should fail)
+console.log("\n--- Test 1: Before unlock ---");
+const currentClock = client.svm.getClock();
+console.log("Current slot:", currentClock.slot);
+
+// In a real test, you would:
+// 1. Build a withdraw instruction
+// 2. Send it and expect it to fail
+console.log("Withdrawal attempt: EXPECTED TO FAIL (too early)");
+
+// Test 2: Warp to after unlock slot
+console.log("\n--- Test 2: After unlock ---");
+client.svm.warpToSlot(unlockSlot + 100n);
+
+const newClock = client.svm.getClock();
+console.log("Current slot:", newClock.slot);
+
+// In a real test:
+// 1. Build a withdraw instruction
+// 2. Send it and expect it to succeed
+console.log("Withdrawal attempt: EXPECTED TO SUCCEED (after unlock)");
+
+// Verify vault state
+const updatedVault = client.svm.getAccount(vaultAddress);
+if (updatedVault.exists) {
+  console.log("\nVault balance:", updatedVault.lamports);
+}
+```
+
+## Reading the Epoch Schedule
+
+You can read the epoch schedule to understand the slot/epoch relationship on the
+cluster:
+
+```typescript
+import { createClient, generateKeyPairSigner } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+client.svm.withSysvars();
+
+const epochSchedule = client.svm.getEpochSchedule();
+console.log("Slots per epoch:", epochSchedule.slotsPerEpoch);
+console.log("First normal epoch:", epochSchedule.firstNormalEpoch);
+console.log("First normal slot:", epochSchedule.firstNormalSlot);
+```
+
+<Callout type="warn">
+  `warpToSlot` advances the clock's `slot` field but does **not** automatically
+  update `epoch` or `unixTimestamp`. Use `setClock` for full control over clock
+  fields.
+</Callout>
+
+## Manual Clock Manipulation
+
+When your program reads `epoch` or `unix_timestamp` from the Clock sysvar, use
+`setClock` to set those fields directly:
+
+```typescript
+import { createClient, generateKeyPairSigner } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+client.svm.withSysvars();
+
+// Get clock, mutate, write back
+const clock = client.svm.getClock();
+clock.slot = 50000n;
+clock.epoch = 5n;
+clock.unixTimestamp = 1700000000n;
+client.svm.setClock(clock);
+
+const after = client.svm.getClock();
+console.log("Slot:", after.slot); // 50000n
+console.log("Epoch:", after.epoch); // 5n
+console.log("Timestamp:", after.unixTimestamp); // 1700000000n
+```
+
+This mirrors the Rust `set_sysvar(&clock)` pattern. Use `warpToSlot` for simple
+slot advancement, `setClock` when you need epoch or timestamp control.
+
+## Use Cases
+
+Time manipulation is useful for testing:
+
+| Scenario                | Approach                           |
+| ----------------------- | ---------------------------------- |
+| Token vesting           | Warp past vesting cliff/milestones |
+| Auction endings         | Warp past auction end slot         |
+| Staking rewards         | Use `setClock` to set epoch        |
+| Time-locked withdrawals | Warp past unlock slot              |
+| Rate limiting           | Warp between allowed intervals     |
+| Expiring orders         | Warp past order expiration         |
+
+<Callout type="info">
+  Remember that `warpToSlot` only changes the slot. The unix timestamp may not
+  update proportionally depending on the SVM implementation.
+</Callout>
+
+## Key Points
+
+1. **Enable Sysvars**: Call `withSysvars()` before using clock methods
+2. **Warp Forward**: Use `warpToSlot(slot)` to advance the slot
+3. **Full Control**: Use `setClock` when you need to set `epoch`,
+   `unixTimestamp`, or other clock fields
+4. **Read Clock**: Use `getClock()` to read current slot, epoch, timestamp
+5. **Test Pattern**: Test before and after time boundaries

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/getting-started.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/getting-started.mdx
@@ -1,0 +1,252 @@
+---
+title: Getting Started
+description: Use LiteSVM with @solana/kit for fast, in-process Solana testing
+---
+
+# LiteSVM for TypeScript
+
+Solana test suites that spin up `solana-test-validator` take seconds per test —
+you're waiting on process startup, RPC connections, and network round-trips.
+LiteSVM runs the same tests in milliseconds. No external process, no network,
+everything in-memory inside your test runner.
+
+<Callout type="info">
+  **Tested against:** `@solana/kit@6.8.0`, `@solana/kit-plugin-litesvm@0.10.0`,
+  `@solana/kit-plugin-signer@0.10.0`, `@solana-program/system@0.12.0`,
+  `@solana-program/token@0.13.0`. These plugin packages are new and evolving
+  quickly — if you hit a mismatch, check
+  [`testing/package.json`](https://github.com/solana-foundation/litesvm-docs/blob/main/testing/package.json)
+  for the exact versions the docs and test suite run against.
+</Callout>
+
+You assemble a Kit client from `@solana/kit` by installing plugins with
+`.use()`: a signer plugin
+([`@solana/kit-plugin-signer`](https://www.npmjs.com/package/@solana/kit-plugin-signer)),
+the LiteSVM plugin
+([`@solana/kit-plugin-litesvm`](https://www.npmjs.com/package/@solana/kit-plugin-litesvm)),
+and any program plugins you need. The result exposes `client.sendTransaction()`,
+`client.rpc`, and direct access to account state, clock, and sysvars — all
+without leaving your process.
+
+## Quick Start
+
+<Steps>
+
+<Step>
+### Install Dependencies
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']} groupId='package-manager'>
+<Tab value="pnpm">
+
+```bash
+pnpm add @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/system
+```
+
+</Tab>
+<Tab value="npm">
+
+```bash
+npm install @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/system
+```
+
+</Tab>
+<Tab value="yarn">
+
+```bash
+yarn add @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/system
+```
+
+</Tab>
+<Tab value="bun">
+
+```bash
+bun add @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/system
+```
+
+</Tab>
+</Tabs>
+
+</Step>
+
+<Step>
+### Create Your Client
+
+```typescript
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+
+// Payer first, then the LiteSVM transport.
+const mySigner = await generateKeyPairSigner();
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
+// Fund the payer
+client.svm.airdrop(client.payer.address, lamports(5_000_000_000n));
+
+// Check the balance
+const balance = client.svm.getBalance(client.payer.address);
+console.log("Balance:", balance, "lamports");
+```
+
+<Callout type="info">
+  `createClient()` returns an empty shell — each `.use(plugin)` layers
+  capabilities onto it. The `signer()` plugin must come **before** `litesvm()`
+  because the transport plugin needs a payer to attach to. `signer(mySigner)` is
+  shorthand for installing the same keypair as both `payer` and `identity` — use
+  `payer()` or `identity()` from the same package if you want to split those
+  roles. This ordering is the same for `solanaRpc()` when you're on a real
+  network.
+</Callout>
+
+<Callout type="info">
+  Prefer a one-line setup for quick experiments? The `litesvm()` bundle includes
+  an airdrop, so you can chain
+  `.use(generatedPayerWithSol(lamports(10_000_000_000n)))` from
+  `@solana/kit-plugin-signer` to auto-generate and fund a payer.
+</Callout>
+
+</Step>
+
+</Steps>
+
+## Understanding the Client
+
+After `.use(signer(...)).use(litesvm())`, the client exposes:
+
+| Property                    | Description                                                                                                                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `client.payer`              | The `TransactionSigner` you installed with the `signer()` plugin (also set as `client.identity`)                                                                                                         |
+| `client.identity`           | The wallet signer that owns accounts, tokens, and authorities                                                                                                                                            |
+| `client.svm`                | Direct [`LiteSVM`](https://www.npmjs.com/package/litesvm) instance for account management, transactions, and configuration                                                                               |
+| `client.rpc`                | Kit-compatible RPC interface (subset: `getAccountInfo`, `getBalance`, `getEpochSchedule`, `getLatestBlockhash`, `getMinimumBalanceForRentExemption`, `getMultipleAccounts`, `getSlot`, `requestAirdrop`) |
+| `client.sendTransaction(s)` | Plan, sign, and send instructions as a transaction                                                                                                                                                       |
+| `client.airdrop`            | Request SOL from the LiteSVM faucet                                                                                                                                                                      |
+| `client.getMinimumBalance`  | Compute minimum lamports for rent exemption                                                                                                                                                              |
+
+### Using client.svm
+
+Direct access to LiteSVM for:
+
+- Account management (`setAccount`, `getAccount`, `airdrop`)
+- Transaction execution (`sendTransaction`, `simulateTransaction`)
+- Configuration (`withSigverify`, `withBlockhashCheck`, etc.)
+- Time manipulation (`warpToSlot`, `getClock`)
+
+```typescript
+import { address, lamports } from "@solana/kit";
+
+// Fund an account
+client.svm.airdrop(address, lamports(1_000_000_000n));
+
+// Set account state directly
+client.svm.setAccount({
+  address: myAddress,
+  data: new Uint8Array([1, 2, 3]),
+  executable: false,
+  lamports: lamports(1_000_000n),
+  programAddress: address("11111111111111111111111111111111"),
+  space: 3n
+});
+
+// Get the latest blockhash
+const blockhash = client.svm.latestBlockhash();
+```
+
+### Using client.rpc
+
+Kit-compatible RPC interface for standard operations:
+
+```typescript
+// Get account info (returns base64-encoded data)
+const { value: account } = await client.rpc.getAccountInfo(address).send();
+
+// Get multiple accounts in one call
+const { value: accounts } = await client.rpc
+  .getMultipleAccounts([addr1, addr2, addr3])
+  .send();
+
+// Get latest blockhash
+const { value: blockhash } = await client.rpc.getLatestBlockhash().send();
+```
+
+<Callout type="warn">
+  The RPC layer only supports **base64 encoding**. Requesting other encodings
+  will throw an error.
+</Callout>
+
+## Configuration
+
+Configure LiteSVM using builder methods on `client.svm`:
+
+```typescript
+const client = createClient().use(signer(mySigner)).use(litesvm());
+
+// Configure for testing
+client.svm
+  .withSigverify(false) // Skip signature verification
+  .withBlockhashCheck(false) // Skip blockhash validation
+  .withSysvars() // Enable Clock, Rent, etc.
+  .withBuiltins() // Enable ed25519, secp256k1
+  .withTransactionHistory(100n); // Store transaction history
+```
+
+## Sending Transactions
+
+Layer in program plugins after the transport — they hang instruction builders
+off the client so you never touch a raw `TransactionMessage`:
+
+```typescript
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+import { systemProgram } from "@solana-program/system";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient()
+  .use(signer(mySigner))
+  .use(litesvm())
+  .use(systemProgram());
+
+client.svm.airdrop(client.payer.address, lamports(10_000_000_000n));
+
+const recipient = await generateKeyPairSigner();
+
+// Build and send in one call
+await client.system.instructions
+  .transferSol({
+    source: client.payer,
+    destination: recipient.address,
+    amount: lamports(1_000_000_000n)
+  })
+  .sendTransaction();
+```
+
+## SVM → RPC Flow
+
+You can set state via SVM and read it via RPC:
+
+```typescript
+import { address, lamports } from "@solana/kit";
+
+// Set account directly via SVM
+client.svm.setAccount({
+  address: myAddress,
+  data: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+  executable: false,
+  lamports: lamports(1_000_000n),
+  programAddress: address("11111111111111111111111111111111"),
+  space: 4n
+});
+
+// Read via RPC (returns base64-encoded data)
+const { value } = await client.rpc.getAccountInfo(myAddress).send();
+console.log("Data:", value?.data); // ['3q2+7w==', 'base64']
+```
+
+## What's Next
+
+This covers the core client — creating accounts, sending instructions, and
+reading state. If your tests involve SPL tokens (mints, ATAs, transfers), the
+[token testing guide](/docs/tools/litesvm/typescript/tokens) shows how the
+`tokenProgram()` plugin collapses ~40 lines of setup into 3 calls. For a full
+API reference, see the [API docs](/docs/tools/litesvm/typescript/api-reference).

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "TypeScript",
+  "pages": ["getting-started", "tokens", "api-reference", "examples"]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/tokens.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/tokens.mdx
@@ -1,0 +1,210 @@
+---
+title: Token Testing
+description: Test with SPL tokens using @solana-program/token and LiteSVM
+---
+
+Testing token logic on Solana means setting up mints, token accounts, and
+authorities before you can test the transfer logic you actually care about. The
+`tokenProgram()` plugin from `@solana-program/token` collapses that setup to a
+few method calls — and handles ATA creation automatically.
+
+<div className="flex items-center gap-3 mb-6">
+  <a
+    href="https://www.npmjs.com/package/@solana-program/token"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="inline-flex items-center gap-2 px-3 py-1.5 bg-fd-muted/50 hover:bg-fd-muted rounded-lg text-sm font-medium transition-colors border border-fd-border/50"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 780 250"
+      className="w-5 h-4"
+      fill="currentColor"
+    >
+      <path d="M240,250h100V0H240ZM340,0h100V200H390V50H340ZM480,0V200H580V250h50V0Z" />
+    </svg>
+    View <code>@solana-program/token</code> on npm
+  </a>
+</div>
+
+## Installation
+
+<Tabs items={['pnpm', 'npm', 'yarn', 'bun']} groupId='package-manager'>
+<Tab value="pnpm">
+
+```bash
+pnpm add @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/token
+```
+
+</Tab>
+<Tab value="npm">
+
+```bash
+npm install @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/token
+```
+
+</Tab>
+<Tab value="yarn">
+
+```bash
+yarn add @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/token
+```
+
+</Tab>
+<Tab value="bun">
+
+```bash
+bun add @solana/kit @solana/kit-plugin-litesvm @solana/kit-plugin-signer @solana-program/token
+```
+
+</Tab>
+</Tabs>
+
+## Create a Mint
+
+```typescript
+import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
+import { litesvm } from "@solana/kit-plugin-litesvm";
+import { signer } from "@solana/kit-plugin-signer";
+import { tokenProgram } from "@solana-program/token";
+
+const mySigner = await generateKeyPairSigner();
+const client = createClient()
+  .use(signer(mySigner))
+  .use(litesvm())
+  .use(tokenProgram());
+
+client.svm.airdrop(client.payer.address, lamports(10_000_000_000n));
+
+const mintAuthority = await generateKeyPairSigner();
+const newMint = await generateKeyPairSigner();
+
+await client.token.instructions
+  .createMint({
+    newMint,
+    decimals: 9,
+    mintAuthority: mintAuthority.address
+  })
+  .sendTransaction();
+
+// Verify
+const mintAccount = await client.token.accounts.mint.fetch(newMint.address);
+console.log(mintAccount.data.supply); // 0n
+console.log(mintAccount.data.decimals); // 9
+```
+
+## Mint Tokens
+
+`mintToATA` issues tokens to an owner's Associated Token Account. If the ATA
+doesn't exist, it's created in the same transaction.
+
+```typescript
+await client.token.instructions
+  .mintToATA({
+    mint: newMint.address,
+    owner: client.payer.address,
+    mintAuthority,
+    amount: 1_000_000_000_000n, // 1000 tokens (9 decimals)
+    decimals: 9
+  })
+  .sendTransaction();
+```
+
+The `decimals` parameter is a safety check — it must match the mint's decimals
+exactly, or the Token program rejects the transaction with error `0x24`. This
+prevents accidentally minting 1000x too many tokens.
+
+## Transfer Tokens
+
+`transferToATA` moves tokens between users. The recipient's ATA is created
+automatically if needed.
+
+```typescript
+const alice = await generateKeyPairSigner();
+const bob = await generateKeyPairSigner();
+
+// Mint to Alice
+await client.token.instructions
+  .mintToATA({
+    mint: newMint.address,
+    owner: alice.address,
+    mintAuthority,
+    amount: 1_000_000_000_000n,
+    decimals: 9
+  })
+  .sendTransaction();
+
+// Transfer 400 tokens from Alice to Bob
+await client.token.instructions
+  .transferToATA({
+    mint: newMint.address,
+    authority: alice,
+    recipient: bob.address,
+    amount: 400_000_000_000n,
+    decimals: 9
+  })
+  .sendTransaction();
+```
+
+The `authority` is the signer who owns the source tokens. The plugin derives
+both source and destination ATAs from their addresses + the mint.
+
+## Verifying Balances
+
+To read back token balances, derive the ATA address with
+`findAssociatedTokenPda` and fetch the decoded account:
+
+```typescript
+import {
+  findAssociatedTokenPda,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+const [aliceAta] = await findAssociatedTokenPda({
+  owner: alice.address,
+  mint: newMint.address,
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+
+const aliceAccount = await client.token.accounts.token.fetch(aliceAta);
+console.log(aliceAccount.data.amount); // 600_000_000_000n
+console.log(aliceAccount.data.mint); // newMint.address
+console.log(aliceAccount.data.owner); // alice.address
+```
+
+## Decimals
+
+Token amounts are always in raw units. 1000 tokens with 9 decimals is
+`1_000_000_000_000n`, not `1000n`.
+
+```typescript
+// USDC has 6 decimals
+const oneUSDC = 10n ** 6n; // 1_000_000n
+
+// SOL has 9 decimals
+const oneSOL = 10n ** 9n; // 1_000_000_000n
+```
+
+<Callout type="warn">
+  Always use `BigInt` for token amounts. JavaScript's `Number` loses precision
+  above 2^53.
+</Callout>
+
+## Plugin Reference
+
+| Method                                      | Description                                                  |
+| ------------------------------------------- | ------------------------------------------------------------ |
+| `client.token.instructions.createMint()`    | Create a new SPL token mint                                  |
+| `client.token.instructions.mintToATA()`     | Mint tokens to an owner's ATA (creates ATA if needed)        |
+| `client.token.instructions.transferToATA()` | Transfer tokens to a recipient's ATA (creates ATA if needed) |
+| `client.token.accounts.mint.fetch()`        | Fetch and decode a mint account                              |
+| `client.token.accounts.token.fetch()`       | Fetch and decode a token account                             |
+
+## Common Errors
+
+| Error                        | Cause                             | Fix                                                    |
+| ---------------------------- | --------------------------------- | ------------------------------------------------------ |
+| `custom program error: 0x24` | `decimals` doesn't match the mint | Use the same decimals value you passed to `createMint` |
+| `AccountNotFound`            | Account doesn't exist yet         | Ensure mint is created before minting                  |
+| `InsufficientFunds`          | Not enough lamports for rent      | Airdrop more SOL to the payer                          |
+| `OwnerMismatch`              | Wrong program owns the account    | Check program ID                                       |

--- a/apps/docs/content/docs/en/tools/meta.json
+++ b/apps/docs/content/docs/en/tools/meta.json
@@ -8,7 +8,8 @@
     "solana-pay",
     "attestations",
     "private-channels",
-    "surfpool"
+    "surfpool",
+    "litesvm"
   ],
   "defaultOpen": true
 }


### PR DESCRIPTION
## Problem

LiteSVM docs live on a separate site (litesvm.com). This centralizes them under solana.com/docs, the same way surfpool was handled.

## Changes

- Migrate all LiteSVM docs into `apps/docs/content/docs/en/tools/litesvm/` — Rust + TypeScript tracks, 43 pages plus a Cards landing.
- Register `litesvm` in `tools/meta.json` and add a card to the tools landing page.
- Migration-only adjustments so the content renders and routes in its new home: re-home internal `/docs/…` links under `/docs/tools/litesvm/`, strip per-file Fumadocs imports (globally registered here), normalize `<Callout>` types to the ones this Fumadocs version renders, and repair a couple malformed source code fences.
- Add cart to `docs/toolls`:
<img width="1624" height="1056" alt="image" src="https://github.com/user-attachments/assets/f3907767-90b1-4bc4-aa36-5f39b97d6a99" />

## Preview

https://solana-com-docs-git-docs-migrate-litesvm-solana-foundation.vercel.app/docs/tools/litesvm

Reachable at `/docs/tools/litesvm`. English-only — locales auto-generate via lingo on merge.

Did not migrate test suite in this PR, just content.

ENG-210
