### PR TITLE
chore: update Next.js to 15.5.21

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     next:
-      specifier: 15.5.18
-      version: 15.5.18
+      specifier: 15.5.21
+      version: 15.5.21
     next-intl:
       specifier: 4.13.0
       version: 4.13.0
@@ -74,7 +74,7 @@ importers:
         version: 15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(postcss@8.5.15)))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.15))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -110,10 +110,10 @@ importers:
         version: 0.528.0(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -180,7 +180,7 @@ importers:
     dependencies:
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -204,10 +204,10 @@ importers:
         version: 12.40.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -271,7 +271,7 @@ importers:
         version: 0.1.2(unified@11.0.5)
       "@fumadocs/mdx-remote":
         specifier: ^1.4.10
-        version: 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       "@mdx-js/react":
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.1.12)(react@19.2.6)
@@ -307,7 +307,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -316,7 +316,7 @@ importers:
         version: link:../../packages/ui-chrome
       "@solana-foundation/solana-lib":
         specifier: ^2.40.3
-        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@vercel/og":
         specifier: ^0.8.6
         version: 0.8.6
@@ -349,13 +349,13 @@ importers:
         version: 3.2.0(date-fns@4.1.0)
       fumadocs-core:
         specifier: 15.6.12
-        version: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fumadocs-mdx:
         specifier: ^12.0.3
-        version: 12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1))
+        version: 12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1))
       fumadocs-ui:
         specifier: 14.7.7
-        version: 14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1))
+        version: 14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1))
       lodash:
         specifier: ^4.17.23
         version: 4.18.1
@@ -367,13 +367,13 @@ importers:
         version: 11.16.0
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-seo:
         specifier: ^6.6.0
