### PR TITLE
docs: add deploy recovery guidance (buffers + loader-v3/v4)

### DIFF
--- a/apps/docs/content/docs/en/core/programs/program-deployment.mdx
+++ b/apps/docs/content/docs/en/core/programs/program-deployment.mdx
@@ -16,7 +16,7 @@ related:
   Programs deployed via loader-v3 can be upgraded when an upgrade authority is
   set. Revoking the authority makes the program immutable. Covers the upgrade
   mechanism, loader-v3 deployment and upgrade instructions, build verification,
-  and the available loader programs.
+  and the available loader programs, including Loader V4.
 </Callout>
 
 ## Deploying programs
@@ -96,9 +96,10 @@ to independently verify onchain programs.
 
 ## Loader programs
 
-| Loader                     | Address                                       | Upgradeable                         | Description                                           |
-| -------------------------- | --------------------------------------------- | ----------------------------------- | ----------------------------------------------------- |
-| **Native Loader**          | `NativeLoader1111111111111111111111111111111` | Only via validator software upgrade | Owns builtins (System, Vote, Stake) and other loaders |
-| **BPF Loader (v1)**        | `BPFLoader1111111111111111111111111111111111` | No (loader management disabled)     | Legacy programs                                       |
-| **BPF Loader (v2)**        | `BPFLoader2111111111111111111111111111111111` | No (loader management disabled)     | Legacy programs                                       |
-| **BPF Loader Upgradeable** | `BPFLoaderUpgradeab1e11111111111111111111111` | Yes, if upgrade authority is set    | Owns all newly deployed programs                      |
+| Loader                     | Address                                       | Upgradeable                         | Description                                                      |
+| -------------------------- | --------------------------------------------- | ----------------------------------- | ---------------------------------------------------------------- |
+| **Native Loader**          | `NativeLoader1111111111111111111111111111111` | Only via validator software upgrade | Owns builtins (System, Vote, Stake) and other loaders            |
+| **BPF Loader (v1)**        | `BPFLoader1111111111111111111111111111111111` | No (loader management disabled)     | Legacy programs                                                  |
+| **BPF Loader (v2)**        | `BPFLoader2111111111111111111111111111111111` | No (loader management disabled)     | Legacy programs                                                  |
+| **BPF Loader Upgradeable** | `BPFLoaderUpgradeab1e11111111111111111111111` | Yes, if upgrade authority is set    | Default owner for programs deployed with `solana program deploy` |
+| **Loader V4**              | `LoaderV411111111111111111111111111111111111` | Yes, until finalized                | Managed with the separate `solana program-v4` command group      |

--- a/apps/docs/content/docs/en/programs/deploying.mdx
+++ b/apps/docs/content/docs/en/programs/deploying.mdx
@@ -15,6 +15,10 @@ the Solana CLI.
 | Build program                      | `cargo build-sbf`                                                                             |
 | Deploy new program                 | `solana program deploy <path_to_program.so>`                                                  |
 | Update existing program            | `solana program deploy <path_to_program.so>` (same as deploy)                                 |
+| Resume deploy from buffer          | `solana program deploy <path_to_program.so> --buffer <buffer-keypair>`                        |
+| List buffer accounts               | `solana program show --buffers`                                                               |
+| Close buffer account               | `solana program close <buffer-address>`                                                       |
+| Deploy with loader-v4              | `solana program-v4 deploy <path_to_program.so>`                                               |
 | Show program info                  | `solana program show <program-id>`                                                            |
 | Transfer program authority         | `solana program set-upgrade-authority <program-id> --new-upgrade-authority <path_to_keypair>` |
 | Make program immutable             | `solana program set-upgrade-authority <program-id> --final`                                   |
@@ -35,6 +39,13 @@ Before diving in, let's clarify some terminology:
   deployed executable code.
 - **Program Authority**: The account that has permission to update or close the
   program. By default, this is your CLI wallet.
+- **Buffer Account**: A temporary account used while program bytes are uploaded
+  during deployment or upgrade. Successful deployments close the buffer
+  automatically; failed or interrupted deployments can leave buffers behind.
+- **Loader**: The onchain program that owns and manages deployed executable
+  program accounts. `solana program deploy` uses loader-v3, also known as the
+  BPF Upgradeable Loader. Loader-v4 uses the separate `solana program-v4`
+  command group.
 
 ## Prerequisites
 
