### PR TITLE
fix(web): prevent stale hub translations breaking links

### DIFF
--- a/apps/web/src/__tests__/data/navigation-hubs.test.ts
+++ b/apps/web/src/__tests__/data/navigation-hubs.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { mergeHubConfig } from "@/data/navigation-hubs";
+
+describe("mergeHubConfig", () => {
+  it("uses static arrays as the navigation topology", () => {
+    const result = mergeHubConfig(
+      [{ href: "/wallets" }],
+      [
+        { title: "Wallets" },
+        { title: "Stale translated link without a static href" },
+      ],
+    );
+
+    expect(result).toEqual([{ href: "/wallets", title: "Wallets" }]);
+  });
+
+  it("preserves arrays that exist only in translated content", () => {
+    const metrics = [{ value: "01", label: "Choose a wallet" }];
+
+    expect(mergeHubConfig(undefined, metrics)).toEqual(metrics);
+  });
+});

--- a/apps/web/src/data/navigation-hubs.ts
+++ b/apps/web/src/data/navigation-hubs.ts
@@ -688,7 +688,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function mergeHubConfig(
+export function mergeHubConfig(
   staticValue: unknown,
   translatedValue: unknown,
 ): unknown {
@@ -701,7 +701,13 @@ function mergeHubConfig(
     const translatedArray = Array.isArray(translatedValue)
       ? translatedValue
       : [];
-    const length = Math.max(staticArray.length, translatedArray.length);
+    // Static arrays define the page structure (and contain non-translatable
+    // values such as hrefs). Ignore stale translated entries that no longer
+    // have a static counterpart, while preserving translation-only arrays
+    // such as metrics and overview points.
+    const length = Array.isArray(staticValue)
+      ? staticArray.length
+      : translatedArray.length;
 
     return Array.from({ length }, (_, index) =>
       mergeHubConfig(staticArray[index], translatedArray[index]),


### PR DESCRIPTION
## Summary

- make static navigation hub arrays authoritative for page structure and hrefs
- ignore stale translated array entries that no longer have a static counterpart
- preserve translation-only arrays such as metrics and overview points
- add regression coverage for both behaviors

## Root cause

The wallet release reduced the static `/use-solana` resource links from six entries to five, while localized catalogs still contained six translated entries. `mergeHubConfig` used the longer array and emitted a translated-only link without an `href`. Server rendering then called `startsWith` on that undefined value, returning 500 for `/use-solana` in every locale.

## Verification

- `pnpm --filter solana-com test`
- `pnpm --filter solana-com lint`
- local `GET /use-solana` returns 200
- local `GET /zh/use-solana` returns 200
