### PR TITLE
Add how to verify a token guide

### DIFF
--- a/apps/docs/content/guides/getstarted/how-to-verify-a-token.mdx
+++ b/apps/docs/content/guides/getstarted/how-to-verify-a-token.mdx
@@ -1,0 +1,164 @@
+---
+date: 2026-07-15T00:00:00Z
+difficulty: intro
+title: "How to verify a token and make it appear in Solana Explorer"
+seoTitle: "How to verify a Solana token (Explorer search & verified status)"
+description:
+  "How token verification works on Solana. Solana Explorer aggregates several
+  independent verifiers (RugCheck, Jupiter, CoinGecko, Solflare, and Bluprynt).
+  Getting verified by any one of them makes your token show up in Explorer
+  search."
+tags:
+  - token
+  - explorer
+keywords:
+  - verify token
+  - token verification
+  - solana explorer
+  - verified token
+  - rugcheck
+  - jupiter verified
+  - coingecko
+  - solflare
+  - bluprynt
+---
+
+# How to verify a token and make it appear in Solana Explorer
+
+A common question from token creators is: _"Why doesn't my token show up when I
+search for it on Solana Explorer, and how do I get it verified?"_
+
+The short answer: Solana Explorer does not run its own single verification
+process. Instead, it **aggregates several independent verification providers**.
+If your token becomes verified through **any one** of these providers, it will
+surface in Explorer's search results and display verification information.
+
+This guide explains each provider, what "verified" does (and does not) mean, and
+how to get your token verified.
+
+## What "verified" means (and what it doesn't)
+
+Verification confirms that a token is the **canonical / correct token** for a
+given name, symbol, and mint address. It helps users avoid impersonators and
+duplicate tokens, since anyone can mint a token with any name on Solana.
+
+Verification is **not** an endorsement of a project, and it is **not** a
+guarantee of a token's value, safety, or legitimacy. Always do your own
+research.
+
+## The verification providers behind Solana Explorer
+
+Solana Explorer checks the following independent verifiers. Getting picked up by
+any of them (RugCheck is automatic; the others require action) makes your token
+appear in Explorer search.
+
+### 1. RugCheck (automatic)
+
+[RugCheck](https://rugcheck.xyz) performs automated on-chain analysis and
+automatically tracks tokens. Because it is automatic, you generally do not need
+to submit anything — RugCheck evaluates on-chain risk signals (mint/freeze
+authority, holder distribution, liquidity, etc.) and tracks the token on its
+own.
+
+There is special handling for certain stablecoins, where projects can contact
+the RugCheck team directly for appropriate treatment.
+
+Example token page:
+[`rugcheck.xyz/tokens/<mint>`](https://rugcheck.xyz/tokens/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)
+
+### 2. Jupiter
+
+[Jupiter](https://jup.ag) maintains a verified token list (VRFD) that is widely
+integrated across the Solana ecosystem — DEXes, wallets, and screeners. A
+verified token receives a green checkmark across Jupiter products and partner
+platforms.
+
+To get verified, submit your token for review:
+
+- Submit at [verified.jup.ag/tokens](https://verified.jup.ag/tokens)
+- Anyone can submit a token (not just the project team)
+- You can optionally connect the project's X account to link the contract
+  address to a specific account
+- Jupiter runs a holistic review (liquidity, metadata standards compliance, and
+  other signals) rather than checking a single metric
+
+Example token page:
+[`jup.ag/tokens/<mint>`](https://jup.ag/tokens/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v)
+
+### 3. CoinGecko
+
+[CoinGecko](https://www.coingecko.com) verification lists your token with market
+data. When you verify with CoinGecko, be sure to include the token's **contract
+address** (on Solana, this is the mint address) so downstream integrations can
+resolve prices correctly.
+
+Follow the official CoinGecko listing/update guide:
+
+- [Verification guide for listing & update requests on CoinGecko](https://support.coingecko.com/hc/en-us/articles/23725417857817-Verification-Guide-for-Listing-Update-Requests-on-CoinGecko)
+
+Example coin page:
+[`coingecko.com/en/coins/<token>`](https://www.coingecko.com/en/coins/usdc)
+
+### 4. Solflare
+
+[Solflare](https://solflare.com) surfaces tokens through a verification process
+that relies heavily on the Jupiter aggregator's criteria. For a new token to
+appear in Solflare's in-app swap list, it typically must:
+
+- Be a valid token on the Solana blockchain with metadata that follows the
+  Metaplex Token Metadata standard
+- Have sufficient liquidity (a minimum USD value of the token available for
+  trading)
+- Keep price impact within acceptable limits for typical swaps
+
+Once these criteria are met, tokens usually appear within a few minutes. See:
+
+- [I cannot find a token in Solflare](https://help.solflare.com/en/articles/9260147-i-cannot-find-a-token-in-solflare)
+
+Example token page:
+[`solflare.com/prices/<name>/<mint>`](https://www.solflare.com/prices/usd-coin/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/)
+
+### 5. Bluprynt (enhanced KYC)
+
+[Bluprynt](https://app.bluprynt.com/register/account) offers an enhanced
+verification path with a KYC protocol. This is a more rigorous, identity-backed
+process suitable for projects that want a stronger verification signal.
+
+- Register via the
+  [Bluprynt onboarding for Solana Explorer](https://app.bluprynt.com/register/account)
+
+Example verified asset page:
+[`verified.bluprynt.com/verified-assets/<mint>/solana`](https://verified.bluprynt.com/verified-assets/EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v/solana)
+
+## How it all comes together
+
+- **RugCheck** happens automatically via on-chain analysis — no submission
+  needed.
+- **Jupiter, CoinGecko, Solflare, and Bluprynt** each require you to submit /
+  complete their respective process.
+- As soon as your token is verified by **at least one** of these providers, it
+  will appear in **Solana Explorer** search and show verification details.
+
+If your token is not appearing in Explorer search yet, the fastest path is
+usually to submit for Jupiter verification and/or complete a CoinGecko listing,
+since both are widely integrated across the ecosystem.
+
+## Prerequisites that help verification succeed
+
+Regardless of the provider, these on-chain fundamentals make verification much
+more likely to succeed:
+
+- **Valid metadata**: your token should have on-chain metadata that follows the
+  Metaplex Token Metadata standard (name, symbol, logo URI).
+- **Liquidity**: provide enough liquidity on a supported DEX so the token can be
+  traded and evaluated.
+- **Correct contract address**: whenever you submit to a provider, always use
+  your token's **mint address** as the contract address.
+
+## Summary
+
+Solana Explorer aggregates multiple independent verifiers — **RugCheck**
+(automatic), **Jupiter**, **CoinGecko**, **Solflare**, and **Bluprynt** (KYC).
+Verification through any one of them makes your token discoverable in Explorer
+search. Verification confirms the canonical token identity; it is not an
+endorsement, so users should always do their own research.

--- a/apps/docs/content/guides/getstarted/how-to-verify-a-token.mdx
+++ b/apps/docs/content/guides/getstarted/how-to-verify-a-token.mdx
@@ -77,7 +77,7 @@ To get verified, submit your token for review:
 
 - Submit at [verified.jup.ag/tokens](https://verified.jup.ag/tokens)
 - Anyone can submit a token (not just the project team)
-- You can optionally connect the project's X account to link the contract
+- You can optionally connect the project's X account to link the token's mint
   address to a specific account
 - Jupiter runs a holistic review (liquidity, metadata standards compliance, and
   other signals) rather than checking a single metric
@@ -88,9 +88,9 @@ Example token page:
 ### 3. CoinGecko
 
 [CoinGecko](https://www.coingecko.com) verification lists your token with market
-data. When you verify with CoinGecko, be sure to include the token's **contract
-address** (on Solana, this is the mint address) so downstream integrations can
-resolve prices correctly.
+data. When you verify with CoinGecko, be sure to include the token's **mint
+address** (CoinGecko's form labels this the "contract address") so downstream
+integrations can resolve prices correctly.
 
 Follow the official CoinGecko listing/update guide:
 
@@ -101,9 +101,10 @@ Example coin page:
 
 ### 4. Solflare
 
-[Solflare](https://solflare.com) surfaces tokens through a verification process
-that relies heavily on the Jupiter aggregator's criteria. For a new token to
-appear in Solflare's in-app swap list, it typically must:
+[Solflare](https://solflare.com) is an independent validator in Solana
+Explorer's verification framework. In practice its token-listing criteria
+overlap heavily with Jupiter's, because Solflare's in-app swap list is powered
+by the Jupiter aggregator. For a new token to appear, it typically must:
 
 - Be a valid token on the Solana blockchain with metadata that follows the
   Metaplex Token Metadata standard
@@ -111,7 +112,10 @@ appear in Solflare's in-app swap list, it typically must:
   trading)
 - Keep price impact within acceptable limits for typical swaps
 
-Once these criteria are met, tokens usually appear within a few minutes. See:
+Because of this overlap, tokens that complete Jupiter verification are often
+already eligible on Solflare without a separate submission — so you usually do
+not need to treat Solflare as an extra manual step. Once the criteria are met,
+tokens usually appear within a few minutes. See:
 
 - [I cannot find a token in Solflare](https://help.solflare.com/en/articles/9260147-i-cannot-find-a-token-in-solflare)
 
@@ -152,8 +156,9 @@ more likely to succeed:
   Metaplex Token Metadata standard (name, symbol, logo URI).
 - **Liquidity**: provide enough liquidity on a supported DEX so the token can be
   traded and evaluated.
-- **Correct contract address**: whenever you submit to a provider, always use
-  your token's **mint address** as the contract address.
+- **Correct mint address**: whenever you submit to a provider, always use your
+  token's **mint address** (labeled the "contract address" in some provider
+  forms).
 
 ## Summary
 

--- a/apps/docs/content/guides/getstarted/meta.json
+++ b/apps/docs/content/guides/getstarted/meta.json
@@ -3,6 +3,7 @@
   "pages": [
     "intro-to-ai",
     "solana-token-airdrop-and-faucets",
+    "how-to-verify-a-token",
     "build-a-x402-facilitator",
     "intro-to-x402",
     "supabase-auth-guide"


### PR DESCRIPTION
### Problem

There was no docs page on how to verify a token to get it listed in the solana explorer. 

### Summary of Changes

Added a guide. 