@@ -277,6 +288,76 @@ Extended Program Id 7NxQjW8H8hVcqBKgXbVDWqGQCovHbqDW9p1SJJwUyTpE by 1000 bytes
 ```
 
 </Callout>
+
+### Recover Failed Deployments
+
+Program deployment uploads the compiled `.so` file into a buffer account before
+the final deploy or upgrade instruction completes. If deployment fails after the
+buffer is created, you can reuse that buffer instead of paying to upload the
+same bytes again.
+
+If the CLI generated a buffer seed phrase during the failed deploy, recover it
+to a keypair file:
+
+```terminal
+$ solana-keygen recover -o ./target/deploy/buffer-keypair.json
+```
+
+Then resume the deploy with the recovered buffer:
+
+```terminal
+$ solana program deploy ./target/deploy/hello_world.so \
+    --buffer ./target/deploy/buffer-keypair.json
+```
+
+If you are deploying to a specific program ID, include the same `--program-id`
+argument you used before:
+
+```terminal
+$ solana program deploy ./target/deploy/hello_world.so \
+    --program-id ./custom-keypair.json \
+    --buffer ./target/deploy/buffer-keypair.json
+```
+
+You can also choose the buffer keypair before deploying. This makes retries
+straightforward because the buffer is already saved locally:
+
+```terminal
+$ solana-keygen new -o ./target/deploy/buffer-keypair.json
+$ solana program deploy ./target/deploy/hello_world.so \
+    --buffer ./target/deploy/buffer-keypair.json
+```
+
+To inspect or clean up leftover buffers for your current authority, use:
+
+```terminal
+$ solana program show --buffers
+$ solana program close <buffer-address>
+```
+
+<Callout type="warn">
+  Only close a buffer once you are sure you no longer need it for a pending
+  deploy or upgrade. Closing the buffer reclaims its SOL but removes the
+  uploaded program bytes.
+</Callout>
+
+### Loader Versions
+
+`cargo build-sbf` produces the compiled SBF ELF file. The loader version is
+chosen when you deploy that file, not when you build it.
+
+| Loader                           | CLI command                                                                                       |
+| -------------------------------- | ------------------------------------------------------------------------------------------------- |
+| loader-v3 / BPF Upgradeable      | `solana program deploy ./target/deploy/hello_world.so`                                            |
+| loader-v4 / Loader V4 (advanced) | `solana program-v4 deploy ./target/deploy/hello_world.so --program-keypair ./custom-keypair.json` |
+
+For most programs, use `solana program deploy`. It uses loader-v3 and supports
+the program authority, buffer, upgrade, and close workflows documented on this
+page. Loader-v4 has its own `program-v4` subcommands, including `deploy`,
+`finalize`, `retract`, `show`, and `transfer-authority`.
+
+For the lower-level runtime details, see
+[Program Deployment](/docs/core/programs/program-deployment).
 
 ## Program Management
 


### PR DESCRIPTION
## Summary
Restores and expands the missing **failed deploy recovery** and **loader version** guidance on the Deploying Programs page after the #747 rewrite.

Fixes #775

## Changes
### `apps/docs/content/docs/en/programs/deploying.mdx`
- CLI reference rows for resume-from-buffer, list/close buffers, and loader-v4 deploy
- Key concepts: buffer account + loader
- **Recover Failed Deployments** section:
  - `solana-keygen recover -o ./target/deploy/buffer-keypair.json`
  - `solana program deploy ... --buffer ...`
  - pre-create buffer keypair for easier retries
  - `solana program show --buffers` / `solana program close`
- **Loader Versions** table: loader-v3 (`solana program`) vs loader-v4 (`solana program-v4`)

### `apps/docs/content/docs/en/core/programs/program-deployment.mdx`
- Add **Loader V4** row to the loader programs table
- Clarify BPF Loader Upgradeable as default for `solana program deploy`

## Validation
- Cross-checked CLI flags against local `solana-cli 2.2.14` (`program deploy --buffer`, `solana-keygen recover`, `program-v4 deploy`)
- Docs-only MDX; no runtime code changes
- Note: a prior closed attempt existed as #1665 (`codex/issue-775-deploy-failure-recovery`); this re-opens the contribution on a fresh head after maintainer re-invited PRs on the issue

## Why re-submit
Issue #775 was re-triaged with maintainer guidance to raise a PR; the earlier #1665 was closed without merge while the page still lacks the recovery steps.