### PR TITLE
content(media): Add BLS pubkey and VAT upgrades page

### DIFF
--- a/apps/media/content/upgrades/alpenglow.mdx
+++ b/apps/media/content/upgrades/alpenglow.mdx
@@ -106,11 +106,13 @@ changes, fast leader handoff markers, and VAT implementation details.
 | [SIMD-0384](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0384-alpenglow-migration.md)                   | Alpenglow Migration                        |
 | [SIMD-0387](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0387-bls-pubkey-management-in-vote-account.md) | BLS Pubkey Management in Vote Account      |
 
-**Shipping timeline:** Both the Alpenglow Validator Admission Ticket (VAT,
-SIMD-0357) and BLS Pubkey Management in Vote Account (SIMD-0387) ship in Agave
-4.3, estimated Q3 2026. Validator operators must create and register their BLS
-key onchain **before** the VAT feature gate is activated — otherwise their
-validator will not be admitted under Alpenglow consensus.
+**Shipping timeline:** BLS Pubkey Management in Vote Account (SIMD-0387) is
+already live on mainnet. The Validator Admission Ticket (VAT, SIMD-0357) is
+scheduled for mainnet activation immenently in Agave 4.1. Validator operators
+must register their BLS pubkey on-chain **before** the VAT feature gate is
+activated — otherwise their validator will not be admitted under Alpenglow
+consensus. See [BLS Pubkeys and the Validator Admission Ticket](/upgrades/bls-pubkey-vat)
+for the registration steps and current activation status.
 
 ---
 

--- a/apps/media/content/upgrades/alpenglow.mdx
+++ b/apps/media/content/upgrades/alpenglow.mdx
@@ -108,7 +108,7 @@ changes, fast leader handoff markers, and VAT implementation details.
 
 **Shipping timeline:** BLS Pubkey Management in Vote Account (SIMD-0387) is
 already live on mainnet. The Validator Admission Ticket (VAT, SIMD-0357) is
-scheduled for mainnet activation immenently in Agave 4.1. Validator operators
+scheduled for mainnet activation imminently in Agave 4.1. Validator operators
 must register their BLS pubkey on-chain **before** the VAT feature gate is
 activated — otherwise their validator will not be admitted under Alpenglow
 consensus. See [BLS Pubkeys and the Validator Admission Ticket](/upgrades/bls-pubkey-vat)

--- a/apps/media/content/upgrades/bls-pubkey-vat.mdx
+++ b/apps/media/content/upgrades/bls-pubkey-vat.mdx
@@ -52,7 +52,7 @@ for voting.
 |                                  |                                                                                       |
 | -------------------------------- | ------------------------------------------------------------------------------------- |
 | Expected Mainnet Activation Date | BLS pubkeys: live now. VAT: pending, ahead of Agave 4.3                               |
-| Devnet / Testnet Activation                | Live — both BLS pubkeys and VAT are active on devnet and testnet                      |
+| Devnet / Testnet Activation      | Live — both BLS pubkeys and VAT are active on devnet and testnet                      |
 | Breaking Change?                 | Yes — validators without a BLS pubkey lose consensus participation when VAT activates |
 
 ## Technical Details

--- a/apps/media/content/upgrades/bls-pubkey-vat.mdx
+++ b/apps/media/content/upgrades/bls-pubkey-vat.mdx
@@ -52,7 +52,7 @@ for voting.
 |                                  |                                                                                       |
 | -------------------------------- | ------------------------------------------------------------------------------------- |
 | Expected Mainnet Activation Date | BLS pubkeys: live now. VAT: pending, ahead of Agave 4.3                               |
-| Devnet Activation                | Live — both BLS pubkeys and VAT are active on devnet and testnet                      |
+| Devnet / Testnet Activation                | Live — both BLS pubkeys and VAT are active on devnet and testnet                      |
 | Breaking Change?                 | Yes — validators without a BLS pubkey lose consensus participation when VAT activates |
 
 ## Technical Details

--- a/apps/media/content/upgrades/bls-pubkey-vat.mdx
+++ b/apps/media/content/upgrades/bls-pubkey-vat.mdx
@@ -31,8 +31,8 @@ tags:
 Q3 2026 • Solana Foundation
 
 Solana mainnet validators can now create a BLS pubkey on-chain, the
