### PR TITLE
End Epoch 1000 homepage takeover

### DIFF
--- a/apps/web/src/components/index/campaigns/config.ts
+++ b/apps/web/src/components/index/campaigns/config.ts
@@ -26,7 +26,7 @@ export const CAMPAIGNS: Campaign[] = [
   {
     id: "epoch1000",
     start: "2026-07-09",
-    end: "2026-07-17",
+    end: "2026-07-15",
   },
 ];
 


### PR DESCRIPTION
## Summary

- end the Epoch 1000 campaign window so the standard homepage hero resumes
- retain the homepage campaign takeover infrastructure and standalone `/epoch1000` experience

## Testing

- `pnpm --filter solana-com lint` (passes with 6 existing warnings)
- `pnpm --filter solana-com test` (19 files passed; 133 tests passed, 18 skipped)