### PR TITLE
docs: align shared navigation with the new sections

### DIFF
--- a/packages/i18n/messages/web/ar/common.json
+++ b/packages/i18n/messages/web/ar/common.json
@@ -793,7 +793,10 @@
       "templates": "القوالب",
       "toolkit": "Toolkit",
       "skills": "المهارات",
-      "data": "البيانات"
+      "data": "البيانات",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "السابق",

--- a/packages/i18n/messages/web/de/common.json
+++ b/packages/i18n/messages/web/de/common.json
@@ -793,7 +793,10 @@
       "templates": "Vorlagen",
       "toolkit": "Toolkit",
       "skills": "Skills",
-      "data": "Daten"
+      "data": "Daten",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Zurück",

--- a/packages/i18n/messages/web/el/common.json
+++ b/packages/i18n/messages/web/el/common.json
@@ -793,7 +793,10 @@
       "templates": "Πρότυπα",
       "toolkit": "Toolkit",
       "skills": "Δεξιότητες",
-      "data": "Δεδομένα"
+      "data": "Δεδομένα",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Προηγούμενο",

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -793,7 +793,10 @@
       "templates": "Templates",
       "toolkit": "Toolkit",
       "skills": "Skills",
-      "data": "Data"
+      "data": "Data",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Previous",

--- a/packages/i18n/messages/web/es/common.json
+++ b/packages/i18n/messages/web/es/common.json
@@ -793,7 +793,10 @@
       "templates": "Plantillas",
       "toolkit": "Toolkit",
       "skills": "Habilidades",
-      "data": "Datos"
+      "data": "Datos",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Anterior",

--- a/packages/i18n/messages/web/fi/common.json
+++ b/packages/i18n/messages/web/fi/common.json
@@ -793,7 +793,10 @@
       "templates": "Mallipohjat",
       "toolkit": "Toolkit",
       "skills": "Taidot",
-      "data": "Data"
+      "data": "Data",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Edellinen",

--- a/packages/i18n/messages/web/fr/common.json
+++ b/packages/i18n/messages/web/fr/common.json
@@ -793,7 +793,10 @@
       "templates": "Modèles",
       "toolkit": "Toolkit",
       "skills": "Compétences",
-      "data": "Données"
+      "data": "Données",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Précédent",

--- a/packages/i18n/messages/web/id/common.json
+++ b/packages/i18n/messages/web/id/common.json
@@ -793,7 +793,10 @@
       "templates": "Template",
       "toolkit": "Toolkit",
       "skills": "Keterampilan",
-      "data": "Data"
+      "data": "Data",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Sebelumnya",

--- a/packages/i18n/messages/web/it/common.json
+++ b/packages/i18n/messages/web/it/common.json
@@ -793,7 +793,10 @@
       "templates": "Template",
       "toolkit": "Toolkit",
       "skills": "Competenze",
-      "data": "Dati"
+      "data": "Dati",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Precedente",

--- a/packages/i18n/messages/web/ja/common.json
+++ b/packages/i18n/messages/web/ja/common.json
@@ -793,7 +793,10 @@
       "templates": "テンプレート",
       "toolkit": "Toolkit",
       "skills": "スキル",
-      "data": "データ"
+      "data": "データ",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "前へ",

--- a/packages/i18n/messages/web/ko/common.json
+++ b/packages/i18n/messages/web/ko/common.json
@@ -793,7 +793,10 @@
       "templates": "템플릿",
       "toolkit": "Toolkit",
       "skills": "스킬",
-      "data": "데이터"
+      "data": "데이터",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "이전",

--- a/packages/i18n/messages/web/nl/common.json
+++ b/packages/i18n/messages/web/nl/common.json
@@ -793,7 +793,10 @@
       "templates": "Sjablonen",
       "toolkit": "Toolkit",
       "skills": "Skills",
-      "data": "Data"
+      "data": "Data",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Vorige",

