### PR TITLE
fix(deps): patch high-severity audit findings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,7 +24,9 @@ catalogs:
 
 overrides:
   esbuild@>=0.17.0 <0.28.1: 0.28.1
-  nth-check@<2.0.1: 2.1.1
+  immutable@>=5.0.0-beta.1 <5.1.8: 5.1.9
+  fast-uri@>=3.0.0 <3.1.3: 3.1.3
+  seti-icons@0.0.4>svgo: 2.8.3
   thrift@0.23.0>uuid: 11.1.1
 
 importers:
@@ -9760,12 +9762,6 @@ packages:
         integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==,
       }
 
-  "@types/q@1.5.8":
-    resolution:
-      {
-        integrity: sha512-hroOstUScF6zhIi+5+x0dzqrHA1EJi+Irri6b1fxolMTqqHIV/Cg77EtnQcZqZCu8hR3mX2BzIxN4/GzI68Kfw==,
-      }
-
   "@types/react-dom@19.1.9":
     resolution:
       {
@@ -10516,13 +10512,6 @@ packages:
         integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==,
       }
 
-  ansi-styles@3.2.1:
-    resolution:
-      {
-        integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==,
-      }
-    engines: { node: ">=4" }
-
   ansi-styles@4.3.0:
     resolution:
       {
@@ -10654,13 +10643,6 @@ packages:
     resolution:
       {
         integrity: sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==,
-      }
-    engines: { node: ">= 0.4" }
-
-  array.prototype.reduce@1.0.8:
-    resolution:
-      {
-        integrity: sha512-DwuEqgXFBwbmZSRqt3BpQigWNUoqw9Ml2dTWdF3B2zQlQX4OeUE0zyuzX0fX0IbTvjdkZbcBTU3idgpO78qkTw==,
       }
     engines: { node: ">= 0.4" }
 
@@ -11075,13 +11057,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  chalk@2.4.2:
-    resolution:
-      {
-        integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==,
-      }
-    engines: { node: ">=4" }
-
   chalk@3.0.0:
     resolution:
       {
@@ -11226,13 +11201,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  coa@2.0.2:
-    resolution:
-      {
-        integrity: sha512-q5/jG+YQnSy4nRTV4F7lPepBJZ8qBNJJDBuJdoejDyLXgmL7IEo+Le2JDZudFTFt7mrCqIRaSjws4ygRCTCAXA==,
-      }
-    engines: { node: ">= 4.0" }
-
   codehike@1.0.7:
     resolution:
       {
@@ -11243,12 +11211,6 @@ packages:
     resolution:
       {
         integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==,
-      }
-
-  color-convert@1.9.3:
-    resolution:
-      {
-        integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==,
       }
 
   color-convert@2.0.1:
@@ -11264,12 +11226,6 @@ packages:
         integrity: sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==,
       }
     engines: { node: ">=14.6" }
-
-  color-name@1.1.3:
-    resolution:
-      {
-        integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==,
-      }
 
   color-name@1.1.4:
     resolution:
@@ -11604,16 +11560,10 @@ packages:
     peerDependencies:
       postcss: ^8.4
 
-  css-select-base-adapter@0.1.1:
+  css-select@4.3.0:
     resolution:
       {
-        integrity: sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w==,
-      }
-
-  css-select@2.1.0:
-    resolution:
-      {
-        integrity: sha512-Dqk7LQKpwLoH3VovzZnkzegqNSuAziQyNZUcrdDM401iY+R5NkGBXGmtO05/yaXQziALuPogeG0b7UAgjnTJTQ==,
+        integrity: sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==,
       }
 
   css-select@5.2.2:
@@ -11627,13 +11577,6 @@ packages:
       {
         integrity: sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==,
       }
-
-  css-tree@1.0.0-alpha.37:
-    resolution:
-      {
-        integrity: sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==,
-      }
-    engines: { node: ">=8.0.0" }
 
   css-tree@1.1.3:
     resolution:
@@ -11655,13 +11598,6 @@ packages:
         integrity: sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==,
       }
     engines: { node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0 }
-
-  css-what@3.4.2:
-    resolution:
-      {
-        integrity: sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==,
-      }
-    engines: { node: ">= 6" }
 
   css-what@6.2.2:
     resolution:
@@ -12279,10 +12215,10 @@ packages:
         integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==,
       }
 