-cryptographic prerequisite for Alpenglow consensus. The feature gate that
-enables this
+cryptographic prerequisite for [Alpenglow](/upgrades/alpenglow) consensus.
+The feature gate that enables this
 ([SIMD-0387](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0387-bls-pubkey-management-in-vote-account.md))
 is already active on mainnet. A separate feature gate, the Validator
 Admission Ticket

--- a/apps/media/content/upgrades/bls-pubkey-vat.mdx
+++ b/apps/media/content/upgrades/bls-pubkey-vat.mdx
@@ -1,0 +1,157 @@
+---
+title: BLS Pubkey and the Validator Admission Ticket
+description: >-
+  Validators must register a BLS pubkey on-chain before the Validator
+  Admission Ticket (VAT) feature gate activates on mainnet, or they will
+  not be included in consensus once VAT is activated.
+subtitle: What validator operators must do before the VAT feature gate activates
+publishedAt: 2026-07-16T00:00:00.000Z
+status: published
+author: solana-foundation
+badges:
+  - text: BLS Pubkeys Live on Mainnet
+    color: green
+    variant: badge
+  - text: VAT Action Required
+    color: red
+    variant: badge
+metrics:
+  - value: "2,000"
+    label: Max validators admitted under VAT
+  - value: 1.6 SOL
+    label: VAT fee per epoch, burned
+categories:
+  - category: upgrades
+tags:
+  - tag: announcements
+---
+
+# BLS Pubkey and the Validator Admission Ticket
+
+Q3 2026 • Solana Foundation
+
+Solana mainnet validators can now create a BLS pubkey on-chain, the
+cryptographic prerequisite for Alpenglow consensus. The feature gate that
+enables this
+([SIMD-0387](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0387-bls-pubkey-management-in-vote-account.md))
+is already active on mainnet. A separate feature gate, the Validator
+Admission Ticket
+([SIMD-0357](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0357-alpenglow_validator_admission_ticket.md),
+VAT), will enforce the requirement: once VAT activates on mainnet, any
+validator without a registered BLS pubkey stops participating in consensus.
+
+The VAT feature activation does not turn on Alpenglow itself. Alpenglow's
+consensus switch lands separately in Agave 4.3. The VAT feature only gates
+admission into the validator set based on the existence of the BLS pubkey. Once
+the full Alpenglow consensus switch happens in Agave 4.3, the complete VAT
+feature will be enabled. When both VAT and Alpenglow are enabled, validators
+will have 1.6 SOL deducted from their _vote account_ at the start of each epoch.
+Votes will no longer be on-chain transactions, so there will no longer be fees
+for voting.
+
+|                                  |                                                                                       |
+| -------------------------------- | ------------------------------------------------------------------------------------- |
+| Expected Mainnet Activation Date | BLS pubkeys: live now. VAT: pending, ahead of Agave 4.3                               |
+| Devnet Activation                | Live — both BLS pubkeys and VAT are active on devnet and testnet                      |
+| Breaking Change?                 | Yes — validators without a BLS pubkey lose consensus participation when VAT activates |
+
+## Technical Details
+
+### What a BLS Pubkey Is, and Why Alpenglow Needs One
+
+Solana validators currently vote using ed25519 signatures, verified one at a
+time. Alpenglow's voting algorithm, Votor, needs to combine thousands of
+individual validator votes into a single succinct certificate rather than
+verifying each vote independently. BLS (Boneh–Lynn–Shacham) signatures
+support this kind of aggregation: many BLS signatures over the same message
+can be combined into one aggregate signature that still proves every
+contributing validator voted. Ed25519 does not support this, which is why
+Alpenglow requires a separate BLS keypair for each validator rather than
+reusing the existing vote-account identity.
+
+### Registering Your BLS Pubkey On-Chain
+
+Registering a BLS pubkey requires the **Solana CLI version
+4.1.0 or higher**. The registration flow, documented in
+[Anza's vote account guide](https://docs.anza.xyz/operations/guides/vote-accounts#set-the-bls-public-key),
+runs through the CLI:
+
+```bash
+# Derive the BLS pubkey from your authorized voter keypair
+solana-keygen bls_pubkey <AUTHORIZED_VOTER_KEYPAIR>
+
+# Register it on-chain against your vote account
+solana vote-authorize-voter-checked <VOTE_ACCOUNT> <AUTHORIZED_VOTER_KEYPAIR> <AUTHORIZED_VOTER_KEYPAIR>
+
+# Confirm it took effect
+solana vote-account <VOTE_ACCOUNT> | grep "BLS Public Key"
+```
+
+Under the hood, this submits a new `VoterWithBLS` vote-authorization variant
+that carries both the 48-byte compressed BLS pubkey and a 96-byte proof of
+possession. The proof of possession signs a domain-separated message binding
+the vote account to the BLS key, which stops an attacker from registering a
+rogue key that could interfere with aggregate signature verification. This
+means updating a BLS pubkey does not require changing your authorized
+voter — it is a distinct, additive registration.
+
+### The Validator Admission Ticket (VAT)
+
+VAT is a separate feature gate that changes how validators are admitted
+into the active set each epoch. The VAT feature activation has two different
+states: before Alpenglow is enabled and after Alpenglow is enabled.
+
+_VAT Before Alpenglow_
+
+In the first state, before Alpenglow is enabled, the VAT feature gate will
+require that all voting validators have a BLS pubkey enabled and it will also
+enforce a limit of 2,000 validators. Since TowerBFT, the current Solana consensus
+algorithm, will remain in effect, votes will continue to be transactions that
+land on-chain. Voting validators will continue to be charged about 2 SOL per
+epoch in aggregate voting costs.
+
+_VAT After Alpenglow_
+
+In the second state, after Alpenglow is
+enabled, every voting validator included for the next epoch is charged a
+flat 1.6 SOL fee per epoch, burned directly to the incinerator rather than
+redistributed to block proposers as transaction and vote fees are today. That
+figure is intentionally close to existing voting costs (roughly 2 SOL per epoch).
+
+### What Happens When VAT Activates
+
+Once the VAT feature gate is live on mainnet:
+
+- Validators without a registered BLS pubkey are excluded from the
+  admitted set and stop voting — they do not participate in consensus and
+  stop earning inflation rewards.
+- Validators with a BLS pubkey registered but outside the top 2,000 by
+  stake are excluded from the admitted set for that epoch.
+- None of this turns on Alpenglow consensus itself. VAT only determines who
+  is eligible to participate once Alpenglow activates later, in Agave 4.3.
+
+Registering a BLS pubkey today is an important action item to make sure your
+voting validator continues to participate in consensus.
+
+### Current Activation Status
+
+As of this writing:
+
+- **BLS pubkey registration** ([feature gate](https://explorer.solana.com/address/AnAP9zPV4KL7czAPQbFhpDKV2tx7g4UGNbK9wvXwjaRo/feature-gate?cluster=mainnet-beta)):
+  active on mainnet, devnet, and testnet.
+- **VAT** ([feature gate](https://explorer.solana.com/address/VAT9huvhPjRN9cyrPytq9rwvEJ3J4ADtjdncgZRyANJ/feature-gate?cluster=mainnet-beta)):
+  active on devnet and testnet, not yet activated on mainnet. Scheduled for
+  mainnet activation the week of July 20, 2026.
+
+## About This Upgrade
+
+BLS pubkeys and VAT are important prerequisites, not the full Alpenglow feature
+set. The new Alpenglow consensus algorithm with 150ms finality and off-chain
+voting will arrive in Agave 4.3. The migration to Alpenglow only works if the
+validator set is ready before the switch: every validator needs a BLS key
+registered, and the network needs a defined, capped admission process to move
+into place first. Validator operators who fail to create a BLS pubkey
+before the VAT activation will be unable to participate in consensus and will not
+receive on-chain inflationary rewards or block fees.
+
+**Learn more:** [Solana Upgrades](/upgrades)


### PR DESCRIPTION
Explains the requirements of the BLS pubkey and what VAT does before and after Alpenglow feature gate.

### Problem

Operators need more information about what the BLS pubkey is and why they need to activate it before the VAT
feature gate. 

### Summary of Changes

Created a BLS pubkey and VAT page on the /upgrades page.

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
