### PR TITLE
fix(web): prevent Arabic Epoch 1000 OG failures

### DIFF
--- a/apps/web/src/app/api/epoch1000/og/route.tsx
+++ b/apps/web/src/app/api/epoch1000/og/route.tsx
@@ -19,9 +19,15 @@ type MessageTree = Record<string, unknown>;
 type MessageValues = Record<string, number | string>;
 
 const messageCache = new Map<string, Promise<MessageTree>>();
+const OG_LOCALE_FALLBACKS: Record<string, string> = {
+  // Satori cannot shape the Arabic translations with the current embedded
+  // fonts. Keep the card available in English instead of returning a 500.
+  ar: "en",
+};
 
 function messagesFor(localeParam: string | null) {
-  const locale = resolveLocale(localeParam);
+  const requestedLocale = resolveLocale(localeParam);
+  const locale = OG_LOCALE_FALLBACKS[requestedLocale] ?? requestedLocale;
   let messages = messageCache.get(locale);
 
   if (!messages) {


### PR DESCRIPTION
## Summary

- fall back to English copy for Arabic Epoch 1000 OG cards
- avoid Satori's unsupported Arabic font-substitution path returning HTTP 500
- keep all other localized OG cards unchanged
- fixes [JAVASCRIPT-NEXTJS-2A1](https://solana-fndn.sentry.io/issues/JAVASCRIPT-NEXTJS-2A1)

## Validation

- requested the endpoint for all 19 supported locales; every response returned HTTP 200
- `pnpm --filter solana-com check-types`
- `pnpm --filter solana-com lint` (passes with 6 pre-existing warnings)