### PR TITLE
fix(media): replace Builder token extensions link

### DIFF
--- a/apps/media/content/posts/network-health-report-june-2025.mdx
+++ b/apps/media/content/posts/network-health-report-june-2025.mdx
@@ -97,7 +97,7 @@ Powerful tooling was released in the Solana ecosystem over the past year, includ
 
 ##### Token Extensions
 
-[Token extensions](https://cdn.builder.io/o/assets%2Fce0c7323a97a4d91bd0baa7490ec9139%2F83c26b9268f64400b8eb67442579a31a?alt=media&token=525415b0-d3ea-48d7-83d6-0fb0d9e522c6) (released in early 2024) are the next generation of the Solana Program Library Token standard. Over a dozen extensions, such as confidential transfers, transfer hooks, and interest-bearing tokens, provide advanced configurable functionality. Token extensions give teams flexibility and advanced features in their tokens.
+[Token extensions](https://xbjpr0reg4kgflon.public.blob.vercel-storage.com/token-extensions-paper.pdf) (released in early 2024) are the next generation of the Solana Program Library Token standard. Over a dozen extensions, such as confidential transfers, transfer hooks, and interest-bearing tokens, provide advanced configurable functionality. Token extensions give teams flexibility and advanced features in their tokens.
 
 Examples of products using Token Extensions include [PayPal’s PYUSD](https://solana.com/news/paypal-pyusd-on-solana) stablecoin and the [Global Dollar Network’s](https://globaldollar.com/) [USDG](https://explorer.solana.com/address/2u1tszSeqZ3qBWF3uNGPFc8TzMk2tdiwknnRMWGWjGWH/token-extensions).
 


### PR DESCRIPTION
### Problem

The June 2025 Network Health Report links the Token Extensions paper through the deprecated Builder CDN.

### Summary of Changes

- Replace the Builder asset URL with the Solana Vercel Blob URL.
- Preserve the existing six-page Token Extensions PDF destination.
- No code, dependencies, or security-sensitive behavior changed.

### Validation

- `pnpm --filter solana-com-media exec prettier --ignore-path ../../.prettierignore --check content/posts/network-health-report-june-2025.mdx`
- `pnpm --filter solana-com-media exec eslint content/posts/network-health-report-june-2025.mdx`
- `pnpm --filter solana-com-media test` — 91 tests passed
- Confirmed the replacement URL returns HTTP 200 with `application/pdf`

---

### Change classification (SDLC §2)

- [ ] Critical
- [ ] Standard
- [x] Low — content-only link migration with no security impact

### Security checklist

- [x] No secrets, tokens, or credentials added.
- [x] No user input or external service processing changed.
- [x] No dependencies added or updated.
- [x] No production error-handling paths changed.

New dependencies: none

Threat-model note: n/a