-  dom-serializer@0.2.2:
+  dom-serializer@1.4.1:
     resolution:
       {
-        integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==,
+        integrity: sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==,
       }
 
   dom-serializer@2.0.0:
@@ -12291,17 +12227,18 @@ packages:
         integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==,
       }
 
-  domelementtype@1.3.1:
-    resolution:
-      {
-        integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==,
-      }
-
   domelementtype@2.3.0:
     resolution:
       {
         integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==,
       }
+
+  domhandler@4.3.1:
+    resolution:
+      {
+        integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==,
+      }
+    engines: { node: ">= 4" }
 
   domhandler@5.0.3:
     resolution:
@@ -12322,10 +12259,10 @@ packages:
         integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==,
       }
 
-  domutils@1.7.0:
+  domutils@2.8.0:
     resolution:
       {
-        integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==,
+        integrity: sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==,
       }
 
   domutils@3.2.2:
@@ -12507,12 +12444,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  es-array-method-boxes-properly@1.0.0:
-    resolution:
-      {
-        integrity: sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==,
-      }
-
   es-define-property@1.0.1:
     resolution:
       {
@@ -12624,13 +12555,6 @@ packages:
       {
         integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==,
       }
-
-  escape-string-regexp@1.0.5:
-    resolution:
-      {
-        integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==,
-      }
-    engines: { node: ">=0.8.0" }
 
   escape-string-regexp@2.0.0:
     resolution:
@@ -12983,10 +12907,10 @@ packages:
         integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==,
       }
 
-  fast-uri@3.1.2:
+  fast-uri@3.1.3:
     resolution:
       {
-        integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==,
+        integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==,
       }
 
   fastestsmallesttextencoderdecoder@1.0.22:
@@ -13557,13 +13481,6 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  has-flag@3.0.0:
-    resolution:
-      {
-        integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==,
-      }
-    engines: { node: ">=4" }
-
   has-flag@4.0.0:
     resolution:
       {
@@ -13880,10 +13797,10 @@ packages:
         integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==,
       }
 
-  immutable@5.1.5:
+  immutable@5.1.9:
     resolution:
       {
-        integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==,
+        integrity: sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==,
       }
 
   import-fresh@3.3.1:
@@ -15153,12 +15070,6 @@ packages:
         integrity: sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==,
       }
 
-  mdn-data@2.0.4:
-    resolution:
-      {
-        integrity: sha512-iV3XNKw06j5Q7mi6h+9vbx23Tv7JkjEVgKHW4pimwyDGWm0OIQntJJ+u1C6mg6mK1EaTv42XQ7w76yuzH7M2cA==,
-      }
-
   memoize-one@5.2.1:
     resolution:
       {
@@ -15477,12 +15388,6 @@ packages:
       }
     engines: { node: ">=16 || 14 >=14.17" }
 
-  minimist@1.2.8:
-    resolution:
-      {
-        integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==,
-      }
-
   minipass-collect@2.0.1:
     resolution:
       {
@@ -15531,13 +15436,6 @@ packages:
         integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==,
       }
     engines: { node: ">=16 || 14 >=14.17" }
-
-  mkdirp@0.5.6:
-    resolution:
-      {
-        integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==,
-      }
-    hasBin: true
 
   mlly@1.8.0:
     resolution:
@@ -15960,13 +15858,6 @@ packages:
         integrity: sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==,
       }
     engines: { node: ">= 0.4" }
-
-  object.getownpropertydescriptors@2.1.8:
-    resolution:
-      {
-        integrity: sha512-qkHIGe4q0lSYMv0XI4SsBTJz3WaURhLvd0lKSgtVuOsJ2krg4SgMw3PIRQFMp07yi++UR3se2mkcLqsBNpBb/A==,
-      }
-    engines: { node: ">= 0.8" }
 
   object.values@1.2.1:
     resolution:
@@ -17664,12 +17555,6 @@ packages:
       }
     engines: { node: ">=16" }
 
-  sax@1.2.4:
-    resolution:
-      {
-        integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==,
-      }
-
   sax@1.4.1:
     resolution:
       {
@@ -18309,13 +18194,6 @@ packages:
       }
     engines: { node: ">=14.0.0" }
 
