### PR TITLE
fix: make workspace clean scripts reliable

### DIFF
--- a/apps/accelerate/package.json
+++ b/apps/accelerate/package.json
@@ -11,7 +11,7 @@
     "check-types": "tsc --noEmit",
     "i18n:lingo": "pnpm --dir ../.. i18n:app accelerate",
     "sync:sponsors": "tsx scripts/sync-sponsors.ts",
-    "clean": "rm -rf node_modules .next"
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "dependencies": {
     "@mdx-js/loader": "^3.1.1",

--- a/apps/breakpoint/package.json
+++ b/apps/breakpoint/package.json
@@ -10,7 +10,7 @@
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write apps/breakpoint",
     "check-types": "tsc --noEmit",
     "test": "vitest run",
-    "clean": "rm -rf node_modules .next coverage"
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "dependencies": {
     "@sentry/nextjs": "^10.11.0",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -93,7 +93,7 @@
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write apps/docs",
     "postinstall": "fumadocs-mdx",
     "add:radix": "npx @radix-ui/scripts",
-    "clean": "rm -rf node_modules .next"
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "packageManager": "pnpm@10.15.1"
 }

--- a/apps/media/package.json
+++ b/apps/media/package.json
@@ -13,7 +13,7 @@
     "check:images": "node scripts/check-images.mjs",
     "dedupe:links": "node scripts/dedupe-links.mjs",
     "i18n:lingo": "pnpm --dir ../.. i18n:app media",
-    "clean": "rm -rf node_modules .next",
+    "clean": "node ../../scripts/clean.mjs .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "screenshots": "playwright test e2e/walkthrough-screenshots.spec.ts"

--- a/apps/templates/package.json
+++ b/apps/templates/package.json
@@ -11,7 +11,7 @@
     "check-types": "tsc --noEmit",
     "test": "vitest run",
     "i18n:lingo": "pnpm --dir ../.. i18n:app templates",
-    "clean": "rm -rf node_modules .next"
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "dependencies": {
     "@inkeep/cxkit-react": "^0.5.117",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -122,7 +122,7 @@
     "lint": "pnpm exec eslint . && pnpm -w exec prettier --ignore-path .prettierignore --check apps/web",
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write apps/web",
     "add:radix": "npx @radix-ui/scripts",
-    "clean": "rm -rf node_modules .next"
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "packageManager": "pnpm@10.15.1"
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "i18n:docs": "node ./scripts/i18n/run.mjs docs",
     "i18n:prune": "node ./scripts/i18n/prune-messages.mjs",
     "i18n:app": "node ./scripts/i18n/run.mjs app",
-    "clean": "turbo run clean && find . -type d \\( -name 'node_modules' -o -name '.next' -o -name '.turbo'  -o -name '.source' \\) -prune -exec rm -rf '{}' +",
+    "clean": "node ./scripts/clean.mjs",
     "media:optimize-images": "pnpm --filter solana-com-media exec node scripts/optimize-images.mjs",
     "media:check-images": "pnpm --filter solana-com-media exec node scripts/check-images.mjs",
     "prepare": "husky"

--- a/packages/config-eslint/package.json
+++ b/packages/config-eslint/package.json
@@ -10,6 +10,9 @@
     "./react-internal": "./react-internal.js",
     "./vite": "./vite.js"
   },
+  "scripts": {
+    "clean": "node ../../scripts/clean.mjs ."
+  },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@next/eslint-plugin-next": "^15.5.18",

--- a/packages/config-typescript/package.json
+++ b/packages/config-typescript/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.0",
   "private": true,
   "license": "GPL-3.0-or-later",
+  "scripts": {
+    "clean": "node ../../scripts/clean.mjs ."
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/docs-examples/package.json
+++ b/packages/docs-examples/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
-    "lint": "tsc --noEmit"
+    "lint": "tsc --noEmit",
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "dependencies": {
     "@metaplex-foundation/mpl-token-metadata-kit": "^0.0.3",

--- a/packages/ecosystem-data/package.json
+++ b/packages/ecosystem-data/package.json
@@ -12,7 +12,8 @@
     "audit:data": "node ./scripts/audit-ecosystem-data.mjs",
     "lint": "pnpm exec eslint . --max-warnings 0 && pnpm -w exec prettier --ignore-path .prettierignore --check packages/ecosystem-data",
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write packages/ecosystem-data",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/packages/fab-menu/package.json
+++ b/packages/fab-menu/package.json
@@ -42,7 +42,8 @@
     "dev": "tsup --watch",
     "check-types": "tsc --noEmit",
     "lint": "pnpm exec eslint . --max-warnings 0",
-    "prepack": "pnpm run build"
+    "prepack": "pnpm run build",
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "peerDependencies": {
     "react": "^19.1.2",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -10,7 +10,8 @@
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write packages/i18n",
     "check-types": "tsc --noEmit",
     "test": "vitest run",
-    "i18n:lingo": "pnpm -w i18n:verify-source-locales && npx lingo.dev@latest run"
+    "i18n:lingo": "pnpm -w i18n:verify-source-locales && npx lingo.dev@latest run",
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/packages/sentry/package.json
+++ b/packages/sentry/package.json
@@ -12,7 +12,8 @@
     "lint": "pnpm exec eslint . --max-warnings 0 && pnpm -w exec prettier --ignore-path .prettierignore --check packages/sentry",
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write packages/sentry",
     "check-types": "tsc --noEmit",
-    "test": "vitest run --config vitest.config.ts"
+    "test": "vitest run --config vitest.config.ts",
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/packages/sitemap/package.json
+++ b/packages/sitemap/package.json
@@ -9,7 +9,8 @@
     ".": "./src/index.ts"
   },
   "scripts": {
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "dependencies": {
     "@workspace/i18n": "workspace:*"

--- a/packages/ui-chrome/package.json
+++ b/packages/ui-chrome/package.json
@@ -30,7 +30,8 @@
     "lint": "pnpm exec eslint . --max-warnings 0 && pnpm -w exec prettier --ignore-path .prettierignore --check packages/ui-chrome",
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write packages/ui-chrome",
     "check-types": "tsc --noEmit",
-    "test": "vitest run --config vitest.config.ts"
+    "test": "vitest run --config vitest.config.ts",
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -34,7 +34,8 @@
   "scripts": {
     "lint": "pnpm exec eslint . --max-warnings 0 && pnpm -w exec prettier --ignore-path .prettierignore --check packages/ui",
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write packages/ui",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "clean": "node ../../scripts/clean.mjs ."
   },
   "devDependencies": {
     "@workspace/config-eslint": "workspace:*",

--- a/scripts/clean.mjs
+++ b/scripts/clean.mjs
@@ -1,0 +1,58 @@
+import { opendir, rm } from "node:fs/promises";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const cleanRoot = process.argv[2]
+  ? resolve(process.cwd(), process.argv[2])
+  : repoRoot;
+
+const cleanRootFromRepo = relative(repoRoot, cleanRoot);
+
+if (
+  cleanRootFromRepo === ".." ||
+  cleanRootFromRepo.startsWith(`..${sep}`) ||
+  isAbsolute(cleanRootFromRepo)
+) {
+  throw new Error(`Clean target must be inside the repository: ${cleanRoot}`);
+}
+
+const generatedDirectoryNames = new Set([
+  ".next",
+  ".source",
+  ".turbo",
+  "coverage",
+  "dist",
+  "node_modules",
+  "playwright-report",
+  "test-results",
+]);
+
+async function cleanDirectory(directory) {
+  const entries = await opendir(directory);
+
+  for await (const entry of entries) {
+    if (entry.name === ".git") {
+      continue;
+    }
+
+    const entryPath = join(directory, entry.name);
+
+    if (generatedDirectoryNames.has(entry.name)) {
+      await rm(entryPath, {
+        force: true,
+        maxRetries: 3,
+        recursive: true,
+        retryDelay: 100,
+      });
+      console.log(`Removed ${relative(repoRoot, entryPath)}`);
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      await cleanDirectory(entryPath);
+    }
+  }
+}
+
+await cleanDirectory(cleanRoot);

--- a/turbo.json
+++ b/turbo.json
@@ -101,6 +101,7 @@
       "persistent": true
     },
     "clean": {
+      "cache": false,
       "outputs": []
     }
   }


### PR DESCRIPTION
### Problem

`pnpm clean` depended on the local Turbo binary before removing `node_modules`, including Turbo itself. That made cleanup unreliable when dependencies were missing or after a prior clean. Workspace clean scripts also used inconsistent output lists, package workspaces had no clean task, and Turbo clean tasks were cacheable.

### Summary of Changes

- Add a dependency-free repository cleaner that removes generated dependency, build, cache, coverage, and test-report directories.
- Support package-scoped cleanup while rejecting targets outside the repository.
- Route all 16 app and package workspace clean scripts through the shared implementation.
- Disable caching for the Turbo clean task.
- Keep root cleanup independent of Turbo so it remains repeatable without installed dependencies.

No production code, dependencies, or lockfile entries changed.

### Validation

- `pnpm exec turbo run clean` — 16/16 tasks passed with cache bypassed.
- `pnpm -r clean` — all workspace tasks passed.
- `pnpm clean` — passed repeatedly without dependencies installed.
- Scoped cleanup isolation and outside-repository path rejection verified.
- Pre-commit ESLint and Prettier hooks passed.

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] The optional local clean target is validated to remain inside the repository; no user-facing HTML or external input is involved.
- [ ] `pnpm audit --audit-level high` currently reports the pre-existing Vite advisory GHSA-fx2h-pf6j-xcff. This PR changes no dependencies or lockfile entries.
- [x] Filesystem errors fail the clean command explicitly with a non-zero exit.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependencies: none.

Threat-model note for Critical changes: n/a.
