### PR TITLE
docs: rename surfpool page

### DIFF
--- a/apps/docs/content/docs/en/tools/surfpool/index.mdx
+++ b/apps/docs/content/docs/en/tools/surfpool/index.mdx
@@ -1,5 +1,5 @@
 ---
-title: Surf's up
+title: Surfpool
 description:
   Surfpool is a drop-in replacement for solana-test-validator, purpose-built to
   offer the best possible experience for developers building on Solana.


### PR DESCRIPTION
[Original page](https://github.com/amilz/surfpool-web-ui/blob/d303a12e726cd605578275ec86dc53c2295fe1a2/apps/docs/content/index.mdx) from Surfpool docs was "Surf's Up". This PR renames to Surfpool.


<img width="1002" height="240" alt="image" src="https://github.com/user-attachments/assets/ded8f885-1077-45b2-8e6b-f4fbff9661c3" />

<img width="1106" height="618" alt="image" src="https://github.com/user-attachments/assets/522b9929-01db-4391-a562-08873fa6f97e" />
