### PR TITLE
feat: add Children & Minors section to Breakpoint FAQ

### DIFF
--- a/apps/breakpoint/src/content/faq-page.ts
+++ b/apps/breakpoint/src/content/faq-page.ts
@@ -104,6 +104,18 @@ export const faqPageSections = [
     ],
   },
   {
+    id: "children-minors",
+    title: "Children & Minors",
+    items: [
+      {
+        id: "children-minors-attendance",
+        question: "Can children attend Breakpoint?",
+        answer:
+          "Children 16 and under are welcome to attend Breakpoint when accompanied by a registered parent or legal guardian. Parents and guardians are responsible for supervising their children at all times. Breakpoint does not provide childcare, and access to certain areas may be restricted.",
+      },
+    ],
+  },
+  {
     id: "travel",
     title: "Travel",
     items: [


### PR DESCRIPTION
## Summary
- Add a Children & Minors section to the Breakpoint FAQ content.

## Testing
- Not run; PR creation requested only.