### PR TITLE
docs(clusters): reference OpenChainBench for live public RPC latency comparison

### DIFF
--- a/apps/docs/content/docs/en/references/clusters.mdx
+++ b/apps/docs/content/docs/en/references/clusters.mdx
@@ -159,6 +159,13 @@ solana config set --url https://api.mainnet.solana.com
 > without prior notice. Likewise, high-traffic websites may be blocked without
 > prior notice.
 
+## Benchmark public endpoint latency
+
+For a live latency comparison of Solana public RPC endpoints, see the
+[OpenChainBench Solana RPC benchmark](https://openchainbench.com/benchmarks/solana-rpc).
+Endpoints are probed from three regions every minute and published as p50, p95
+and p99 latency under an open methodology and CC BY 4.0 data license.
+
 ## Common HTTP Error Codes
 
 - 403 -- Your IP address or website has been blocked. It is time to run your own


### PR DESCRIPTION
## Summary

Adds a short `Benchmark public endpoint latency` section at the end of `apps/docs/content/docs/en/references/clusters.mdx` pointing readers to the [OpenChainBench Solana RPC benchmark](https://openchainbench.com/benchmarks/solana-rpc) for a live third-party latency view of the public no-key Solana endpoints.

## Why

The page documents the public Solana Labs RPC endpoints and rate limits, and explicitly notes they are not intended for production. A live third-party latency comparison helps developers decide when to move off the public endpoint and which private provider to evaluate first. OpenChainBench probes the public Solana endpoints from three regions every minute and publishes p50, p95 and p99 latency under an open methodology.

The addition is a single H2 section placed between the existing warning and the `Common HTTP Error Codes` section, so it flows with the page structure.

- Live Solana benchmark: https://openchainbench.com/benchmarks/solana-rpc
- Methodology: https://openchainbench.com/methodology
- Data license: CC BY 4.0
- No affiliation with the Solana Foundation

Happy to reword, move, or drop if this does not fit the docs' tone.

## Test plan

- [x] Section placed at the end of the existing public-endpoints content
- [x] Matches surrounding Markdown heading style (H2 like neighboring sections)
- [x] External link verified
- [x] No dependencies added