### PR TITLE
fix(docs): repair Korean LiteSVM steps markup

### DIFF
--- a/apps/docs/content/docs/ko/tools/litesvm/additional-crates/testing-with-litesvm-loader/index.mdx
+++ b/apps/docs/content/docs/ko/tools/litesvm/additional-crates/testing-with-litesvm-loader/index.mdx
@@ -60,12 +60,12 @@ data account 또는 업그레이드 권한 동작이 필요한 테스트에서
   권한 부여 지원 - 프로그램을 불변으로 만들기 위해 `None` 전달 지원
 </Step>
 
-<Steps>
-  <Step>
-    **실제 로더 상태** - 온체인에서 프로그램이 확인하는 것과 동일한 로더 계정
-    모델 실행 - 테스트에서 program account 및 program data account 검사 가능 -
-    프로그램 직접 삽입으로 숨겨진 실수 발견에 도움
-  </Step>
+<Step>
+  **실제 로더 상태** - 온체인에서 프로그램이 확인하는 것과 동일한 로더 계정 모델
+  실행 - 테스트에서 program account 및 program data account 검사 가능 - 프로그램
+  직접 삽입으로 숨겨진 실수 발견에 도움
+</Step>
+
 </Steps>
 
 <Callout type="info">


### PR DESCRIPTION
## Summary

- replace the accidentally nested `Steps` container with the third `Step`
- restore valid MDX rendering for the Korean LiteSVM loader guide
- fixes [JAVASCRIPT-NEXTJS-2B2](https://solana-fndn.sentry.io/issues/JAVASCRIPT-NEXTJS-2B2)

## Validation

- `pnpm --filter solana-docs postinstall`
- `pnpm --filter solana-docs lint`