### PR TITLE
docs: include tool name in breadcrumbs on tools pages

### DIFF
--- a/apps/docs/src/app/[locale]/docs/tools/tools-page-tree.ts
+++ b/apps/docs/src/app/[locale]/docs/tools/tools-page-tree.ts
@@ -26,6 +26,16 @@ export function getToolsSidebarTree(tree: Root, activeTool?: string): Root {
   ]);
 }
 
+export function getToolBreadcrumbTree(tree: Root, activeTool?: string): Root {
+  const toolsFolder = findToolsFolder(tree);
+  if (!toolsFolder || !activeTool) {
+    return withChildren(tree, []);
+  }
+
+  const activeNode = findToolNode(toolsFolder, activeTool);
+  return withChildren(tree, activeNode ? [activeNode] : []);
+}
+
 export function getToolsNavigationTree(tree: Root, activeTool?: string): Root {
   const toolsFolder = findToolsFolder(tree);
   if (!toolsFolder || !activeTool) {

--- a/apps/docs/src/app/[locale]/docs/tools/tools.tsx
+++ b/apps/docs/src/app/[locale]/docs/tools/tools.tsx
@@ -5,7 +5,9 @@ import { DocsPage } from "@@/src/app/components/docs-page";
 import { mdxComponents } from "@@/src/app/mdx-components";
 import { getMdxMetadata } from "@@/src/app/metadata";
 import { DocsCategory } from "fumadocs-ui/page";
+import { TreeContextProvider } from "fumadocs-ui/provider";
 import type { PageTree } from "fumadocs-core/server";
+import { getToolBreadcrumbTree } from "./tools-page-tree";
 
 export async function ToolsDocsPage({
   slug,
@@ -20,28 +22,36 @@ export async function ToolsDocsPage({
   if (!page) notFound();
   const { body: MDX, toc } = await page.data.load();
   const markdown = await page.data.getText("raw");
+  const breadcrumbTree = getToolBreadcrumbTree(
+    docsSource.pageTree[locale],
+    slug[1],
+  );
   return (
-    <DocsPage
-      toc={toc}
-      full={page.data.full}
-      title={page.data.h1 || page.data.title}
-      filePath={page.data.info.path}
-      hideTableOfContents={page.data.hideTableOfContents}
-      hidePageNavigation={page.data.hidePageNavigation}
-      pageTree={pageTree}
-      href={page.url}
-      markdown={markdown}
-    >
-      <MDX components={mdxComponents} />
-      {page.data.index ? (
-        <DocsCategory
-          page={page}
-          from={
-            docsSource as unknown as ComponentProps<typeof DocsCategory>["from"]
-          }
-        />
-      ) : null}
-    </DocsPage>
+    <TreeContextProvider tree={breadcrumbTree}>
+      <DocsPage
+        toc={toc}
+        full={page.data.full}
+        title={page.data.h1 || page.data.title}
+        filePath={page.data.info.path}
+        hideTableOfContents={page.data.hideTableOfContents}
+        hidePageNavigation={page.data.hidePageNavigation}
+        pageTree={pageTree}
+        href={page.url}
+        markdown={markdown}
+      >
+        <MDX components={mdxComponents} />
+        {page.data.index ? (
+          <DocsCategory
+            page={page}
+            from={
+              docsSource as unknown as ComponentProps<
+                typeof DocsCategory
+              >["from"]
+            }
+          />
+        ) : null}
+      </DocsPage>
+    </TreeContextProvider>
   );
 }
 


### PR DESCRIPTION
## Problem

On `/docs/tools` pages, breadcrumbs omitted the tool name, so nested pages lost the tool as an orientation level:

- Current: `Solana Documentation > Getting Started`
- Expected: `Solana Documentation > Kora > Getting Started`

The tools sidebar tree flattens the active tool's folder (hoisting its children to the tree root and discarding the tool folder node), so the breadcrumb had no tool ancestor to emit.

Before: 
<img width="1036" height="177" alt="image" src="https://github.com/user-attachments/assets/3b86cb98-20b6-4a4f-9f36-8745af493705" />


## Changes

After: 

<img width="1036" height="177" alt="image" src="https://github.com/user-attachments/assets/2b35c070-b5cf-4a42-abf6-a53fd7cc845d" />

- `getToolBreadcrumbTree` builds a tool-preserving tree (keeps the tool folder intact) instead of the flattened sidebar tree.
- The tools page wraps its content in Fumadocs' `TreeContextProvider` carrying that tree, so Fumadocs' built-in breadcrumb renders `Root > Tool > Section` on its own — no custom breadcrumb markup.
- The sidebar tree is untouched; the wrap only scopes the breadcrumb (the repo's `DocsPage` uses a custom footer with an explicit page tree, so tree context otherwise affects only the breadcrumb).

## Result

| Page | Breadcrumb |
|---|---|
| `kora/getting-started/installation` | `Solana Documentation > Kora > Getting Started` |
| `surfpool/toolchain/getting-started` | `Solana Documentation > Surfpool > Toolchain` |
| tool landings (e.g. `/docs/tools/kora`) | `Solana Documentation` only (no duplicate/empty segment) |
| non-tools docs pages | unchanged |

- Tool name links to the tool landing page; no "Tools" rung; works across all tools; sidebar navigation unchanged.

Ref: PRO-1539