### PR TITLE
fix(web): restore endorsed skills grid + pin links to canonical GitHub URL

### DIFF
--- a/apps/web/src/__tests__/skills/parseSkillMarkdown.test.ts
+++ b/apps/web/src/__tests__/skills/parseSkillMarkdown.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { parseSkillMarkdown } from "@/app/[locale]/skills/skills";
+
+const CANONICAL_HTML_URL =
+  "https://github.com/solana-foundation/solana-dev-skill/blob/main/skills/solana-dev/references/security.md";
+
+describe("parseSkillMarkdown endorsed skill URL", () => {
+  it("falls back to the canonical html_url when frontmatter url is stale/invalid", () => {
+    const content = [
+      "---",
+      "title: Security Checklist",
+      "description: Program and client security checklist.",
+      "url: https://github.com/solana-foundation/solana-dev-skill/blob/main/skill/references/security.md",
+      "---",
+      "",
+      "# Security",
+    ].join("\n");
+
+    const skill = parseSkillMarkdown(
+      "security.md",
+      content,
+      CANONICAL_HTML_URL,
+    );
+
+    expect(skill.githubUrl).toBe(CANONICAL_HTML_URL);
+    expect(skill.githubUrl).not.toContain("/skill/references/");
+  });
+
+  it("uses the canonical html_url when frontmatter has no url", () => {
+    const content = [
+      "---",
+      "title: Frontend",
+      "description: Frontend reference.",
+      "---",
+      "",
+      "# Frontend",
+    ].join("\n");
+
+    const skill = parseSkillMarkdown(
+      "frontend.md",
+      content,
+      CANONICAL_HTML_URL,
+    );
+
+    expect(skill.githubUrl).toBe(CANONICAL_HTML_URL);
+  });
+
+  it("honors a canonical frontmatter url when present", () => {
+    const canonicalFrontmatterUrl =
+      "https://github.com/solana-foundation/solana-dev-skill/blob/main/skills/solana-dev/references/testing.md";
+    const content = [
+      "---",
+      "title: Testing",
+      "description: Testing reference.",
+      `url: ${canonicalFrontmatterUrl}`,
+      "---",
+      "",
+      "# Testing",
+    ].join("\n");
+
+    const skill = parseSkillMarkdown("testing.md", content, CANONICAL_HTML_URL);
+
+    expect(skill.githubUrl).toBe(canonicalFrontmatterUrl);
+  });
+});

--- a/apps/web/src/__tests__/skills/parseSkillMarkdown.test.ts
+++ b/apps/web/src/__tests__/skills/parseSkillMarkdown.test.ts
@@ -45,6 +45,42 @@ describe("parseSkillMarkdown endorsed skill URL", () => {
     expect(skill.githubUrl).toBe(CANONICAL_HTML_URL);
   });
 
