### PR TITLE
fix(security): patch audit advisories and scope PR audits

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,16 +44,50 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check for dependency changes
+        id: dependency-changes
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- \
+            package.json \
+            ':(glob)**/package.json' \
+            pnpm-lock.yaml \
+            pnpm-workspace.yaml \
+            .github/workflows/security.yml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No dependency inputs changed; the full audit runs on main and weekly."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Skip audit for unrelated pull request
+        if:
+          github.event_name == 'pull_request' &&
+          steps.dependency-changes.outputs.changed != 'true'
+        run: echo "Dependency audit not required for this pull request."
       - name: Install pnpm
+        if:
+          github.event_name != 'pull_request' ||
+          steps.dependency-changes.outputs.changed == 'true'
         uses: pnpm/action-setup@v6
         with:
           version: 11.13.0
           run_install: false
       - name: Install Node.js
+        if:
+          github.event_name != 'pull_request' ||
+          steps.dependency-changes.outputs.changed == 'true'
         uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
       - name: Audit production dependencies
+        if:
+          github.event_name != 'pull_request' ||
+          steps.dependency-changes.outputs.changed == 'true'
         # Fails on High/Critical advisories per the Solana Foundation SDLC.
         # Known-unfixable advisories are ignored via auditConfig.ignoreGhsas
         # in pnpm-workspace.yaml with a documented justification.

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -57,7 +57,7 @@
     "rtl-detect": "^1.1.2",
     "sass": "^1.80.7",
     "seti-icons": "^0.0.4",
-    "sharp": "^0.33.5",
+    "sharp": "^0.35.0",
     "svg-pan-zoom": "^3.6.2",
     "swr": "^2.2.5",
     "tailwind-merge": "^3.3.1",

--- a/apps/media/package.json
+++ b/apps/media/package.json
@@ -81,7 +81,7 @@
     "postcss": "^8.5.15",
     "postcss-import": "^16.1.1",
     "postcss-nesting": "^13.0.2",
-    "sharp": "^0.33.5",
+    "sharp": "^0.35.0",
     "typescript": "5.8.3",
     "vitest": "catalog:"
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -72,7 +72,7 @@
     "remark-gfm": "^4.0.1",
     "rtl-detect": "^1.1.2",
     "sass": "^1.80.7",
-    "sharp": "^0.33.5",
+    "sharp": "^0.35.0",
     "slick-carousel": "^1.8.1",
     "swr": "^2.2.5",
     "tailwind-merge": "^3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,7 +25,8 @@ catalogs:
 overrides:
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   immutable@>=5.0.0-beta.1 <5.1.8: 5.1.9
-  fast-uri@>=3.0.0 <3.1.3: 3.1.3
+  fast-uri@>=3.0.0 <3.1.4: 3.1.4
+  sharp@<0.35.0: 0.35.3
   seti-icons@0.0.4>svgo: 2.8.3
   thrift@0.23.0>uuid: 11.1.1
 
@@ -73,7 +74,7 @@ importers:
         version: 15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(postcss@8.5.15)))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.15))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -109,10 +110,10 @@ importers:
         version: 0.528.0(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -179,7 +180,7 @@ importers:
     dependencies:
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -203,10 +204,10 @@ importers:
         version: 12.40.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -270,7 +271,7 @@ importers:
         version: 0.1.2(unified@11.0.5)
       "@fumadocs/mdx-remote":
         specifier: ^1.4.10
-        version: 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       "@mdx-js/react":
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.1.12)(react@19.2.6)
@@ -306,7 +307,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -315,7 +316,7 @@ importers:
         version: link:../../packages/ui-chrome
       "@solana-foundation/solana-lib":
         specifier: ^2.40.3
-        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@vercel/og":
         specifier: ^0.8.6
         version: 0.8.6
@@ -348,13 +349,13 @@ importers:
         version: 3.2.0(date-fns@4.1.0)
       fumadocs-core:
         specifier: 15.6.12
-        version: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fumadocs-mdx:
         specifier: ^12.0.3
-        version: 12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1))
+        version: 12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1))
       fumadocs-ui:
         specifier: 14.7.7
-        version: 14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1))
+        version: 14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1))
       lodash:
         specifier: ^4.17.23
         version: 4.18.1
@@ -366,13 +367,13 @@ importers:
         version: 11.16.0
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-seo:
         specifier: ^6.6.0