-  supports-color@5.5.0:
-    resolution:
-      {
-        integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==,
-      }
-    engines: { node: ">=4" }
-
   supports-color@7.2.0:
     resolution:
       {
@@ -18391,13 +18269,12 @@ packages:
         integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==,
       }
 
-  svgo@1.3.2:
+  svgo@2.8.3:
     resolution:
       {
-        integrity: sha512-yhy/sQYxR5BkC98CY7o31VGsg014AKLEPxdfhora76l36hD9Rdy5NZA/Ocn6yayNPgSamYdtX2rFJdcv07AYVw==,
+        integrity: sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==,
       }
-    engines: { node: ">=4.0.0" }
-    deprecated: This SVGO version is no longer supported. Upgrade to v2.x.x.
+    engines: { node: ">=10.13.0" }
     hasBin: true
 
   svgo@3.3.3:
@@ -19110,12 +18987,6 @@ packages:
         integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==,
       }
 
-  unquote@1.1.1:
-    resolution:
-      {
-        integrity: sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==,
-      }
-
   update-browserslist-db@1.1.3:
     resolution:
       {
@@ -19261,12 +19132,6 @@ packages:
     resolution:
       {
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==,
-      }
-
-  util.promisify@1.0.1:
-    resolution:
-      {
-        integrity: sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==,
       }
 
   uuid@11.1.0:
@@ -26376,8 +26241,6 @@ snapshots:
 
   "@types/prop-types@15.7.15": {}
 
-  "@types/q@1.5.8": {}
-
   "@types/react-dom@19.1.9(@types/react@19.1.12)":
     dependencies:
       "@types/react": 19.1.12
@@ -26952,7 +26815,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -26967,10 +26830,6 @@ snapshots:
   ansi-regex@6.2.2: {}
 
   ansi-sequence-parser@1.1.1: {}
-
-  ansi-styles@3.2.1:
-    dependencies:
-      color-convert: 1.9.3
 
   ansi-styles@4.3.0:
     dependencies:
@@ -27064,17 +26923,6 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.24.0
       es-shim-unscopables: 1.1.0
-
-  array.prototype.reduce@1.0.8:
-    dependencies:
-      call-bind: 1.0.8
-      call-bound: 1.0.4
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-array-method-boxes-properly: 1.0.0
-      es-errors: 1.3.0
-      es-object-atoms: 1.1.1
-      is-string: 1.1.1
 
   array.prototype.tosorted@1.1.4:
     dependencies:
@@ -27314,12 +27162,6 @@ snapshots:
     dependencies:
       chalk: 4.1.2
 
-  chalk@2.4.2:
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
-
   chalk@3.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -27408,12 +27250,6 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  coa@2.0.2:
-    dependencies:
-      "@types/q": 1.5.8
-      chalk: 2.4.2
-      q: 1.5.1
-
   codehike@1.0.7:
     dependencies:
       "@code-hike/lighter": 1.0.1
@@ -27426,10 +27262,6 @@ snapshots:
 
   collapse-white-space@2.1.0: {}
 
-  color-convert@1.9.3:
-    dependencies:
-      color-name: 1.1.3
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -27437,8 +27269,6 @@ snapshots:
   color-convert@3.1.3:
     dependencies:
       color-name: 2.1.0
-
-  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -27606,13 +27436,12 @@ snapshots:
     dependencies:
       postcss: 8.5.15
 
-  css-select-base-adapter@0.1.1: {}
-
-  css-select@2.1.0:
+  css-select@4.3.0:
     dependencies:
       boolbase: 1.0.0
-      css-what: 3.4.2
-      domutils: 1.7.0
+      css-what: 6.2.2
+      domhandler: 4.3.1
+      domutils: 2.8.0
       nth-check: 2.1.1
 
   css-select@5.2.2:
@@ -27629,11 +27458,6 @@ snapshots:
       css-color-keywords: 1.0.0
       postcss-value-parser: 4.2.0
 
-  css-tree@1.0.0-alpha.37:
-    dependencies:
-      mdn-data: 2.0.4
-      source-map: 0.6.1
-
   css-tree@1.1.3:
     dependencies:
       mdn-data: 2.0.14
@@ -27648,8 +27472,6 @@ snapshots:
     dependencies:
       mdn-data: 2.0.30
       source-map-js: 1.2.1
-
-  css-what@3.4.2: {}
 
   css-what@6.2.2: {}
 
@@ -27989,9 +27811,10 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  dom-serializer@0.2.2:
+  dom-serializer@1.4.1:
     dependencies:
       domelementtype: 2.3.0
+      domhandler: 4.3.1
       entities: 2.2.0
 
   dom-serializer@2.0.0:
@@ -28000,9 +27823,11 @@ snapshots:
       domhandler: 5.0.3
       entities: 4.5.0
 
-  domelementtype@1.3.1: {}
-
   domelementtype@2.3.0: {}
+
+  domhandler@4.3.1:
+    dependencies:
+      domelementtype: 2.3.0
 
   domhandler@5.0.3:
     dependencies:
@@ -28016,10 +27841,11 @@ snapshots:
     optionalDependencies:
       "@types/trusted-types": 2.0.7
 
-  domutils@1.7.0:
+  domutils@2.8.0:
     dependencies:
-      dom-serializer: 0.2.2
-      domelementtype: 1.3.1
+      dom-serializer: 1.4.1
+      domelementtype: 2.3.0
+      domhandler: 4.3.1
 
   domutils@3.2.2:
     dependencies:
@@ -28156,8 +27982,6 @@ snapshots:
       unbox-primitive: 1.1.0
       which-typed-array: 1.1.19
 
-  es-array-method-boxes-properly@1.0.0: {}
-
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
@@ -28260,8 +28084,6 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
-
-  escape-string-regexp@1.0.5: {}
 
   escape-string-regexp@2.0.0: {}
 
@@ -28526,7 +28348,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.3: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
@@ -28915,8 +28737,6 @@ snapshots:
 
   has-bigints@1.1.0: {}
 
-  has-flag@3.0.0: {}
-
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -29170,7 +28990,7 @@ snapshots:
 
   immer@9.0.21: {}
 
-  immutable@5.1.5: {}
+  immutable@5.1.9: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -29979,8 +29799,6 @@ snapshots:
 
   mdn-data@2.0.30: {}
 
-  mdn-data@2.0.4: {}
-
   memoize-one@5.2.1: {}
 
   merge-anything@5.1.7:
@@ -30317,8 +30135,6 @@ snapshots:
     dependencies:
       brace-expansion: 5.0.7
 
-  minimist@1.2.8: {}
-
   minipass-collect@2.0.1:
     dependencies:
       minipass: 7.1.2
@@ -30340,10 +30156,6 @@ snapshots:
   minipass@7.1.2: {}
 
   minipass@7.1.3: {}
-
-  mkdirp@0.5.6:
-    dependencies:
-      minimist: 1.2.8
 
   mlly@1.8.0:
     dependencies:
@@ -30587,16 +30399,6 @@ snapshots:
       define-properties: 1.2.1
       es-abstract: 1.24.0
       es-object-atoms: 1.1.1
-
-  object.getownpropertydescriptors@2.1.8:
-    dependencies:
-      array.prototype.reduce: 1.0.8
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      es-object-atoms: 1.1.1
-      gopd: 1.2.0
-      safe-array-concat: 1.1.3
 
   object.values@1.2.1:
     dependencies:
@@ -31851,7 +31653,7 @@ snapshots:
   sass@1.92.1:
     dependencies:
       chokidar: 4.0.3
-      immutable: 5.1.5
+      immutable: 5.1.9
       source-map-js: 1.2.1
     optionalDependencies:
       "@parcel/watcher": 2.5.1
@@ -31869,8 +31671,6 @@ snapshots:
       parse-css-color: 0.2.1
       postcss-value-parser: 4.2.0
       yoga-layout: 3.2.1
-
-  sax@1.2.4: {}
 
   sax@1.4.1: {}
 
@@ -31937,7 +31737,7 @@ snapshots:
   seti-icons@0.0.4:
     dependencies:
       "@types/svgo": 1.3.6
-      svgo: 1.3.2
+      svgo: 2.8.3
 
   sharp@0.33.5:
     dependencies:
@@ -32317,10 +32117,6 @@ snapshots:
 
   superstruct@2.0.2: {}
 
-  supports-color@5.5.0:
-    dependencies:
-      has-flag: 3.0.0
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -32352,21 +32148,15 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
-  svgo@1.3.2:
+  svgo@2.8.3:
     dependencies:
-      chalk: 2.4.2
-      coa: 2.0.2
-      css-select: 2.1.0
-      css-select-base-adapter: 0.1.1
-      css-tree: 1.0.0-alpha.37
+      commander: 7.2.0
+      css-select: 4.3.0
+      css-tree: 1.1.3
       csso: 4.2.0
-      js-yaml: 3.15.0
-      mkdirp: 0.5.6
-      object.values: 1.2.1
-      sax: 1.2.4
+      picocolors: 1.1.1
+      sax: 1.6.0
       stable: 0.1.8
-      unquote: 1.1.1
-      util.promisify: 1.0.1
 
   svgo@3.3.3:
     dependencies:
@@ -32855,8 +32645,6 @@ snapshots:
       webpack-sources: 3.3.3
       webpack-virtual-modules: 0.5.0
 
-  unquote@1.1.1: {}
-
   update-browserslist-db@1.1.3(browserslist@4.25.4):
     dependencies:
       browserslist: 4.25.4
@@ -32942,13 +32730,6 @@ snapshots:
     optional: true
 
   util-deprecate@1.0.2: {}
-
-  util.promisify@1.0.1:
-    dependencies:
-      define-properties: 1.2.1
-      es-abstract: 1.24.0
-      has-symbols: 1.1.0
-      object.getownpropertydescriptors: 2.1.8
 
   uuid@11.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,9 +16,13 @@ catalog:
 overrides:
   # Keep transitive build tooling on the release patched for GHSA-g7r4-m6w7-qqqr.
   "esbuild@>=0.17.0 <0.28.1": 0.28.1
-  # No patched seti-icons release is available; its SVGO 1 chain requires
-  # overriding nth-check across a major boundary.
-  "nth-check@<2.0.1": 2.1.1
+  # Pin transitive releases containing the latest Immutable.js 5 security fixes.
+  "immutable@>=5.0.0-beta.1 <5.1.8": 5.1.9
+  # Keep AJV's URI parser on the release patched for GHSA-4c8g-83qw-93j6.
+  "fast-uri@>=3.0.0 <3.1.3": 3.1.3
+  # seti-icons only consumes its prebuilt icon data at runtime, so its legacy
+  # SVGO dependency can safely use the first patched 2.x release.
+  "seti-icons@0.0.4>svgo": 2.8.3
   # @databricks/sql 2 requires Thrift's UUID dependency to remain CJS-compatible.
   # Package-level overrides are not inherited by pnpm consumers.
   "thrift@0.23.0>uuid": 11.1.1


### PR DESCRIPTION
### Problem

`pnpm audit --audit-level high --prod` fails on four high-severity advisories in transitive production dependencies: two Immutable.js denial-of-service advisories, a fast-uri host-confusion advisory, and an SVGO script-removal advisory.

### Summary of Changes

- Override vulnerable Immutable.js 5 releases with `5.1.9`.
- Override vulnerable fast-uri 3 releases with `3.1.3`.
- Move the legacy `seti-icons` SVGO dependency from `1.3.2` to patched `2.8.3`. This is safe because the package runtime consumes prebuilt icon JSON and does not import SVGO.
- Regenerate the lockfile, removing the obsolete SVGO 1 dependency tree and the redundant nth-check workaround.

### Validation

- `pnpm audit --audit-level high --prod` — passes; 0 high/critical findings
- `pnpm install --frozen-lockfile`
- `pnpm --filter solana-com-accelerate check-types`
- `pnpm --filter solana-com-accelerate lint` — 0 errors, 1 pre-existing warning
- `pnpm --filter solana-docs check-types`
- `pnpm --filter solana-docs lint`
- `seti-icons` runtime smoke test

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] Input from users or external services is validated before use; no new input handling or HTML rendering was added.
- [x] Updated dependencies are justified above, and `pnpm audit` passes with no High/Critical advisories.
- [x] Errors are handled explicitly; no production error paths changed.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependencies: none; existing transitive dependencies were updated.

Threat-model note: n/a