### PR TITLE
docs(guides): clarify token_acl auto-thaw is SDK-side (not Phantom)

### DIFF
--- a/apps/docs/content/guides/advanced/acl.mdx
+++ b/apps/docs/content/guides/advanced/acl.mdx
@@ -230,8 +230,8 @@ Token ACL consists of three main components:
    issuer intervention, as long as the Gate Program approves.
 
 4. **TokenMetadata Integration**: Adding a `token_acl` field to your mint's
-   metadata enables automatic detection by wallets and SDKs like
-   `@solana/token-helpers`.
+   metadata enables automatic detection by SDKs like `@solana/token-helpers`
+   when *they* build create-account transactions.
 
 <Callout type="info" title="Auto-Detection with TokenMetadata">
 
@@ -239,6 +239,15 @@ When you add a `token_acl` field to your mint's TokenMetadata extension pointing
 to the Gate Program address, SDKs like `@solana/token-helpers` can automatically
 detect Token ACL mints and include thaw instructions when creating token
 accounts.
+
+This is primarily an **SDK / integrating-app** behavior today. Do **not** assume
+that wallets automatically append a permissionless thaw when a user receives
+tokens or creates an ATA. In particular, **Phantom does not currently support**
+auto-detecting `token_acl` and adding thaw instructions on account creation
+(confirmed with Phantom DevRel as of the report in
+[#1686](https://github.com/solana-foundation/solana-com/issues/1686)). If your
+flow depends on a thawed ATA, include the thaw instruction yourself (or use an
+SDK that does).
 
 </Callout>
 
@@ -1119,7 +1128,7 @@ solana config set --url localhost
 # - Token-2022 program
 # - Freeze authority enabled
 # - Default account state = frozen (all new accounts start frozen)
-# - Metadata extension with token_acl field for auto-detection
+# - Metadata extension with token_acl field for SDK auto-detection
 spl-token create-token \
   --program-id TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb \
   --enable-freeze \
@@ -1136,8 +1145,8 @@ MINT=7KzLwpXMzKa8JiqYr2ookFjxLx1xMF4xM4YhVqPJpump
 # Initialize the token metadata
 spl-token initialize-metadata $MINT "Compliant Token" "COMP" "https://example.com/metadata.json"
 
-# Add the token_acl field for wallet auto-detection
-# This tells wallets/SDKs which gate program to use for thaw
+# Add the token_acl field for SDK auto-detection
+# This tells integrating SDKs which gate program to use for thaw
 spl-token update-metadata $MINT token_acl GATEzzqxhJnsWF6vHRsgtixxSB8PaQdcqGEVTEHWiULz
 
 # Verify the token was created correctly
@@ -1236,9 +1245,16 @@ spl-token balance $MINT
 
 <Callout type="info" title="Token Metadata for Auto-Detection">
 
-Adding the `token_acl` metadata field is crucial for wallet integration. When
-wallets like Phantom or SDKs like `@solana/token-helpers` see this field, they
-automatically include thaw instructions when creating token accounts.
+Adding the `token_acl` metadata field is important for **SDK and app
+integration**. When an integrating SDK such as `@solana/token-helpers` sees this
+field, it can automatically include thaw instructions when *it* creates token
+accounts.
+
+**Wallet support is not universal.** As of this writing, **Phantom does not**
+auto-detect `token_acl` or append a permissionless thaw when creating ATAs.
+Treat automatic wallet-side thaw as optional/aspirational unless you have
+verified support for the specific wallet your users use. For production flows,
+prefer explicitly building the thaw instruction (or using an SDK that does).
 
 ```bash
 spl-token update-metadata $MINT token_acl GATEzzqxhJnsWF6vHRsgtixxSB8PaQdcqGEVTEHWiULz


### PR DESCRIPTION
## Summary
- Corrects the Token ACL guide so it no longer states that wallets like **Phantom** automatically detect `token_acl` and append a permissionless thaw when creating token accounts.
- Clarifies that auto-detection is primarily an **SDK / integrating-app** behavior (e.g. `@solana/token-helpers`).
- Notes that **Phantom does not currently support** this wallet-side flow (reporter confirmed with Phantom DevRel).

Fixes #1686

## Why
The previous wording caused real integration failures: Phantom created a frozen ATA without thaw, and transfers failed with Token-2022 `AccountFrozen` (`0x11`).

## Changes
- `apps/docs/content/guides/advanced/acl.mdx`
  - Key concept + callouts updated
  - CLI workshop comments no longer say "wallet auto-detection" as a guarantee

## Validation
- Diff reviewed against issue report and rendered section path `guides/advanced/acl.mdx`
- No code/runtime changes (docs-only MDX)

## Notes
- No verified public list of wallets that currently ship this auto-thaw was available; docs intentionally avoid naming unsupported wallets as examples.