-        version: 6.8.0(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       node-fetch-cache:
         specifier: ^5.1.0
         version: 5.1.0
@@ -410,8 +411,8 @@ importers:
         specifier: ^0.0.4
         version: 0.0.4
       sharp:
-        specifier: ^0.33.5
-        version: 0.33.5
+        specifier: ^0.35.0
+        version: 0.35.3(@types/node@24.13.3)
       svg-pan-zoom:
         specifier: ^3.6.2
         version: 3.6.2
@@ -487,10 +488,10 @@ importers:
         version: 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@keystatic/core":
         specifier: ^0.5.50
-        version: 0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@keystatic/next":
         specifier: ^5.0.4
-        version: 5.0.4(@keystatic/core@0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 5.0.4(@keystatic/core@0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@radix-ui/react-avatar":
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -499,7 +500,7 @@ importers:
         version: 1.2.4(@types/react@19.1.12)(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -550,10 +551,10 @@ importers:
         version: 12.40.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -661,8 +662,8 @@ importers:
         specifier: ^13.0.2
         version: 13.0.2(postcss@8.5.15)
       sharp:
-        specifier: ^0.33.5
-        version: 0.33.5
+        specifier: ^0.35.0
+        version: 0.35.3(@types/node@24.13.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -704,13 +705,13 @@ importers:
         version: 16.4.2
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       nuqs:
         specifier: ^2.4.3
-        version: 2.7.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6)
+        version: 2.7.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -822,7 +823,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -834,7 +835,7 @@ importers:
         version: link:../../packages/sitemap
       "@solana-foundation/solana-lib":
         specifier: ^2.40.3
-        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@typeform/embed":
         specifier: ^5.1.0
         version: 5.5.0
@@ -915,10 +916,10 @@ importers:
         version: 0.475.0(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -974,8 +975,8 @@ importers:
         specifier: ^1.80.7
         version: 1.92.1
       sharp:
-        specifier: ^0.33.5
-        version: 0.33.5
+        specifier: ^0.35.0
+        version: 0.35.3(@types/node@24.13.3)
       slick-carousel:
         specifier: ^1.8.1
         version: 1.8.1(jquery@3.7.1)
@@ -993,7 +994,7 @@ importers:
         version: 3.4.1
       unicornstudio-react:
         specifier: ^1.4.33
-        version: 1.5.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.5.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       yup:
         specifier: ^1.4.0
         version: 1.7.0
@@ -1226,10 +1227,10 @@ importers:
     dependencies:
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -1318,7 +1319,7 @@ importers:
         version: 0.528.0(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -1379,10 +1380,10 @@ importers:
         version: 2.5.1
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -3164,10 +3165,10 @@ packages:
       }
     engines: { node: ">=10.0.0" }
 
-  "@emnapi/runtime@1.5.0":
+  "@emnapi/runtime@1.11.2":
     resolution:
       {
-        integrity: sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==,
+        integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==,
       }
 
   "@emotion/babel-plugin@11.13.5":
@@ -3756,379 +3757,246 @@ packages:
         integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==,
       }
 
-  "@img/sharp-darwin-arm64@0.33.5":
+  "@img/colour@1.1.0":
     resolution:
       {
-        integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==,
+        integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=18" }
+
+  "@img/sharp-darwin-arm64@0.35.3":
+    resolution:
+      {
+        integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==,
+      }
+    engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [darwin]
 
-  "@img/sharp-darwin-arm64@0.34.3":
+  "@img/sharp-darwin-x64@0.35.3":
     resolution:
       {
-        integrity: sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg==,
+        integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [arm64]
-    os: [darwin]
-
-  "@img/sharp-darwin-x64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [darwin]
 
-  "@img/sharp-darwin-x64@0.34.3":
+  "@img/sharp-freebsd-wasm32@0.35.3":
     resolution:
       {
-        integrity: sha512-yHpJYynROAj12TA6qil58hmPmAwxKKC7reUqtGLzsOHfP7/rniNGTL8tjWX6L3CTV4+5P4ypcS7Pp+7OB+8ihA==,
+        integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [x64]
-    os: [darwin]
+    engines: { node: ">=20.9.0" }
+    os: [freebsd]
 
-  "@img/sharp-libvips-darwin-arm64@1.0.4":
+  "@img/sharp-libvips-darwin-arm64@1.3.2":
     resolution:
       {
-        integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==,
-      }
-    cpu: [arm64]
-    os: [darwin]
-
-  "@img/sharp-libvips-darwin-arm64@1.2.0":
-    resolution:
-      {
-        integrity: sha512-sBZmpwmxqwlqG9ueWFXtockhsxefaV6O84BMOrhtg/YqbTaRdqDE7hxraVE3y6gVM4eExmfzW4a8el9ArLeEiQ==,
+        integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==,
       }
     cpu: [arm64]
     os: [darwin]
 
-  "@img/sharp-libvips-darwin-x64@1.0.4":
+  "@img/sharp-libvips-darwin-x64@1.3.2":
     resolution:
       {
-        integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==,
+        integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@img/sharp-libvips-darwin-x64@1.2.0":
+  "@img/sharp-libvips-linux-arm64@1.3.2":
     resolution:
       {
-        integrity: sha512-M64XVuL94OgiNHa5/m2YvEQI5q2cl9d/wk0qFTDVXcYzi43lxuiFTftMR1tOnFQovVXNZJ5TURSDK2pNe9Yzqg==,
-      }
-    cpu: [x64]
-    os: [darwin]
-
-  "@img/sharp-libvips-linux-arm64@1.0.4":
-    resolution:
-      {
-        integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==,
+        integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==,
       }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-arm64@1.2.0":
+  "@img/sharp-libvips-linux-arm@1.3.2":
     resolution:
       {
-        integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==,
-      }
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-libvips-linux-arm@1.0.5":
-    resolution:
-      {
-        integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==,
+        integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==,
       }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-arm@1.2.0":
+  "@img/sharp-libvips-linux-ppc64@1.3.2":
     resolution:
       {
-        integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==,
-      }
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-libvips-linux-ppc64@1.2.0":
-    resolution:
-      {
-        integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==,
+        integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==,
       }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-s390x@1.0.4":
+  "@img/sharp-libvips-linux-riscv64@1.3.2":
     resolution:
       {
-        integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==,
+        integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==,
+      }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-libvips-linux-s390x@1.3.2":
+    resolution:
+      {
+        integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==,
       }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-s390x@1.2.0":
+  "@img/sharp-libvips-linux-x64@1.3.2":
     resolution:
       {
-        integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==,
-      }
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-libvips-linux-x64@1.0.4":
-    resolution:
-      {
-        integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==,
+        integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==,
       }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-x64@1.2.0":
+  "@img/sharp-libvips-linuxmusl-arm64@1.3.2":
     resolution:
       {
-        integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==,
-      }
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-libvips-linuxmusl-arm64@1.0.4":
-    resolution:
-      {
-        integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==,
+        integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==,
       }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-libvips-linuxmusl-arm64@1.2.0":
+  "@img/sharp-libvips-linuxmusl-x64@1.3.2":
     resolution:
       {
-        integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==,
-      }
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  "@img/sharp-libvips-linuxmusl-x64@1.0.4":
-    resolution:
-      {
-        integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==,
+        integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==,
       }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-libvips-linuxmusl-x64@1.2.0":
+  "@img/sharp-linux-arm64@0.35.3":
     resolution:
       {
-        integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==,
+        integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==,
       }
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  "@img/sharp-linux-arm64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-arm64@0.34.3":
+  "@img/sharp-linux-arm@0.35.3":
     resolution:
       {
-        integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==,
+        integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-linux-arm@0.33.5":
-    resolution:
-      {
-        integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-arm@0.34.3":
+  "@img/sharp-linux-ppc64@0.35.3":
     resolution:
       {
-        integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==,
+        integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [arm]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-linux-ppc64@0.34.3":
-    resolution:
-      {
-        integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-s390x@0.33.5":
+  "@img/sharp-linux-riscv64@0.35.3":
     resolution:
       {
-        integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==,
+        integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  "@img/sharp-linux-s390x@0.35.3":
+    resolution:
+      {
+        integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==,
+      }
+    engines: { node: ">=20.9.0" }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-s390x@0.34.3":
+  "@img/sharp-linux-x64@0.35.3":
     resolution:
       {
-        integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==,
+        integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [s390x]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-linux-x64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-x64@0.34.3":
+  "@img/sharp-linuxmusl-arm64@0.35.3":
     resolution:
       {
-        integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==,
+        integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  "@img/sharp-linuxmusl-arm64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-linuxmusl-arm64@0.34.3":
+  "@img/sharp-linuxmusl-x64@0.35.3":
     resolution:
       {
-        integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==,
+        integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  "@img/sharp-linuxmusl-x64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-linuxmusl-x64@0.34.3":
+  "@img/sharp-wasm32@0.35.3":
     resolution:
       {
-        integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==,
+        integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
+    engines: { node: ">=20.9.0" }
 
-  "@img/sharp-wasm32@0.33.5":
+  "@img/sharp-webcontainers-wasm32@0.35.3":
     resolution:
       {
-        integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==,
+        integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
     cpu: [wasm32]
 
-  "@img/sharp-wasm32@0.34.3":
+  "@img/sharp-win32-arm64@0.35.3":
     resolution:
       {
-        integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==,
+        integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [wasm32]
-
-  "@img/sharp-win32-arm64@0.34.3":
-    resolution:
-      {
-        integrity: sha512-MjnHPnbqMXNC2UgeLJtX4XqoVHHlZNd+nPt1kRPmj63wURegwBhZlApELdtxM2OIZDRv/DFtLcNhVbd1z8GYXQ==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [win32]
 
-  "@img/sharp-win32-ia32@0.33.5":
+  "@img/sharp-win32-ia32@0.35.3":
     resolution:
       {
-        integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==,
+        integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ^20.9.0 }
     cpu: [ia32]
     os: [win32]
 
-  "@img/sharp-win32-ia32@0.34.3":
+  "@img/sharp-win32-x64@0.35.3":
     resolution:
       {
-        integrity: sha512-xuCdhH44WxuXgOM714hn4amodJMZl3OEvf0GVTm0BEyMeA2to+8HEdRPShH0SLYptJY1uBw+SCFP9WVQi1Q/cw==,
+        integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [ia32]
-    os: [win32]
-
-  "@img/sharp-win32-x64@0.33.5":
-    resolution:
-      {
-        integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-    cpu: [x64]
-    os: [win32]
-
-  "@img/sharp-win32-x64@0.34.3":
-    resolution:
-      {
-        integrity: sha512-OWwz05d++TxzLEv4VnsTz5CmZ6mI6S05sfQGEMrNrQcOEERbX46332IvE7pO/EUiw7jUrrS40z/M7kPyjfl04g==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [win32]
 
@@ -11240,25 +11108,12 @@ packages:
       }
     engines: { node: ">=12.20" }
 
-  color-string@1.9.1:
-    resolution:
-      {
-        integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==,
-      }
-
   color-string@2.1.4:
     resolution:
       {
         integrity: sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==,
       }
     engines: { node: ">=18" }
-
-  color@4.2.3:
-    resolution:
-      {
-        integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==,
-      }
-    engines: { node: ">=12.5.0" }
 
   color@5.0.3:
     resolution:
@@ -12138,10 +11993,10 @@ packages:
     engines: { node: ">=0.10" }
     hasBin: true
 
-  detect-libc@2.0.4:
+  detect-libc@2.1.2:
     resolution:
       {
-        integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==,
+        integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==,
       }
     engines: { node: ">=8" }
 
@@ -12907,10 +12762,10 @@ packages:
         integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==,
       }
 
-  fast-uri@3.1.3:
+  fast-uri@3.1.4:
     resolution:
       {
-        integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==,
+        integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==,
       }
 
   fastestsmallesttextencoderdecoder@1.0.22:
@@ -13917,12 +13772,6 @@ packages:
     resolution:
       {
         integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==,
-      }
-
-  is-arrayish@0.3.2:
-    resolution:
-      {
-        integrity: sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==,
       }
 
   is-async-function@2.1.1:
@@ -17620,18 +17469,18 @@ packages:
       }
     hasBin: true
 
-  semver@7.7.2:
-    resolution:
-      {
-        integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==,
-      }
-    engines: { node: ">=10" }
-    hasBin: true
-
   semver@7.7.4:
     resolution:
       {
         integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
+
+  semver@7.8.5:
+    resolution:
+      {
+        integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==,
       }
     engines: { node: ">=10" }
     hasBin: true
@@ -17669,19 +17518,17 @@ packages:
         integrity: sha512-DXP6OzUzPtfSHQHKQ++U4mFByATGlN/fs5e43W3EAUtWf1FKauA3Li6Z2SQDB70l1m1Kr0mYzCtP6TsvRYT4Uw==,
       }
 
-  sharp@0.33.5:
+  sharp@0.35.3:
     resolution:
       {
-        integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==,
+        integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==,
       }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
-
-  sharp@0.34.3:
-    resolution:
-      {
-        integrity: sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==,
-      }
-    engines: { node: ^18.17.0 || ^20.3.0 || >=21.0.0 }
+    engines: { node: ">=20.9.0" }
+    peerDependencies:
+      "@types/node": "*"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
 
   shebang-command@2.0.0:
     resolution:
@@ -17749,12 +17596,6 @@ packages:
         integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
       }
     engines: { node: ">=14" }
-
-  simple-swizzle@0.2.2:
-    resolution:
-      {
-        integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==,
-      }
 
   sirv@2.0.4:
     resolution:
@@ -21047,7 +20888,7 @@ snapshots:
 
   "@discoveryjs/json-ext@0.5.7": {}
 
-  "@emnapi/runtime@1.5.0":
+  "@emnapi/runtime@1.11.2":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -21329,10 +21170,10 @@ snapshots:
     dependencies:
       "@formatjs/fast-memoize": 3.1.6
 
-  "@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)":
+  "@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@mdx-js/mdx": 3.1.1
-      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       js-yaml: 4.3.0
       react: 19.2.6
       unified: 11.0.5
@@ -21376,165 +21217,110 @@ snapshots:
       "@iconify/types": 2.0.0
       import-meta-resolve: 4.2.0
 
-  "@img/sharp-darwin-arm64@0.33.5":
+  "@img/colour@1.1.0": {}
+
+  "@img/sharp-darwin-arm64@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-darwin-arm64": 1.0.4
+      "@img/sharp-libvips-darwin-arm64": 1.3.2
     optional: true
 
-  "@img/sharp-darwin-arm64@0.34.3":
+  "@img/sharp-darwin-x64@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-darwin-arm64": 1.2.0
+      "@img/sharp-libvips-darwin-x64": 1.3.2
     optional: true
 
-  "@img/sharp-darwin-x64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-darwin-x64": 1.0.4
-    optional: true
-
-  "@img/sharp-darwin-x64@0.34.3":
-    optionalDependencies:
-      "@img/sharp-libvips-darwin-x64": 1.2.0
-    optional: true
-
-  "@img/sharp-libvips-darwin-arm64@1.0.4":
-    optional: true
-
-  "@img/sharp-libvips-darwin-arm64@1.2.0":
-    optional: true
-
-  "@img/sharp-libvips-darwin-x64@1.0.4":
-    optional: true
-
-  "@img/sharp-libvips-darwin-x64@1.2.0":
-    optional: true
-
-  "@img/sharp-libvips-linux-arm64@1.0.4":
-    optional: true
-
-  "@img/sharp-libvips-linux-arm64@1.2.0":
-    optional: true
-
-  "@img/sharp-libvips-linux-arm@1.0.5":
-    optional: true
-
-  "@img/sharp-libvips-linux-arm@1.2.0":
-    optional: true
-
-  "@img/sharp-libvips-linux-ppc64@1.2.0":
-    optional: true
-
-  "@img/sharp-libvips-linux-s390x@1.0.4":
-    optional: true
-
-  "@img/sharp-libvips-linux-s390x@1.2.0":
-    optional: true
-
-  "@img/sharp-libvips-linux-x64@1.0.4":
-    optional: true
-
-  "@img/sharp-libvips-linux-x64@1.2.0":
-    optional: true
-
-  "@img/sharp-libvips-linuxmusl-arm64@1.0.4":
-    optional: true
-
-  "@img/sharp-libvips-linuxmusl-arm64@1.2.0":
-    optional: true
-
-  "@img/sharp-libvips-linuxmusl-x64@1.0.4":
-    optional: true
-
-  "@img/sharp-libvips-linuxmusl-x64@1.2.0":
-    optional: true
-
-  "@img/sharp-linux-arm64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-arm64": 1.0.4
-    optional: true
-
-  "@img/sharp-linux-arm64@0.34.3":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-arm64": 1.2.0
-    optional: true
-
-  "@img/sharp-linux-arm@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-arm": 1.0.5
-    optional: true
-
-  "@img/sharp-linux-arm@0.34.3":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-arm": 1.2.0
-    optional: true
-
-  "@img/sharp-linux-ppc64@0.34.3":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-ppc64": 1.2.0
-    optional: true
-
-  "@img/sharp-linux-s390x@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-s390x": 1.0.4
-    optional: true
-
-  "@img/sharp-linux-s390x@0.34.3":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-s390x": 1.2.0
-    optional: true
-
-  "@img/sharp-linux-x64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-x64": 1.0.4
-    optional: true
-
-  "@img/sharp-linux-x64@0.34.3":
-    optionalDependencies:
-      "@img/sharp-libvips-linux-x64": 1.2.0
-    optional: true
-
-  "@img/sharp-linuxmusl-arm64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-arm64": 1.0.4
-    optional: true
-
-  "@img/sharp-linuxmusl-arm64@0.34.3":
-    optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-arm64": 1.2.0
-    optional: true
-
-  "@img/sharp-linuxmusl-x64@0.33.5":
-    optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-x64": 1.0.4
-    optional: true
-
-  "@img/sharp-linuxmusl-x64@0.34.3":
-    optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-x64": 1.2.0
-    optional: true
-
-  "@img/sharp-wasm32@0.33.5":
+  "@img/sharp-freebsd-wasm32@0.35.3":
     dependencies:
-      "@emnapi/runtime": 1.5.0
+      "@img/sharp-wasm32": 0.35.3
     optional: true
 
-  "@img/sharp-wasm32@0.34.3":
+  "@img/sharp-libvips-darwin-arm64@1.3.2":
+    optional: true
+
+  "@img/sharp-libvips-darwin-x64@1.3.2":
+    optional: true
+
+  "@img/sharp-libvips-linux-arm64@1.3.2":
+    optional: true
+
+  "@img/sharp-libvips-linux-arm@1.3.2":
+    optional: true
+
+  "@img/sharp-libvips-linux-ppc64@1.3.2":
+    optional: true
+
+  "@img/sharp-libvips-linux-riscv64@1.3.2":
+    optional: true
+
+  "@img/sharp-libvips-linux-s390x@1.3.2":
+    optional: true
+
+  "@img/sharp-libvips-linux-x64@1.3.2":
+    optional: true
+
+  "@img/sharp-libvips-linuxmusl-arm64@1.3.2":
+    optional: true
+
+  "@img/sharp-libvips-linuxmusl-x64@1.3.2":
+    optional: true
+
+  "@img/sharp-linux-arm64@0.35.3":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-arm64": 1.3.2
+    optional: true
+
+  "@img/sharp-linux-arm@0.35.3":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-arm": 1.3.2
+    optional: true
+
+  "@img/sharp-linux-ppc64@0.35.3":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-ppc64": 1.3.2
+    optional: true
+
+  "@img/sharp-linux-riscv64@0.35.3":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-riscv64": 1.3.2
+    optional: true
+
+  "@img/sharp-linux-s390x@0.35.3":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-s390x": 1.3.2
+    optional: true
+
+  "@img/sharp-linux-x64@0.35.3":
+    optionalDependencies:
+      "@img/sharp-libvips-linux-x64": 1.3.2
+    optional: true
+
+  "@img/sharp-linuxmusl-arm64@0.35.3":
+    optionalDependencies:
+      "@img/sharp-libvips-linuxmusl-arm64": 1.3.2
+    optional: true
+
+  "@img/sharp-linuxmusl-x64@0.35.3":
+    optionalDependencies:
+      "@img/sharp-libvips-linuxmusl-x64": 1.3.2
+    optional: true
+
+  "@img/sharp-wasm32@0.35.3":
     dependencies:
-      "@emnapi/runtime": 1.5.0
+      "@emnapi/runtime": 1.11.2
     optional: true
 
-  "@img/sharp-win32-arm64@0.34.3":
+  "@img/sharp-webcontainers-wasm32@0.35.3":
+    dependencies:
+      "@img/sharp-wasm32": 0.35.3
     optional: true
 
-  "@img/sharp-win32-ia32@0.33.5":
+  "@img/sharp-win32-arm64@0.35.3":
     optional: true
 
-  "@img/sharp-win32-ia32@0.34.3":
+  "@img/sharp-win32-ia32@0.35.3":
     optional: true
 
-  "@img/sharp-win32-x64@0.33.5":
-    optional: true
-
-  "@img/sharp-win32-x64@0.34.3":
+  "@img/sharp-win32-x64@0.35.3":
     optional: true
 
   "@inkeep/cxkit-color-mode@0.5.119": {}
@@ -21831,7 +21617,7 @@ snapshots:
 
   "@juggle/resize-observer@3.4.0": {}
 
-  "@keystar/ui@0.7.21(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@keystar/ui@0.7.21(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
       "@emotion/css": 11.13.5
@@ -21924,18 +21710,18 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@keystatic/core@0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@keystatic/core@0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
       "@braintree/sanitize-url": 6.0.4
       "@emotion/weak-memoize": 0.3.1
       "@floating-ui/react": 0.24.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@internationalized/string": 3.2.7
-      "@keystar/ui": 0.7.21(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@keystar/ui": 0.7.21(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@markdoc/markdoc": 0.4.0(@types/react@19.1.12)(react@19.2.6)
       "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -22006,13 +21792,13 @@ snapshots:
       - next
       - supports-color
 
-  "@keystatic/next@5.0.4(@keystatic/core@0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@keystatic/next@5.0.4(@keystatic/core@0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
-      "@keystatic/core": 0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@keystatic/core": 0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@types/react": 19.1.12
       chokidar: 3.6.0
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       server-only: 0.0.1
@@ -24545,7 +24331,7 @@ snapshots:
 
   "@sentry/core@10.11.0": {}
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.15))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.15))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -24559,7 +24345,7 @@ snapshots:
       "@sentry/vercel-edge": 10.11.0
       "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(postcss@8.5.15))
       chalk: 3.0.0
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -24572,7 +24358,7 @@ snapshots:
       - supports-color
       - webpack
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -24586,7 +24372,7 @@ snapshots:
       "@sentry/vercel-edge": 10.11.0
       "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       chalk: 3.0.0
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -24599,7 +24385,7 @@ snapshots:
       - supports-color
       - webpack
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -24613,7 +24399,7 @@ snapshots:
       "@sentry/vercel-edge": 10.11.0
       "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
       chalk: 3.0.0
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -24807,13 +24593,13 @@ snapshots:
       color: 5.0.3
       text-hex: 1.0.0
 
-  "@solana-foundation/solana-lib@2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@solana-foundation/solana-lib@2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@radix-ui/react-tooltip": 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@types/react-slick": 0.23.13
       class-variance-authority: 0.7.1
       html-react-parser: 5.2.6(@types/react@19.1.12)(react@19.2.6)
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       prismjs: 1.30.0
       react: 19.2.6
       react-countup: 6.5.3(react@19.2.6)
@@ -26815,7 +26601,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -27274,19 +27060,9 @@ snapshots:
 
   color-name@2.1.0: {}
 
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.2
-
   color-string@2.1.4:
     dependencies:
       color-name: 2.1.0
-
-  color@4.2.3:
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
 
   color@5.0.3:
     dependencies:
@@ -27783,7 +27559,7 @@ snapshots:
 
   detect-libc@1.0.3: {}
 
-  detect-libc@2.0.4: {}
+  detect-libc@2.1.2: {}
 
   detect-node-es@1.1.0: {}
 
@@ -28348,7 +28124,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.4: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
@@ -28469,7 +28245,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       "@formatjs/intl-localematcher": 0.6.1
       "@orama/orama": 3.1.14
@@ -28490,20 +28266,20 @@ snapshots:
       unist-util-visit: 5.1.0
     optionalDependencies:
       "@types/react": 19.1.12
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1)):
+  fumadocs-mdx@12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1)):
     dependencies:
       "@mdx-js/mdx": 3.1.1
       "@standard-schema/spec": 1.0.0
       chokidar: 4.0.3
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.4.0
-      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       js-yaml: 4.3.0
       lru-cache: 11.2.2
       mdast-util-to-markdown: 2.1.2
@@ -28516,14 +28292,14 @@ snapshots:
       unist-util-visit: 5.1.0
       zod: 4.4.3
     optionalDependencies:
-      "@fumadocs/mdx-remote": 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      "@fumadocs/mdx-remote": 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       vite: 7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1)):
+  fumadocs-ui@14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1)):
     dependencies:
       "@radix-ui/react-accordion": 1.2.12(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@radix-ui/react-collapsible": 1.1.12(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -28535,10 +28311,10 @@ snapshots:
       "@radix-ui/react-slot": 1.2.4(@types/react@19.1.12)(react@19.2.6)
       "@radix-ui/react-tabs": 1.1.13(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
-      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       lodash.merge: 4.6.2
       lucide-react: 0.473.0(react@19.2.6)
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-themes: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       postcss-selector-parser: 7.1.0
       react: 19.2.6
@@ -29055,8 +28831,6 @@ snapshots:
 
   is-arrayish@0.2.1: {}
 
-  is-arrayish@0.3.2: {}
-
   is-async-function@2.1.1:
     dependencies:
       async-function: 1.0.0
@@ -29439,7 +29213,7 @@ snapshots:
 
   lightningcss@1.32.0:
     dependencies:
-      detect-libc: 2.0.4
+      detect-libc: 2.1.2
     optionalDependencies:
       lightningcss-android-arm64: 1.32.0
       lightningcss-darwin-arm64: 1.32.0
@@ -30211,14 +29985,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.0: {}
 
-  next-intl@4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
+  next-intl@4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
     dependencies:
       "@formatjs/intl-localematcher": 0.8.10
       "@parcel/watcher": 2.5.1
       "@swc/core": 1.15.41(@swc/helpers@0.5.17)
       icu-minify: 4.13.0
       negotiator: 1.0.0
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl-swc-plugin-extractor: 4.13.0
       po-parser: 2.1.1
       react: 19.2.6
@@ -30242,9 +30016,9 @@ snapshots:
       - "@types/react"
       - supports-color
 
-  next-seo@6.8.0(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -30253,7 +30027,7 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1):
+  next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1):
     dependencies:
       "@next/env": 15.5.18
       "@swc/helpers": 0.5.15
@@ -30274,9 +30048,10 @@ snapshots:
       "@opentelemetry/api": 1.9.0
       "@playwright/test": 1.58.2
       sass: 1.92.1
-      sharp: 0.34.3
+      sharp: 0.35.3(@types/node@24.13.3)
     transitivePeerDependencies:
       - "@babel/core"
+      - "@types/node"
       - babel-plugin-macros
 
   no-case@3.0.4:
@@ -30356,12 +30131,12 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuqs@2.7.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6):
+  nuqs@2.7.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6):
     dependencies:
       "@standard-schema/spec": 1.0.0
       react: 19.2.6
     optionalDependencies:
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react-router: 6.3.0(react@19.2.6)
       react-router-dom: 6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
@@ -31706,9 +31481,9 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.2: {}
-
   semver@7.7.4: {}
+
+  semver@7.8.5: {}
 
   server-only@0.0.1: {}
 
@@ -31739,61 +31514,38 @@ snapshots:
       "@types/svgo": 1.3.6
       svgo: 2.8.3
 
-  sharp@0.33.5:
+  sharp@0.35.3(@types/node@24.13.3):
     dependencies:
-      color: 4.2.3
-      detect-libc: 2.0.4
-      semver: 7.7.2
+      "@img/colour": 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
     optionalDependencies:
-      "@img/sharp-darwin-arm64": 0.33.5
-      "@img/sharp-darwin-x64": 0.33.5
-      "@img/sharp-libvips-darwin-arm64": 1.0.4
-      "@img/sharp-libvips-darwin-x64": 1.0.4
-      "@img/sharp-libvips-linux-arm": 1.0.5
-      "@img/sharp-libvips-linux-arm64": 1.0.4
-      "@img/sharp-libvips-linux-s390x": 1.0.4
-      "@img/sharp-libvips-linux-x64": 1.0.4
-      "@img/sharp-libvips-linuxmusl-arm64": 1.0.4
-      "@img/sharp-libvips-linuxmusl-x64": 1.0.4
-      "@img/sharp-linux-arm": 0.33.5
-      "@img/sharp-linux-arm64": 0.33.5
-      "@img/sharp-linux-s390x": 0.33.5
-      "@img/sharp-linux-x64": 0.33.5
-      "@img/sharp-linuxmusl-arm64": 0.33.5
-      "@img/sharp-linuxmusl-x64": 0.33.5
-      "@img/sharp-wasm32": 0.33.5
-      "@img/sharp-win32-ia32": 0.33.5
-      "@img/sharp-win32-x64": 0.33.5
-
-  sharp@0.34.3:
-    dependencies:
-      color: 4.2.3
-      detect-libc: 2.0.4
-      semver: 7.7.4
-    optionalDependencies:
-      "@img/sharp-darwin-arm64": 0.34.3
-      "@img/sharp-darwin-x64": 0.34.3
-      "@img/sharp-libvips-darwin-arm64": 1.2.0
-      "@img/sharp-libvips-darwin-x64": 1.2.0
-      "@img/sharp-libvips-linux-arm": 1.2.0
-      "@img/sharp-libvips-linux-arm64": 1.2.0
-      "@img/sharp-libvips-linux-ppc64": 1.2.0
-      "@img/sharp-libvips-linux-s390x": 1.2.0
-      "@img/sharp-libvips-linux-x64": 1.2.0
-      "@img/sharp-libvips-linuxmusl-arm64": 1.2.0
-      "@img/sharp-libvips-linuxmusl-x64": 1.2.0
-      "@img/sharp-linux-arm": 0.34.3
-      "@img/sharp-linux-arm64": 0.34.3
-      "@img/sharp-linux-ppc64": 0.34.3
-      "@img/sharp-linux-s390x": 0.34.3
-      "@img/sharp-linux-x64": 0.34.3
-      "@img/sharp-linuxmusl-arm64": 0.34.3
-      "@img/sharp-linuxmusl-x64": 0.34.3
-      "@img/sharp-wasm32": 0.34.3
-      "@img/sharp-win32-arm64": 0.34.3
-      "@img/sharp-win32-ia32": 0.34.3
-      "@img/sharp-win32-x64": 0.34.3
-    optional: true
+      "@img/sharp-darwin-arm64": 0.35.3
+      "@img/sharp-darwin-x64": 0.35.3
+      "@img/sharp-freebsd-wasm32": 0.35.3
+      "@img/sharp-libvips-darwin-arm64": 1.3.2
+      "@img/sharp-libvips-darwin-x64": 1.3.2
+      "@img/sharp-libvips-linux-arm": 1.3.2
+      "@img/sharp-libvips-linux-arm64": 1.3.2
+      "@img/sharp-libvips-linux-ppc64": 1.3.2
+      "@img/sharp-libvips-linux-riscv64": 1.3.2
+      "@img/sharp-libvips-linux-s390x": 1.3.2
+      "@img/sharp-libvips-linux-x64": 1.3.2
+      "@img/sharp-libvips-linuxmusl-arm64": 1.3.2
+      "@img/sharp-libvips-linuxmusl-x64": 1.3.2
+      "@img/sharp-linux-arm": 0.35.3
+      "@img/sharp-linux-arm64": 0.35.3
+      "@img/sharp-linux-ppc64": 0.35.3
+      "@img/sharp-linux-riscv64": 0.35.3
+      "@img/sharp-linux-s390x": 0.35.3
+      "@img/sharp-linux-x64": 0.35.3
+      "@img/sharp-linuxmusl-arm64": 0.35.3
+      "@img/sharp-linuxmusl-x64": 0.35.3
+      "@img/sharp-webcontainers-wasm32": 0.35.3
+      "@img/sharp-win32-arm64": 0.35.3
+      "@img/sharp-win32-ia32": 0.35.3
+      "@img/sharp-win32-x64": 0.35.3
+      "@types/node": 24.13.3
 
   shebang-command@2.0.0:
     dependencies:
@@ -31845,10 +31597,6 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
-
-  simple-swizzle@0.2.2:
-    dependencies:
-      is-arrayish: 0.3.2
 
   sirv@2.0.4:
     dependencies:
@@ -32551,12 +32299,12 @@ snapshots:
       pako: 0.2.9
       tiny-inflate: 1.0.3
 
-  unicornstudio-react@1.5.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  unicornstudio-react@1.5.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
 
   unified-engine@11.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,8 +18,11 @@ overrides:
   "esbuild@>=0.17.0 <0.28.1": 0.28.1
   # Pin transitive releases containing the latest Immutable.js 5 security fixes.
   "immutable@>=5.0.0-beta.1 <5.1.8": 5.1.9
-  # Keep AJV's URI parser on the release patched for GHSA-4c8g-83qw-93j6.
-  "fast-uri@>=3.0.0 <3.1.3": 3.1.3
+  # Keep AJV's URI parser on the release patched for GHSA-v2hh-gcrm-f6hx.
+  "fast-uri@>=3.0.0 <3.1.4": 3.1.4
+  # Next.js 15 still requests Sharp 0.34, so force its optional dependency onto
+  # the current patched release containing the updated libvips binaries.
+  "sharp@<0.35.0": 0.35.3
   # seti-icons only consumes its prebuilt icon data at runtime, so its legacy
   # SVGO dependency can safely use the first patched 2.x release.
   "seti-icons@0.0.4>svgo": 2.8.3


### PR DESCRIPTION
## Summary

- update the fast-uri override to 3.1.4 for GHSA-v2hh-gcrm-f6hx
- upgrade and deduplicate Sharp to 0.35.3 for the patched libvips binaries
- run the pull-request dependency audit only when dependency inputs change
- keep full dependency audits on every main push and the weekly schedule

## Why

New advisories in the registry currently make the existing high-severity audit fail on every pull request, including changes that do not touch dependencies. This keeps dependency-changing pull requests gated while allowing unrelated pull requests to proceed; main and the weekly security run remain the full-repository sentinels.

## Validation

- pnpm audit --audit-level high --prod (passes; no high or critical findings)
- pnpm why fast-uri --prod (3.1.4 only)
- pnpm why sharp --prod (0.35.3 only)
- Sharp PNG conversion smoke test
- pnpm --filter solana-com-accelerate build
- Prettier and git diff checks