### PR TITLE
docs: simplify navigation and add Start Here

### DIFF
--- a/apps/docs/content/docs/en/index.mdx
+++ b/apps/docs/content/docs/en/index.mdx
@@ -7,6 +7,19 @@ description:
   blockchain applications.
 ---
 
+## Building with an AI agent?
+
+Copy this to your agent — it installs the official Solana skill, giving it the
+context to write correct Solana code:
+
+```bash
+npx skills add https://github.com/solana-foundation/solana-dev-skill
+```
+
+Or point your agent directly at [solana.com/SKILL.md](/SKILL.md). Every page in
+these docs is also available as raw Markdown — append `.md` to any URL, or start
+from the [llms.txt](/llms.txt) index.
+
 ## What do you want to build?
 
 <Cards>

--- a/apps/docs/content/docs/en/index.mdx
+++ b/apps/docs/content/docs/en/index.mdx
@@ -16,9 +16,8 @@ context to write correct Solana code:
 npx skills add https://github.com/solana-foundation/solana-dev-skill
 ```
 
-Or point your agent directly at [solana.com/SKILL.md](/SKILL.md). Every page in
-these docs is also available as raw Markdown — append `.md` to any URL, or start
-from the [llms.txt](/llms.txt) index.
+Every page in these docs is also available as raw Markdown — append `.md` to any
+URL.
 
 ## What do you want to build?
 

--- a/apps/docs/content/docs/en/intro/meta.json
+++ b/apps/docs/content/docs/en/intro/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Getting Started",
-  "pages": ["installation", "quick-start"],
+  "pages": ["with-an-ai-agent", "installation", "quick-start"],
   "defaultOpen": false
 }

--- a/apps/docs/content/docs/en/intro/with-an-ai-agent.mdx
+++ b/apps/docs/content/docs/en/intro/with-an-ai-agent.mdx
@@ -1,0 +1,59 @@
+---
+title: With an AI Agent
+description:
+  Set up Claude Code, Cursor, or any coding agent to write correct Solana code —
+  install the Solana skill, connect the MCP server, and ship your first program.
+---
+
+Most Solana development now starts with a coding agent. Out of the box, agents
+often reach for outdated APIs — two minutes of setup fixes that.
+
+## 1. Give your agent the Solana skill
+
+The official Solana skill packages current APIs, patterns, and conventions so
+your agent writes modern Solana code. From your project directory:
+
+```bash
+npx skills add https://github.com/solana-foundation/solana-dev-skill
+```
+
+This works with Claude Code, Cursor, and other agents that support skills. The
+skill is also served directly at
+[solana.com/SKILL.md](https://solana.com/SKILL.md) if you'd rather paste it into
+your agent's context yourself. More skills — for specific programs, tokens, and
+DeFi protocols — are on the [Agent Skills](/skills) page.
+
+## 2. Connect the Solana MCP server
+
+The [Solana Developer MCP](https://mcp.solana.com/) lets your agent query
+current Solana documentation, Anchor docs, program examples, and StackExchange
+answers while it works, instead of relying on training data. Setup instructions
+for each editor are on the MCP site.
+
+## 3. Point it at the docs
+
+Every page on this site is agent-readable:
+
+- Append `.md` to any docs URL for raw Markdown — e.g.
+  [`/docs/core/accounts.md`](/docs/core/accounts.md)
+- [`/llms.txt`](/llms.txt) is an index of every page;
+  [`/llms-full.txt`](/llms-full.txt) is the whole corpus in one file
+
+## 4. Ship something
+
+Good first prompts, once the skill is installed:
+
+- _"Create and deploy a counter program on Solana devnet, then write a client
+  that increments it."_
+- _"Build a script that sends USDC on devnet with a memo."_
+
+Have the agent verify its own work on devnet — it can request test SOL itself
+([airdrops and faucets](/developers/cookbook/development/airdrops-and-faucets))
+and confirm transactions with the [RPC API](/docs/rpc).
+
+## Going deeper
+
+- [AI tools on Solana](/docs/tools/ai) — the full catalog: agent frameworks,
+  Solana Agent Kit, and building AI-powered apps
+- [Quickstart](/docs/intro/quick-start) — the human-paced version of your first
+  program

--- a/apps/docs/content/docs/en/references/index.mdx
+++ b/apps/docs/content/docs/en/references/index.mdx
@@ -1,0 +1,19 @@
+---
+title: References
+description:
+  Network references for Solana — clusters and endpoints, staking, and
+  terminology.
+hideTableOfContents: true
+---
+
+<Cards>
+  <Card title="Clusters & Endpoints" href="/docs/references/clusters">
+    Mainnet, devnet, and testnet — public RPC endpoints and rate limits.
+  </Card>
+  <Card title="Staking" href="/docs/references/staking">
+    How staking works: stake accounts, delegation, and the stake program.
+  </Card>
+  <Card title="Terminology" href="/docs/references/terminology">
+    Definitions for the vocabulary used across Solana and these docs.
+  </Card>
+</Cards>

--- a/apps/docs/content/docs/en/rpc/http/meta.json
+++ b/apps/docs/content/docs/en/rpc/http/meta.json
@@ -54,5 +54,5 @@
     "sendtransaction",
     "simulatetransaction"
   ],
-  "defaultOpen": true
+  "defaultOpen": false
 }

--- a/apps/docs/content/docs/en/tools/index.mdx
+++ b/apps/docs/content/docs/en/tools/index.mdx
@@ -26,6 +26,9 @@ hidePageNavigation: true
     Get onchain data into your systems — polling, websockets, webhooks, and
     Geyser streaming.
   </Card>
+  <Card title="References" href="/docs/references">
+    Clusters and endpoints, staking, and terminology.
+  </Card>
 </Cards>
 
 ## Learn by example

--- a/apps/docs/content/docs/en/tools/index.mdx
+++ b/apps/docs/content/docs/en/tools/index.mdx
@@ -85,7 +85,18 @@ hidePageNavigation: true
   </Card>
 </Cards>
 
-## Get help
+## Ecosystem
 
-Ask questions on [Solana StackExchange](https://solana.stackexchange.com) — the
-fastest way to get unblocked, and your question helps the next developer.
+<Cards>
+  <Card title="Agent Skills" href="/skills">
+    Pre-built skills for AI agents building on Solana — programs, tokens, DeFi
+    protocols, and more.
+  </Card>
+  <Card title="Data" href="/data">
+    Network, token, and ecosystem dashboards and API products.
+  </Card>
+  <Card title="Get support" href="https://solana.stackexchange.com">
+    Ask questions on Solana StackExchange — the fastest way to get unblocked,
+    and your question helps the next developer.
+  </Card>
+</Cards>

--- a/apps/docs/src/app/[locale]/docs/(main)/layout.tsx
+++ b/apps/docs/src/app/[locale]/docs/(main)/layout.tsx
@@ -5,9 +5,9 @@ import { DocsLayout } from "@@/src/app/components/docs-layout";
 import { InkeepChatButton } from "@solana-com/ui-chrome";
 
 function folderContainsRoute(node: PageTree.Node, route: string): boolean {
-  if (node.type === "page") return node.url?.startsWith(route) ?? false;
+  if (node.type === "page") return node.url?.includes(route) ?? false;
   if (node.type === "folder") {
-    if (node.index?.url?.startsWith(route)) return true;
+    if (node.index?.url?.includes(route)) return true;
     return node.children.some((child) => folderContainsRoute(child, route));
   }
   return false;

--- a/apps/docs/src/app/[locale]/docs/(main)/layout.tsx
+++ b/apps/docs/src/app/[locale]/docs/(main)/layout.tsx
@@ -1,7 +1,17 @@
 import { docsSource } from "@@/src/app/sources/docs";
 import type { ReactNode } from "react";
+import type { PageTree } from "fumadocs-core/server";
 import { DocsLayout } from "@@/src/app/components/docs-layout";
 import { InkeepChatButton } from "@solana-com/ui-chrome";
+
+function folderContainsRoute(node: PageTree.Node, route: string): boolean {
+  if (node.type === "page") return node.url?.startsWith(route) ?? false;
+  if (node.type === "folder") {
+    if (node.index?.url?.startsWith(route)) return true;
+    return node.children.some((child) => folderContainsRoute(child, route));
+  }
+  return false;
+}
 
 export default async function Layout({
   children,
@@ -24,13 +34,21 @@ export default async function Layout({
   ];
   const pageTree = {
     ...tree,
-    children: tree.children?.filter(
-      (child) =>
-        child.type !== "folder" ||
-        !standaloneDocsRoutes.some((route) =>
-          child.index?.url?.includes(route),
-        ),
-    ),
+    children: (tree.children ?? [])
+      .filter(
+        (child) =>
+          child.type !== "folder" ||
+          !standaloneDocsRoutes.some((route) =>
+            child.index?.url?.includes(route),
+          ),
+      )
+      // The nav item is already "Start here", so hoist Getting Started's
+      // contents to the top level instead of nesting the same idea twice.
+      .flatMap((child) =>
+        child.type === "folder" && folderContainsRoute(child, "/docs/intro")
+          ? child.children
+          : [child],
+      ),
   };
   return (
     <DocsLayout tree={pageTree} locale={locale}>

--- a/apps/docs/src/app/[locale]/docs/core/[...slug]/page.tsx
+++ b/apps/docs/src/app/[locale]/docs/core/[...slug]/page.tsx
@@ -1,0 +1,24 @@
+import { docsSource } from "@@/src/app/sources/docs";
+import { getMetadataFromSlug, CoreDocsPage } from "../core";
+import { toStaticParams } from "@@/src/app/sources/utils";
+
+type Props = {
+  params: Promise<{ slug: string[]; locale: string }>;
+};
+
+export default async function Page(props: Props) {
+  const { slug, locale } = await props.params;
+  return <CoreDocsPage slug={["core", ...slug]} locale={locale} />;
+}
+
+export async function generateStaticParams() {
+  return toStaticParams(docsSource)
+    .filter((param) => param.slug[0] === "core")
+    .map((param) => ({ slug: param.slug.slice(1) }))
+    .filter((param) => param.slug.length > 0);
+}
+
+export async function generateMetadata(props: Props) {
+  const { slug, locale } = await props.params;
+  return getMetadataFromSlug(["core", ...slug], locale);
+}

--- a/apps/docs/src/app/[locale]/docs/core/core.tsx
+++ b/apps/docs/src/app/[locale]/docs/core/core.tsx
@@ -1,0 +1,49 @@
+import { docsSource } from "@@/src/app/sources/docs";
+import { notFound } from "next/navigation";
+import type { ComponentProps } from "react";
+import { DocsPage } from "@@/src/app/components/docs-page";
+import { mdxComponents } from "@@/src/app/mdx-components";
+import { getMdxMetadata } from "@@/src/app/metadata";
+import { DocsCategory } from "fumadocs-ui/page";
+
+export async function CoreDocsPage({
+  slug,
+  locale,
+}: {
+  slug: string[];
+  locale: string;
+}) {
+  const page = docsSource.getPage(slug, locale);
+  if (!page) notFound();
+  const { body: MDX, toc } = await page.data.load();
+  const markdown = await page.data.getText("raw");
+  return (
+    <DocsPage
+      toc={toc}
+      full={page.data.full}
+      title={page.data.h1 || page.data.title}
+      filePath={page.data.info.path}
+      hideTableOfContents={page.data.hideTableOfContents}
+      hidePageNavigation={page.data.hidePageNavigation}
+      pageTree={docsSource.pageTree[locale]}
+      href={page.url}
+      markdown={markdown}
+    >
+      <MDX components={mdxComponents} />
+      {page.data.index ? (
+        <DocsCategory
+          page={page}
+          from={
+            docsSource as unknown as ComponentProps<typeof DocsCategory>["from"]
+          }
+        />
+      ) : null}
+    </DocsPage>
+  );
+}
+
+export function getMetadataFromSlug(slug: string[], locale: string) {
+  const page = docsSource.getPage(slug, locale);
+  if (!page) notFound();
+  return getMdxMetadata(page);
+}

--- a/apps/docs/src/app/[locale]/docs/core/layout.tsx
+++ b/apps/docs/src/app/[locale]/docs/core/layout.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from "react";
 import { DocsLayout } from "@@/src/app/components/docs-layout";
 import { InkeepChatButton } from "@solana-com/ui-chrome";
 
+const SIDEBAR_ROUTES = ["/docs/core", "/docs/tokens"];
+
 export default async function Layout({
   children,
   params,
@@ -12,25 +14,14 @@ export default async function Layout({
 }) {
   const { locale } = await params;
   const tree = docsSource.pageTree[locale];
-  const standaloneDocsRoutes = [
-    "/docs/core",
-    "/docs/tokens",
-    "/docs/references",
-    "/docs/rpc",
-    "/docs/payments",
-    "/docs/tokenization",
-    "/docs/defi",
-    "/docs/tools",
-  ];
   const pageTree = {
     ...tree,
-    children: tree.children?.filter(
-      (child) =>
-        child.type !== "folder" ||
-        !standaloneDocsRoutes.some((route) =>
-          child.index?.url?.includes(route),
-        ),
-    ),
+    children:
+      tree.children?.filter(
+        (child) =>
+          child.type === "folder" &&
+          SIDEBAR_ROUTES.some((route) => child.index?.url?.includes(route)),
+      ) ?? [],
   };
   return (
     <DocsLayout tree={pageTree} locale={locale}>

--- a/apps/docs/src/app/[locale]/docs/core/layout.tsx
+++ b/apps/docs/src/app/[locale]/docs/core/layout.tsx
@@ -16,12 +16,19 @@ export default async function Layout({
   const tree = docsSource.pageTree[locale];
   const pageTree = {
     ...tree,
-    children:
-      tree.children?.filter(
+    children: (tree.children ?? [])
+      .filter(
         (child) =>
           child.type === "folder" &&
           SIDEBAR_ROUTES.some((route) => child.index?.url?.includes(route)),
-      ) ?? [],
+      )
+      // The nav item is already "Concepts", so hoist Core Concepts' pages to
+      // the top level instead of repeating the same idea as a folder header.
+      .flatMap((child) =>
+        child.type === "folder" && child.index?.url?.includes("/docs/core")
+          ? child.children
+          : [child],
+      ),
   };
   return (
     <DocsLayout tree={pageTree} locale={locale}>

--- a/apps/docs/src/app/[locale]/docs/core/page.tsx
+++ b/apps/docs/src/app/[locale]/docs/core/page.tsx
@@ -1,0 +1,16 @@
+import { CoreDocsPage, getMetadataFromSlug } from "./core";
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function Page(props: Props) {
+  const { locale } = await props.params;
+  // We use an index page instead of an optional catch-all route
+  // because the optional catch-all route is 404ing in Vercel for localized routes
+  // similar to https://github.com/vercel/next.js/issues/62657
+  return <CoreDocsPage slug={["core"]} locale={locale} />;
+}
+
+export async function generateMetadata(props: Props) {
+  const { locale } = await props.params;
+  return getMetadataFromSlug(["core"], locale);
+}

--- a/apps/docs/src/app/[locale]/docs/references/[...slug]/page.tsx
+++ b/apps/docs/src/app/[locale]/docs/references/[...slug]/page.tsx
@@ -1,0 +1,24 @@
+import { docsSource } from "@@/src/app/sources/docs";
+import { getMetadataFromSlug, ReferencesDocsPage } from "../references";
+import { toStaticParams } from "@@/src/app/sources/utils";
+
+type Props = {
+  params: Promise<{ slug: string[]; locale: string }>;
+};
+
+export default async function Page(props: Props) {
+  const { slug, locale } = await props.params;
+  return <ReferencesDocsPage slug={["references", ...slug]} locale={locale} />;
+}
+
+export async function generateStaticParams() {
+  return toStaticParams(docsSource)
+    .filter((param) => param.slug[0] === "references")
+    .map((param) => ({ slug: param.slug.slice(1) }))
+    .filter((param) => param.slug.length > 0);
+}
+
+export async function generateMetadata(props: Props) {
+  const { slug, locale } = await props.params;
+  return getMetadataFromSlug(["references", ...slug], locale);
+}

--- a/apps/docs/src/app/[locale]/docs/references/layout.tsx
+++ b/apps/docs/src/app/[locale]/docs/references/layout.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from "react";
 import { DocsLayout } from "@@/src/app/components/docs-layout";
 import { InkeepChatButton } from "@solana-com/ui-chrome";
 
+const SIDEBAR_ROUTES = ["/docs/references"];
+
 export default async function Layout({
   children,
   params,
@@ -12,25 +14,14 @@ export default async function Layout({
 }) {
   const { locale } = await params;
   const tree = docsSource.pageTree[locale];
-  const standaloneDocsRoutes = [
-    "/docs/core",
-    "/docs/tokens",
-    "/docs/references",
-    "/docs/rpc",
-    "/docs/payments",
-    "/docs/tokenization",
-    "/docs/defi",
-    "/docs/tools",
-  ];
   const pageTree = {
     ...tree,
-    children: tree.children?.filter(
-      (child) =>
-        child.type !== "folder" ||
-        !standaloneDocsRoutes.some((route) =>
-          child.index?.url?.includes(route),
-        ),
-    ),
+    children:
+      tree.children?.filter(
+        (child) =>
+          child.type === "folder" &&
+          SIDEBAR_ROUTES.some((route) => child.index?.url?.includes(route)),
+      ) ?? [],
   };
   return (
     <DocsLayout tree={pageTree} locale={locale}>

--- a/apps/docs/src/app/[locale]/docs/references/page.tsx
+++ b/apps/docs/src/app/[locale]/docs/references/page.tsx
@@ -1,0 +1,16 @@
+import { ReferencesDocsPage, getMetadataFromSlug } from "./references";
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function Page(props: Props) {
+  const { locale } = await props.params;
+  // We use an index page instead of an optional catch-all route
+  // because the optional catch-all route is 404ing in Vercel for localized routes
+  // similar to https://github.com/vercel/next.js/issues/62657
+  return <ReferencesDocsPage slug={["references"]} locale={locale} />;
+}
+
+export async function generateMetadata(props: Props) {
+  const { locale } = await props.params;
+  return getMetadataFromSlug(["references"], locale);
+}

--- a/apps/docs/src/app/[locale]/docs/references/references.tsx
+++ b/apps/docs/src/app/[locale]/docs/references/references.tsx
@@ -1,0 +1,49 @@
+import { docsSource } from "@@/src/app/sources/docs";
+import { notFound } from "next/navigation";
+import type { ComponentProps } from "react";
+import { DocsPage } from "@@/src/app/components/docs-page";
+import { mdxComponents } from "@@/src/app/mdx-components";
+import { getMdxMetadata } from "@@/src/app/metadata";
+import { DocsCategory } from "fumadocs-ui/page";
+
+export async function ReferencesDocsPage({
+  slug,
+  locale,
+}: {
+  slug: string[];
+  locale: string;
+}) {
+  const page = docsSource.getPage(slug, locale);
+  if (!page) notFound();
+  const { body: MDX, toc } = await page.data.load();
+  const markdown = await page.data.getText("raw");
+  return (
+    <DocsPage
+      toc={toc}
+      full={page.data.full}
+      title={page.data.h1 || page.data.title}
+      filePath={page.data.info.path}
+      hideTableOfContents={page.data.hideTableOfContents}
+      hidePageNavigation={page.data.hidePageNavigation}
+      pageTree={docsSource.pageTree[locale]}
+      href={page.url}
+      markdown={markdown}
+    >
+      <MDX components={mdxComponents} />
+      {page.data.index ? (
+        <DocsCategory
+          page={page}
+          from={
+            docsSource as unknown as ComponentProps<typeof DocsCategory>["from"]
+          }
+        />
+      ) : null}
+    </DocsPage>
+  );
+}
+
+export function getMetadataFromSlug(slug: string[], locale: string) {
+  const page = docsSource.getPage(slug, locale);
+  if (!page) notFound();
+  return getMdxMetadata(page);
+}

--- a/apps/docs/src/app/[locale]/docs/tokens/[...slug]/page.tsx
+++ b/apps/docs/src/app/[locale]/docs/tokens/[...slug]/page.tsx
@@ -1,0 +1,24 @@
+import { docsSource } from "@@/src/app/sources/docs";
+import { getMetadataFromSlug, TokensDocsPage } from "../tokens";
+import { toStaticParams } from "@@/src/app/sources/utils";
+
+type Props = {
+  params: Promise<{ slug: string[]; locale: string }>;
+};
+
+export default async function Page(props: Props) {
+  const { slug, locale } = await props.params;
+  return <TokensDocsPage slug={["tokens", ...slug]} locale={locale} />;
+}
+
+export async function generateStaticParams() {
+  return toStaticParams(docsSource)
+    .filter((param) => param.slug[0] === "tokens")
+    .map((param) => ({ slug: param.slug.slice(1) }))
+    .filter((param) => param.slug.length > 0);
+}
+
+export async function generateMetadata(props: Props) {
+  const { slug, locale } = await props.params;
+  return getMetadataFromSlug(["tokens", ...slug], locale);
+}

--- a/apps/docs/src/app/[locale]/docs/tokens/layout.tsx
+++ b/apps/docs/src/app/[locale]/docs/tokens/layout.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from "react";
 import { DocsLayout } from "@@/src/app/components/docs-layout";
 import { InkeepChatButton } from "@solana-com/ui-chrome";
 
+const SIDEBAR_ROUTES = ["/docs/core", "/docs/tokens"];
+
 export default async function Layout({
   children,
   params,
@@ -12,25 +14,14 @@ export default async function Layout({
 }) {
   const { locale } = await params;
   const tree = docsSource.pageTree[locale];
-  const standaloneDocsRoutes = [
-    "/docs/core",
-    "/docs/tokens",
-    "/docs/references",
-    "/docs/rpc",
-    "/docs/payments",
-    "/docs/tokenization",
-    "/docs/defi",
-    "/docs/tools",
-  ];
   const pageTree = {
     ...tree,
-    children: tree.children?.filter(
-      (child) =>
-        child.type !== "folder" ||
-        !standaloneDocsRoutes.some((route) =>
-          child.index?.url?.includes(route),
-        ),
-    ),
+    children:
+      tree.children?.filter(
+        (child) =>
+          child.type === "folder" &&
+          SIDEBAR_ROUTES.some((route) => child.index?.url?.includes(route)),
+      ) ?? [],
   };
   return (
     <DocsLayout tree={pageTree} locale={locale}>

--- a/apps/docs/src/app/[locale]/docs/tokens/layout.tsx
+++ b/apps/docs/src/app/[locale]/docs/tokens/layout.tsx
@@ -16,12 +16,19 @@ export default async function Layout({
   const tree = docsSource.pageTree[locale];
   const pageTree = {
     ...tree,
-    children:
-      tree.children?.filter(
+    children: (tree.children ?? [])
+      .filter(
         (child) =>
           child.type === "folder" &&
           SIDEBAR_ROUTES.some((route) => child.index?.url?.includes(route)),
-      ) ?? [],
+      )
+      // The nav item is already "Concepts", so hoist Core Concepts' pages to
+      // the top level instead of repeating the same idea as a folder header.
+      .flatMap((child) =>
+        child.type === "folder" && child.index?.url?.includes("/docs/core")
+          ? child.children
+          : [child],
+      ),
   };
   return (
     <DocsLayout tree={pageTree} locale={locale}>

--- a/apps/docs/src/app/[locale]/docs/tokens/page.tsx
+++ b/apps/docs/src/app/[locale]/docs/tokens/page.tsx
@@ -1,0 +1,16 @@
+import { TokensDocsPage, getMetadataFromSlug } from "./tokens";
+
+type Props = { params: Promise<{ locale: string }> };
+
+export default async function Page(props: Props) {
+  const { locale } = await props.params;
+  // We use an index page instead of an optional catch-all route
+  // because the optional catch-all route is 404ing in Vercel for localized routes
+  // similar to https://github.com/vercel/next.js/issues/62657
+  return <TokensDocsPage slug={["tokens"]} locale={locale} />;
+}
+
+export async function generateMetadata(props: Props) {
+  const { locale } = await props.params;
+  return getMetadataFromSlug(["tokens"], locale);
+}

--- a/apps/docs/src/app/[locale]/docs/tokens/tokens.tsx
+++ b/apps/docs/src/app/[locale]/docs/tokens/tokens.tsx
@@ -1,0 +1,49 @@
+import { docsSource } from "@@/src/app/sources/docs";
+import { notFound } from "next/navigation";
+import type { ComponentProps } from "react";
+import { DocsPage } from "@@/src/app/components/docs-page";
+import { mdxComponents } from "@@/src/app/mdx-components";
+import { getMdxMetadata } from "@@/src/app/metadata";
+import { DocsCategory } from "fumadocs-ui/page";
+
+export async function TokensDocsPage({
+  slug,
+  locale,
+}: {
+  slug: string[];
+  locale: string;
+}) {
+  const page = docsSource.getPage(slug, locale);
+  if (!page) notFound();
+  const { body: MDX, toc } = await page.data.load();
+  const markdown = await page.data.getText("raw");
+  return (
+    <DocsPage
+      toc={toc}
+      full={page.data.full}
+      title={page.data.h1 || page.data.title}
+      filePath={page.data.info.path}
+      hideTableOfContents={page.data.hideTableOfContents}
+      hidePageNavigation={page.data.hidePageNavigation}
+      pageTree={docsSource.pageTree[locale]}
+      href={page.url}
+      markdown={markdown}
+    >
+      <MDX components={mdxComponents} />
+      {page.data.index ? (
+        <DocsCategory
+          page={page}
+          from={
+            docsSource as unknown as ComponentProps<typeof DocsCategory>["from"]
+          }
+        />
+      ) : null}
+    </DocsPage>
+  );
+}
+
+export function getMetadataFromSlug(slug: string[], locale: string) {
+  const page = docsSource.getPage(slug, locale);
+  if (!page) notFound();
+  return getMdxMetadata(page);
+}

--- a/packages/i18n/messages/web/ar/common.json
+++ b/packages/i18n/messages/web/ar/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/ar/common.json
+++ b/packages/i18n/messages/web/ar/common.json
@@ -796,7 +796,9 @@
       "data": "البيانات",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "السابق",

--- a/packages/i18n/messages/web/de/common.json
+++ b/packages/i18n/messages/web/de/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/de/common.json
+++ b/packages/i18n/messages/web/de/common.json
@@ -796,7 +796,9 @@
       "data": "Daten",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Zurück",

--- a/packages/i18n/messages/web/el/common.json
+++ b/packages/i18n/messages/web/el/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/el/common.json
+++ b/packages/i18n/messages/web/el/common.json
@@ -796,7 +796,9 @@
       "data": "Δεδομένα",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Προηγούμενο",

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -796,7 +796,9 @@
       "data": "Data",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Previous",

--- a/packages/i18n/messages/web/es/common.json
+++ b/packages/i18n/messages/web/es/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/es/common.json
+++ b/packages/i18n/messages/web/es/common.json
@@ -796,7 +796,9 @@
       "data": "Datos",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Anterior",

--- a/packages/i18n/messages/web/fi/common.json
+++ b/packages/i18n/messages/web/fi/common.json
@@ -796,7 +796,9 @@
       "data": "Data",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Edellinen",

--- a/packages/i18n/messages/web/fi/common.json
+++ b/packages/i18n/messages/web/fi/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/fr/common.json
+++ b/packages/i18n/messages/web/fr/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/fr/common.json
+++ b/packages/i18n/messages/web/fr/common.json
@@ -796,7 +796,9 @@
       "data": "Données",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Précédent",

--- a/packages/i18n/messages/web/id/common.json
+++ b/packages/i18n/messages/web/id/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/id/common.json
+++ b/packages/i18n/messages/web/id/common.json
@@ -796,7 +796,9 @@
       "data": "Data",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Sebelumnya",

--- a/packages/i18n/messages/web/it/common.json
+++ b/packages/i18n/messages/web/it/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/it/common.json
+++ b/packages/i18n/messages/web/it/common.json
@@ -796,7 +796,9 @@
       "data": "Dati",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Precedente",

--- a/packages/i18n/messages/web/ja/common.json
+++ b/packages/i18n/messages/web/ja/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/ja/common.json
+++ b/packages/i18n/messages/web/ja/common.json
@@ -796,7 +796,9 @@
       "data": "データ",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "前へ",

--- a/packages/i18n/messages/web/ko/common.json
+++ b/packages/i18n/messages/web/ko/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/ko/common.json
+++ b/packages/i18n/messages/web/ko/common.json
@@ -796,7 +796,9 @@
       "data": "데이터",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "이전",

--- a/packages/i18n/messages/web/nl/common.json
+++ b/packages/i18n/messages/web/nl/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/nl/common.json
+++ b/packages/i18n/messages/web/nl/common.json
@@ -796,7 +796,9 @@
       "data": "Data",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Vorige",

--- a/packages/i18n/messages/web/pl/common.json
+++ b/packages/i18n/messages/web/pl/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/pl/common.json
+++ b/packages/i18n/messages/web/pl/common.json
@@ -796,7 +796,9 @@
       "data": "Dane",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Poprzedni",

--- a/packages/i18n/messages/web/pt/common.json
+++ b/packages/i18n/messages/web/pt/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/pt/common.json
+++ b/packages/i18n/messages/web/pt/common.json
@@ -796,7 +796,9 @@
       "data": "Dados",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Anterior",

--- a/packages/i18n/messages/web/ru/common.json
+++ b/packages/i18n/messages/web/ru/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/ru/common.json
+++ b/packages/i18n/messages/web/ru/common.json
@@ -796,7 +796,9 @@
       "data": "Данные",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Назад",

--- a/packages/i18n/messages/web/tr/common.json
+++ b/packages/i18n/messages/web/tr/common.json
@@ -796,7 +796,9 @@
       "data": "Veri",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Önceki",

--- a/packages/i18n/messages/web/tr/common.json
+++ b/packages/i18n/messages/web/tr/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/uk/common.json
+++ b/packages/i18n/messages/web/uk/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/uk/common.json
+++ b/packages/i18n/messages/web/uk/common.json
@@ -796,7 +796,9 @@
       "data": "Дані",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Попередній",

--- a/packages/i18n/messages/web/vi/common.json
+++ b/packages/i18n/messages/web/vi/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/vi/common.json
+++ b/packages/i18n/messages/web/vi/common.json
@@ -796,7 +796,9 @@
       "data": "Dữ Liệu",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "Trước",

--- a/packages/i18n/messages/web/zh/common.json
+++ b/packages/i18n/messages/web/zh/common.json
@@ -797,7 +797,7 @@
       "tokenization": "Tokenization",
       "defi": "DeFi",
       "resources": "Resources",
-      "quickstart": "Quickstart",
+      "quickstart": "Start here",
       "concepts": "Concepts"
     },
     "carousel": {

--- a/packages/i18n/messages/web/zh/common.json
+++ b/packages/i18n/messages/web/zh/common.json
@@ -796,7 +796,9 @@
       "data": "数据",
       "tokenization": "Tokenization",
       "defi": "DeFi",
-      "resources": "Resources"
+      "resources": "Resources",
+      "quickstart": "Quickstart",
+      "concepts": "Concepts"
     },
     "carousel": {
       "prev": "上一页",

--- a/packages/ui-chrome/src/developers-nav.tsx
+++ b/packages/ui-chrome/src/developers-nav.tsx
@@ -56,9 +56,6 @@ export function DevelopersNav({
                 partiallyActiveIgnore={[
                   "/docs/core",
                   "/docs/tokens",
-                  "/docs/programs",
-                  "/docs/frontend",
-                  "/docs/clients",
                   "/docs/references",
                   "/docs/rpc",
                   "/docs/payments",
@@ -80,13 +77,7 @@ export function DevelopersNav({
               <NavLink
                 partiallyActive
                 to="/docs/core"
-                partiallyActiveMatch={[
-                  "/docs/tokens",
-                  "/docs/programs",
-                  "/docs/frontend",
-                  "/docs/clients",
-                  "/docs/references",
-                ]}
+                partiallyActiveMatch={["/docs/tokens"]}
                 activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
               >
                 <CoursesIcon
@@ -153,6 +144,7 @@ export function DevelopersNav({
               <NavLink
                 partiallyActive
                 to="/docs/tools"
+                partiallyActiveMatch={["/docs/references"]}
                 activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
               >
                 <ToolsIcon

--- a/packages/ui-chrome/src/developers-nav.tsx
+++ b/packages/ui-chrome/src/developers-nav.tsx
@@ -1,12 +1,11 @@
 import { Link } from "./link";
 import DocsIcon from "./assets/developers/docs.inline.svg";
 import RpcApiIcon from "./assets/developers/api.inline.svg";
-import CookbookIcon from "./assets/developers/cookbook.inline.svg";
+import CoursesIcon from "./assets/developers/courses.inline.svg";
 import ToolsIcon from "./assets/developers/templates.inline.svg";
 import WalletIcon from "./assets/developers/wallet.inline.svg";
 import SkillsIcon from "./assets/developers/skills.inline.svg";
 import StatisticsIcon from "./assets/developers/statistics.inline.svg";
-import StackExchangeIcon from "./assets/developers/stackexchange.inline.svg";
 import { useTranslations } from "next-intl";
 import { useRouter } from "@workspace/i18n/use-router";
 import {
@@ -55,6 +54,12 @@ export function DevelopersNav({
                 partiallyActive
                 to="/docs"
                 partiallyActiveIgnore={[
+                  "/docs/core",
+                  "/docs/tokens",
+                  "/docs/programs",
+                  "/docs/frontend",
+                  "/docs/clients",
+                  "/docs/references",
                   "/docs/rpc",
                   "/docs/payments",
                   "/docs/tokenization",
@@ -69,7 +74,28 @@ export function DevelopersNav({
                   className="inline-block mr-2"
                 />
                 <span className="align-middle">
-                  {t("developers.nav.documentation")}
+                  {t("developers.nav.quickstart")}
+                </span>
+              </NavLink>
+              <NavLink
+                partiallyActive
+                to="/docs/core"
+                partiallyActiveMatch={[
+                  "/docs/tokens",
+                  "/docs/programs",
+                  "/docs/frontend",
+                  "/docs/clients",
+                  "/docs/references",
+                ]}
+                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
+              >
+                <CoursesIcon
+                  height="16"
+                  width="16"
+                  className="inline-block mr-2"
+                />
+                <span className="align-middle">
+                  {t("developers.nav.concepts")}
                 </span>
               </NavLink>
               <NavLink
@@ -114,20 +140,6 @@ export function DevelopersNav({
               </NavLink>
               <NavLink
                 partiallyActive
-                to="/developers/cookbook"
-                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
-              >
-                <CookbookIcon
-                  height="16"
-                  width="16"
-                  className="inline-block mr-2"
-                />
-                <span className="align-middle">
-                  {t("developers.nav.cookbook")}
-                </span>
-              </NavLink>
-              <NavLink
-                partiallyActive
                 to="/docs/rpc"
                 activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
               >
@@ -151,15 +163,6 @@ export function DevelopersNav({
                 <span className="align-middle">
                   {t("developers.nav.resources")}
                 </span>
-              </NavLink>
-              <NavLink href="https://solana.stackexchange.com/" target="_blank">
-                <StackExchangeIcon
-                  height="16"
-                  width="16"
-                  className="inline-block mr-2"
-                  fill="currentColor"
-                />
-                <span className="align-middle">Get Support</span>
               </NavLink>
             </nav>
           </div>

--- a/packages/ui-chrome/src/link.tsx
+++ b/packages/ui-chrome/src/link.tsx
@@ -13,6 +13,7 @@ interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
   activeClassName?: string;
   partiallyActive?: boolean;
   partiallyActiveIgnore?: string[];
+  partiallyActiveMatch?: string[];
   className?: string;
   scroll?: boolean;
   prefetch?: boolean;
@@ -29,6 +30,7 @@ const Link = ({
   activeClassName = "",
   partiallyActive = false,
   partiallyActiveIgnore = [],
+  partiallyActiveMatch = [],
   className,
   ...other
 }: LinkProps) => {
@@ -42,11 +44,18 @@ const Link = ({
   const isActive = useMemo(() => {
     return (
       asPath === linkTo ||
+      partiallyActiveMatch.some((el) => asPath.startsWith(el)) ||
       (partiallyActive &&
         asPath.includes(linkTo) &&
         !partiallyActiveIgnore.filter((el) => asPath.startsWith(el)).length)
     );
-  }, [partiallyActive, asPath, linkTo, partiallyActiveIgnore]);
+  }, [
+    partiallyActive,
+    asPath,
+    linkTo,
+    partiallyActiveIgnore,
+    partiallyActiveMatch,
+  ]);
 
   if (useNextLink) {
     const { scroll, prefetch, ...aProps } = other;


### PR DESCRIPTION
## Summary

Introduces the main Start Here path and clearer top-level documentation sections.

## What changed

- Adds dedicated landing routes for Core, Tokens, and References.
- Adds an AI-assisted getting-started guide and refreshes the docs entry page.
- Collapses HTTP method detail in the RPC sidebar by default.
- Updates shared navigation links and locale labels for the new hierarchy.

## Stack position

PR 9 of 12 in the docs restructure stack.

Previous: #1745  
Next: #1730

## Validation

Validated on the completed stack with the docs typecheck and production build.