-        version: 6.8.0(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       node-fetch-cache:
         specifier: ^5.1.0
         version: 5.1.0
@@ -488,10 +488,10 @@ importers:
         version: 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@keystatic/core":
         specifier: ^0.5.50
-        version: 0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.5.50(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@keystatic/next":
         specifier: ^5.0.4
-        version: 5.0.4(@keystatic/core@0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 5.0.4(@keystatic/core@0.5.50(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@radix-ui/react-avatar":
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -500,7 +500,7 @@ importers:
         version: 1.2.4(@types/react@19.1.12)(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -551,10 +551,10 @@ importers:
         version: 12.40.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -705,13 +705,13 @@ importers:
         version: 16.4.2
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       nuqs:
         specifier: ^2.4.3
-        version: 2.7.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6)
+        version: 2.7.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -823,7 +823,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -835,7 +835,7 @@ importers:
         version: link:../../packages/sitemap
       "@solana-foundation/solana-lib":
         specifier: ^2.40.3
-        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@typeform/embed":
         specifier: ^5.1.0
         version: 5.5.0
@@ -916,10 +916,10 @@ importers:
         version: 0.475.0(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -994,7 +994,7 @@ importers:
         version: 3.4.1
       unicornstudio-react:
         specifier: ^1.4.33
-        version: 1.5.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.5.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       yup:
         specifier: ^1.4.0
         version: 1.7.0
@@ -1227,10 +1227,10 @@ importers:
     dependencies:
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -1319,7 +1319,7 @@ importers:
         version: 0.528.0(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -1380,10 +1380,10 @@ importers:
         version: 2.5.1
       next:
         specifier: "catalog:"
-        version: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -4411,10 +4411,10 @@ packages:
         integrity: sha512-Egh7VRZktquGix3FdTiOtKhbz+67qYoAJyPyt2h0QEUBA1RA22fSDTCsihXtJvtKTYm2jom0cw8O3+BH4Xv4Aw==,
       }
 
-  "@next/env@15.5.18":
+  "@next/env@15.5.21":
     resolution:
       {
-        integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==,
+        integrity: sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw==,
       }
 
   "@next/eslint-plugin-next@15.5.19":
@@ -4437,77 +4437,77 @@ packages:
       "@mdx-js/react":
         optional: true
 
-  "@next/swc-darwin-arm64@15.5.18":
+  "@next/swc-darwin-arm64@15.5.21":
     resolution:
       {
-        integrity: sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==,
+        integrity: sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [darwin]
 
-  "@next/swc-darwin-x64@15.5.18":
+  "@next/swc-darwin-x64@15.5.21":
     resolution:
       {
-        integrity: sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==,
+        integrity: sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
     os: [darwin]
 
-  "@next/swc-linux-arm64-gnu@15.5.18":
+  "@next/swc-linux-arm64-gnu@15.5.21":
     resolution:
       {
-        integrity: sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==,
+        integrity: sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@next/swc-linux-arm64-musl@15.5.18":
+  "@next/swc-linux-arm64-musl@15.5.21":
     resolution:
       {
-        integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==,
+        integrity: sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@next/swc-linux-x64-gnu@15.5.18":
+  "@next/swc-linux-x64-gnu@15.5.21":
     resolution:
       {
-        integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==,
+        integrity: sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@next/swc-linux-x64-musl@15.5.18":
+  "@next/swc-linux-x64-musl@15.5.21":
     resolution:
       {
-        integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==,
+        integrity: sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@next/swc-win32-arm64-msvc@15.5.18":
+  "@next/swc-win32-arm64-msvc@15.5.21":
     resolution:
       {
-        integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==,
+        integrity: sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [win32]
 
-  "@next/swc-win32-x64-msvc@15.5.18":
+  "@next/swc-win32-x64-msvc@15.5.21":
     resolution:
       {
-        integrity: sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==,
+        integrity: sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
@@ -15456,10 +15456,10 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@15.5.18:
+  next@15.5.21:
     resolution:
       {
-        integrity: sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==,
+        integrity: sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ==,
       }
     engines: { node: ^18.18.0 || ^19.8.0 || >= 20.0.0 }
     hasBin: true
@@ -21170,10 +21170,10 @@ snapshots:
     dependencies:
       "@formatjs/fast-memoize": 3.1.6
 
-  "@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)":
+  "@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@mdx-js/mdx": 3.1.1
-      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       js-yaml: 4.3.0
       react: 19.2.6
       unified: 11.0.5
@@ -21617,7 +21617,7 @@ snapshots:
 
   "@juggle/resize-observer@3.4.0": {}
 
-  "@keystar/ui@0.7.21(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@keystar/ui@0.7.21(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
       "@emotion/css": 11.13.5
@@ -21710,18 +21710,18 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@keystatic/core@0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@keystatic/core@0.5.50(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
       "@braintree/sanitize-url": 6.0.4
       "@emotion/weak-memoize": 0.3.1
       "@floating-ui/react": 0.24.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@internationalized/string": 3.2.7
-      "@keystar/ui": 0.7.21(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@keystar/ui": 0.7.21(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@markdoc/markdoc": 0.4.0(@types/react@19.1.12)(react@19.2.6)
       "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -21792,13 +21792,13 @@ snapshots:
       - next
       - supports-color
 
-  "@keystatic/next@5.0.4(@keystatic/core@0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@keystatic/next@5.0.4(@keystatic/core@0.5.50(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
-      "@keystatic/core": 0.5.50(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@keystatic/core": 0.5.50(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@types/react": 19.1.12
       chokidar: 3.6.0
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       server-only: 0.0.1
@@ -21875,7 +21875,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  "@next/env@15.5.18": {}
+  "@next/env@15.5.21": {}
 
   "@next/eslint-plugin-next@15.5.19":
     dependencies:
@@ -21888,28 +21888,28 @@ snapshots:
       "@mdx-js/loader": 3.1.1(webpack@5.101.3(postcss@8.5.15))
       "@mdx-js/react": 3.1.1(@types/react@19.1.12)(react@19.2.6)
 
-  "@next/swc-darwin-arm64@15.5.18":
+  "@next/swc-darwin-arm64@15.5.21":
     optional: true
 
-  "@next/swc-darwin-x64@15.5.18":
+  "@next/swc-darwin-x64@15.5.21":
     optional: true
 
-  "@next/swc-linux-arm64-gnu@15.5.18":
+  "@next/swc-linux-arm64-gnu@15.5.21":
     optional: true
 
-  "@next/swc-linux-arm64-musl@15.5.18":
+  "@next/swc-linux-arm64-musl@15.5.21":
     optional: true
 
-  "@next/swc-linux-x64-gnu@15.5.18":
+  "@next/swc-linux-x64-gnu@15.5.21":
     optional: true
 
-  "@next/swc-linux-x64-musl@15.5.18":
+  "@next/swc-linux-x64-musl@15.5.21":
     optional: true
 
-  "@next/swc-win32-arm64-msvc@15.5.18":
+  "@next/swc-win32-arm64-msvc@15.5.21":
     optional: true
 
-  "@next/swc-win32-x64-msvc@15.5.18":
+  "@next/swc-win32-x64-msvc@15.5.21":
     optional: true
 
   "@noble/curves@1.9.7":
@@ -24331,7 +24331,7 @@ snapshots:
 
   "@sentry/core@10.11.0": {}
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.15))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.15))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -24345,7 +24345,7 @@ snapshots:
       "@sentry/vercel-edge": 10.11.0
       "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(postcss@8.5.15))
       chalk: 3.0.0
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -24358,7 +24358,7 @@ snapshots:
       - supports-color
       - webpack
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -24372,7 +24372,7 @@ snapshots:
       "@sentry/vercel-edge": 10.11.0
       "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
       chalk: 3.0.0
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -24385,7 +24385,7 @@ snapshots:
       - supports-color
       - webpack
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -24399,7 +24399,7 @@ snapshots:
       "@sentry/vercel-edge": 10.11.0
       "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
       chalk: 3.0.0
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -24593,13 +24593,13 @@ snapshots:
       color: 5.0.3
       text-hex: 1.0.0
 
-  "@solana-foundation/solana-lib@2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@solana-foundation/solana-lib@2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@radix-ui/react-tooltip": 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@types/react-slick": 0.23.13
       class-variance-authority: 0.7.1
       html-react-parser: 5.2.6(@types/react@19.1.12)(react@19.2.6)
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       prismjs: 1.30.0
       react: 19.2.6
       react-countup: 6.5.3(react@19.2.6)
@@ -28245,7 +28245,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       "@formatjs/intl-localematcher": 0.6.1
       "@orama/orama": 3.1.14
@@ -28266,20 +28266,20 @@ snapshots:
       unist-util-visit: 5.1.0
     optionalDependencies:
       "@types/react": 19.1.12
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1)):
+  fumadocs-mdx@12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1)):
     dependencies:
       "@mdx-js/mdx": 3.1.1
       "@standard-schema/spec": 1.0.0
       chokidar: 4.0.3
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.4.0
-      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       js-yaml: 4.3.0
       lru-cache: 11.2.2
       mdast-util-to-markdown: 2.1.2
@@ -28292,14 +28292,14 @@ snapshots:
       unist-util-visit: 5.1.0
       zod: 4.4.3
     optionalDependencies:
-      "@fumadocs/mdx-remote": 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      "@fumadocs/mdx-remote": 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       vite: 7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1)):
+  fumadocs-ui@14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1)):
     dependencies:
       "@radix-ui/react-accordion": 1.2.12(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@radix-ui/react-collapsible": 1.1.12(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -28311,10 +28311,10 @@ snapshots:
       "@radix-ui/react-slot": 1.2.4(@types/react@19.1.12)(react@19.2.6)
       "@radix-ui/react-tabs": 1.1.13(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
-      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       lodash.merge: 4.6.2
       lucide-react: 0.473.0(react@19.2.6)
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-themes: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       postcss-selector-parser: 7.1.0
       react: 19.2.6
@@ -29985,14 +29985,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.0: {}
 
-  next-intl@4.13.0(@swc/helpers@0.5.17)(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
+  next-intl@4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
     dependencies:
       "@formatjs/intl-localematcher": 0.8.10
       "@parcel/watcher": 2.5.1
       "@swc/core": 1.15.41(@swc/helpers@0.5.17)
       icu-minify: 4.13.0
       negotiator: 1.0.0
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl-swc-plugin-extractor: 4.13.0
       po-parser: 2.1.1
       react: 19.2.6
@@ -30016,9 +30016,9 @@ snapshots:
       - "@types/react"
       - supports-color
 
-  next-seo@6.8.0(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -30027,24 +30027,24 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1):
+  next@15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1):
     dependencies:
-      "@next/env": 15.5.18
+      "@next/env": 15.5.21
       "@swc/helpers": 0.5.15
-      caniuse-lite: 1.0.30001793
+      caniuse-lite: 1.0.30001806
       postcss: 8.4.31
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.6)
     optionalDependencies:
-      "@next/swc-darwin-arm64": 15.5.18
-      "@next/swc-darwin-x64": 15.5.18
-      "@next/swc-linux-arm64-gnu": 15.5.18
-      "@next/swc-linux-arm64-musl": 15.5.18
-      "@next/swc-linux-x64-gnu": 15.5.18
-      "@next/swc-linux-x64-musl": 15.5.18
-      "@next/swc-win32-arm64-msvc": 15.5.18
-      "@next/swc-win32-x64-msvc": 15.5.18
+      "@next/swc-darwin-arm64": 15.5.21
+      "@next/swc-darwin-x64": 15.5.21
+      "@next/swc-linux-arm64-gnu": 15.5.21
+      "@next/swc-linux-arm64-musl": 15.5.21
+      "@next/swc-linux-x64-gnu": 15.5.21
+      "@next/swc-linux-x64-musl": 15.5.21
+      "@next/swc-win32-arm64-msvc": 15.5.21
+      "@next/swc-win32-x64-msvc": 15.5.21
       "@opentelemetry/api": 1.9.0
       "@playwright/test": 1.58.2
       sass: 1.92.1
@@ -30131,12 +30131,12 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuqs@2.7.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6):
+  nuqs@2.7.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6):
     dependencies:
       "@standard-schema/spec": 1.0.0
       react: 19.2.6
     optionalDependencies:
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react-router: 6.3.0(react@19.2.6)
       react-router-dom: 6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
@@ -32299,12 +32299,12 @@ snapshots:
       pako: 0.2.9
       tiny-inflate: 1.0.3
 
-  unicornstudio-react@1.5.2(next@15.5.18(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  unicornstudio-react@1.5.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
-      next: 15.5.18(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
 
   unified-engine@11.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,7 @@ packages:
 verifyDepsBeforeRun: false
 
 catalog:
-  next: 15.5.18
+  next: 15.5.21
   next-intl: 4.13.0
   react: 19.2.6
   react-dom: 19.2.6


### PR DESCRIPTION
### Problem

The workspace currently pins Next.js 15.5.18 and needs the 15.5.21 patch release across all catalog consumers.

### Summary of Changes

- Update the shared Next.js catalog entry from 15.5.18 to 15.5.21.
- Regenerate the pnpm lockfile for the updated Next.js dependency graph.
- No application code or runtime configuration changes.

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] No user-input or external-service handling paths changed.
- [ ] Updated dependency is justified below. The audit still reports two pre-existing transitive High advisories; neither dependency is changed by this PR.
- [x] No production error-handling paths changed.
- [ ] For Critical changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

Updated dependency: Next.js 15.5.21, a patch upgrade to the shared framework version used across the workspace.

Audit note: pnpm audit --audit-level high reports existing advisories in bigint-buffer and svgo. This PR does not introduce or update either dependency.

Threat-model note: n/a

### Validation

- pnpm install --frozen-lockfile
- pnpm check-types
- pnpm lint (passes with existing warnings)
- pnpm audit --audit-level high (reports the two pre-existing advisories noted above)