--- a/packages/i18n/messages/web/pl/common.json
+++ b/packages/i18n/messages/web/pl/common.json
@@ -793,7 +793,10 @@
       "templates": "Szablony",
       "toolkit": "Toolkit",
       "skills": "Umiejętności",
-      "data": "Dane"
+      "data": "Dane",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Poprzedni",

--- a/packages/i18n/messages/web/pt/common.json
+++ b/packages/i18n/messages/web/pt/common.json
@@ -793,7 +793,10 @@
       "templates": "Modelos",
       "toolkit": "Toolkit",
       "skills": "Habilidades",
-      "data": "Dados"
+      "data": "Dados",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Anterior",

--- a/packages/i18n/messages/web/ru/common.json
+++ b/packages/i18n/messages/web/ru/common.json
@@ -793,7 +793,10 @@
       "templates": "Шаблоны",
       "toolkit": "Инструментарий",
       "skills": "Навыки",
-      "data": "Данные"
+      "data": "Данные",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Назад",

--- a/packages/i18n/messages/web/tr/common.json
+++ b/packages/i18n/messages/web/tr/common.json
@@ -793,7 +793,10 @@
       "templates": "Şablonlar",
       "toolkit": "Toolkit",
       "skills": "Yetenekler",
-      "data": "Veri"
+      "data": "Veri",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Önceki",

--- a/packages/i18n/messages/web/uk/common.json
+++ b/packages/i18n/messages/web/uk/common.json
@@ -793,7 +793,10 @@
       "templates": "Шаблони",
       "toolkit": "Toolkit",
       "skills": "Навички",
-      "data": "Дані"
+      "data": "Дані",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Попередній",

--- a/packages/i18n/messages/web/vi/common.json
+++ b/packages/i18n/messages/web/vi/common.json
@@ -793,7 +793,10 @@
       "templates": "Mẫu",
       "toolkit": "Toolkit",
       "skills": "Kỹ năng",
-      "data": "Dữ Liệu"
+      "data": "Dữ Liệu",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "Trước",

--- a/packages/i18n/messages/web/zh/common.json
+++ b/packages/i18n/messages/web/zh/common.json
@@ -793,7 +793,10 @@
       "templates": "模板",
       "toolkit": "Toolkit",
       "skills": "技能",