+  it("rejects a frontmatter url that only smuggles the canonical path in the query string", () => {
+    const content = [
+      "---",
+      "title: Spoofed",
+      "description: Spoofed reference.",
+      "url: https://github.com/solana-foundation/solana-dev-skill/blob/main/README.md?target=/skills/solana-dev/references/security.md",
+      "---",
+      "",
+      "# Spoofed",
+    ].join("\n");
+
+    const skill = parseSkillMarkdown("spoofed.md", content, CANONICAL_HTML_URL);
+
+    expect(skill.githubUrl).toBe(CANONICAL_HTML_URL);
+  });
+
+  it("rejects a frontmatter url whose canonical segment is only in the fragment", () => {
+    const content = [
+      "---",
+      "title: Fragment",
+      "description: Fragment reference.",
+      "url: https://github.com/solana-foundation/solana-dev-skill/blob/main/README.md#/skills/solana-dev/references/security.md",
+      "---",
+      "",
+      "# Fragment",
+    ].join("\n");
+
+    const skill = parseSkillMarkdown(
+      "fragment.md",
+      content,
+      CANONICAL_HTML_URL,
+    );
+
+    expect(skill.githubUrl).toBe(CANONICAL_HTML_URL);
+  });
+
   it("honors a canonical frontmatter url when present", () => {
     const canonicalFrontmatterUrl =
       "https://github.com/solana-foundation/solana-dev-skill/blob/main/skills/solana-dev/references/testing.md";

--- a/apps/web/src/__tests__/skills/parseSkillMarkdown.test.ts
+++ b/apps/web/src/__tests__/skills/parseSkillMarkdown.test.ts
@@ -81,6 +81,46 @@ describe("parseSkillMarkdown endorsed skill URL", () => {
     expect(skill.githubUrl).toBe(CANONICAL_HTML_URL);
   });
 
+  it("rejects a frontmatter url that plants the canonical segment in the branch ref", () => {
+    const content = [
+      "---",
+      "title: Branch Ref",
+      "description: Branch ref reference.",
+      "url: https://github.com/solana-foundation/solana-dev-skill/blob/skills/solana-dev/references/main/evil.md",
+      "---",
+      "",
+      "# Branch Ref",
+    ].join("\n");
+
+    const skill = parseSkillMarkdown(
+      "branch-ref.md",
+      content,
+      CANONICAL_HTML_URL,
+    );
+
+    expect(skill.githubUrl).toBe(CANONICAL_HTML_URL);
+  });
+
+  it("rejects a frontmatter url on a look-alike host", () => {
+    const content = [
+      "---",
+      "title: Look-alike",
+      "description: Look-alike host.",
+      "url: https://github.com.evil.example/solana-foundation/solana-dev-skill/blob/main/skills/solana-dev/references/security.md",
+      "---",
+      "",
+      "# Look-alike",
+    ].join("\n");
+
+    const skill = parseSkillMarkdown(
+      "look-alike.md",
+      content,
+      CANONICAL_HTML_URL,
+    );
+
+    expect(skill.githubUrl).toBe(CANONICAL_HTML_URL);
+  });
+
   it("honors a canonical frontmatter url when present", () => {
     const canonicalFrontmatterUrl =
       "https://github.com/solana-foundation/solana-dev-skill/blob/main/skills/solana-dev/references/testing.md";

--- a/apps/web/src/__tests__/skills/skillsApiUrl.test.ts
+++ b/apps/web/src/__tests__/skills/skillsApiUrl.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { SOLANA_DEV_SKILLS_GITHUB_API_URL } from "@/components/skills/skills";
+
+describe("SOLANA_DEV_SKILLS_GITHUB_API_URL", () => {
+  it("targets the canonical solana-dev-skill references path", () => {
+    expect(SOLANA_DEV_SKILLS_GITHUB_API_URL).toBe(
+      "https://api.github.com/repos/solana-foundation/solana-dev-skill/contents/skills/solana-dev/references",
+    );
+  });
+
+  it("does not use the stale singular /contents/skill/references path", () => {
+    expect(SOLANA_DEV_SKILLS_GITHUB_API_URL).not.toContain(
+      "/contents/skill/references",
+    );
+  });
+});

--- a/apps/web/src/app/[locale]/skills/skills.tsx
+++ b/apps/web/src/app/[locale]/skills/skills.tsx
@@ -18,16 +18,24 @@ function resolveEndorsedSkillUrl(
   htmlUrl: string,
 ): string {
   // Prefer the canonical GitHub `html_url` returned by the contents API.
-  // Only honor a frontmatter `url` when it is a canonical solana-dev-skill
-  // reference blob URL; stale/invalid metadata (e.g. the singular
-  // `/skill/references/...` path) falls back to `html_url` so links never
-  // point at a 404 or the wrong page.
+  // Only honor a frontmatter `url` when its parsed pathname is a canonical
+  // solana-dev-skill reference blob path; stale/invalid metadata (e.g. the
+  // singular `/skill/references/...` path, or a canonical segment smuggled
+  // into a query/fragment) falls back to `html_url` so links never point at
+  // a 404 or the wrong page.
   if (
     typeof frontmatterUrl === "string" &&
-    frontmatterUrl.startsWith(CANONICAL_SKILLS_URL_PREFIX) &&
-    frontmatterUrl.includes(CANONICAL_SKILLS_PATH_SEGMENT)
+    frontmatterUrl.startsWith(CANONICAL_SKILLS_URL_PREFIX)
   ) {
-    return frontmatterUrl;
+    try {
+      if (
+        new URL(frontmatterUrl).pathname.includes(CANONICAL_SKILLS_PATH_SEGMENT)
+      ) {
+        return frontmatterUrl;
+      }
+    } catch {
+      // Malformed URL: fall back to the canonical html_url below.
+    }
   }
 
   return htmlUrl;

--- a/apps/web/src/app/[locale]/skills/skills.tsx
+++ b/apps/web/src/app/[locale]/skills/skills.tsx
@@ -9,7 +9,31 @@ import { Divider } from "@/components/solutions/divider.v2";
 import { COMMUNITY_SKILLS } from "@/data/skills/communitySkills";
 import { SOLANA_DEV_SKILLS_GITHUB_API_URL } from "@/components/skills/skills";
 
-function parseSkillMarkdown(
+const CANONICAL_SKILLS_URL_PREFIX =
+  "https://github.com/solana-foundation/solana-dev-skill/blob/";
+const CANONICAL_SKILLS_PATH_SEGMENT = "/skills/solana-dev/references/";
+
+function resolveEndorsedSkillUrl(
+  frontmatterUrl: unknown,
+  htmlUrl: string,
+): string {
+  // Prefer the canonical GitHub `html_url` returned by the contents API.
+  // Only honor a frontmatter `url` when it is a canonical solana-dev-skill
+  // reference blob URL; stale/invalid metadata (e.g. the singular
+  // `/skill/references/...` path) falls back to `html_url` so links never
+  // point at a 404 or the wrong page.
+  if (
+    typeof frontmatterUrl === "string" &&
+    frontmatterUrl.startsWith(CANONICAL_SKILLS_URL_PREFIX) &&
+    frontmatterUrl.includes(CANONICAL_SKILLS_PATH_SEGMENT)
+  ) {
+    return frontmatterUrl;
+  }
+
+  return htmlUrl;
+}
+
+export function parseSkillMarkdown(
   filename: string,
   content: string,
   htmlUrl: string,
@@ -21,7 +45,7 @@ function parseSkillMarkdown(
     slug,
     title: data.title ?? slug,
     description: data.description ?? "",
-    githubUrl: htmlUrl,
+    githubUrl: resolveEndorsedSkillUrl(data.url, htmlUrl),
     sourceType: "official",
   };
 }

--- a/apps/web/src/app/[locale]/skills/skills.tsx
+++ b/apps/web/src/app/[locale]/skills/skills.tsx
@@ -9,27 +9,29 @@ import { Divider } from "@/components/solutions/divider.v2";
 import { COMMUNITY_SKILLS } from "@/data/skills/communitySkills";
 import { SOLANA_DEV_SKILLS_GITHUB_API_URL } from "@/components/skills/skills";
 
-const CANONICAL_SKILLS_URL_PREFIX =
-  "https://github.com/solana-foundation/solana-dev-skill/blob/";
-const CANONICAL_SKILLS_PATH_SEGMENT = "/skills/solana-dev/references/";
+const CANONICAL_SKILLS_URL_ORIGIN = "https://github.com";
+const CANONICAL_SKILLS_PATH_PREFIX =
+  "/solana-foundation/solana-dev-skill/blob/main/skills/solana-dev/references/";
 
 function resolveEndorsedSkillUrl(
   frontmatterUrl: unknown,
   htmlUrl: string,
 ): string {
   // Prefer the canonical GitHub `html_url` returned by the contents API.
-  // Only honor a frontmatter `url` when its parsed pathname is a canonical
-  // solana-dev-skill reference blob path; stale/invalid metadata (e.g. the
-  // singular `/skill/references/...` path, or a canonical segment smuggled
-  // into a query/fragment) falls back to `html_url` so links never point at
-  // a 404 or the wrong page.
-  if (
-    typeof frontmatterUrl === "string" &&
-    frontmatterUrl.startsWith(CANONICAL_SKILLS_URL_PREFIX)
-  ) {
+  // Only honor a frontmatter `url` when its parsed origin is github.com and
+  // its pathname *starts with* the fully-qualified canonical reference blob
+  // path. Anchoring with `startsWith` on the parsed pathname keeps the check
+  // position-sensitive: stale/invalid metadata (e.g. the singular
+  // `/skill/references/...` path, a canonical segment smuggled into a
+  // query/fragment, or the segment planted inside a crafted branch ref such
+  // as `/blob/skills/solana-dev/references/main/evil.md`) all fall back to
+  // `html_url` so links never point at a 404 or the wrong page.
+  if (typeof frontmatterUrl === "string") {
     try {
+      const parsed = new URL(frontmatterUrl);
       if (
-        new URL(frontmatterUrl).pathname.includes(CANONICAL_SKILLS_PATH_SEGMENT)
+        parsed.origin === CANONICAL_SKILLS_URL_ORIGIN &&
+        parsed.pathname.startsWith(CANONICAL_SKILLS_PATH_PREFIX)
       ) {
         return frontmatterUrl;
       }

--- a/apps/web/src/components/skills/skills.ts
+++ b/apps/web/src/components/skills/skills.ts
@@ -1,5 +1,5 @@
 export const SOLANA_DEV_SKILLS_GITHUB_API_URL =
-  "https://api.github.com/repos/solana-foundation/solana-dev-skill/contents/skill/references";
+  "https://api.github.com/repos/solana-foundation/solana-dev-skill/contents/skills/solana-dev/references";
 
 export const SOLANA_DEV_SKILLS_REPO_URL =
   "https://github.com/solana-foundation/solana-dev-skill";


### PR DESCRIPTION
## Problem

The **Endorsed Skills** section on `/skills` (`apps/web`) is broken: it renders empty in production and, when populated, its links can resolve to a 404.

The page fetches the endorsed skill list from the `solana-dev-skill` repo via the GitHub contents API. That repo was restructured — the reference markdown now lives under the canonical `skills/solana-dev/references/` (plural) path — but the app still requested the stale singular `skill/references` path, which now returns `404`. The fetch fails silently, so the endorsed grid shows nothing.

Separately, the parser that builds each endorsed link did not defensively pin the link target to the canonical GitHub `html_url`. If a skill's frontmatter ever carried a stale/invalid `url` (e.g. a `/skill/...` singular path), that value could be used as the link target and send users to a 404 or the wrong page.

This matters because these links are the entry point to the Foundation-maintained skill content; unreliable targets erode trust in the page.

## Summary of Changes

Surgical fix in `apps/web`, scoped to the skills page data path:

1. **Correct the stale GitHub contents API path** — `apps/web/src/components/skills/skills.ts`:  `.../contents/skill/references` → `.../contents/skills/solana-dev/references`. This is the actual `/skill/` → `/skills/` bug; the endorsed grid loads again.

2. **Harden the endorsed link target** — `apps/web/src/app/[locale]/skills/skills.tsx`: `parseSkillMarkdown` now resolves the link via `resolveEndorsedSkillUrl`, which prefers the canonical GitHub `html_url` from the contents API and only honors a frontmatter `url` when its **parsed `URL().pathname`** matches the canonical `solana-dev-skill` reference blob path. Stale/invalid metadata — including a canonical segment smuggled into a query string or fragment, or a malformed URL — falls back to `html_url`. So endorsed links never point at a 404 or the wrong page.

3. **Regression tests** (narrowly scoped, Vitest):
   - `parseSkillMarkdown.test.ts` — stale `/skill/...` frontmatter → canonical fallback; no-frontmatter-url → canonical; query-string spoof rejected; fragment spoof rejected; a genuinely canonical frontmatter url is honored.
   - `skillsApiUrl.test.ts` — asserts the canonical API path and guards against the stale `/contents/skill/references` path.

No refactors or unrelated edits. Community skills and other page behavior are
untouched.

**Where the links now lead (verified locally):** each endorsed card opens `https://github.com/solana-foundation/solana-dev-skill/blob/main/skills/solana-dev/references/<name>.md` — the real reference content, not a 404.

## Local verification performed

Run from `apps/web` (Vitest is the test runner per `apps/web/AGENTS.md`):

- `pnpm --filter solana-com test -- src/__tests__/skills` — **21 files pass, 140 tests (18 skipped)**, including the 5 new URL tests + 2 API-path tests.
- `pnpm --filter solana-com lint` — **0 errors** (only pre-existing warnings in unrelated files).
- Live contents-API probe confirms all 11 reference files resolve under `/skills/solana-dev/references/`:

<details open>
<summary>Reproduce the canonical-path check</summary>

```js

const api =
  "https://api.github.com/repos/solana-foundation/solana-dev-skill/contents/skills/solana-dev/references";

const files = await fetch(api).then((res) => res.json());

files
  .filter((f) => f.name.endsWith(".md") && f.name !== "SKILL.md")
  .forEach((f) =>
    console.log(
      f.html_url.includes("/skills/solana-dev/references/") ? "OK " : "BAD",
      f.name,
    ),
);

```
</details>


- `pnpm --filter solana-com dev` → `http://localhost:3000/skills`: the Endorsed Skills grid renders cards (previously empty), and each card navigates to the correct canonical GitHub reference page. Confirmed manually.

> A minor finding from a local CodeRabbit CLI review (query/fragment segment
> smuggling in the URL guard) was addressed in its own commit
> (`fix(web): validate endorsed skill url pathname (CodeRabbit CLI)`), with the
> parsed-`pathname` validation and two added regression tests above.

## Fixes

**There doesn't appear to be an Open Issue about this, yet. Might be wrong here.**

## Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

<!-- Standard: production-facing marketing route (/skills) behavior + an outbound GitHub API path, no auth/secret/fund impact. -->

## Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the browser).
- [x] Input from users or external services is validated before use; no `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input. (The GitHub-sourced frontmatter `url` is now validated via `URL().pathname` against a canonical allowlist before it can become a link target.)
- [x] New or updated dependencies are justified below, and `pnpm audit` passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths. (Malformed frontmatter URLs are caught and fall back to the canonical `html_url`; the existing fetch error path is unchanged.)
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

## New dependencies (name + why), or "none":

None

## Threat-model note for Critical changes, or "n/a":

N/A

Suggested label: `bug` (for maintainers to apply).