-      "data": "数据"
+      "data": "数据",
+      "tokenization": "Tokenization",
+      "defi": "DeFi",
+      "resources": "Resources"
     },
     "carousel": {
       "prev": "上一页",

--- a/packages/ui-chrome/src/__tests__/developer-routes.test.ts
+++ b/packages/ui-chrome/src/__tests__/developer-routes.test.ts
@@ -31,7 +31,7 @@ describe("developer route matching", () => {
 
   it("keeps theme support on docs developer routes", () => {
     expect(isThemeRoute("/docs/rpc")).toBe(true);
-    expect(isThemeRoute("/developers/guides/getting-started")).toBe(true);
+    expect(isThemeRoute("/developers/bootcamp/foundations")).toBe(true);
     expect(isThemeRoute("/data")).toBe(false);
     expect(isThemeRoute("/database")).toBe(false);
   });

--- a/packages/ui-chrome/src/__tests__/url-config.test.ts
+++ b/packages/ui-chrome/src/__tests__/url-config.test.ts
@@ -36,7 +36,7 @@ describe("cross-app URL configuration", () => {
     const shouldUseNextLink = await loadShouldUseNextLink("docs");
 
     expect(shouldUseNextLink("/docs")).toBe(true);
-    expect(shouldUseNextLink("/developers/guides")).toBe(true);
+    expect(shouldUseNextLink("/developers/cookbook")).toBe(true);
     expect(shouldUseNextLink("/data")).toBe(false);
   });
 

--- a/packages/ui-chrome/src/developer-routes.ts
+++ b/packages/ui-chrome/src/developer-routes.ts
@@ -32,7 +32,6 @@ export function isThemeRoute(pathname: string | null | undefined) {
   return (
     matchesRouteSegment(pathname, "/docs") ||
     matchesRouteSegment(pathname, "/developers/cookbook") ||
-    matchesRouteSegment(pathname, "/developers/guides") ||
     matchesRouteSegment(pathname, "/developers/bootcamp")
   );
 }

--- a/packages/ui-chrome/src/developers-nav.tsx
+++ b/packages/ui-chrome/src/developers-nav.tsx
@@ -2,7 +2,6 @@ import { Link } from "./link";
 import DocsIcon from "./assets/developers/docs.inline.svg";
 import RpcApiIcon from "./assets/developers/api.inline.svg";
 import CookbookIcon from "./assets/developers/cookbook.inline.svg";
-import CoursesIcon from "./assets/developers/courses.inline.svg";
 import ToolsIcon from "./assets/developers/templates.inline.svg";
 import WalletIcon from "./assets/developers/wallet.inline.svg";
 import SkillsIcon from "./assets/developers/skills.inline.svg";
@@ -58,6 +57,8 @@ export function DevelopersNav({
                 partiallyActiveIgnore={[
                   "/docs/rpc",
                   "/docs/payments",
+                  "/docs/tokenization",
+                  "/docs/defi",
                   "/docs/tools",
                 ]}
                 activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.2)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.2)] light:hover:border-[rgba(0,0,0,0.3)]"
@@ -69,46 +70,6 @@ export function DevelopersNav({
                 />
                 <span className="align-middle">
                   {t("developers.nav.documentation")}
-                </span>
-              </NavLink>
-              <NavLink
-                partiallyActive
-                to="/docs/rpc"
-                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
-              >
-                <RpcApiIcon
-                  height="16"
-                  width="16"
-                  className="inline-block mr-2"
-                />
-                <span className="align-middle">{t("developers.nav.rpc")}</span>
-              </NavLink>
-              <NavLink
-                partiallyActive
-                to="/developers/cookbook"
-                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
-              >
-                <CookbookIcon
-                  height="16"
-                  width="16"
-                  className="inline-block mr-2"
-                />
-                <span className="align-middle">
-                  {t("developers.nav.cookbook")}
-                </span>
-              </NavLink>
-              <NavLink
-                partiallyActive
-                to="/developers/bootcamp"
-                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
-              >
-                <CoursesIcon
-                  height="16"
-                  width="16"
-                  className="inline-block mr-2"
-                />
-                <span className="align-middle">
-                  {t("developers.nav.bootcamp")}
                 </span>
               </NavLink>
               <NavLink
@@ -127,6 +88,58 @@ export function DevelopersNav({
               </NavLink>
               <NavLink
                 partiallyActive
+                to="/docs/tokenization"
+                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
+              >
+                <SkillsIcon
+                  height="16"
+                  width="16"
+                  className="inline-block mr-2"
+                />
+                <span className="align-middle">
+                  {t("developers.nav.tokenization")}
+                </span>
+              </NavLink>
+              <NavLink
+                partiallyActive
+                to="/docs/defi"
+                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
+              >
+                <StatisticsIcon
+                  height="16"
+                  width="16"
+                  className="inline-block mr-2"
+                />
+                <span className="align-middle">{t("developers.nav.defi")}</span>
+              </NavLink>
+              <NavLink
+                partiallyActive
+                to="/developers/cookbook"
+                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
+              >
+                <CookbookIcon
+                  height="16"
+                  width="16"
+                  className="inline-block mr-2"
+                />
+                <span className="align-middle">
+                  {t("developers.nav.cookbook")}
+                </span>
+              </NavLink>
+              <NavLink
+                partiallyActive
+                to="/docs/rpc"
+                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
+              >
+                <RpcApiIcon
+                  height="16"
+                  width="16"
+                  className="inline-block mr-2"
+                />
+                <span className="align-middle">{t("developers.nav.rpc")}</span>
+              </NavLink>
+              <NavLink
+                partiallyActive
                 to="/docs/tools"
                 activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
               >
@@ -136,33 +149,7 @@ export function DevelopersNav({
                   className="inline-block mr-2"
                 />
                 <span className="align-middle">
-                  {t("developers.nav.tools")}
-                </span>
-              </NavLink>
-              <NavLink
-                partiallyActive
-                to="/data"
-                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
-              >
-                <StatisticsIcon
-                  height="16"
-                  width="16"
-                  className="inline-block mr-2"
-                />
-                <span className="align-middle">{t("developers.nav.data")}</span>
-              </NavLink>
-              <NavLink
-                partiallyActive
-                to="/skills"
-                activeClassName="!text-white light:!text-gray-900 bg-[rgba(204,204,204,0.1)] border-[rgba(255,255,255,0.1)] hover:border-[rgba(255,255,255,0.2)] light:bg-[rgba(204,204,204,0.35)] light:border-[rgba(0,0,0,0.1)] light:hover:border-[rgba(0,0,0,0.3)]"
-              >
-                <SkillsIcon
-                  height="16"
-                  width="16"
-                  className="inline-block mr-2"
-                />
-                <span className="align-middle">
-                  {t("developers.nav.skills")}
+                  {t("developers.nav.resources")}
                 </span>
               </NavLink>
               <NavLink href="https://solana.stackexchange.com/" target="_blank">

--- a/packages/ui-chrome/src/footer.tsx
+++ b/packages/ui-chrome/src/footer.tsx
@@ -79,7 +79,6 @@ const FOOTER_COLUMNS: FooterColumnConfig[] = [
     links: [
       { labelKey: "footer.build.developers", href: "/developers" },
       { labelKey: "footer.build.docs", href: "/docs" },
-      { labelKey: "footer.build.guides", href: "/developers/guides" },
       { labelKey: "footer.build.templates", href: "/developers/templates" },
     ],
   },

--- a/packages/ui-chrome/src/nav-section-content-config.tsx
+++ b/packages/ui-chrome/src/nav-section-content-config.tsx
@@ -151,12 +151,6 @@ export const buildStartItems: NavItemDefinition[] = [
 
 export const buildResourceItems: NavItemDefinition[] = [
   {
-    id: "build-guides",
-    titleKey: "nav.build.resources.items.guides.title",
-    href: "/developers/guides",
-    icon: DocumentsIcon,
-  },
-  {
     id: "build-cookbook",
     titleKey: "nav.build.resources.items.cookbook.title",
     href: "/developers/cookbook",

--- a/packages/ui-chrome/src/url-config.ts
+++ b/packages/ui-chrome/src/url-config.ts
@@ -16,8 +16,8 @@ const APP_NAME = process.env.NEXT_PUBLIC_APP_NAME;
  * Routes not matching will use <a> tags for full page load.
  */
 const APP_INTERNAL_ROUTES: Record<string, RegExp> = {
-  // docs app handles: /docs/*, /learn/*, /developers, /developers/cookbook/*, /developers/guides/*, /developers/bootcamp/*
-  docs: /^\/(?:docs|learn)(?:\/|$)|^\/developers(?:$|\/(?:cookbook|guides|bootcamp)(?:\/|$))/,
+  // docs app handles: /docs/*, /learn/*, /developers, /developers/cookbook/*, /developers/bootcamp/*
+  docs: /^\/(?:docs|learn)(?:\/|$)|^\/developers(?:$|\/(?:cookbook|bootcamp)(?:\/|$))/,
   media: /^\/(?:news|podcasts)(?:\/|$)/,
   // templates app handles: /developers/templates/*
   templates: /^\/developers\/templates(?:\/|$)/,


### PR DESCRIPTION
## Summary

Updates shared site chrome so every app points at the restructured documentation.

## What changed

- Reworks the shared developer navigation and footer destinations.
- Removes legacy guide route ownership from cross-app link handling.
- Propagates the new navigation labels through all supported locale catalogs.
- Updates route and URL-configuration tests.

## Stack position

PR 5 of 12 in the docs restructure stack.

Previous: #1740  
Next: #1743

## Validation

Validated on the completed stack with the docs typecheck and production build.