### PR TITLE
docs: add task guides to the cookbook

### DIFF
--- a/apps/docs/content/cookbook/accounts/calculate-rent.mdx
+++ b/apps/docs/content/cookbook/accounts/calculate-rent.mdx
@@ -6,9 +6,9 @@ description:
 ---
 
 Keeping accounts alive on Solana incurs a data storage cost called
-[rent](/docs/core/accounts#rent). For the calculation, you need to consider the
-amount of data you intend to store in the account. Rent can be reclaimed in full
-if the account is closed.
+[rent](/docs/core/accounts/account-structure). For the calculation, you need to
+consider the amount of data you intend to store in the account. Rent can be
+reclaimed in full if the account is closed.
 
 <CodeTabs storage="cookbook" flags="r">
 

--- a/apps/docs/content/cookbook/depin.mdx
+++ b/apps/docs/content/cookbook/depin.mdx
@@ -1,0 +1,481 @@
+---
+featured: false
+featuredPriority: 1
+date: 2025-07-29T00:00:00Z
+difficulty: beginner
+seoTitle: "DePIN Quickstart Guide"
+title: "Physical Infrastructure (DePIN)"
+description:
+  "While each DePIN network has a unique product focus, most DePIN networks
+  utilize Solana for a common set of use-cases. This guide is meant to help
+  builders get oriented to common onchain DePIN use-cases."
+keywords:
+  - DePIN
+  - token
+  - governance
+tags:
+  - depin
+  - governance
+  - zk compression
+---
+
+DePIN (Decentralized Physical Infrastructure Network) refers to blockchain-based
+networks that incentivize the deployment, operation, and sharing of real-world
+physical infrastructure through decentralized mechanisms. These networks
+leverage tokens to reward participants for contributing to and maintaining the
+infrastructure, creating a decentralized alternative to traditional centralized
+systems. Examples include wireless, content delivery, and mapping networks.
+
+For instance, Helium creates a wireless network more cheaply than traditional
+carriers by enabling individuals to deploy and maintain network hotspots. This
+approach eliminates the need for centralized infrastructure investments and
+operational costs, allowing the network to scale more cost-effectively.
+
+While each DePIN network has a unique product focus, most DePIN networks utilize
+Solana for a common set of use cases. This guide is meant to help builders get
+oriented to these common onchain DePIN use cases. Topics covered include:
+
+- [Choosing a blockchain for your DePIN](#choosing-a-blockchain-for-your-depin-and-why-you-should-choose-solana)
+- [What to use blockchain for in a DePIN](#what-to-use-blockchain-for-in-a-depin)
+- [Minting and managing a token](#minting-and-managing-a-token)
+- [Staking](#staking)
+- [Rewards Distribution](#rewards-distribution)
+- [Proof of Contribution](#proof-of-contribution--consensus)
+- [Storage](#storage)
+- [Logging onchain demand](#logging-onchain-demand)
+- [Governance](#governance)
+- [Migrations](#migrations)
+- [Examples & reference code](#examples-and-reference-code)
+
+## Choosing a blockchain for your DePIN (and why you should choose Solana)
+
+There are many reasons to build on Solana, including the deep DeFi ecosystem,
+the opportunity to collaborate with the world's biggest DePIN projects, and the
+incredible community of early adopters and deployers. Below, we focus at a high
+level on some of the technical tradeoffs builders should consider when building
+a DePIN and reasons to build on Solana from a technical perspective:
+
+- **Scalability, combined with market access**: Solana's architecture processes
+  thousands of transactions per second–all on a single global state. Solana is
+  unique in its ability to offer best in class scalability, combined with broad
+  access to internet capital markets. Solana's DeFi ecosystem is second to none,
+  simplifying access to the world's biggest internet capital markets.
+- **Affordability**: Solana average transaction costs are ~.00025SOL, enabling
+  microtransactions that are unfeasible on many other chains. Compression
+  technologies like merkelization, cNFTs, and zk proofs also offer opportunities
+  for further cost reduction.
+- **Ready-made-tooling**: Solana offers SDKs, oracles (like Pyth), and
+  frameworks for DeFi and NFTs, to accelerate development cycles.
+  - **Development framework**: Anchor framework provides type safety, IDL
+    integration, and standardized program architecture, reducing boilerplate
+    code by ~40%.
+  - **Existing protocol integrations**: Native interfaces for oracles (Pyth,
+    Switchboard), cross-chain messaging (Wormhole), and identity verification
+    (Solana Attestation Service) reduce integration effort.
+- **Strong consumer UX**: Solana offers a range of best-in-class consumer
+  wallets, including Phantom, Solflare, and Backpack.
+
+Some DePIN teams consider rolling their own chains. Launching a proprietary
+chain comes with significant added complexity and cost, both from the up front
+build and requiring continued maintenance. These are some considerations teams
+should think through:
+
+- **Exchange Integration Pipeline**: Rolling your own chain requires maintenance
+  of custom node implementations for centralized exchange APIs (approximately
+  1-2 FTEs annually). This applies to DeFi protocols as well.
+- **Hardware Security Modules**: Developing and maintaining signing applications
+  for hardware wallets like Ledger (3-6 months of engineering work)
+- **Bridge integration**: Proprietary integration with bridges like Wormhole,
+  Chainlink, LayerZero, versus taking advantage of existing infrastructure.
+  These bridges will often charge significant amounts for integration.
+- **Infra/research talent recruitment**: Teams must manage and recruit their own
+  talent to improve the core L1 experience.
+- **Explorers and analytics integrations**
+- **Custodian and community infrastructure integration**: Custody solutions and
+  custodians typically have a long integration backlog and will charge for
+  integrations.
+- **Existing DePIN community**: It's much easier to gain early adopters among
+  existing DePIN holders, and the largest such community is already on Solana.
+
+We recommend this
+[in-depth technical analysis](https://medium.com/@hrknsinst/why-every-major-depin-project-is-migrating-to-solana-and-what-this-reveals-about-the-a3269ea431a7)
+of why major DePINs have been migrating to Solana. It includes a deep dive on
+the impact of migrations of major projects onto Solana, including throughput and
+blockspeed, node growth, and transaction cost.
+
+Notably, Helium started out as a proprietary L1 and migrated to Solana after
+concluding that running their own chain was too burdensome.
+
+## What to use blockchain for in a DePIN
+
+In DePIN, blockchains are particularly good for rewards distribution. DePINs
+reward node operators for their contributions to the network. These rewards
+happen in discrete (often small) amounts, are distributed globally, and need to
+be linked directly to one's contributions to the network. These are all good use
+cases for blockchain.
+
+DePIN Node operators provide a service that often requires additional computing
+resources. For example, a mapping company requires somewhere to store data
+collected through the process of map creation. Unless there's a strong reason
+otherwise, this mapping data generally should not be stored on a blockchain–it's
+expensive and a poor use of what blockchain is good at.
+
+Teams often believe that data collected through the servicing of a DePIN should
+be stored on chain for verifiability purposes (ie, in order to ensure the
+accuracy of the data and that it was collected without cheating, it must be
+stored on chain). There are almost always ways to ensure the verifiability of
+data without storing it all on chain. For example:
+
+- The data can be stored on a decentralized blockchain, unlike Solana, that
+  specializes in data storage (such as Filecoin)
+- You can utilize proofs to verify individual nodes' contributions to the
+  network
+- Data can be saved on chain using a trusted oracle that allows for saving
+  verifiable proofs of data on chain instead. Tools like
+  [Data Anchor](https://dataanchor.com/) from Termina can help with this
+  process.
+
+When building your DePIN, we encourage you to consider what parts of your
+project belong on chain and which do not. Generally, rewards distributions
+should happen on chain, and not much else. Rewards are typically distributed in
+the form of a token, which brings us to token minting and management.
+
+## Minting and Managing a Token
+
+### Issuing rewards before token launch
+
+TGEs (token generating events) are a business decision, and deciding whether,
+when, and how to conduct one is your team's prerogative.
+
+Many DePIN projects launch without a live token, in order to make progress in
+their business before doing a TGE. These projects make their product available
+to beta users and identify another way (such as points) to track users'
+contributions to the network, so they can reward them commensurately after
+tokens are launched. Teams that make this choice often cite the need to better
+understand the supply/demand dynamics and tackle major bugs in their project
+before going live.
+
+### Token Minting
+
+When minting a token on Solana, there are two token programs to choose from: the
+[Token program](https://spl.solana.com/token) or the
+[Token22 program](https://spl.solana.com/token-2022). There are tradeoffs to
+consider (discussed
+[here](https://solana.stackexchange.com/questions/9205/what-is-the-advantage-of-using-the-token22-token-extensions-program-over-the-old)).
+The recommended selection between the two options ultimately reduces to whether
+the features in the token extensions program would be of use to the application.
+
+For most developers, we recommend using the Token Program, unless your team is
+Solana native and has a deep understanding of the Token22 program, its
+tradeoffs, and a specific reason why Token22 would be useful to your
+application.
+
+### Token Listing
+
+In order to have your token appear in explorers, decentralized exchanges, and
+other ecosystem token lists,
+[getting the token verified through Jupiter Verification](https://station.jup.ag/guides/general/get-your-token-on-jupiter)
+is recommended.
+
+### Modeling Token Distribution
+
+For DePIN teams looking to optimize the way they allocate their token across
+various needs and stakeholders (rewards for participating / supplying network
+resources, private or public token sales etc.), tools like
+[Forgd](https://www.forgd.com/) can be used to model out and refine token
+distribution strategies.
+
+### Token Management
+
+Most teams utilize [DFNS](https://www.dfns.co/),
+[Fireblocks](https://www.fireblocks.com/), [Squads](https://squads.so/) or
+[Utila](https://utila.io/) for their on chain treasury management, and leverage
+features such as MPC, multi-sig, and time-based lockups. Squads allows for
+multi-sig setups for treasury wallets and governance, while DFNS, Fireblocks,
+and Utila leverage MPC.
+
+One option to manage internal token distributions and vesting is
+[Pulley](https://pulley.com/). For distributions at the protocol level (for
+example, distributing tokens to contributors), you might check out
+[Magna](https://magna.so/).
+
+Squads can be used for free, while DFNS, Fireblocks, and Utila charge for
+enterprise licenses.
+
+## Staking
+
+DePINs can implement staking mechanisms for nodes in the underlying network.
+This enables the ability to introduce a higher set of staked nodes to
+participate in consensus protocol (see below) and/or utilize stake to coordinate
+work and rewards across devices, ensuring economic alignment in the network.
+[Jito Network](https://www.jito.network/) currently operates Solana's largest
+stake pool and is building staking infrastructure to enable any DePIN to build
+custom proof of stake protocol. See the
+[full documentation here](https://jito-foundation.gitbook.io/jito/).
+
+For example, [DAWN](https://www.dawninternet.com/) is using Jito Network's
+staking infrastructure to build its proof of bandwidth protocol. In this
+construction, a set of staked "challenger" node operators are running ping tests
+on DAWN devices to measure backhaul metrics. This node operator set builds a log
+of accounts and backhaul metrics, performs an operation on the results to
+calculate rewards for each device, and submits a log containing claimants,
+metrics, and rewards to an onchain program to facilitate rewards distributions
+on Solana. Stake and/or rewards can be slashed or refunded based on results and
+post-consensus operations.
+
+## Rewards Distribution
+
+A critical decision in DePIN architecture design is how and how often to
+distribute your token. There are three major approaches to rewards
+distributions:
+
+1. **Claim based**: Users have to claim their reward. This can be done in
+   multiple ways, detailed further below.
+2. **Push based**: Rewards are directly sent to contributors. It's the most
+   expensive structure, due to the direct nature of the reward distribution.
+
+Of these, a claims-based model is strongly recommended, given its efficiency.
+There are also ways to combine these models, such as allowing users to automate
+claiming-on-demand (Helium does this). However, it's recommended to start with
+one model and then add customizations as your solution scales.
+
+Below, we dig in deeper on how the push and claim based approaches work, and
+compare the costs of each approach.
+
+### Claim based distribution
+
+Users have to claim their reward. This can be done in multiple ways:
+
+- Via an off chain oracle that signs messages that people can use to claim in
+  combination with on chain accounts that save the already claimed rewards
+- By co-signing claim transactions via an oracle
+- Saving the whole data on chain and calculating the rewards on the demand
+- Web2 backend where people authenticate and register with their wallet
+  addresses and sending transactions from the backend on demand
+
+Costs can be reduced by using Merkle tree airdrop on a customizable reward
+cadence.
+
+Reward distribution via Merkle tree allows for efficient batch processing of
+claims. This approach is used to minimize the number of transactions on the
+blockchain by allowing users to claim their rewards based on a published Merkle
+root.
+
+The application constructs a Merkle tree on a regular basis and publishes the
+root onchain. Each leaf node represents a recipient's rewards.
+
+In order for users to claim their rewards, they generate a Merkle proof that
+demonstrates a particular leaf is part of the published Merkle root. Once their
+claim is verified, the rewards are distributed to the user's wallet.
+
+See
+[example code](https://gist.github.com/lanvidr/88a594da06ba867bf8201fe8c6331dc0)
+and
+[Jupiter's Merkle distributor](https://github.com/jup-ag/merkle-distributor-sdk)
+for an additional reference.
+
+You can also use [Tuktuk](https://github.com/helium/tuktuk), a primitive
+published by Helium, to push reward claims via remote oracle.
+
+### Push based distribution
+
+An alternative to having users proactively claim rewards is automating rewards
+distribution. On a regular basis, this "rewards crank" fetches rewards for an
+associated set of users by querying and constructing transactions to distribute
+rewards to the specified accounts. Merkle tree updates can be posted by the
+automated process, allowing for the reward distribution mechanism to remain
+permissionless.
+
+[Dispatch](https://github.com/paxosglobal/dispatch) is a reference
+implementation for efficient and secure distribution of PYUSD to many recipients
+for applications such as Universal Basic Income (UBI) and can be adapted for
+push-based distribution.
+
+### An alternative to Merkle Trees - ZK Compression
+
+For networks that anticipate needing to distribute rewards to tens of thousands
+(or more) of nodes, participants, or contributors, a newer approach to rewards
+distribution is to use [ZK compression](https://www.zkcompression.com/). Instead
+of regular accounts, compressed accounts are generated for reward recipients,
+minimizing the state and [rent costs](/docs/core/accounts/account-structure)
+associated with account creation.
+
+Implementing ZK compression is often cheaper in terms of storage costs. However,
+because it is a relatively new feature, the level of ecosystem support and
+tooling is not yet as extensive.
+
+See
+[example code](https://gist.github.com/lanvidr/4595f7b02236ffb2a3fb3ce9347ca044).
+
+### Cost analysis
+
+Let's estimate the cost of distributing rewards using both the Merkle tree
+approach and the ZK compression option. We'll consider transaction fees, rent
+costs, and storage costs.
+
+In both approaches, updating the rewards per claim period requires a single
+transaction by the application, so the cost difference is minimal, as it doesn't
+scale per the number of users. Both strategies require one transaction per user
+to claim their rewards.
+
+ZK compression is more cost-effective in storage costs, due to the reduced
+storage requirements of compressed data. Here is a hypothetical cost analysis to
+compare the storage costs.
+
+If we assume a reward distribution to 10,000 users, with an average reward
+amount per user of 100 tokens, and the transaction fee on Solana to be 0.000007
+SOL (7,000 lamports):
+
+**Storage Costs using a Merkle tree distribution strategy:**
+
+- The Merkle tree requires storing the leaf nodes and the internal nodes
+  - Leaf Nodes: 10,000 \* 32 bytes = 320,000 bytes
+  - Internal Nodes: (2^14 - 1) \* 32 bytes = 524,256 bytes
+  - Total Storage Cost: (320,000 + 524,256) \* 0.00000348 SOL/byte (per epoch) =
+    2.94 SOL
+- Total Cost (Merkle Tree): 0.050005 SOL + 0.00007323 SOL + 2.94 SOL = 2.99 SOL
+
+**Storage Costs using a ZK compression distribution strategy:**
+
+- Compressed Token Account: The compressed token account stores the compressed
+  reward data
+  - Compressed Data Size: Assuming a compression ratio of 50%, the total
+    compressed data size would be approximately 500 KB
+- Total Storage Cost: 500 \* 1024 \* 0.00000348 SOL/byte (per epoch) = 1.78 SOL
+- Total Cost (ZK Compression): 0.050005 SOL + 0.00000223 SOL + 1.78 SOL = 1.83
+  SOL
+
+**Storage Costs without compression:**
+
+- Saving the claimed amount in a normal Solana account state
+- Saving authority, device pubkey and claimed amount comes down to 72 bytes ->
+  0.001392 SOL in rent cost per account
+- Not scaling very well for big networks but has less complexity and the costs
+  can be distributed to the users theoretically
+
+We can extrapolate this across different numbers of reward distributions:
+
+| Number of Distributions | Merkle Tree Storage Cost (SOL) | ZK Compression Storage Cost (SOL) | No compression |
+| ----------------------- | ------------------------------ | --------------------------------- | -------------- |
+| 1,000                   | 0.06                           | 0.03                              | 1.392          |
+| 10,000                  | 0.58                           | 0.29                              | 13.92          |
+| 100,000                 | 5.80                           | 2.90                              | 139.2          |
+| 1,000,000               | 58.00                          | 29.00                             | 1392           |
+| 5,000,000               | 290.00                         | 145.00                            | 6960           |
+
+## Proof of Contribution / Consensus
+
+DePIN networks generally need a way to prove contributions from network
+participants. The application needs a method of verifying that participants have
+provided the resource in question honestly and consistently. As DePIN networks
+scale, proof of contributions are critical to ensuring the data or resource
+you're providing are real, a necessary step for teams who want to scale to serve
+major companies or institutions.
+
+Reporting the contributions through Solana makes it possible to use the
+blockchain's inherent security properties to enable the secure validation of the
+contribution.
+
+While almost all DePIN networks require proof-of-contribution in some form, the
+exact mechanism can vary significantly from protocol to protocol. A number of
+teams are building tooling to help DePIN projects develop their proof of
+contribution model (check out
+[Proof of Coverage by Helium](https://docs.helium.com/iot/proof-of-coverage)).
+
+In addition, DePINs can incrementally decentralize these offchain proof of
+contribution processes by introducing node operators that achieve consensus on
+contributions.
+
+[Jito Network](https://www.jito.network/) is building infrastructure to enable
+implementing custom consensus protocols (called node consensus networks) that
+decentralize proof of contribution models. E.g. a distributed set of staked node
+operators can participate in proof of coverage and achieve consensus on
+contributions to inform the correct distribution of rewards (and enforce
+economic penalties). (See "Staking" section above). For more information about
+Jito's staking infrastructure, see their
+[docs](https://jito-foundation.gitbook.io/jito/) and this
+[implementation guide](https://jito-foundation.gitbook.io/jito/ncn-development)
+to walk through key components for building NCNs.
+
+## Storage
+
+DePIN networks use a range of options for storage. Remember, it's important to
+separate between your needs for what needs to happen on chain (primarily,
+rewards distribution), versus off chain (often, storage of data collected from
+running nodes, such as photos or video).
+
+## Logging onchain demand
+
+DePINs are two sided marketplaces. Supply is facilitated by your node operators,
+and reflecting supply on chain is a more straightforward process, since it's
+demonstrable in the token rewards distributed to node operators.
+
+As your project grows, reflecting demand on chain is an important step to bring
+transparency and trust into your project and the blockchain infrastructure.
+
+There are many ways to reflect demand on chain. One method is through
+[IO.net's](https://io.net/) model of "Total Network Earnings" or TNE. TNE makes
+it simple for users to track:
+
+- Total network earnings over time
+- Daily earnings trends
+- On chain transactions
+
+[Helium Mobile](https://mobile.helium.com/) takes a similar approach through
+their [Helium World explorer](https://explorer.helium.com/), which maps global
+hotposts, monthly revenue, daily users, and data transfers.
+
+## Governance
+
+DePIN protocols tend to follow a path of measured, gradual decentralization that
+shifts decision-making for the protocol to onchain governance by token holders
+over time. This could take the form of a social framework like a
+[DAO](https://www.realms.today/) or leverage
+[liquid restaking](https://docs.fragmetric.xyz/fragsol/).
+
+For examples, see
+[Modular Governance by Helium](https://docs.helium.com/governance/staking-with-helium-vote/)
+or
+[Network Governance by Hivemapper](https://docs.hivemapper.com/welcome/network-governance).
+
+## Migrations
+
+If you are a DePIN builder who has historically only been familiar with building
+on EVM, not to worry! A number of large DePIN teams who began on EVM chains have
+successfully migrated to Solana (see Render, Geodnet, and Xnet, amongst others).
+There are
+[specific resources to help developers make the transition from EVM to SVM](/developers/evm-to-svm).
+Bridge infrastructure like
+[Wormhole's NTT](https://wormhole.com/products/native-token-transfers)
+streamline the process of shifting your tokens to Solana.
+
+Read the
+[proposal for Render Network's migration here](https://gov.render.com/t/rip-17-rndr-migration-to-solana/1378).
+
+![DePIN Migration to Solana](/assets/guides/depin/migration-chart.png)
+
+Source:
+[Why Every Major DePIN Project is Migrating to Solana](https://medium.com/@hrknsinst/why-every-major-depin-project-is-migrating-to-solana-and-what-this-reveals-about-the-a3269ea431a7)
+
+## Examples and reference code
+
+Check out these sample reference implementations that might be useful as you
+build your DePIN:
+
+- [Reward Distribution examples](https://github.com/solana-foundation/depin-examples)
+  using an offchain oracle and an anchor program writing temperature data and
+  rewarding the users in SPL tokens
+- [Rewards Distribution "How to" video](https://youtu.be/dAF1BGFF6Jc)
+- [Data Anchor by Termina](https://dataanchor.com/): Anchor large batches of
+  device data directly on Solana using Termina
+- [Write Sensor data on chain](https://github.com/solana-foundation/depin-examples):
+  How to write sensor on chain using a Solana Pay transaction request
+- [Claiming Rewards (Helium's approach)](https://github.com/helium/tuktuk)
+
+Access the full
+[Solana Foundation DePIN examples repo](https://github.com/solana-foundation/depin-examples).
+
+### Case studies
+
+[Helium's Noah Prince explains how Helium works](https://youtu.be/gLb4Q78N1og)
+and the details of Helium's migration to Solana.

--- a/apps/docs/content/cookbook/development/airdrops-and-faucets.mdx
+++ b/apps/docs/content/cookbook/development/airdrops-and-faucets.mdx
@@ -1,0 +1,203 @@
+---
+date: 2023-07-29T00:00:00Z
+featured: true
+difficulty: intro
+title: "How to get Solana devnet SOL (including airdrops and faucets)"
+seoTitle: "Faucets: How to get Solana devnet SOL"
+description:
+  "A list of the most common ways to get devnet and testnet SOL tokens for
+  Solana development. Including: airdrop, web3.js, POW faucet, and more."
+tags:
+  - faucet
+keywords:
+  - faucet
+  - blockchain
+  - devnet
+  - testnet
+---
+
+# How to get Solana devnet SOL (including airdrops and faucets)
+
+This is a collection of the different ways for developers to acquire SOL on
+Solana's testing networks, the Solana devnet and testnet.
+
+## 1. Solana Airdrop
+
+_Available on Devnet and Testnet_
+
+This is the base way of acquiring SOL, but it can be subject to rate limits when
+there is a high number of airdrops.
+
+Here are three different ways of requesting airdrops with it:
+
+### Using the Solana CLI:
+
+```shell
+solana airdrop 2
+```
+
+### Using web3.js:
+
+```js
+const connection = new Connection("https://api.devnet.solana.com");
+connection.requestAirdrop();
+```
+
+See more:
+[`requestAirdrop()`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#requestAirdrop)
+documentation inside web3.js.
+
+## 2. Web Faucet
+
+_Available for Devnet_
+
+1. [faucet.solana.com](https://faucet.solana.com) - A public web faucet hosted
+   by the Solana Foundation
+2. [SolFaucet.com](https://solfaucet.com/) - Web UI for airdrops from the public
+   RPC endpoints
+3. [QuickNode](https://faucet.quicknode.com/solana/devnet) - A web faucet
+   operated by QuickNode
+4. [DevnetFaucet.org](https://devnetfaucet.org) - A web faucet with a rate limit
+   separate than the public RPC endpoints, operated by
+   [@Ferric](https://twitter.com/ferric)
+5. [Blueshift Faucet](https://faucet.blueshift.gg) - A web faucet for Blueshift
+   NFT holders
+6. [Pine Stake Faucet](https://www.pinestake.com/faucet) - A public web faucet
+   hosted by Pine Stake
+
+_Available for Testnet_
+
+1. [faucet.solana.com](https://faucet.solana.com) - A public web faucet hosted
+   by the Solana Foundation
+2. [SolFaucet.com](https://solfaucet.com/) - Web UI for airdrops from the public
+   RPC endpoints
+3. [QuickNode](https://faucet.quicknode.com/solana/testnet) - A web faucet
+   operated by QuickNode
+4. [TestnetFaucet.org](https://testnetfaucet.org) - A web faucet with a rate
+   limit separate than the public RPC endpoints, operated by
+   [@Ferric](https://twitter.com/ferric)
+5. [Blueshift Faucet](https://faucet.blueshift.gg) - A web faucet for Blueshift
+   NFT holders
+6. [Pine Stake Faucet](https://www.pinestake.com/faucet) - A public web faucet
+   hosted by Pine Stake
+
+## 3. RPC Provider Faucets
+
+_Available for Devnet_
+
+RPC Providers can opt in to distributing devnet SOL via their devnet Validators.
+
+> If you are an RPC Provider and want to distribute SOL please
+> [get in touch here](https://c852ena8x5c.typeform.com/to/cUj1iRhS).
+
+Currently supported:
+
+1. [Helius](https://www.helius.dev/)
+2. [QuickNode](https://faucet.quicknode.com/solana/devnet)
+3. [Triton](https://triton.one/)
+
+### Using the Solana CLI
+
+Specify your [Cluster](/docs/references/clusters) to be your RPC provider's URL:
+
+```shell
+solana config set --url <your RPC url>
+```
+
+Then you can request an airdrop like you would in the first option in this
+guide:
+
+```shell
+solana airdrop 2
+```
+
+### Using Web3.js
+
+```js
+const connection = new Connection("your RPC url");
+connection.requestAirdrop();
+```
+
+## 4. Proof of work Faucet
+
+_Available for Devnet_
+
+This is a proof of work Faucet where devnet SOL can be distributed to you thanks
+to your computing power.
+
+**Install the Devnet POW Crate:**
+
+```shell
+cargo install devnet-pow
+```
+
+**Start mining devnet SOL**
+
+```shell
+devnet-pow mine
+```
+
+_⚠️ The [POW Faucet](https://github.com/jarry-xiao/proof-of-work-faucet) is
+maintained by Ellipsis Labs_
+
+## 5. Discord Faucets
+
+Various Discord communities have setup devnet SOL Faucets as BOTs.
+
+| Community      | Usage                                                       | Link                                         |
+| -------------- | ----------------------------------------------------------- | -------------------------------------------- |
+| The 76 Devs    | Run `!gibsol` in the BOT commands channel.                  | [Join Server](https://discord.gg/RrChGyDeRv) |
+| The LamportDAO | Run `/drop <address> <amount>` in the BOT commands channel. | [Join Server](https://discord.gg/JBVrJgtFkq) |
+
+## 6. Reuse devnet SOL
+
+The most sustainable way to save SOL is to reuse it. With the Solana CLI you can
+show and close all previous buffer accounts with the following command:
+
+```shell
+solana program show --buffers
+```
+
+<Callout title="What's a buffer account?">
+
+Buffer accounts are automatically created when you deploy a program. All the
+program's data is transferred into this account during the deployment. When its
+done, the data of your program is replaced with the new data.
+
+</Callout>
+
+Normally, these buffer accounts are closed automatically. In the event they are
+not, you can close them manually to reclaim the SOL in them using the following
+command:
+
+```shell
+solana program close <buffer account>
+```
+
+You can also the `show` subcommand to show all programs you deployed have
+already deployed to your currently selected cluster:
+
+```shell
+solana program show --programs
+```
+
+You can then close each program with the `close` subcommand to close them and
+retrieve the SOL you used to deploy them:
+
+```shell
+solana program close <program id>
+```
+
+You can then use that SOL to deploy new programs.
+
+<Callout type="warn">
+
+You will **NOT** able to use the same program id again once you closed the
+program. So make sure are closing the right program and that you will not need
+that id anymore.
+
+If you get rate limited by the RPC endpoint your Solana CLI is configured to
+use, you can add `-u "urlToYourRpc"` to the any of these command to use a
+different RPC endpoint.
+
+</Callout>

--- a/apps/docs/content/cookbook/development/crud-dapp.mdx
+++ b/apps/docs/content/cookbook/development/crud-dapp.mdx
@@ -1,0 +1,585 @@
+---
+date: 2024-03-18T00:00:00Z
+difficulty: intro
+title: "How to create a CRUD dApp on Solana"
+description:
+  "Solana developer quickstart guide to learn how to create a basic CRUD dApp on
+  the Solana blockchain with a simple journal program and interact with the
+  program via a UI."
+tags:
+  - quickstart
+  - dApp
+  - crud
+  - anchor
+  - rust
+  - react
+  - program
+keywords:
+  - solana dapp
+  - onchain
+  - rust
+  - anchor program
+  - crud dapp
+  - create dapp
+  - create solana dapp
+  - tutorial
+  - intro to solana development
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+  - web3 crud app
+---
+
+In this guide, you will learn how to create and deploy both the Solana program
+and UI for a basic onchain CRUD dApp. This dApp will allow you to create journal
+entries, update journal entries, read journal entries, and delete journal
+entries all through onchain transactions.
+
+## What you will learn
+
+- Setting up your environment
+- Using `npx create-solana-dapp`
+- Anchor program development
+- Anchor PDAs and accounts
+- Deploying a Solana program
+- Testing an onchain program
+- Connecting an onchain program to a React UI
+
+## Prerequisites
+
+For this guide, you will need to have your local development environment setup
+with a few tools:
+
+- [Rust](https://www.rust-lang.org/tools/install)
+- [Node JS](https://nodejs.org/en/download)
+- [Solana CLI & Anchor](/docs/intro/installation)
+
+## Setting up the project
+
+```shell
+npx create-solana-dapp
+```
+
+This CLI command enables quick Solana dApp creation. You can find the source
+code [here](https://github.com/solana-developers/create-solana-dapp).
+
+Now respond to the prompts as follows:
+
+- Enter project name: `my-journal-dapp`
+- Select a preset: `Next.js`
+- Select a UI library: `Tailwind`
+- Select an Anchor template: `counter` program
+
+By selecting `counter` for the Anchor template, a simple counter
+[program](/docs/references/terminology#program), written in rust using the
+Anchor framework, will be generated for you. Before we start editing this
+generated template program, let's make sure everything is working as expected:
+
+```shell
+cd my-journal-dapp
+
+npm install
+
+npm run dev
+```
+
+## Writing a Solana program with Anchor
+
+If you're new to Anchor, [The Anchor Book](https://www.anchor-lang.com/docs) and
+[Anchor Examples](https://examples.anchor-lang.com/) are great references to
+help you learn.
+
+In `my-journal-dapp`, navigate to `anchor/programs/journal/src/lib.rs`. There
+will already be template code generated in this folder. Let's delete it and
+start from scratch so we can walk through each step.
+
+### Define your Anchor program
+
+```rust
+use anchor_lang::prelude::*;
+
+// This is your program's public key and it will update automatically when you build the project.
+declare_id!("7AGmMcgd1SjoMsCcXAAYwRgB9ihCyM8cZqjsUqriNRQt");
+
+#[program]
+pub mod journal {
+    use super::*;
+}
+```
+
+### Define your program state
+
+The state is the data structure used to define the information you want to save
+to the account. Since Solana onchain programs do not have storage, the data is
+stored in accounts that live on the blockchain.
+
+When using Anchor, the `#[account]` attribute macro is used to define your
+program state.
+
+```rust
+#[account]
+#[derive(InitSpace)]
+pub struct JournalEntryState {
+    pub owner: Pubkey,
+    #[max_len(50)]
+    pub title: String,
+     #[max_len(1000)]
+    pub message: String,
+}
+```
+
+For this journal dApp, we will be storing:
+
+- the journal's owner
+- the title of each journal entry, and
+- the message of each journal entry
+
+Note: Space must be defined when initializing an account. The `InitSpace` macro
+used in the above code will help calculate the space needed when initializing an
+account. For more information on space, read
+[here](https://www.anchor-lang.com/docs/space#the-init-space-macro).
+
+### Create a journal entry
+
+Now, let's add an
+[instruction handler](/docs/references/terminology#instruction-handler) to this
+program that creates a new journal entry. To do this, we will update the
+`#[program]` code that we already defined earlier to include an instruction for
+`create_journal_entry`.
+
+When creating a journal entry, the user will need to provide the `title` and
+`message` of the journal entry. So we need to add those two variables as
+additional arguments.
+
+When calling this instruction handler function, we want to save the `owner` of
+the account, the journal entry `title`, and the journal entry `message` to the
+account's `JournalEntryState`.
+
+```rust
+#[program]
+mod journal {
+    use super::*;
+
+    pub fn create_journal_entry(
+        ctx: Context<CreateEntry>,
+        title: String,
+        message: String,
+    ) -> Result<()> {
+        msg!("Journal Entry Created");
+        msg!("Title: {}", title);
+        msg!("Message: {}", message);
+
+        let journal_entry = &mut ctx.accounts.journal_entry;
+        journal_entry.owner = ctx.accounts.owner.key();
+        journal_entry.title = title;
+        journal_entry.message = message;
+        Ok(())
+    }
+}
+```
+
+With the Anchor framework, every instruction takes a `Context` type as its first
+argument. The `Context` macro is used to define a struct that encapsulates
+accounts that will be passed to a given instruction handler. Therefore, each
+`Context` must have a specified type with respect to the instruction handler. In
+our case, we need to define a data structure for `CreateEntry`:
+
+```rust
+#[derive(Accounts)]
+#[instruction(title: String, message: String)]
+pub struct CreateEntry<'info> {
+    #[account(
+        init_if_needed,
+        seeds = [title.as_bytes(), owner.key().as_ref()],
+        bump,
+        payer = owner,
+        space = 8 + JournalEntryState::INIT_SPACE
+    )]
+    pub journal_entry: Account<'info, JournalEntryState>,
+    #[account(mut)]
+    pub owner: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+```
+
+In the above code, we used the following macros:
+
+- `#[derive(Accounts)]` macro is used to deserialize and validate the list of
+  accounts specified within the struct
+- `#[instruction(...)]` attribute macro is used to access the instruction data
+  passed into the instruction handler
+- `#[account(...)]` attribute macro then specifies additional constraints on the
+  accounts
+
+Each journal entry is a Program Derived Address ( [PDA](/docs/core/pda)) that
+stores the entries state onchain. Since we are creating a new journal entry
+here, it needs to be initialized using the `init_if_needed` constraint.
+
+With Anchor, a PDA is initialized with the `seeds`, `bumps`, and
+`init_if_needed` constraints. The `init_if_needed` constraint also requires the
+`payer` and `space` constraints to define who is paying the
+[rent](/docs/references/terminology#rent) to hold this account's data onchain
+and how much space needs to be allocated for that data.
+
+Note: By using the `InitSpace` macro in the `JournalEntryState`, we are able to
+calculate space by using the `INIT_SPACE` constant and adding `8` to the space
+constraint for Anchor's internal discriminator.
+
+### Updating a journal entry
+
+Now that we can create a new journal entry, let's add an `update_journal_entry`
+instruction handler with a context that has an `UpdateEntry` type.
+
+To do this, the instruction will need to rewrite/update the data for a specific
+PDA that was saved to the `JournalEntryState` of the account when the owner of
+the journal entry calls the `update_journal_entry` instruction.
+
+```rust
+#[program]
+mod journal {
+    use super::*;
+
+    ...
+
+    pub fn update_journal_entry(
+        ctx: Context<UpdateEntry>,
+        title: String,
+        message: String,
+    ) -> Result<()> {
+        msg!("Journal Entry Updated");
+        msg!("Title: {}", title);
+        msg!("Message: {}", message);
+
+        let journal_entry = &mut ctx.accounts.journal_entry;
+        journal_entry.message = message;
+
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(title: String, message: String)]
+pub struct UpdateEntry<'info> {
+    #[account(
+        mut,
+        seeds = [title.as_bytes(), owner.key().as_ref()],
+        bump,
+        realloc = 8 + 32 + 1 + 4 + title.len() + 4 + message.len(),
+        realloc::payer = owner,
+        realloc::zero = true,
+    )]
+    pub journal_entry: Account<'info, JournalEntryState>,
+    #[account(mut)]
+    pub owner: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+```
+
+In the above code, you should notice that it is very similar to creating a
+journal entry but there are a couple key differences. Since
+`update_journal_entry` is editing an already existing PDA, we do not need to
+initialize it. However, the message being passed to the instruction handler
+could have a different space size required to store it (i.e. the `message` could
+be shorter or longer), so we will need to use a few specific `realloc`
+constraints to reallocate the space for the account onchain:
+
+- `realloc` - sets the new space required
+- `realloc::payer` - defines the account that will either pay or be refunded
+  based on the newly required lamports
+- `realloc::zero` - defines that the account may be updated multiple times when
+  set to `true`
+
+The `seeds` and `bump` constraints are still needed to be able to find the
+specific PDA we want to update.
+
+The `mut` constraints allows us to mutate/change the data within the account.
+Because how the Solana blockchain handles reading from accounts and writing to
+accounts differently, we must explicitly define which accounts will be mutable
+so the Solana runtime can correctly process them.
+
+Note: In Solana, when you perform a reallocation, which changes the account's
+size, the transaction must cover the rent for the new account size. The
+realloc::payer = owner attribute indicates that the owner account will pay for
+the rent. For an account to be able to cover the rent, it typically needs to be
+a signer (to authorize the deduction of funds), and in Anchor, it also needs to
+be mutable so that the runtime can deduct the lamports to cover the rent from
+the account.
+
+### Delete a journal entry
+
+Lastly, we will add a `delete_journal_entry` instruction handler with a context
+that has a `DeleteEntry` type.
+
+To do this, we will simply need to close the account for the specified journal
+entry.
+
+```rust
+#[program]
+mod journal {
+    use super::*;
+
+    ...
+
+    pub fn delete_journal_entry(_ctx: Context<DeleteEntry>, title: String) -> Result<()> {
+        msg!("Journal entry titled {} deleted", title);
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+#[instruction(title: String)]
+pub struct DeleteEntry<'info> {
+    #[account(
+        mut,
+        seeds = [title.as_bytes(), owner.key().as_ref()],
+        bump,
+        close = owner,
+    )]
+    pub journal_entry: Account<'info, JournalEntryState>,
+    #[account(mut)]
+    pub owner: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+```
+
+In the above code, we use the `close` constraint to close out the account
+onchain and refund the rent back to the journal entry's owner.
+
+The `seeds` and `bump` constraints are needed to validate the account.
+
+### Build and deploy your Anchor program
+
+```shell
+npm run anchor build
+npm run anchor deploy
+```
+
+## Connecting a Solana program to a UI
+
+`create-solana-dapp` already sets up a UI with a wallet connector for you. All
+we need to do is simply modify if to fit your newly created program.
+
+Since this journal program has the three instructions, we will need components
+in the UI that will be able to call each of these instructions:
+
+- create entry
+- update entry
+- delete entry
+
+Within your project's repo, open the
+`web/components/journal/journal-data-access.tsx` to add code to be able to call
+each of our instructions.
+
+Update the `useJournalProgram` function to be able to create an entry:
+
+```typescript
+const createEntry = useMutation<string, Error, CreateEntryArgs>({
+  mutationKey: ["journalEntry", "create", { cluster }],
+  mutationFn: async ({ title, message, owner }) => {
+    const [journalEntryAddress] = await PublicKey.findProgramAddress(
+      [Buffer.from(title), owner.toBuffer()],
+      programId
+    );
+
+    return program.methods
+      .createJournalEntry(title, message)
+      .accounts({
+        journalEntry: journalEntryAddress
+      })
+      .rpc();
+  },
+  onSuccess: (signature) => {
+    transactionToast(signature);
+    accounts.refetch();
+  },
+  onError: (error) => {
+    toast.error(`Failed to create journal entry: ${error.message}`);
+  }
+});
+```
+
+Then update the `useJournalProgramAccount` function to be able to update and
+delete entries:
+
+```typescript
+const updateEntry = useMutation<string, Error, CreateEntryArgs>({
+  mutationKey: ["journalEntry", "update", { cluster }],
+  mutationFn: async ({ title, message, owner }) => {
+    const [journalEntryAddress] = await PublicKey.findProgramAddress(
+      [Buffer.from(title), owner.toBuffer()],
+      programId
+    );
+
+    return program.methods
+      .updateJournalEntry(title, message)
+      .accounts({
+        journalEntry: journalEntryAddress
+      })
+      .rpc();
+  },
+  onSuccess: (signature) => {
+    transactionToast(signature);
+    accounts.refetch();
+  },
+  onError: (error) => {
+    toast.error(`Failed to update journal entry: ${error.message}`);
+  }
+});
+
+const deleteEntry = useMutation({
+  mutationKey: ["journal", "deleteEntry", { cluster, account }],
+  mutationFn: (title: string) =>
+    program.methods
+      .deleteJournalEntry(title)
+      .accounts({ journalEntry: account })
+      .rpc(),
+  onSuccess: (tx) => {
+    transactionToast(tx);
+    return accounts.refetch();
+  }
+});
+```
+
+Next, update the UI in `web/components/journal/journal-ui.tsx` to take in user
+input values for the `title` and `message` of when creating a journal entry:
+
+```tsx
+export function JournalCreate() {
+  const { createEntry } = useJournalProgram();
+  const { publicKey } = useWallet();
+  const [title, setTitle] = useState("");
+  const [message, setMessage] = useState("");
+
+  const isFormValid = title.trim() !== "" && message.trim() !== "";
+
+  const handleSubmit = () => {
+    if (publicKey && isFormValid) {
+      createEntry.mutateAsync({ title, message, owner: publicKey });
+    }
+  };
+
+  if (!publicKey) {
+    return <p>Connect your wallet</p>;
+  }
+
+  return (
+    <div>
+      <input
+        type="text"
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        className="input input-bordered w-full max-w-xs"
+      />
+      <textarea
+        placeholder="Message"
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        className="textarea textarea-bordered w-full max-w-xs"
+      />
+      <br></br>
+      <button
+        type="button"
+        className="btn btn-xs lg:btn-md btn-primary"
+        onClick={handleSubmit}
+        disabled={createEntry.isPending || !isFormValid}
+      >
+        Create Journal Entry {createEntry.isPending && "..."}
+      </button>
+    </div>
+  );
+}
+```
+
+Lastly, update the UI in `journal-ui.tsx` to take in a user input values for the
+`message` of when updating a journal entry:
+
+```tsx
+function JournalCard({ account }: { account: PublicKey }) {
+  const { accountQuery, updateEntry, deleteEntry } = useJournalProgramAccount({
+    account
+  });
+  const { publicKey } = useWallet();
+  const [message, setMessage] = useState("");
+  const title = accountQuery.data?.title;
+
+  const isFormValid = message.trim() !== "";
+
+  const handleSubmit = () => {
+    if (publicKey && isFormValid && title) {
+      updateEntry.mutateAsync({ title, message, owner: publicKey });
+    }
+  };
+
+  if (!publicKey) {
+    return <p>Connect your wallet</p>;
+  }
+
+  return accountQuery.isLoading ? (
+    <span className="loading loading-spinner loading-lg"></span>
+  ) : (
+    <div className="card card-bordered border-base-300 border-4 text-neutral-content">
+      <div className="card-body items-center text-center">
+        <div className="space-y-6">
+          <h2
+            className="card-title justify-center text-3xl cursor-pointer"
+            onClick={() => accountQuery.refetch()}
+          >
+            {accountQuery.data?.title}
+          </h2>
+          <p>{accountQuery.data?.message}</p>
+          <div className="card-actions justify-around">
+            <textarea
+              placeholder="Update message here"
+              value={message}
+              onChange={(e) => setMessage(e.target.value)}
+              className="textarea textarea-bordered w-full max-w-xs"
+            />
+            <button
+              className="btn btn-xs lg:btn-md btn-primary"
+              onClick={handleSubmit}
+              disabled={updateEntry.isPending || !isFormValid}
+            >
+              Update Journal Entry {updateEntry.isPending && "..."}
+            </button>
+          </div>
+          <div className="text-center space-y-4">
+            <p>
+              <ExplorerLink
+                path={`account/${account}`}
+                label={ellipsify(account.toString())}
+              />
+            </p>
+            <button
+              className="btn btn-xs btn-secondary btn-outline"
+              onClick={() => {
+                if (
+                  !window.confirm(
+                    "Are you sure you want to close this account?"
+                  )
+                ) {
+                  return;
+                }
+                const title = accountQuery.data?.title;
+                if (title) {
+                  return deleteEntry.mutateAsync(title);
+                }
+              }}
+              disabled={deleteEntry.isPending}
+            >
+              Close
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+## Resources
+
+- Journal dApp:
+  [solana-journal-eight.vercel.app](https://solana-journal-eight.vercel.app)
+- Example code:
+  [https://github.com/solana-foundation/CRUD-dApp](https://github.com/solana-foundation/CRUD-dApp)

--- a/apps/docs/content/cookbook/development/meta.json
+++ b/apps/docs/content/cookbook/development/meta.json
@@ -4,7 +4,9 @@
   "pages": [
     "connect-environment",
     "test-sol",
+    "airdrops-and-faucets",
     "subscribing-events",
-    "load-keypair-from-file"
+    "load-keypair-from-file",
+    "crud-dapp"
   ]
 }

--- a/apps/docs/content/cookbook/games/energy-system.mdx
+++ b/apps/docs/content/cookbook/games/energy-system.mdx
@@ -1,0 +1,314 @@
+---
+date: 2025-03-12T00:00:00Z
+difficulty: intermediate
+title: Build an Energy System for Casual Games on Solana
+description:
+  Learn how to build an onchain energy system for a game, allowing players to
+  expend energy to perform actions, refilling it over time.
+tags:
+  - games
+  - anchor
+  - program
+  - react
+  - web3js
+  - unity
+  - rust
+keywords:
+  - tutorial
+  - transactions
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+  - anchor
+  - games
+  - energy system
+  - time based
+  - onchain timer
+  - example
+---
+
+Casual games commonly use energy systems, meaning that actions in the game cost
+energy which refills over time. In this guide we will walk through how to build
+one on Solana. If you don't have any prior Solana knowledge, start with the
+[Hello World Example](/developers/cookbook/games/hello-world) instead.
+
+You can easily set up a new game with an energy system and a React client using
+[Create Solana Game](https://github.com/solana-developers/solana-game-preset).
+Just run the command:
+
+```bash
+npx create-solana-game your-game-name
+```
+
+> You can find a tutorial on
+> [how to use `create-solana-game`](https://youtu.be/fnhivg_pemI?si=6xIubFFYPOGiEjKY).
+> and also a
+> [video walkthrough](https://youtu.be/YYQtRCXJBgs?si=fIZRFkIYJ9wYjEcI) of the
+> example being explained in this guide below.
+
+## Anchor program
+
+For starters, we will guide you through creating an Anchor program that
+gradually replenishes the player's energy reserves over time. The energy will
+enable them to execute various actions within the game. In our example, a
+lumberjack will chop trees with every tree rewarding one wood and costing one
+energy point.
+
+### Creating the player account
+
+First the player needs to create an account which saves the state of our player.
+We will also save the Unix time stamp of the player's last interaction with the
+program in the `last_login` value. With this state, we will be able to calculate
+how much energy the player has at a certain point in time. We also have a value
+for how much wood the lumberjack cuts in the game.
+
+```rust
+pub fn init_player(ctx: Context<InitPlayer>) -> Result<()> {
+    ctx.accounts.player.energy = MAX_ENERGY;
+    ctx.accounts.player.last_login = Clock::get()?.unix_timestamp;
+    Ok(())
+}
+
+...
+
+#[derive(Accounts)]
+pub struct InitPlayer <'info> {
+    #[account(
+        init,
+        payer = signer,
+        space = 1000,
+        seeds = [b"player".as_ref(), signer.key().as_ref()],
+        bump,
+    )]
+    pub player: Account<'info, PlayerData>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[account]
+pub struct PlayerData {
+    pub name: String,
+    pub level: u8,
+    pub xp: u64,
+    pub wood: u64,
+    pub energy: u64,
+    pub last_login: i64
+}
+```
+
+### Chopping trees
+
+Then whenever the player calls the `chop_tree` instruction we will check if the
+player has enough energy and reward them with one wood (by incrementing the
+player's wood count).
+
+```rust
+#[error_code]
+pub enum ErrorCode {
+    #[msg("Not enough energy")]
+    NotEnoughEnergy,
+}
+
+pub fn chop_tree(mut ctx: Context<ChopTree>) -> Result<()> {
+    let account = &mut ctx.accounts;
+    update_energy(account)?;
+
+    if ctx.accounts.player.energy == 0 {
+        return err!(ErrorCode::NotEnoughEnergy);
+    }
+
+    ctx.accounts.player.wood = ctx.accounts.player.wood + 1;
+    ctx.accounts.player.energy = ctx.accounts.player.energy - 1;
+    msg!("You chopped a tree and got 1 wood. You have {} wood and {} energy left.", ctx.accounts.player.wood, ctx.accounts.player.energy);
+    Ok(())
+}
+```
+
+### Calculating the energy
+
+The interesting part happens in the `update_energy` function. We check how much
+time has passed and calculate the energy that the player will have at the given
+time. We will do the same in the client. We lazily update the energy instead of
+polling it all the time. This is a common technique in game development.
+
+```rust
+const TIME_TO_REFILL_ENERGY: i64 = 60;
+const MAX_ENERGY: u64 = 10;
+
+pub fn update_energy(ctx: &mut ChopTree) -> Result<()> {
+    let mut time_passed: i64 = &Clock::get()?.unix_timestamp - &ctx.player.last_login;
+    let mut time_spent: i64 = 0;
+    while time_passed > TIME_TO_REFILL_ENERGY {
+        ctx.player.energy = ctx.player.energy + 1;
+        time_passed -= TIME_TO_REFILL_ENERGY;
+        time_spent += TIME_TO_REFILL_ENERGY;
+        if ctx.player.energy == MAX_ENERGY {
+            break;
+        }
+    }
+
+    if ctx.player.energy >= MAX_ENERGY {
+        ctx.player.last_login = Clock::get()?.unix_timestamp;
+    } else {
+        ctx.player.last_login += time_spent;
+    }
+
+    Ok(())
+}
+```
+
+## JavaScript client
+
+Here is a
+[complete example](https://github.com/solana-developers/solana-game-examples/tree/main/lumberjack)
+using `create-solana-game`, with a React client.
+
+### Create connection
+
+In the Anchor.ts file we create a connection to the Solana blockchain (in this
+case, devnet):
+
+```js
+export const connection = new Connection(
+  "https://api.devnet.solana.com",
+  "confirmed"
+);
+```
+
+Notice that the confirmation parameter is set to `confirmed`. This means that we
+wait until the transactions are `confirmed` instead of `finalized`. This means
+that we wait until the super majority of the network said that the transaction
+is valid. This takes around 400ms and there was never a confirmed transaction
+which did not get finalized. Generally for games, `confirmed` is the perfect
+transaction commitment level.
+
+### Initialize player data
+
+First, we will find the program address for the player account using the seed
+string `player` and the player's public key
+([deriving the PDA](/docs/core/pda)). Then we call `initPlayer` to create the
+account.
+
+```js
+const [pda] = PublicKey.findProgramAddressSync(
+  [Buffer.from("player", "utf8"), publicKey.toBuffer()],
+  new PublicKey(LUMBERJACK_PROGRAM_ID)
+);
+
+const transaction = program.methods
+  .initPlayer()
+  .accounts({
+    player: pda,
+    signer: publicKey,
+    systemProgram: SystemProgram.programId
+  })
+  .transaction();
+
+const tx = await transaction;
+const txSig = await sendTransaction(tx, connection, {
+  skipPreflight: true
+});
+
+await connection.confirmTransaction(txSig, "confirmed");
+```
+
+### Subscribe to account updates
+
+Next we will use websockets within the JavaScript client to subscribe and listen
+for changes on the player's account. We use websockets here (over manually
+polling the RPC) because it is a faster way to get the changes.
+
+`connection.onAccountChange` creates a socket connection to the RPC node which
+will push any changes that happen to the account to the client. We can then use
+the `program.coder` to decode the account data into the TypeScript types and
+directly use it in the game.
+
+```js
+useEffect(() => {
+  if (!publicKey) {
+    console.log("Missing public key");
+    return;
+  }
+
+  const [pda] = PublicKey.findProgramAddressSync(
+    [Buffer.from("player", "utf8"), publicKey.toBuffer()],
+    new PublicKey(LUMBERJACK_PROGRAM_ID),
+  );
+
+  const fetchPlayerData = async () => {
+    try {
+      const data = await program.account.playerData.fetch(pda);
+      setGameState(data);
+    } catch (error) {
+      console.error("Error fetching player data:", error);
+      window.alert("No player data found, please init!");
+    }
+  };
+
+  fetchPlayerData();
+
+  const handleAccountChange = (account: AccountInfo<Buffer>) => {
+    try {
+      const decodedData = program.coder.accounts.decode("playerData", account.data);
+      setGameState(decodedData);
+    } catch (error) {
+      console.error("Error decoding account data:", error);
+    }
+  };
+
+  const subscriptionId = connection.onAccountChange(pda, handleAccountChange);
+
+  return () => {
+    connection.removeAccountChangeListener(subscriptionId);
+  };
+}, [publicKey]);
+
+```
+
+### Calculate energy and show count down
+
+In the JavaScript client, we can now perform the same logic as in the program to
+precalculate how much energy the player would have at this point in time and
+show a countdown timer for the player so that he knows when the next energy will
+be available:
+
+```js
+useEffect(() => {
+    const interval = setInterval(async () => {
+        if (gameState == null || gameState.lastLogin == undefined || gameState.energy >= 10) {return;}
+        const lastLoginTime = gameState.lastLogin * 1000;
+        let timePassed = ((Date.now() - lastLoginTime) / 1000);
+        while (timePassed > TIME_TO_REFILL_ENERGY && gameState.energy < MAX_ENERGY) {
+            gameState.energy = (parseInt(gameState.energy) + 1);
+            gameState.lastLogin = parseInt(gameState.lastLogin) + TIME_TO_REFILL_ENERGY;
+            timePassed -= TIME_TO_REFILL_ENERGY;
+        }
+        setTimePassed(timePassed);
+        let nextEnergyIn = Math.floor(TIME_TO_REFILL_ENERGY - timePassed);
+        if (nextEnergyIn < TIME_TO_REFILL_ENERGY && nextEnergyIn > 0) {
+            setEnergyNextIn(nextEnergyIn);
+        } else {
+            setEnergyNextIn(0);
+        }
+
+    }, 1000);
+
+    return () => clearInterval(interval);
+}, [gameState, timePassed]);
+
+...
+
+{(gameState && <div className="flex flex-col items-center">
+    {("Wood: " + gameState.wood + " Energy: " + gameState.energy + " Next energy in: " + nextEnergyIn )}
+</div>)}
+
+```
+
+With this you can now build any energy based game and even if someone builds a
+bot for the game the most they can do is play optimally, which may be even
+easier to achieve when playing normally depending on the logic of your game.
+
+This game becomes even better when you add the ability to
+[use tokens in games](/developers/cookbook/games/interact-with-tokens). For
+example, rewarding players with some SPL tokens for their actions in game..

--- a/apps/docs/content/cookbook/games/game-examples.mdx
+++ b/apps/docs/content/cookbook/games/game-examples.mdx
@@ -1,0 +1,255 @@
+---
+date: 2025-03-12T00:00:00Z
+difficulty: intro
+title: Solana Game Development Examples
+description:
+  A list of open source games and examples on Solana with tutorials to get you
+  started.
+tags:
+  - games
+  - anchor
+  - program
+  - react
+  - web3js
+  - unity
+  - rust
+keywords:
+  - tutorial
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+  - anchor
+  - games
+  - example
+---
+
+[Solana Game Examples](https://github.com/solana-developers/solana-game-examples)
+includes many open source game examples and tools for game development. Looking
+at these examples and seeing how certain features are implemented can vastly
+improve your development speed. If you have other example games feel free to
+[submit a PR](https://github.com/solana-developers/solana-game-examples/pulls).
+
+## Using create-solana-game
+
+A simple npx command that sets up a new Solana game project with a Unity client,
+Anchor program and a Next.js frontend. Supported features are:
+
+- Wallet adapter
+- Anchor program
+- Unity client
+- Next.js frontend
+- Renaming all mentions of the project to your own game's name
+- NFT and compressed NFT support
+- [Session keys](https://docs.magicblock.gg/Build/Session%20Keys/introduction)
+  for auto approving transactions
+
+With this command you can easily set up a new game with all these features
+working and ready go:
+
+```bash
+npx create-solana-game your-game-name
+```
+
+Here you can learn how it works:
+
+- [Video](https://www.youtube.com/watch?v=fnhivg_pemI)
+- [Source and docs](https://github.com/solana-developers/solana-game-preset)
+
+## Interacting with Anchor Programs from Unity
+
+Tiny adventure is a simple example moving a player left and right onchain using
+Anchor framework and Unity SDK.
+
+- [Tutorial Guide](/developers/cookbook/games/hello-world)
+- [Video](https://www.youtube.com/watch?v=_vQ3bSs3svs)
+- [Playground](https://beta.solpg.io/tutorials/tiny-adventure)
+- [Unity Client](https://github.com/solana-developers/solana-game-examples/tree/main/seven-seas/unity/Assets/SolPlay/Examples/TinyAdventure)
+
+## Saving SOL in a PDA
+
+Learn how to save SOL in a PDA seed vault and send it back to a player. This
+backend is written in Anchor and the frontend is using the Unity SDK.
+
+- [Tutorial Guide](/developers/cookbook/games/store-sol-in-pda)
+- [Video](https://www.youtube.com/watch?v=gILXyWvXu7M)
+- [Source](https://beta.solpg.io/tutorials/tiny-adventure-two)
+
+## Use Solana Pay QR codes to control a game
+
+Solana Pay transaction requests can not only be used for payments but for
+signing any transactions on a phone wallet or a link, including for games. Tug
+of war is a multiplayer game which can be player with many people on a big
+screen, using Solana Pay QR codes to pull the rope one way or the other, which
+in turn changes data in an account. The rewards will be payed out to the team
+that manages to the rope pull completely to one side. The backend is Anchor and
+the frontend is React.js and Next.js 13.
+
+- [Tutorial](https://www.youtube.com/watch?v=_XBvEHwSqJc&ab_channel=SolPlay)
+- [Live version on devnet](https://tug-of-war-solana-pay.vercel.app/?network=devnet)
+- [Source](https://github.com/Solana-Workshops/tug-of-war-solana-pay)
+
+## How to build a round-based multiplayer game
+
+A simple multiplayer tic tac toe game written in Anchor
+
+- [Tutorial](https://book.anchor-lang.com/anchor_in_depth/milestone_project_tic-tac-toe.html)
+- [Source](https://github.com/coral-xyz/anchor-book/tree/master/programs/tic-tac-toe)
+- [Magic Block Bolt Tic Tac Toe](https://github.com/magicblock-labs/bolt-tic-tac-toe)
+
+## Onchain Chess
+
+Complete onchain playable chess game written in Anchor with a 3D Unity
+implementation. Send someone a link to start a game.
+
+[Source](https://github.com/magicblock-labs/Solana-Unity-Chess/)
+
+## Multiplayer Game using voting system
+
+A Pokemon-style game where people collectively vote on moves. Every move is
+recorded and each move can be minted as an NFTs. The live version is not
+available any more but the source code is still available.
+
+- [Video](https://x.com/sol_idity/status/1610297510299590656)
+- [Source](https://github.com/nelsontky/web3-plays-pokemon)
+
+## Entity component system examples
+
+### MagicBlock Bolt
+
+MagicBlock Bolt is an onchain entity component system. MagicBlock is also  
+working on an ephemeral rollup system for super fast transactions.
+
+- [Bolt article](https://blog.magicblock.gg/bolt-v0.1/)
+- [Bolt Source](https://github.com/magicblock-labs/bolt)
+
+## Hide game state from other players
+
+Hiding data on chain is difficult because all accounts, including data accounts,
+are public and can be read by anyone. There are some solutions to the problem
+though.
+
+### Light protocol
+
+Light protocol is a ZK layer solution on Solana that lets you built on Solana  
+with ZK compression, a new primitive that enables the secure scaling of state
+directly on the L1.
+
+- [Source](https://github.com/Lightprotocol/light-protocol)
+- [Website](https://lightprotocol.com/)
+
+### Race Protocol
+
+Race protocol is building an on chain poker game and have two solutions for  
+hiding data. One is server-based and one relies on players sending encrypted  
+data to each other.
+
+[Source](https://github.com/RACE-Game)
+
+### Stone paper scissors
+
+A game where onchain data is hidden by saving a hash in the client until reveal.
+SPL Tokens are given as prizes for the winner.
+
+[Source](https://github.com/kevinrodriguez-io/bonk-paper-scissors)
+
+## Real-time pvp onchain game
+
+### Solana Civ
+
+A Civilization-style game where you can build cities, trade with other players
+and fight wars. Progress through the ages by unlocking new technologies, conquer
+lands and build a civilization that will stand the test of time. All open source
+and crowd-built by the Solana community, through gib.work.
+
+- [Source](https://github.com/proxycapital/solana-civ)
+- [Website](https://solciv.com/)
+- [Participate](https://gib.work)
+
+### Seven Seas
+
+Seven Seas is a real-time Solana Battle Royale game. Using an Anchor program,
+the UnitySDK, and WebSocket account subscriptions. Players can spawn their ships
+represented as NFTs on a grid and move around. If a player hits another player
+or chest he collect its SOL and some Pirate Coin SPL tokens. The grid is
+implemented as a two dimensional array where every tile saves the players wallet
+key and the NFT public key. There is also a QR code in the top left corner that
+triggers a Solana Pay transaction request, which players can sign on their
+phones, to let Cthulhu shoot at the closest ship.
+
+- [Example](https://solplay.de/sevenseas)
+- [Source](https://github.com/solana-developers/solana-game-examples/tree/main/seven-seas)
+- [Eight Hour video boot camp](https://www.youtube.com/playlist?list=PLilwLeBwGuK6NsYMPP_BlVkeQgff0NwvU)
+
+### Blob Wars onchain strategy game ala Dark Forest
+
+Blob Wars shows you how you can build a strategy game like Dark Forest or Tribal
+Wars, but without the ZK features. Every player spawns their home blob with a
+color that is derived from their public key. These blobs can then be used to
+attack other blobs and conquer them. Blobs regenerate color over time, so there
+are lots of tactics involved on where to spawn blobs and how to combine attacks.
+
+[Source](https://github.com/Woody4618/colosseum_2024)
+[Demo Video](https://www.youtube.com/watch?v=XNHxqdd6pz8)
+
+## Tale of Kentridge
+
+This is a game built with the Turbo game engine.
+[Turbo](https://turbo.computer/) is a from the ground up freshly written Rust
+game engine which focuses on lightweight architecture and fast iteration times
+always with Solana in mind. It is beginner friendly and comes with full Solana
+RPC support. You can even use its AI tools to generate complete games.
+
+- [Example game](https://github.com/super-turbo-society/turbo-demos/tree/main/solana-lumberjack)
+- [Docs](https://turbo.computer/docs/intro/)
+
+## Roguelike game
+
+A game where you can explore a cave and find treasures. The game is written in
+Anchor and the frontend is a Unity client. You progress through a cave from
+level 0 to 100 to fight the ultimate enemy. Every time you die you start again
+from level 1. There are chests that offer items and resources and the items from
+blue chests can be kept for the next run. A special feature is that a floor can
+be owned by a certain player and when you pass that floor you either need to
+fight that player or pay a little fee to be able to pass.
+
+- [Devnet example](https://solplay.de/ancientcave/)
+- [Source](https://github.com/Woody4618/speedrun2)
+
+## Onchain city builder example
+
+This example shows you how you can build an onchain city builder. The special
+feature is that it is a competitive but also cooperative city builder since all
+resources are shared between the players, but depending if you build your
+
+buildings on the left or the right you either support the goblins or the humans.
+
+- [Devnet example](https://solplay.de/humansandgoblins/)
+- [Source](https://github.com/solana-developers/solana-game-examples/tree/main/city-builder)
+
+## Rebirth rumble PVP battler
+
+A 5 vs 5 PVP game where you can fight against other players. The game is written
+in Anchor and the frontend is a Unity client. You can choose between different
+characters and fight against other players. The game is still in development and
+was the winner of the second [Solana Speedrun](https://solanaspeedrun.com/).
+
+- [Source](https://github.com/kimo-do/Speedrun2)
+- [xNFT version](https://www.xnft.gg/app/8iGi6rMEPbjTHofEwU8MNsy5MTPfhorj9QXCfH8dKBme)
+
+## Onchain Matchmaking
+
+A multiplayer match three game which uses NFT stats for the character stats in
+the game and has an interesting onchain matchmaking system.
+
+- [Live Version](https://deezquest.vercel.app/)
+- [Source](https://github.com/val-samonte/deezquest)
+
+## Game Dev Tutorial Videos
+
+- [Building Games on Solana](https://www.youtube.com/watch?v=KT9anz_V9ns)
+- [Eight hour bootcamp](https://www.youtube.com/watch?v=0P8JeL3TURU&t=1s)
+- [Energy System](https://www.youtube.com/watch?v=YYQtRCXJBgs&t=3s)
+- [Session Keys](https://www.youtube.com/watch?v=oKvWZoybv7Y)
+- [Memory on Solana](https://www.youtube.com/watch?v=zs_yU0IuJxc)
+- [Dynamic Metadata NFTs](https://www.youtube.com/watch?v=n-ym1utpzhk)
+- [Advanced Topics](https://www.youtube.com/watch?v=jW8ep_bmaIw)

--- a/apps/docs/content/cookbook/games/getting-started-with-game-development.mdx
+++ b/apps/docs/content/cookbook/games/getting-started-with-game-development.mdx
@@ -1,0 +1,151 @@
+---
+date: 2025-03-14T00:00:00Z
+difficulty: intro
+title: Getting started with game development on Solana
+description:
+  Learn how to build games on Solana. Solana is well built for web3 games of all
+  genres utilizing speed, low fees, and more to create an amazing gaming
+  experience
+tags:
+  - games
+  - unity
+  - quickstart
+keywords:
+  - tutorial
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+  - anchor
+  - games
+  - example
+---
+
+The gaming space in the Solana ecosystem is expanding rapidly. Integrating with
+Solana can provide numerous benefits for games, such as enabling players to own
+and trade their assets (via NFTs in games), building an open and composable
+in-game economy (using various DeFi protocols), creating composable game
+programs, and allowing players to compete for valuable assets.
+
+Solana is nearly purpose-built for games. With its 400ms block time and
+lightning-fast confirmations: it's a real-time database that is accessible for
+all. It's especially perfect for genres like strategy games, city builders,
+turn-based games, and more.
+
+With extremely cheap transaction fees, smaller integrations using NFTs that
+represent game items or achievements, or that use USDC micro payments for in
+game items can be done easily. There are already many tools and SDKs available
+to start building these types of onchain interactions today, using many of the
+game development frameworks that you know and love.
+
+You can build your game in
+[JavaScript](https://solana.com/docs/clients/official/javascript) and Canvas,
+[Phaser](https://github.com/Bread-Heads-NFT/phaser-solana-platformer-template),
+[Turbo Rust](https://turbo.computer/), or use one of the Solana Game SDKs for
+the three biggest game engines -
+[UnitySDK](/docs/clients/community/game-sdks#unity-sdk),
+[UnrealSDK](https://github.com/staratlasmeta/FoundationKit), and
+[Godot](https://github.com/Virus-Axel/godot-solana-sdk). Find a list of all
+gaming SDKs here: [Game SDKs](/docs/clients/community/game-sdks).
+
+## What are the benefits of building games on Solana?
+
+1. No user management: players can use their Solana wallet to authenticate
+   themselves in the game.
+2. No server costs: Solana is a decentralized network, so you don't need to pay
+   for additional backed servers.
+3. No running costs for your program. You can even
+   [close the program](/developers/cookbook/development/airdrops-and-faucets#6-reuse-devnet-sol)
+   to get the SOL back.
+4. The ability to reward players for great achievements or let them play against
+   each other for assets with real value outside the game.
+5. The ability to permissionlessly use all of the other programs deployed on
+   Solana, like decentralized exchanges, NFT marketplaces, lending protocols,
+   high score programs, loyalty/referral programs, and more.
+6. The ability to write your own onchain programs. If some game functionality
+   you want does not already exist, you can always
+   [write and deploy](/docs/core/programs) your own custom onchain program.
+7. Platform independent payments, for all browsers, Android/iOS, and any other
+   platform - as long as the players can sign a transaction they can buy assets.
+8. No 30% fee that Apple and Google take for in-app purchases by deploying
+   directly to the
+   [Saga dApp store](https://docs.solanamobile.com/dapp-publishing/intro).
+
+## How to integrate Solana into your game?
+
+1. Give players digital collectibles for in-game items or use them as
+   characters. See [NFTs in games](/developers/cookbook/games/nfts-in-games)
+2. Use tokens for in-app purchases or micro-payments in the game. See
+   [Using tokens in games](/developers/cookbook/games/interact-with-tokens)
+3. Use the player's wallet to authenticate them in the game using the
+   [Solana Wallet Adapter](https://github.com/anza-xyz/wallet-adapter) framework
+4. Run tournaments and pay out crypto rewards to your players.
+5. Develop the game entirely onchain to:
+   - reward your players in every step they take
+   - allow any game/app/device to connect with your game
+   - enact governance for the game's future
+   - ledger verifiable activity for anti-cheat systems
+
+> See our [Solana games "Hello world"](/developers/cookbook/games/hello-world)
+> for a detailed guide on how to get started with building games on Solana.
+
+## Game SDKs
+
+With all these benefits, Solana is quickly becoming the go-to platform for game
+developers. Get started today by first picking your favorite gaming SDK:
+
+| Platform                                                                             | Language                            |
+| ------------------------------------------------------------------------------------ | ----------------------------------- |
+| [Unity SDK](/docs/clients/community/game-sdks#unity-sdk)                             | C#                                  |
+| [Godot SDK](/docs/clients/community/game-sdks#godot-sdk)                             | GD script and C++                   |
+| [Turbo.Computer](/docs/clients/community/game-sdks#turbocomputer---rust-game-engine) | Rust                                |
+| [Honeycomb Protocol](/docs/clients/community/game-sdks#honeycomb-protocol)           | Rust and JavaScript                 |
+| [Unreal SDKs](/docs/clients/community/game-sdks#unreal-sdks)                         | C++, C#, Blueprints                 |
+| [Next js, React, Anchor](/docs/clients/community/game-sdks#nextjsreact--anchor)      | Rust/Anchor, JavaScript, C#, NextJS |
+| [Flutter](/docs/clients/community/game-sdks#flutter)                                 | Dart                                |
+| [Phaser](/docs/clients/community/game-sdks#phaser)                                   | HTML5, JavaScript                   |
+| [Python](/docs/clients/community/game-sdks#python)                                   | Python                              |
+| [Native C#](/docs/clients/community/game-sdks#native-c)                              | C#                                  |
+
+## Game Distribution
+
+Distribution of your game depends highly on the platform you are using. With
+Solana, there are [game SDKs](#game-sdks) you can build for iOS, Android, Web
+and Native Windows or Mac. Using the Unity SDK you could even connect Nintendo
+Switch or XBox to Solana theoretically. Many game companies are pivoting to a
+mobile first approach because there are so many people with mobile phones in the
+world. Mobile comes with its own complications though, so you should pick what
+fits best to your game.
+
+Solana has a distinct edge over other blockchain platforms due to its offering
+of a crypto-native mobile phone from [Solana Mobile](https://solanamobile.com),
+named Saga. The Android based [Saga phone](https://solanamobile.com/hardware)
+comes equipped with an innovative dApps store that enables the distribution of
+crypto games without the limitations imposed by conventional app stores,
+including those from Google or Apple.
+
+## Publishing Platforms
+
+Platforms where you can host and/or publish your games:
+
+| Platform                                                                                         | Description                                                                                                                                                                                                                                                                                                                                                                                         |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [Indie.fun](https://indie.fun/)                                                                  | A community-driven fundraising platform within the Solana ecosystem that enables game developers to simultaneously launch games and tokens.                                                                                                                                                                                                                                                         |
+| [Solana mobile dApp Store](https://github.com/solana-mobile/dapp-publishing/blob/main/README.md) | The Solana alternative to Google Play and the Apple App Store. A crypto first variant of a dApp store, which is open source free for everyone to use. See([video walkthrough](https://youtu.be/IgeE1mg1aYk?si=fZmU1WNiW-kR3qFa))                                                                                                                                                                    |
+| [Fractal](https://www.fractal.is/games)                                                          | A game publishing platform that supports Solana and Ethereum. They also have their own wallet and account handling and there is an SDK for high scores and tournaments.                                                                                                                                                                                                                             |
+| [Apple App Store](https://www.apple.com/app-store/)                                              | The Apple app store has a high reach and is trusted by its customers. The entrance barrier for crypto games is high though. The rules are very strict for everything that tries to circumvent the fees that Apple takes for in app purchases. A soon as an NFT provides benefits for the player for example Apple requires you for example to have them purchased via their in app purchase system. |
+| [Google Play Store](https://play.google.com/store/games)                                         | Google is much more crypto friendly and games with NFTs and wallet deep links for example have had a track record of being approved for the official Play Store.                                                                                                                                                                                                                                    |
+| [Elixir Games](https://elixir.games/)                                                            | Elixir Games is a platform that focuses on blockchain-based games. They support a variety of blockchain technologies and offer a platform for developers to publish their games.                                                                                                                                                                                                                    |
+| Self Hosting                                                                                     | Just host your game yourself. For example, using [Vercel](https://vercel.com/) which can be easily setup so that a new version get deployed as soon as you push to your repository. Other options are [GitHub pages](https://pages.github.com/) or [Google Firebase](https://firebase.google.com/docs/hosting) but there are many more.                                                             |
+
+## Next Steps
+
+If you would like to learn more about developing games on Solana, take a look at
+these developer resources and guides:
+
+- [Solana Gaming SDKs](/docs/clients/community/game-sdks)
+- [Hello world onchain game](/developers/cookbook/games/hello-world)
+- [Learn by example](/developers/cookbook/games/game-examples)
+- [Energy System](/developers/cookbook/games/energy-system)
+- [NFTs in games](/developers/cookbook/games/nfts-in-games)
+- [Dynamic metadata NFTs](/developers/guides/token-extensions/dynamic-meta-data-nft)
+- [Token in games](/developers/cookbook/games/interact-with-tokens)

--- a/apps/docs/content/cookbook/games/hello-world.mdx
+++ b/apps/docs/content/cookbook/games/hello-world.mdx
@@ -1,0 +1,542 @@
+---
+date: 2024-04-25T00:00:00Z
+difficulty: beginner
+title: Hello World for Solana Game Development
+description:
+  Get started building Solana games with a basic adventure game using the Anchor
+  framework.
+tags:
+  - games
+  - anchor
+  - program
+  - web3js
+  - quickstart
+  - rust
+keywords:
+  - tutorial
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+  - anchor
+  - games
+  - example
+---
+
+In this development guide, we will walkthrough a simple onchain game using the
+Solana blockchain. This game, lovingly called _Tiny Adventure_, is a
+beginner-friendly Solana program created using the
+[Anchor framework](https://www.anchor-lang.com/docs). The goal of this program
+is to show you how to create a simple game that allows players to track their
+position and move left or right.
+
+> You can find the complete source code, available to deploy from your browser,
+> in this
+> [Solana Playground example](https://beta.solpg.io/tutorials/tiny-adventure).
+
+If need to familiarize yourself with the Anchor framework, feel free to check
+out the [Anchor documentation](https://www.anchor-lang.com/docs).
+
+## Video Walkthrough
+
+<Embed url="https://www.youtube.com/embed/_vQ3bSs3svs" />
+
+## Getting Started
+
+To help make our initial Solana development faster, we will use the Solana
+Playground (web based IDE) to code, build, and deploy our onchain program. This
+will make it so we do not have to setup or install anything locally to get
+started with Solana development.
+
+### Solana Playground
+
+Visit the [Solana Playground](https://beta.solpg.io/) and create a new Anchor
+project. If you're new to Solana Playground, you'll also need to create a
+Playground Wallet. Here is an example of how to use Solana Playground:
+
+![Setting up the Solana Playground](/assets/guides/hello-world/solpg.gif)
+
+### Initial Program Code
+
+After creating a new Playground project, replace the default starter code in
+`lib.rs` with the code below:
+
+```rust title="lib.rs"
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+mod tiny_adventure {
+    use super::*;
+
+    // instruction handlers will go here
+}
+
+// structs will go here
+
+fn print_player(player_position: u8) {
+    if player_position == 0 {
+        msg!("A Journey Begins!");
+        msg!("o.......");
+    } else if player_position == 1 {
+        msg!("..o.....");
+    } else if player_position == 2 {
+        msg!("....o...");
+    } else if player_position == 3 {
+        msg!("........\\o/");
+        msg!("You have reached the end! Super!");
+    }
+}
+```
+
+In this game, the player starts at position 0 and can move left or right. To
+show the player's progress throughout the game, we'll use message logs to
+display their journey.
+
+## Defining the Game Data Account
+
+The first step in building the game is to define a structure for the onchain
+account that will store the player's position.
+
+The `GameDataAccount` struct contains a single field, `player_position`, which
+stores the player's current position as an unsigned 8-bit integer.
+
+```rust title="lib.rs" {13-16} /GameDataAccount/ /player_position/
+use anchor_lang::prelude::*;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+mod tiny_adventure {
+    use super::*;
+
+    ...
+}
+
+// Define the Game Data Account structure
+#[account]
+pub struct GameDataAccount {
+    player_position: u8,
+}
+
+...
+```
+
+## Program Instructions
+
+Our Tiny Adventure program consists of only 3
+[instruction handlers](/docs/core/instructions):
+
+- `initialize` - sets up an onchain account to store the player's position
+- `move_left` - lets the player move their position to the left
+- `move_right` - lets the player move their position to the right
+
+### Initialize Instruction
+
+Our `initialize` instruction initializes the `GameDataAccount` if it does not
+already exist, sets the `player_position` to 0, and print some message logs.
+
+The `initialize` instruction requires 3 accounts:
+
+- `new_game_data_account` - the `GameDataAccount` we are initializing
+- `signer` - the player paying for the initialization of the `GameDataAccount`
+- `system_program` - a required account when creating a new account
+
+```rust title="lib.rs" {5-11} /new_game_data_account/ /signer/ /system_program/
+#[program]
+pub mod tiny_adventure {
+    use super::*;
+
+    // Instruction to initialize GameDataAccount and set position to 0
+    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
+        ctx.accounts.new_game_data_account.player_position = 0;
+        msg!("A Journey Begins!");
+        msg!("o.......");
+        Ok(())
+    }
+}
+
+// Specify the accounts required by the initialize instruction
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(
+        init_if_needed,
+        seeds = [b"level1"],
+        bump,
+        payer = signer,
+        space = 8 + 1
+    )]
+    pub new_game_data_account: Account<'info, GameDataAccount>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+...
+```
+
+In this example, a [Program Derived Address (PDA)](/docs/core/pda) is used for
+the `GameDataAccount` address. This enables us to deterministically locate the
+address later on. It is important to note that the PDA in this example is
+generated with a single fixed value as the seed (`level1`), limiting our program
+to creating only one `GameDataAccount`. The `init_if_needed` constraint then
+ensures that the `GameDataAccount` is initialized only if it doesn't already
+exist.
+
+It is worth noting that the current implementation does not have any
+restrictions on who can modify the `GameDataAccount`. This effectively
+transforms the game into a multiplayer experience where everyone can control the
+player's movement.
+
+Alternatively, you can use the signer's address as an extra seed in the
+`initialize` instruction, which would enable each player to create their own
+`GameDataAccount`.
+
+### Move Left Instruction
+
+Now that we can initialize a `GameDataAccount` account, let's implement the
+`move_left` instruction which allows a player update their `player_position`.
+
+In this example, moving left simply means decrementing the `player_position`
+by 1. We'll also set the minimum position to 0. The only account needed for this
+instruction is the `GameDataAccount`.
+
+```rust title="lib.rs" {6-16} /player_position/ /GameDataAccount/
+#[program]
+pub mod tiny_adventure {
+    use super::*;
+    ...
+
+    // Instruction to move left
+    pub fn move_left(ctx: Context<MoveLeft>) -> Result<()> {
+        let game_data_account = &mut ctx.accounts.game_data_account;
+        if game_data_account.player_position == 0 {
+            msg!("You are back at the start.");
+        } else {
+            game_data_account.player_position -= 1;
+            print_player(game_data_account.player_position);
+        }
+        Ok(())
+    }
+}
+
+// Specify the account required by the move_left instruction
+#[derive(Accounts)]
+pub struct MoveLeft<'info> {
+    #[account(mut)]
+    pub game_data_account: Account<'info, GameDataAccount>,
+}
+
+...
+```
+
+### Move Right Instruction
+
+Lastly, let's implement the `move_right` instruction. Similarly, moving right
+will simply mean incrementing the `player_position` by 1. We'll also limit the
+maximum position to 3.
+
+Just like before, the only account needed for this instruction is the
+`GameDataAccount`.
+
+```rust title="lib.rs"  {6-16} /player_position/ /GameDataAccount/
+#[program]
+pub mod tiny_adventure {
+    use super::*;
+		...
+
+		// Instruction to move right
+		pub fn move_right(ctx: Context<MoveRight>) -> Result<()> {
+		    let game_data_account = &mut ctx.accounts.game_data_account;
+		    if game_data_account.player_position == 3 {
+		        msg!("You have reached the end! Super!");
+		    } else {
+		        game_data_account.player_position = game_data_account.player_position + 1;
+		        print_player(game_data_account.player_position);
+		    }
+		    Ok(())
+		}
+}
+
+// Specify the account required by the move_right instruction
+#[derive(Accounts)]
+pub struct MoveRight<'info> {
+    #[account(mut)]
+    pub game_data_account: Account<'info, GameDataAccount>,
+}
+
+...
+```
+
+## Build and Deploy
+
+We've now completed the Tiny Adventure program! Your final program should
+resemble the following:
+
+```rust title="lib.rs"
+use anchor_lang::prelude::*;
+
+// This is your program's public key and it will update
+// automatically when you build the project.
+declare_id!("BouPBVWkdVHbxsdzqeMwkjqd5X67RX5nwMEwxn8MDpor");
+
+#[program]
+mod tiny_adventure {
+    use super::*;
+
+    pub fn initialize(ctx: Context<Initialize>) -> Result<()> {
+        ctx.accounts.new_game_data_account.player_position = 0;
+        msg!("A Journey Begins!");
+        msg!("o.......");
+        Ok(())
+    }
+
+    pub fn move_left(ctx: Context<MoveLeft>) -> Result<()> {
+        let game_data_account = &mut ctx.accounts.game_data_account;
+        if game_data_account.player_position == 0 {
+            msg!("You are back at the start.");
+        } else {
+            game_data_account.player_position -= 1;
+            print_player(game_data_account.player_position);
+        }
+        Ok(())
+    }
+
+    pub fn move_right(ctx: Context<MoveRight>) -> Result<()> {
+        let game_data_account = &mut ctx.accounts.game_data_account;
+        if game_data_account.player_position == 3 {
+            msg!("You have reached the end! Super!");
+        } else {
+            game_data_account.player_position = game_data_account.player_position + 1;
+            print_player(game_data_account.player_position);
+        }
+        Ok(())
+    }
+}
+
+fn print_player(player_position: u8) {
+    if player_position == 0 {
+        msg!("A Journey Begins!");
+        msg!("o.......");
+    } else if player_position == 1 {
+        msg!("..o.....");
+    } else if player_position == 2 {
+        msg!("....o...");
+    } else if player_position == 3 {
+        msg!("........\\o/");
+        msg!("You have reached the end! Super!");
+    }
+}
+
+#[derive(Accounts)]
+pub struct Initialize<'info> {
+    #[account(
+        init_if_needed,
+        seeds = [b"level1"],
+        bump,
+        payer = signer,
+        space = 8 + 1
+    )]
+    pub new_game_data_account: Account<'info, GameDataAccount>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct MoveLeft<'info> {
+    #[account(mut)]
+    pub game_data_account: Account<'info, GameDataAccount>,
+}
+
+#[derive(Accounts)]
+pub struct MoveRight<'info> {
+    #[account(mut)]
+    pub game_data_account: Account<'info, GameDataAccount>,
+}
+
+#[account]
+pub struct GameDataAccount {
+    player_position: u8,
+}
+```
+
+With the program completed, it's time to build and deploy it on Solana
+Playground!
+
+If this is your first time using Solana Playground, create a Playground Wallet
+first and ensure that you're connected to a Devnet endpoint. Then, run
+`solana airdrop 5`. Once you have enough SOL, build and deploy the program. If
+the command fails you there are other ways on
+[how to get devnet SOL](/developers/cookbook/development/airdrops-and-faucets)
+here.
+
+## Get Started with the Client
+
+This next section will guide you through a simple client-side implementation for
+interacting with the game. We'll break down the code and provide detailed
+explanations for each step. In Solana Playground, navigate to the `client.ts`
+file and add the code snippets from the following sections.
+
+### Derive the GameDataAccount Account Address
+
+First, let's derive the PDA for the `GameDataAccount` using the
+`findProgramAddress` function.
+
+> A [Program Derived Address (PDA)](/docs/core/pda) is unique address in the
+> format of a public key, derived using the program's ID and additional seeds.
+
+```js title="client.ts"
+// The PDA address everyone will be able to control the character if the interact with your program
+const [globalLevel1GameDataAccount, bump] =
+  await anchor.web3.PublicKey.findProgramAddress(
+    [Buffer.from("level1", "utf8")],
+    pg.program.programId
+  );
+```
+
+### Initialize the Game State
+
+Next, let's try to fetch the game data account using the PDA from the previous
+step. If the account doesn't exist, we'll create it by invoking the `initialize`
+instruction from our program.
+
+```ts title="client.ts" {11}
+let txHash;
+let gameDateAccount;
+
+try {
+  gameDateAccount = await pg.program.account.gameDataAccount.fetch(
+    globalLevel1GameDataAccount
+  );
+} catch {
+  // Check if the account is already initialized, other wise initialize it
+  txHash = await pg.program.methods
+    .initialize()
+    .accounts({
+      newGameDataAccount: globalLevel1GameDataAccount,
+      signer: pg.wallet.publicKey,
+      systemProgram: web3.SystemProgram.programId
+    })
+    .signers([pg.wallet.keypair])
+    .rpc();
+
+  console.log(`Use 'solana confirm -v ${txHash}' to see the logs`);
+  await pg.connection.confirmTransaction(txHash);
+  console.log("A journey begins...");
+  console.log("o........");
+}
+```
+
+### Move Left and Right
+
+Now we are ready to interact with the game by moving left or right. This is done
+by invoking the `moveLeft` or `moveRight` instructions from the program by
+submitting a transaction to the Solana network.
+
+You can repeat this step as many times as you like, each will execute the move
+logic onchain, updating the player's state.
+
+```ts title="client.ts" {2,3}
+// Here you can play around now, move left and right
+txHash = await pg.program.methods
+  //.moveLeft()
+  .moveRight()
+  .accounts({
+    gameDataAccount: globalLevel1GameDataAccount
+  })
+  .signers([pg.wallet.keypair])
+  .rpc();
+console.log(`Use 'solana confirm -v ${txHash}' to see the logs`);
+await pg.connection.confirmTransaction(txHash);
+
+gameDateAccount = await pg.program.account.gameDataAccount.fetch(
+  globalLevel1GameDataAccount
+);
+
+console.log("Player position is:", gameDateAccount.playerPosition.toString());
+```
+
+### Logging the Player's Position
+
+Lastly, let's use a `switch` statement to log the character's position based on
+the `playerPosition` value stored in the `gameDateAccount`. We'll use this as a
+visual representation of the character's movement in the game.
+
+```ts title="client.ts"
+switch (gameDateAccount.playerPosition) {
+  case 0:
+    console.log("A journey begins...");
+    console.log("o........");
+    break;
+  case 1:
+    console.log("....o....");
+    break;
+  case 2:
+    console.log("......o..");
+    break;
+  case 3:
+    console.log(".........\\o/");
+    break;
+}
+```
+
+### Run the Client Program
+
+Finally, run the client by clicking the “Run” button in Solana Playground. The
+output should be similar to the following:
+
+```shell
+Running client...
+  client.ts:
+    My address: 8ujtDmwpkQ4Bp4GU4zUWmzf65sc21utdcxFAELESca22
+    My balance: 4.649749614 SOL
+    Use 'solana confirm -v 4MRXEWfGqvmro1KsKb94Zz8qTZsPa9x99oMFbLBz2WicLnr8vdYYsQwT5u3pK5Vt1i9BDrVH5qqTXwtif6sCRJCy' to see the logs
+    Player position is: 1
+    ....o....
+```
+
+Congratulations! You have successfully built, deployed, and invoked the Tiny
+Adventure game from the client.
+
+> To further illustrate the possibilities, check out this
+> [frontend demo](https://nextjs-tiny-adventure.vercel.app/) that demonstrates
+> how to interact with the Tiny Adventure program through a Next.js frontend.
+> You can also view this Next.js project's
+> [source code](https://github.com/solana-developers/solana-game-examples/tree/main/tiny-adventure)
+> here.
+
+## What's Next?
+
+With the basic game complete, unleash your creativity and practice building
+independently by implementing your own ideas to enrich the game experience. Here
+are a few suggestions:
+
+1. Modify the in-game texts to create an intriguing story. Invite a friend to
+   play through your custom narrative and observe the onchain transactions as
+   they unfold!
+2. Add a chest that rewards players with
+   [SOL Rewards](/developers/cookbook/games/store-sol-in-pda) or let the player
+   collect coins and
+   [interact with tokens](/developers/cookbook/games/interact-with-tokens) as
+   they progress through the game.
+3. Create a grid that allows the player to move up, down, left, and right, and
+   introduce multiple players for a more dynamic experience.
+
+### Part Two
+
+You can continue the guided development of our Tiny Adventure game, with this
+guide [Tiny Adventure - Part Two](/developers/cookbook/games/store-sol-in-pda),
+where we will demonstrate how to store SOL in the program and distribute it to
+players as rewards.
+
+### More Resources
+
+You can also discover more Solana game development resources here:
+
+- [Getting Started Guide](/developers/cookbook/games/getting-started-with-game-development)
+- [Solana Gaming SDKs](/docs/clients/community/game-sdks)
+- [Learn by example](/developers/cookbook/games/game-examples)
+- [Energy System](/developers/cookbook/games/energy-system)
+- [NFTs in games](/developers/cookbook/games/nfts-in-games)
+- [Token in games](/developers/cookbook/games/interact-with-tokens)

--- a/apps/docs/content/cookbook/games/interact-with-tokens.mdx
+++ b/apps/docs/content/cookbook/games/interact-with-tokens.mdx
@@ -1,0 +1,925 @@
+---
+date: 2025-03-15T00:00:00Z
+difficulty: intermediate
+title: How to interact with tokens in programs
+description: Learn how to use tokens in Solana games with an onchain tutorial
+tags:
+  - games
+  - anchor
+  - program
+  - web3js
+  - token extensions
+  - token 2022
+  - rust
+keywords:
+  - tutorial
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+  - anchor
+  - games
+  - example
+---
+
+Tokens on Solana can serve various purposes, such as in-game rewards,
+incentives, or other applications. For example, you can create tokens and
+distribute them to players when they complete specific in-game actions. In this
+example we will learn how to setup an Anchor program to mint and burn tokens in
+a game. If you want to instead learn how you can store tokens in a PDA you can
+check out the
+[Token Vault example](https://beta.solpg.io/tutorials/spl-token-vault) in Solana
+Playground.
+
+## Overview
+
+In this tutorial, we will build a game using Anchor to introduce the basics of
+interacting with the [Token Program](/docs/tokens) on Solana. The game will be
+structured around four main actions: creating a new token mint, initializing
+player accounts, rewarding players for defeating enemies, and allowing players
+to heal by burning tokens.
+
+The program consists of 4 [instructions](/docs/core/instructions):
+
+- `create_mint` - this instruction creates a new token mint with a
+  [Program Derived Address (PDA)](/docs/core/pda) as the mint authority and
+  creates the metadata account for the mint. We will add a constraint that
+  allows only an "admin" to invoke this instruction
+- `init_player` - this instruction initializes a new player account with a
+  starting health of 100
+- `kill_enemy` - this instruction deducts 10 health points from the player
+  account upon “defeating an enemy” and mints 1 token as a reward for the player
+- `heal` - this instruction allows a player to burn 1 token to restore their
+  health back to 100
+
+> This example uses some external tools and program, created by Metaplex, for
+> working with tokens. For a high-level overview of the relationship among user
+> wallets, token mints, token accounts, and token metadata accounts, consider
+> exploring this portion of the
+> [Metaplex documentation](https://developers.metaplex.com/token-metadata).
+
+## Getting Started
+
+To start building the program, visit the
+[Solana Playground](https://beta.solpg.io/) and create a new Anchor project. If
+you're new to Solana Playground, you'll also need to create a Playground Wallet.
+You can also find the final example here called
+[Battle coins](https://beta.solpg.io/tutorials/battle-coins)
+
+After creating a new project, replace the default starter code with the code
+below:
+
+```rust title="lib.rs"
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    metadata::{create_metadata_accounts_v3, CreateMetadataAccountsV3, Metadata},
+    token::{burn, mint_to, Burn, Mint, MintTo, Token, TokenAccount},
+};
+use mpl_token_metadata::{pda::find_metadata_account, state::DataV2};
+use solana_program::{pubkey, pubkey::Pubkey};
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+pub mod anchor_token {
+    use super::*;
+}
+```
+
+Here we are simply bringing into scope the crates and corresponding modules we
+will be using for this program. We'll be using the `anchor_spl` and
+`mpl_token_metadata` crates to help us interact with the SPL Token program and
+Metaplex's Token Metadata program.
+
+## Create Mint instruction
+
+First, let's implement an instruction to create a new token mint and its
+metadata account. The onchain token metadata, including the name, symbol, and
+URI, will be provided as parameters to the instruction.
+
+Additionally, we'll only allow an "admin" to invoke this instruction by defining
+an `ADMIN_PUBKEY` constant and using it as a constraint. Be sure to replace the
+`ADMIN_PUBKEY` with your Solana Playground wallet's public key.
+
+The `create_mint` instruction requires the following accounts:
+
+- `admin` - the `ADMIN_PUBKEY` that signs the transaction and pays for the
+  initialization of the accounts
+- `reward_token_mint` - the new token mint we are initializing, using a PDA as
+  both the mint account's address and its mint authority
+- `metadata_account` - the metadata account we are initializing for the token
+  mint
+- `token_program` - required for interacting with instructions on the Token
+  program
+- `token_metadata_program` - required account for interacting with instructions
+  on the Token Metadata program
+- `system_program`- a required account when creating a new account
+- `rent` - Sysvar Rent, a required account when creating the metadata account
+
+```rust title="lib.rs" {2}
+// Only this public key can call this instruction
+const ADMIN_PUBKEY: Pubkey = pubkey!("REPLACE_WITH_YOUR_WALLET_PUBKEY");
+
+#[program]
+pub mod anchor_token {
+    use super::*;
+
+    // Create new token mint with PDA as mint authority
+    pub fn create_mint(
+        ctx: Context<CreateMint>,
+        uri: String,
+        name: String,
+        symbol: String,
+    ) -> Result<()> {
+        // PDA seeds and bump to "sign" for CPI
+        let seeds = b"reward";
+        let bump = *ctx.bumps.get("reward_token_mint").unwrap();
+        let signer: &[&[&[u8]]] = &[&[seeds, &[bump]]];
+
+        // Onchain token metadata for the mint
+        let data_v2 = DataV2 {
+            name: name,
+            symbol: symbol,
+            uri: uri,
+            seller_fee_basis_points: 0,
+            creators: None,
+            collection: None,
+            uses: None,
+        };
+
+        // CPI Context
+        let cpi_ctx = CpiContext::new_with_signer(
+            ctx.accounts.token_metadata_program.to_account_info(),
+            CreateMetadataAccountsV3 {
+                metadata: ctx.accounts.metadata_account.to_account_info(), // the metadata account being created
+                mint: ctx.accounts.reward_token_mint.to_account_info(), // the mint account of the metadata account
+                mint_authority: ctx.accounts.reward_token_mint.to_account_info(), // the mint authority of the mint account
+                update_authority: ctx.accounts.reward_token_mint.to_account_info(), // the update authority of the metadata account
+                payer: ctx.accounts.admin.to_account_info(), // the payer for creating the metadata account
+                system_program: ctx.accounts.system_program.to_account_info(), // the system program account
+                rent: ctx.accounts.rent.to_account_info(), // the rent sysvar account
+            },
+            signer,
+        );
+
+        create_metadata_accounts_v3(
+            cpi_ctx, // cpi context
+            data_v2, // token metadata
+            true,    // is_mutable
+            true,    // update_authority_is_signer
+            None,    // collection details
+        )?;
+
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct CreateMint<'info> {
+    #[account(
+        mut,
+        address = ADMIN_PUBKEY
+    )]
+    pub admin: Signer<'info>,
+
+    // The PDA is both the address of the mint account and the mint authority
+    #[account(
+        init,
+        seeds = [b"reward"],
+        bump,
+        payer = admin,
+        mint::decimals = 9,
+        mint::authority = reward_token_mint,
+
+    )]
+    pub reward_token_mint: Account<'info, Mint>,
+
+    ///CHECK: Using "address" constraint to validate metadata account address
+    #[account(
+        mut,
+        address=find_metadata_account(&reward_token_mint.key()).0
+    )]
+    pub metadata_account: UncheckedAccount<'info>,
+
+    pub token_program: Program<'info, Token>,
+    pub token_metadata_program: Program<'info, Metadata>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+```
+
+The `create_mint` instruction creates a new token mint, using a Program Derived
+Address (PDA) as both the address of the token mint and its mint authority. The
+instruction takes a URI (offchain metadata), name, and symbol as parameters.
+
+This instruction then creates a metadata account for the token mint through a
+[Cross-Program Invocation (CPI)](/docs/core/cpi) calling the
+`create_metadata_accounts_v3` instruction from the Token Metadata program.
+
+The PDA is used to "sign" the CPI since it is the mint authority, which is a
+required signer when creating the metadata account for a mint. The instruction
+data (URI, name, symbol) is included in the `DataV2` struct to specify the new
+token mint's metadata.
+
+We also verify that the address of the `admin` account signing the transaction
+matches the value of the `ADMIN_PUBKEY` constant to ensure only the intended
+wallet can invoke this instruction.
+
+```rust
+const ADMIN_PUBKEY: Pubkey = pubkey!("REPLACE_WITH_YOUR_WALLET_PUBKEY");
+```
+
+## Init Player Instruction
+
+Next, let's implement the `init_player` instruction which creates a new player
+account with an initial health of 100. The constant `MAX_HEALTH` is set to 100
+to represent the starting health.
+
+The `init_player` instruction requires the following accounts:
+
+- `player_data` - the new player account we are initializing, which will store
+  the player's health
+- `player` - the user who signs the transaction and pays for the initialization
+  of the account
+- `system_program` - a required account when creating a new account
+
+```rust title="lib.rs"
+// Player max health
+const MAX_HEALTH: u8 = 100;
+
+#[program]
+pub mod anchor_token {
+    use super::*;
+    ...
+
+    // Create new player account
+    pub fn init_player(ctx: Context<InitPlayer>) -> Result<()> {
+        ctx.accounts.player_data.health = MAX_HEALTH;
+        Ok(())
+    }
+}
+...
+
+#[derive(Accounts)]
+pub struct InitPlayer<'info> {
+    #[account(
+        init,
+        payer = player,
+        space = 8 + 8,
+        seeds = [b"player".as_ref(), player.key().as_ref()],
+        bump,
+    )]
+    pub player_data: Account<'info, PlayerData>,
+    #[account(mut)]
+    pub player: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[account]
+pub struct PlayerData {
+    pub health: u8,
+}
+```
+
+The `player_data` account is initialized using a Program Derived Address (PDA)
+with the `player` public key as one of the seeds. This ensures that each
+`player_data` account is unique and associated with the `player`, allowing every
+player to create their own `player_data` account.
+
+## Kill Enemy Instruction
+
+Next, let's implement the `kill_enemy` instruction which reduces the player's
+health by 10 and mints 1 token to the player's token account as a reward.
+
+The `kill_enemy` instruction requires the following accounts:
+
+- `player` - the player receiving the token
+- `player_data` - the player data account storing the player's current health
+- `player_token_account` - the player's associated token account where tokens
+  will be minted
+- `reward_token_mint` - the token mint account, specifying the type of token
+  that will be minted
+- `token_program` - required for interacting with instructions on the token
+  program
+- `associated_token_program` - required when working with associated token
+  accounts
+- `system_program` - a required account when creating a new account
+
+```rust title="lib.rs"
+#[program]
+pub mod anchor_token {
+    use super::*;
+    ...
+
+    // Mint token to player token account
+    pub fn kill_enemy(ctx: Context<KillEnemy>) -> Result<()> {
+        // Check if player has enough health
+        if ctx.accounts.player_data.health == 0 {
+            return err!(ErrorCode::NotEnoughHealth);
+        }
+        // Subtract 10 health from player
+        ctx.accounts.player_data.health = ctx.accounts.player_data.health.checked_sub(10).unwrap();
+
+        // PDA seeds and bump to "sign" for CPI
+        let seeds = b"reward";
+        let bump = *ctx.bumps.get("reward_token_mint").unwrap();
+        let signer: &[&[&[u8]]] = &[&[seeds, &[bump]]];
+
+        // CPI Context
+        let cpi_ctx = CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            MintTo {
+                mint: ctx.accounts.reward_token_mint.to_account_info(),
+                to: ctx.accounts.player_token_account.to_account_info(),
+                authority: ctx.accounts.reward_token_mint.to_account_info(),
+            },
+            signer,
+        );
+
+        // Mint 1 token, accounting for decimals of mint
+        let amount = (1u64)
+            .checked_mul(10u64.pow(ctx.accounts.reward_token_mint.decimals as u32))
+            .unwrap();
+
+        mint_to(cpi_ctx, amount)?;
+        Ok(())
+    }
+}
+...
+
+#[derive(Accounts)]
+pub struct KillEnemy<'info> {
+    #[account(mut)]
+    pub player: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"player".as_ref(), player.key().as_ref()],
+        bump,
+    )]
+    pub player_data: Account<'info, PlayerData>,
+
+    // Initialize player token account if it doesn't exist
+    #[account(
+        init_if_needed,
+        payer = player,
+        associated_token::mint = reward_token_mint,
+        associated_token::authority = player
+    )]
+    pub player_token_account: Account<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        seeds = [b"reward"],
+        bump,
+    )]
+    pub reward_token_mint: Account<'info, Mint>,
+
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub system_program: Program<'info, System>,
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("Not enough health")]
+    NotEnoughHealth,
+}
+```
+
+The player's health is reduced by 10 to represent the “battle with the enemy”.
+We'll also check the player's current health and return a custom Anchor error if
+the player has 0 health.
+
+The instruction then uses a cross-program invocation (CPI) to call the `mint_to`
+instruction from the Token program and mints 1 token of the `reward_token_mint`
+to the `player_token_account` as a reward for killing the enemy.
+
+Since the mint authority for the token mint is a Program Derived Address (PDA),
+we can mint tokens directly by calling this instruction without additional
+signers. The program can "sign" on behalf of the PDA, allowing token minting
+without explicitly requiring extra signers.
+
+## Heal Instruction
+
+Next, let's implement the `heal` instruction which allows a player to burn 1
+token and restore their health to its maximum value.
+
+The `heal` instruction requires the following accounts:
+
+- `player` - the player executing the healing action
+- `player_data` - the player data account storing the player's current health
+- `player_token_account` - the player's associated token account where the
+  tokens will be burned
+- `reward_token_mint` - the token mint account, specifying the type of token
+  that will be burned
+- `token_program` - required for interacting with instructions on the token
+  program
+- `associated_token_program` - required when working with associated token
+  accounts
+
+```rust title="lib.rs"
+#[program]
+pub mod anchor_token {
+    use super::*;
+    ...
+
+    // Burn token to health player
+    pub fn heal(ctx: Context<Heal>) -> Result<()> {
+        ctx.accounts.player_data.health = MAX_HEALTH;
+
+        // CPI Context
+        let cpi_ctx = CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            Burn {
+                mint: ctx.accounts.reward_token_mint.to_account_info(),
+                from: ctx.accounts.player_token_account.to_account_info(),
+                authority: ctx.accounts.player.to_account_info(),
+            },
+        );
+
+        // Burn 1 token, accounting for decimals of mint
+        let amount = (1u64)
+            .checked_mul(10u64.pow(ctx.accounts.reward_token_mint.decimals as u32))
+            .unwrap();
+
+        burn(cpi_ctx, amount)?;
+        Ok(())
+    }
+}
+...
+
+#[derive(Accounts)]
+pub struct Heal<'info> {
+    #[account(mut)]
+    pub player: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"player".as_ref(), player.key().as_ref()],
+        bump,
+    )]
+    pub player_data: Account<'info, PlayerData>,
+
+    #[account(
+        mut,
+        associated_token::mint = reward_token_mint,
+        associated_token::authority = player
+    )]
+    pub player_token_account: Account<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        seeds = [b"reward"],
+        bump,
+    )]
+    pub reward_token_mint: Account<'info, Mint>,
+
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+}
+```
+
+The player's health is restored to its maximum value using the `heal`
+instruction. The instruction then uses a cross-program invocation (CPI) to call
+the `burn` instruction from the Token program, which burns 1 token from the
+`player_token_account` to heal the player.
+
+## Build and Deploy
+
+Great job! You've now completed the program! Go ahead and build and deploy it
+using the Solana Playground. Your final program should look like this:
+
+```rust title="lib.rs"
+use anchor_lang::prelude::*;
+use anchor_spl::{
+    associated_token::AssociatedToken,
+    metadata::{create_metadata_accounts_v3, CreateMetadataAccountsV3, Metadata},
+    token::{burn, mint_to, Burn, Mint, MintTo, Token, TokenAccount},
+};
+use mpl_token_metadata::{pda::find_metadata_account, state::DataV2};
+use solana_program::{pubkey, pubkey::Pubkey};
+
+declare_id!("CCLnXJAJYFjCHLCugpBCEQKrpiSApiRM4UxkBUHJRrv4");
+
+const ADMIN_PUBKEY: Pubkey = pubkey!("REPLACE_WITH_YOUR_WALLET_PUBKEY");
+const MAX_HEALTH: u8 = 100;
+
+#[program]
+pub mod anchor_token {
+    use super::*;
+
+    // Create new token mint with PDA as mint authority
+    pub fn create_mint(
+        ctx: Context<CreateMint>,
+        uri: String,
+        name: String,
+        symbol: String,
+    ) -> Result<()> {
+        // PDA seeds and bump to "sign" for CPI
+        let seeds = b"reward";
+        let bump = *ctx.bumps.get("reward_token_mint").unwrap();
+        let signer: &[&[&[u8]]] = &[&[seeds, &[bump]]];
+
+        // Onchain token metadata for the mint
+        let data_v2 = DataV2 {
+            name: name,
+            symbol: symbol,
+            uri: uri,
+            seller_fee_basis_points: 0,
+            creators: None,
+            collection: None,
+            uses: None,
+        };
+
+        // CPI Context
+        let cpi_ctx = CpiContext::new_with_signer(
+            ctx.accounts.token_metadata_program.to_account_info(),
+            CreateMetadataAccountsV3 {
+                metadata: ctx.accounts.metadata_account.to_account_info(), // the metadata account being created
+                mint: ctx.accounts.reward_token_mint.to_account_info(), // the mint account of the metadata account
+                mint_authority: ctx.accounts.reward_token_mint.to_account_info(), // the mint authority of the mint account
+                update_authority: ctx.accounts.reward_token_mint.to_account_info(), // the update authority of the metadata account
+                payer: ctx.accounts.admin.to_account_info(), // the payer for creating the metadata account
+                system_program: ctx.accounts.system_program.to_account_info(), // the system program account
+                rent: ctx.accounts.rent.to_account_info(), // the rent sysvar account
+            },
+            signer,
+        );
+
+        create_metadata_accounts_v3(
+            cpi_ctx, // cpi context
+            data_v2, // token metadata
+            true,    // is_mutable
+            true,    // update_authority_is_signer
+            None,    // collection details
+        )?;
+
+        Ok(())
+    }
+
+    // Create new player account
+    pub fn init_player(ctx: Context<InitPlayer>) -> Result<()> {
+        ctx.accounts.player_data.health = MAX_HEALTH;
+        Ok(())
+    }
+
+    // Mint tokens to player token account
+    pub fn kill_enemy(ctx: Context<KillEnemy>) -> Result<()> {
+        // Check if player has enough health
+        if ctx.accounts.player_data.health == 0 {
+            return err!(ErrorCode::NotEnoughHealth);
+        }
+        // Subtract 10 health from player
+        ctx.accounts.player_data.health = ctx.accounts.player_data.health.checked_sub(10).unwrap();
+
+        // PDA seeds and bump to "sign" for CPI
+        let seeds = b"reward";
+        let bump = *ctx.bumps.get("reward_token_mint").unwrap();
+        let signer: &[&[&[u8]]] = &[&[seeds, &[bump]]];
+
+        // CPI Context
+        let cpi_ctx = CpiContext::new_with_signer(
+            ctx.accounts.token_program.to_account_info(),
+            MintTo {
+                mint: ctx.accounts.reward_token_mint.to_account_info(),
+                to: ctx.accounts.player_token_account.to_account_info(),
+                authority: ctx.accounts.reward_token_mint.to_account_info(),
+            },
+            signer,
+        );
+
+        // Mint 1 token, accounting for decimals of mint
+        let amount = (1u64)
+            .checked_mul(10u64.pow(ctx.accounts.reward_token_mint.decimals as u32))
+            .unwrap();
+
+        mint_to(cpi_ctx, amount)?;
+        Ok(())
+    }
+
+    // Burn Token to health player
+    pub fn heal(ctx: Context<Heal>) -> Result<()> {
+        ctx.accounts.player_data.health = MAX_HEALTH;
+
+        // CPI Context
+        let cpi_ctx = CpiContext::new(
+            ctx.accounts.token_program.to_account_info(),
+            Burn {
+                mint: ctx.accounts.reward_token_mint.to_account_info(),
+                from: ctx.accounts.player_token_account.to_account_info(),
+                authority: ctx.accounts.player.to_account_info(),
+            },
+        );
+
+        // Burn 1 token, accounting for decimals of mint
+        let amount = (1u64)
+            .checked_mul(10u64.pow(ctx.accounts.reward_token_mint.decimals as u32))
+            .unwrap();
+
+        burn(cpi_ctx, amount)?;
+        Ok(())
+    }
+}
+
+#[derive(Accounts)]
+pub struct CreateMint<'info> {
+    #[account(
+        mut,
+        address = ADMIN_PUBKEY
+    )]
+    pub admin: Signer<'info>,
+
+    // The PDA is both the address of the mint account and the mint authority
+    #[account(
+        init,
+        seeds = [b"reward"],
+        bump,
+        payer = admin,
+        mint::decimals = 9,
+        mint::authority = reward_token_mint,
+
+    )]
+    pub reward_token_mint: Account<'info, Mint>,
+
+    ///CHECK: Using "address" constraint to validate metadata account address
+    #[account(
+        mut,
+        address=find_metadata_account(&reward_token_mint.key()).0
+    )]
+    pub metadata_account: UncheckedAccount<'info>,
+
+    pub token_program: Program<'info, Token>,
+    pub token_metadata_program: Program<'info, Metadata>,
+    pub system_program: Program<'info, System>,
+    pub rent: Sysvar<'info, Rent>,
+}
+
+#[derive(Accounts)]
+pub struct InitPlayer<'info> {
+    #[account(
+        init,
+        payer = player,
+        space = 8 + 8,
+        seeds = [b"player".as_ref(), player.key().as_ref()],
+        bump,
+    )]
+    pub player_data: Account<'info, PlayerData>,
+    #[account(mut)]
+    pub player: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct KillEnemy<'info> {
+    #[account(mut)]
+    pub player: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"player".as_ref(), player.key().as_ref()],
+        bump,
+    )]
+    pub player_data: Account<'info, PlayerData>,
+
+    // Initialize player token account if it doesn't exist
+    #[account(
+        init_if_needed,
+        payer = player,
+        associated_token::mint = reward_token_mint,
+        associated_token::authority = player
+    )]
+    pub player_token_account: Account<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        seeds = [b"reward"],
+        bump,
+    )]
+    pub reward_token_mint: Account<'info, Mint>,
+
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct Heal<'info> {
+    #[account(mut)]
+    pub player: Signer<'info>,
+
+    #[account(
+        mut,
+        seeds = [b"player".as_ref(), player.key().as_ref()],
+        bump,
+    )]
+    pub player_data: Account<'info, PlayerData>,
+
+    #[account(
+        mut,
+        associated_token::mint = reward_token_mint,
+        associated_token::authority = player
+    )]
+    pub player_token_account: Account<'info, TokenAccount>,
+
+    #[account(
+        mut,
+        seeds = [b"reward"],
+        bump,
+    )]
+    pub reward_token_mint: Account<'info, Mint>,
+
+    pub token_program: Program<'info, Token>,
+    pub associated_token_program: Program<'info, AssociatedToken>,
+}
+
+#[account]
+pub struct PlayerData {
+    pub health: u8,
+}
+
+#[error_code]
+pub enum ErrorCode {
+    #[msg("Not enough health")]
+    NotEnoughHealth,
+}
+```
+
+## Get Started with the Client
+
+In this section, we'll walk you through a simple client-side implementation for
+interacting with the program. To get started, navigate to the `client.ts` file
+in Solana Playground, remove the placeholder code, and add the code snippets
+from the following sections.
+
+Start by adding the following code for the setup.
+
+```js title="client.ts"
+import { Metaplex } from "@metaplex-foundation/js";
+import { getMint, getAssociatedTokenAddressSync } from "@solana/spl-token";
+
+// metaplex token metadata program ID
+const TOKEN_METADATA_PROGRAM_ID = new web3.PublicKey(
+  "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s"
+);
+
+// metaplex setup
+const metaplex = Metaplex.make(pg.connection);
+
+// token metadata
+const metadata = {
+  uri: "https://raw.githubusercontent.com/solana-developers/program-examples/new-examples/tokens/tokens/.assets/spl-token.json",
+  name: "Solana Gold",
+  symbol: "GOLDSOL"
+};
+
+// reward token mint PDA
+const [rewardTokenMintPda] = anchor.web3.PublicKey.findProgramAddressSync(
+  [Buffer.from("reward")],
+  pg.PROGRAM_ID
+);
+
+// player data account PDA
+const [playerPDA] = anchor.web3.PublicKey.findProgramAddressSync(
+  [Buffer.from("player"), pg.wallet.publicKey.toBuffer()],
+  pg.PROGRAM_ID
+);
+
+// reward token mint metadata account address
+const rewardTokenMintMetadataPDA = await metaplex
+  .nfts()
+  .pdas()
+  .metadata({ mint: rewardTokenMintPda });
+
+// player token account address
+const playerTokenAccount = getAssociatedTokenAddressSync(
+  rewardTokenMintPda,
+  pg.wallet.publicKey
+);
+```
+
+Next, add the following two helper functions. These functions will be used to
+confirm transactions and fetch account data.
+
+```js
+async function logTransaction(txHash) {
+  const { blockhash, lastValidBlockHeight } =
+    await pg.connection.getLatestBlockhash();
+
+  await pg.connection.confirmTransaction({
+    blockhash,
+    lastValidBlockHeight,
+    signature: txHash
+  });
+
+  console.log(`Use 'solana confirm -v ${txHash}' to see the logs`);
+}
+
+async function fetchAccountData() {
+  const [playerBalance, playerData] = await Promise.all([
+    pg.connection.getTokenAccountBalance(playerTokenAccount),
+    pg.program.account.playerData.fetch(playerPDA)
+  ]);
+
+  console.log("Player Token Balance: ", playerBalance.value.uiAmount);
+  console.log("Player Health: ", playerData.health);
+}
+```
+
+Next, invoke the `createMint` instruction to create a new token mint if it does
+not already exist:
+
+```js
+let txHash;
+
+try {
+  const mintData = await getMint(pg.connection, rewardTokenMintPda);
+  console.log("Mint Already Exists");
+} catch {
+  txHash = await pg.program.methods
+    .createMint(metadata.uri, metadata.name, metadata.symbol)
+    .accounts({
+      rewardTokenMint: rewardTokenMintPda,
+      metadataAccount: rewardTokenMintMetadataPDA,
+      tokenMetadataProgram: TOKEN_METADATA_PROGRAM_ID
+    })
+    .rpc();
+  await logTransaction(txHash);
+}
+console.log("Token Mint: ", rewardTokenMintPda.toString());
+```
+
+Next, call the `initPlayer` instruction to create a new player account if one
+does not already exist.
+
+```js
+try {
+  const playerData = await pg.program.account.playerData.fetch(playerPDA);
+  console.log("Player Already Exists");
+  console.log("Player Health: ", playerData.health);
+} catch {
+  txHash = await pg.program.methods
+    .initPlayer()
+    .accounts({
+      playerData: playerPDA,
+      player: pg.wallet.publicKey
+    })
+    .rpc();
+  await logTransaction(txHash);
+  console.log("Player Account Created");
+}
+```
+
+Next, invoke the `killEnemy` instruction:
+
+```js
+txHash = await pg.program.methods
+  .killEnemy()
+  .accounts({
+    playerData: playerPDA,
+    playerTokenAccount: playerTokenAccount,
+    rewardTokenMint: rewardTokenMintPda
+  })
+  .rpc();
+await logTransaction(txHash);
+console.log("Enemy Defeated");
+await fetchAccountData();
+```
+
+Next, invoke the `heal` instruction:
+
+```js
+txHash = await pg.program.methods
+  .heal()
+  .accounts({
+    playerData: playerPDA,
+    playerTokenAccount: playerTokenAccount,
+    rewardTokenMint: rewardTokenMintPda
+  })
+  .rpc();
+await logTransaction(txHash);
+console.log("Player Healed");
+await fetchAccountData();
+```
+
+Finally, run the client by clicking the “Run” button in Solana Playground. You
+can copy the Token Mint address printed to the console and verify on Solana
+Explorer that the token now has metadata. The output should be similar to the
+following:
+
+```
+Running client...
+  client.ts:
+    Use 'solana confirm -v 3AWnpt2Wy6jQckue4QeKsgDNKhKkhpewPmRtxvJpzxGgvK9XK9KEpTiUzAQ5vSC6CUoUjc6xWZCtrihVrFy8sACC' to see the logs
+    Token Mint:  3eS7hdyeVX5g8JGhn3Z7qFXJaewoJ8hzgvubovQsPm4S
+    Use 'solana confirm -v 63jbBr5U4LG75TiiHfz65q7yKJfHDhGP2ocCiDat5M2k4cWtUMAx9sHvxhnEguLDKXMbDUQKUt1nhvyQkXoDhxst' to see the logs
+    Player Account Created
+    Use 'solana confirm -v 2ziK41WLoxfEHvtUgc5c1SyKCAr5FvAS54ARBJrjqh9GDwzYqu7qWCwHJCgMZyFEVovYK5nUZhDRHPTMrTjq1Mm6' to see the logs
+    Enemy Defeated
+    Player Token Balance:  1
+    Player Health:  90
+    Use 'solana confirm -v 2QoAH22Q3xXz9t2TYRycQMqpEmauaRvmUfZ7ZNKUEoUyHWqpjW972VD3eZyeJrXsviaiCC3g6TE54oKmKbFQf2Q7' to see the logs
+    Player Healed
+    Player Token Balance:  0
+    Player Health:  100
+```

--- a/apps/docs/content/cookbook/games/meta.json
+++ b/apps/docs/content/cookbook/games/meta.json
@@ -1,0 +1,15 @@
+{
+  "title": "Games",
+  "defaultOpen": false,
+  "pages": [
+    "getting-started-with-game-development",
+    "hello-world",
+    "energy-system",
+    "saving-game-state",
+    "store-sol-in-pda",
+    "interact-with-tokens",
+    "nfts-in-games",
+    "porting-anchor-to-unity",
+    "game-examples"
+  ]
+}

--- a/apps/docs/content/cookbook/games/nfts-in-games.mdx
+++ b/apps/docs/content/cookbook/games/nfts-in-games.mdx
@@ -1,0 +1,270 @@
+---
+date: 2025-03-15T00:00:00Z
+difficulty: intro
+title: Using NFTs and Digital Assets in Games
+description:
+  NFTs can be a powerful tool in blockchain games. Learn how to utilize NFTs in
+  Solana games to their full potential.
+tags:
+  - games
+  - anchor
+  - program
+  - web3js
+  - token extensions
+  - token 2022
+  - nfts
+keywords:
+  - tutorial
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+  - anchor
+  - games
+  - example
+  - nfts
+  - metadata
+---
+
+Non-fungible tokens (NFTs) are rapidly gaining popularity as a means of
+integrating Solana into games. These unique digital assets are stored on the
+Solana blockchain and come with a JSON metadata attached to them. This metadata
+allows developers to store important attributes and information about a specific
+asset, such as its rarity or specific in-game capabilities.
+
+NFTs can be used in games to represent anything from weapons and armor to
+digital real estate and collectibles, providing a new level of ownership and
+scarcity for players. Furthermore NFTs can be representing land, houses,
+achievements or even characters in a game. The possibilities are endless.
+
+## Token gating with NFTs
+
+Using NFTs, you can conditionally gate access to a particular part of a game
+based on owning the NFT. This can form a more tight-knit community within your
+game. In [JavaScript](/docs/clients/official/javascript) using the
+[Metaplex SDK](https://github.com/metaplex-foundation/js#readme) this would look
+like this:
+
+```js
+JSON.parse(
+  // For example '~/.config/solana/id.json'
+  fs.readFileSync("yourKeyPair.json").toString())
+);
+let keyPair = Keypair.fromSecretKey(decodedKey);
+
+const metaplex = Metaplex.make(connection).use(keypairIdentity(keyPair));
+
+const nfts = await metaplex
+  .nfts()
+  .findAllByOwner({ owner: wallet.publicKey })
+
+let collectionNfts = []
+for (let i = 0; i < nfts.length; i++) {
+  if (nfts[i].collection?.address.toString() == collectionAddress.toString()) {
+    collectionNfts.push(nfts[i])
+  }
+}
+```
+
+Another performant way to load NFTs is the
+[DAS asset API](https://docs.helius.dev/compression-and-das-api/digital-asset-standard-das-api).
+You can see an example of this in the Solana games preset in the JavaScript
+client via this
+[Code Example](https://github.com/solana-developers/solana-game-preset/blob/main/app/components/DisplayNfts.tsx)
+or generating a full game scaffold with the following command:
+
+```bash
+npx create-solana-game your-game-name
+```
+
+## Bonus effects with NFTs
+
+In addition to providing new revenue streams, NFTs can also be used to provide
+in-game benefits and bonuses to players. For instance, a player who owns a "coin
+doubler" NFT may receive double the amount of coins for as long as they hold the
+NFT in their wallet.
+
+NFTs could be used as in-game consumables, allowing players to use them a set
+number of times to gain temporary effects (such as potions or spells). Once
+fully consumed, the NFT is burned, and the effect is applied to the player's
+character.
+
+These innovative features of NFTs provide game developers with new opportunities
+to create unique gameplay experiences and reward players for their ownership of
+valuable assets on the Solana blockchain.
+
+> You can follow this developer guide on
+> [how to interact with tokens](/developers/cookbook/games/interact-with-tokens)
+> within a onchain Solana game.
+
+In the example game, Seven Seas, the program uses 3 different digital assets,
+both fungible and non-fungible assets:
+
+- "pirate coins" (fungible tokens) which are used to upgrade ships
+- "rum" (fungible tokens) which increases the health of ships
+- "cannons" (NFTs) which increase ships damage dealt in battles
+
+> You can find the source code
+> [source code](https://github.com/solana-developers/solana-game-examples/tree/main/seven-seas)
+> and a detailed
+> [eight hour video course](https://www.youtube.com/playlist?list=PLilwLeBwGuK6NsYMPP_BlVkeQgff0NwvU)
+> for the Seven Seas game here.
+
+You can also use
+[dynamic metadata](/developers/cookbook/games/interact-with-tokens) (using Token
+Extensions) to save character level and experience or items in an NFT. Here is a
+[Video Walkthrough](https://www.youtube.com/watch?v=n-ym1utpzhk&ab_channel=Solana)
+with source code that explains dynamic metadata NFTs. This could allow the NFTs
+in your game to become more valuable the more the players play with them.
+
+You can also do this with Metaplex's new
+[Core NFT standard](https://developers.metaplex.com/core).
+
+## Using NFT metadata for player stats
+
+NFTs also have metadata which can be used for all kind of traits for game
+objects. For example, an NFT could represent a game character and their traits
+(Strength, Intelligence, Agility, etc) could directly influence how strong the
+character is in the game. You can load NFT metadata and their attributes using
+the Metaplex SDK:
+
+```js
+import { Metaplex, keypairIdentity } from "@metaplex-foundation/js";
+
+JSON.parse(
+  // For example '.config/solana/devnet.json'
+  fs.readFileSync("yourKeyPair.json").toString())
+);
+let keyPair = Keypair.fromSecretKey(decodedKey);
+
+const metaplex = Metaplex.make(connection).use(keypairIdentity(keyPair));
+const nfts = await metaplex.nfts().findAllByOwner({owner: keyPair.publicKey});
+
+const physicalDamage = 5;
+const magicalDamage = 5;
+
+nfts.forEach(async nft => {
+  const metaData = await metaplex.nfts().load({metadata: nft});
+
+    metaData.json.attributes.forEach(async attribute => {
+      if (attribute.trait_type == "Strength") {
+        physicalDamage += parseInt(attribute.value)
+      }
+      if (attribute.trait_type == "Int") {
+        magicalDamage += parseInt(attribute.value)
+      }
+    });
+})
+
+console.log("Player Physical Damage: " + physicalDamage)
+console.log("Player Magical Damage: " + magicalDamage)
+```
+
+## Use NFTs to save a game state
+
+You can also use the mint of an NFT to
+[derive a PDA](/docs/core/pda/pda-derivation) and use it to save the game state
+of a player. This could allow you to save any game state of a player directly in
+an NFT which the player can take with them (including selling it allowing you to
+collect royalties). You can see an example of how that can be done in the
+[Solana 2048 game](https://github.com/solana-developers/solana-2048) and the
+following code snippet:
+
+```rust
+#[account(
+    init,
+    payer = signer,
+    space = 800,
+    seeds = [b"player".as_ref(), nftMint.key().as_ref()],
+    bump,
+)]
+pub player: Account<'info, PlayerData>,
+```
+
+## Fusing NFTs together
+
+The
+[Metaplex Fusion Trifle program](https://docs.metaplex.com/programs/fusion/overview)
+allows NFTs to own other NFTs.
+
+As an example, you could create a plant plot NFT and then use to combine it with
+a water NFT and a seed NFT to create a Tomato NFT.
+
+## Use 3D NFTs in a game
+
+Every NFT metadata can also have an "animation url". This url can contain a
+video, GIF or a 3D file. These 3D files usually use the format `.glb` or `.gltf`
+and can dynamically be loaded into a game.
+
+For Unity, you can use the [GLTFast](https://github.com/atteneder/glTFast)
+package. In JavaScript, the
+[GLTFast JS](https://discoverthreejs.com/book/first-steps/load-models/).
+
+The following is an example code snippet that loads an
+[NFT's metadata with glb model](https://solscan.io/token/DzHPvbGzrHK4UcyeDurw2nuBFKNvt4Kb7K8Bx9dtsfn#metadata)
+in it:
+
+```c#
+var gltf = gameObject.AddComponent<GLTFast.GltfAsset>();
+gltf.url = nft.metadata.animationUrl;
+```
+
+```js
+npm install --save-dev gltf-loader-ts
+
+import { GltfLoader } from 'gltf-loader-ts';
+
+let loader = new GltfLoader();
+let uri = 'https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Models/master/2.0/BoxTextured/glTF/BoxTextured.gltf';
+let asset: Asset = await loader.load(uri);
+let gltf: GlTf = asset.gltf;
+console.log(gltf);
+// -> {asset: {...}, scene: 0, scenes: Array(1), nodes: Array(2), meshes: Array(1), ...}
+
+let data = await asset.accessorData(0); // fetches BoxTextured0.bin
+let image: Image = await asset.imageData.get(0) // fetches CesiumLogoFlat.png
+```
+
+## How to create NFTs in a program and add additional metadata
+
+With the new [Token Extensions](/docs/tokens/extensions), it is possible to
+create NFTs in a program and add additional dynamic onchain traits that can be
+saved in the NFT's mint account itself.
+
+For example, you could save the experience and player level in the NFT itself.
+These NFTs could become more valuable the more the players play with them. A
+player 99 character maybe more desirable than a level 1 character.
+
+You can find more resources on working with this type of onchain metadata with
+the following links:
+
+- [Guide](/docs/tokens/extensions/metadata)
+- [Repository](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer/anchor)
+- [Video](https://www.youtube.com/watch?v=n-ym1utpzhk&ab_channel=Solana)
+
+## How to create an NFT collection
+
+NFTs on Solana commonly follow the Metaplex standard's for collections. Metaplex
+is a company that takes care of the most-used NFT standard on Solana. The most
+common way to create an NFT collection is to create a Metaplex
+"[Candy Machine](https://developers.metaplex.com/candy-machine)" which lets the
+user mint predefined pairs of metadata and images.
+
+You can find more information on working with Metaplex collections in the
+[Metaplex community guides](https://developers.metaplex.com/community-guides).
+
+While Metaplex is common, is popular, there are many more NFT standards on
+Solana:
+
+- spNFTs
+- WNS
+- Core
+- SPL-22
+- SPL-404
+- nifty
+
+## NFT staking and missions
+
+You can allow players to stake NFTs (time lock) to create in-game currency or
+send NFTs on missions to give the players rewards. The
+[Honeycomb Protocol](https://docs.honeycombprotocol.com/) offers this type of
+functionality and more.

--- a/apps/docs/content/cookbook/games/porting-anchor-to-unity.mdx
+++ b/apps/docs/content/cookbook/games/porting-anchor-to-unity.mdx
@@ -1,0 +1,102 @@
+---
+date: 2025-03-15T00:00:00Z
+difficulty: beginner
+title: Port Anchor to Unity
+description:
+  Using Anchor IDL you can interact with your program directly from unity
+tags:
+  - games
+  - anchor
+  - program
+  - unity
+  - rust
+keywords:
+  - tutorial
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+  - anchor
+  - games
+  - example
+---
+
+If you have written a Solana program, you can use it in the Unity game engine
+using a code generator that lets you port an Anchor IDL (a JSON representation
+of a Solana program) to C#. You can find an examples implementation of a Unity
+game client that uses the Anchor to Unity port using the
+[Solana Game Preset](https://solana.com/developers/cookbook/games/game-examples?q=npx%20create-solana-game#using-create-solana-game).
+
+## Generating the Client
+
+When using Anchor you will be able to generate an IDL file which is a JSON
+representation of your program. With this IDL you can then generate different
+clients. For example JavaScript or C# for Unity.
+
+[IDL to C# Converter](https://github.com/magicblock-labs/Solana.Unity.Anchor)
+
+These two lines will generate a C# client for the game.
+
+```js
+dotnet tool install Solana.Unity.Anchor.Tool
+dotnet anchorgen -i idl/file.json -o src/ProgramCode.cs
+```
+
+This will generate you a C# representation of you program, which lets you
+deserialize the data and easily create instructions to the program.
+
+## Building the Transaction in Unity C#
+
+Within Unity game engine we can then use the
+[Solana Unity SDK](https://github.com/magicblock-labs/Solana.Unity-SDK) to
+interact with the program.
+
+1. First we find the onchain address of the game data account with
+   TryFindProgramAddress. We need to pass in this account to the transaction so
+   that the Solana runtime knows that we want to change this account.
+2. Next we use the generated client to create a MoveRight instruction.
+3. Then we request a block hash from an RPC node. This is needed so that Solana
+   knows how long the transaction will be valid.
+4. Next we set the fee payer to be the players wallet.
+5. Then we add the move right instruction to the transaction. We can also add
+   multiple instructions to a singe transaction if needed.
+6. Afterwards the transaction gets signed and then send to the RPC node for
+   processing. Solana has different Commitment levels. If we set the commitment
+   level to Confirmed we will be able to get the new state already within the
+   next 500ms.
+
+7. [Unity Client](https://github.com/solana-developers/solana-game-examples/tree/main/seven-seas/unity/Assets/SolPlay/Examples/TinyAdventure)
+
+```c#
+public async void MoveRight()
+{
+    PublicKey.TryFindProgramAddress(new[]
+    {
+        Encoding.UTF8.GetBytes("level1")
+    },
+    ProgramId, out gameDataAccount, out var bump);
+
+    MoveRightAccounts account = new MoveRightAccounts();
+    account.GameDataAccount = gameDataAccount;
+    TransactionInstruction moveRightInstruction = TinyAdventureProgram.MoveRight(account, ProgramId);
+
+    var walletHolderService = ServiceFactory.Resolve<WalletHolderService>();
+    var result = await walletHolderService.BaseWallet.ActiveRpcClient.GetRecentBlockHashAsync(Commitment.Confirmed);
+
+    Transaction transaction = new Transaction();
+    transaction.FeePayer = walletHolderService.BaseWallet.Account.PublicKey;
+    transaction.RecentBlockHash = result.Result.Value.Blockhash;
+    transaction.Signatures = new List<SignaturePubKeyPair>();
+    transaction.Instructions = new List<TransactionInstruction>();
+    transaction.Instructions.Add(moveRightInstruction);
+
+    Transaction signedTransaction = await walletHolderService.BaseWallet.SignTransaction(transaction);
+
+    RequestResult<string> signature = await walletHolderService.BaseWallet.ActiveRpcClient.SendTransactionAsync(
+        Convert.ToBase64String(signedTransaction.Serialize()),
+        true, Commitment.Confirmed);
+}
+```
+
+A full example of a Unity game that interacts with an Anchor program can be
+found in the Solana Game Preset which you can find
+[here](/developers/cookbook/games/game-examples).

--- a/apps/docs/content/cookbook/games/saving-game-state.mdx
+++ b/apps/docs/content/cookbook/games/saving-game-state.mdx
@@ -1,0 +1,124 @@
+---
+date: 2025-03-15T00:00:00Z
+difficulty: beginner
+title: Saving game state
+description: How to save the state of a game in a Solana program
+tags:
+  - games
+  - anchor
+  - program
+  - solana playground
+  - web3js
+  - native
+  - rust
+keywords:
+  - tutorial
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+  - anchor
+  - games
+  - example
+---
+
+You can use Solana blockchain to save the state of your game in program
+accounts. These are accounts that are owned by your program and they are derived
+from the program ID and some seeds. These can be thought of as database entries.
+We can for example create a PlayerData account and use the players public key as
+a seed. This means every player can have one player account per wallet. These
+accounts can be up to 10Kb by default. If you need a bigger account look into
+[how to handle big accounts](https://github.com/solana-developers/anchor-zero-copy-example)
+This can be done in a program like this:
+
+```rust
+pub fn init_player(ctx: Context<InitPlayer>) -> Result<()> {
+    ctx.accounts.player.energy = MAX_ENERGY;
+    ctx.accounts.player.health = MAX_HEALTH;
+    ctx.accounts.player.last_login = Clock::get()?.unix_timestamp;
+    Ok(())
+}
+
+#[derive(Accounts)]
+pub struct InitPlayer <'info> {
+    #[account(
+        init,
+        payer = signer,
+        space = 1000,
+        seeds = [b"player".as_ref(), signer.key().as_ref()],
+        bump,
+    )]
+    pub player: Account<'info, PlayerData>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[account]
+pub struct PlayerData {
+    pub name: String,
+    pub level: u8,
+    pub xp: u64,
+    pub health: u64,
+    pub log: u64,
+    pub energy: u64,
+    pub last_login: i64
+}
+
+```
+
+You can then interact with this player data via transaction instructions. Lets
+say we want the player to get experience for killing a monster for example:
+
+```rust
+    pub fn kill_enemy(mut ctx: Context<KillEnemy>, enemyId: u8) -> Result<()> {
+        let account = &mut ctx.accounts;
+
+        ... handle energy
+
+        if ctx.accounts.player.energy == 0 {
+            return err!(ErrorCode::NotEnoughEnergy);
+        }
+
+        ... get enemy values by id and calculate battle
+
+        ctx.accounts.player.xp = ctx.accounts.player.xp + 1;
+        ctx.accounts.player.energy = ctx.accounts.player.energy - 1;
+
+        ... handle level up
+
+        msg!("You killed enemy and got 1 xp. You have {} xp and {} energy left.", ctx.accounts.player.xp, ctx.accounts.player.energy);
+        Ok(())
+    }
+```
+
+This is how this would look like from a JavaScript client:
+
+```js
+const wallet = useAnchorWallet();
+const provider = new AnchorProvider(connection, wallet, {});
+setProvider(provider);
+const program = new Program(IDL, PROGRAM_ID, provider);
+
+const [pda] = PublicKey.findProgramAddressSync(
+  [Buffer.from("player", "utf8"),
+  publicKey.toBuffer()],
+  new PublicKey(PROGRAM_ID)
+);
+
+try {
+  const transaction = program.methods
+    .initPlayer()
+    .accounts({
+      player: pda,
+      signer: publicKey,
+      systemProgram: SystemProgram.programId,
+    })
+    .transaction();
+
+  const tx = await transaction;
+  const txSig = await sendTransaction(tx, connection);
+  await connection.confirmTransaction(txSig, "confirmed");
+```
+
+How to actually build this energy system you can learn here:
+[Building an Energy system](/developers/cookbook/games/energy-system)

--- a/apps/docs/content/cookbook/games/store-sol-in-pda.mdx
+++ b/apps/docs/content/cookbook/games/store-sol-in-pda.mdx
@@ -1,0 +1,752 @@
+---
+date: 2025-03-15T00:00:00Z
+difficulty: intermediate
+title: Storing SOL in a PDA
+description:
+  Using PDAs, you can reward SOL to players playing your game. Learn how to
+  reward SOL from a PDA when players find chests in this game.
+tags:
+  - games
+  - anchor
+  - program
+  - web3js
+  - rust
+keywords:
+  - tutorial
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+  - anchor
+  - games
+  - example
+---
+
+Here you will learn how to store SOL in a PDA. In the example we will use it to
+reward players in a game. We will build a simple game where players can move
+right and collect a reward when they reach a specific position. The reward will
+be stored in a PDA, and players can claim it by interacting with the game.
+
+Video walkthrough:
+
+<Embed url="https://www.youtube.com/watch?v=gILXyWvXu7M" />
+
+## Tiny Adventure Anchor Program - Part Two
+
+In this tutorial, we will rebuild the Tiny Adventure game and introduce a chest
+with a reward of 0.1 SOL. The chest will "spawn" at a specific position, and
+when the player reaches that position, they will receive the reward. The goal of
+this program is to demonstrate how to store SOL within a program account and
+distribute it to players.
+
+The Tiny Adventure Two Program consists of 3 instructions:
+
+- `initialize_level_one` - This instruction initializes two onchain accounts:
+  one for recording the player's position and another for holding the SOL reward
+  that represents the “reward chest”.
+- `reset_level_and_spawn_chest` - This instruction resets the player's position
+  to zero and "respawns" a reward chest by transferring SOL from the user
+  invoking the instruction to the reward chest account.
+- `move_right` - This instruction allows the player to move their position to
+  the right and collect the SOL in the reward chest once they reach a specific
+  position.
+
+In the following sections, we will guide you through building the program step
+by step. You can find the complete source code, which can be deployed directly
+from your browser using the Solana Playground, at this link:
+[Open In Playground](https://beta.solpg.io/tutorials/tiny-adventure-two).
+
+### Getting Started
+
+To start building the Tiny Adventure game, follow these steps:
+
+Visit the [Solana Playground](https://beta.solpg.io/) and create a new Anchor
+project. If you're new to Solana Playground, you'll also need to create a
+Playground Wallet.
+
+After creating a new project, replace the default starter code with the code
+below:
+
+```rust
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::native_token::LAMPORTS_PER_SOL;
+use anchor_lang::system_program;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+mod tiny_adventure_two {
+    use super::*;
+}
+
+fn print_player(player_position: u8) {
+    if player_position == 0 {
+        msg!("A Journey Begins!");
+        msg!("o.........💎");
+    } else if player_position == 1 {
+        msg!("..o.......💎");
+    } else if player_position == 2 {
+        msg!("....o.....💎");
+    } else if player_position == 3 {
+        msg!("........\\o/💎");
+        msg!("..........\\o/");
+        msg!("You have reached the end! Super!");
+    }
+}
+```
+
+In this game, the player starts at position 0 and can only move right. To
+visualize the player's progress throughout the game, we'll use message logs to
+represent their journey towards the reward chest!
+
+### Defining the Chest Vault Account
+
+Add the `CHEST_REWARD` constant at the beginning of the program. The
+`CHEST_REWARD` represents the amount of lamports that will be put into the chest
+and given out as rewards. Lamports are the smallest fractions of a SOL, with 1
+billion lamports being equal to 1 SOL.
+
+To store the SOL reward, we will define a new `ChestVaultAccount` struct. This
+is an empty struct because we will be directly updating the lamports in the
+account. The account will hold the SOL reward and does not need to store any
+additional data.
+
+```rust
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::native_token::LAMPORTS_PER_SOL;
+use anchor_lang::system_program;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+mod tiny_adventure_two {
+    use super::*;
+
+    // The amount of lamports that will be put into chests and given out as rewards.
+    const CHEST_REWARD: u64 = LAMPORTS_PER_SOL / 10; // 0.1 SOL
+}
+
+...
+
+// Define the Chest Vault Account structure
+#[account]
+pub struct ChestVaultAccount {}
+```
+
+### Defining the Game Data Account
+
+To keep track of the player's position within the game, we need to define a
+structure for the onchain account that will store the player's position.
+
+The `GameDataAccount` struct contains a single field, `player_position`, which
+stores the player's current position as an unsigned 8-bit integer.
+
+```rust
+
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::native_token::LAMPORTS_PER_SOL;
+use anchor_lang::system_program;
+
+declare_id!("11111111111111111111111111111111");
+
+#[program]
+mod tiny_adventure_two {
+    use super::*;
+    ...
+
+}
+
+...
+
+// Define the Game Data Account structure
+#[account]
+pub struct GameDataAccount {
+    player_position: u8,
+}
+```
+
+With the `GameDataAccount` struct defined, you can now use it to store and
+update the player's position as they interact with the game. As the player moves
+right and progresses through the game, their position will be updated within the
+`GameDataAccount`, allowing you to track their progress towards the chest
+containing the SOL reward.
+
+### Initialize Level One Instruction
+
+With the `GameDataAccount` and `ChestVaultAccount` defined, let's implement the
+`initialize_level_one` instruction. This instruction initializes both the
+`GameDataAccount` and `ChestVaultAccount`, sets the player's position to 0, and
+displays the starting message.
+
+The `initialize_level_one` instruction requires 4 accounts:
+
+- `new_game_data_account` - the `GameDataAccount` we are initializing to store
+  the player's position
+- `chest_vault` - the `ChestVaultAccount` we are initializing to store the SOL
+  reward
+- `signer` - the player paying for the initialization of the accounts
+- `system_program` - a required account when creating a new account
+
+```rust
+#[program]
+pub mod tiny_adventure_two {
+    use super::*;
+
+    pub fn initialize_level_one(_ctx: Context<InitializeLevelOne>) -> Result<()> {
+        msg!("A Journey Begins!");
+        msg!("o.......💎");
+        Ok(())
+    }
+
+    ...
+}
+
+// Specify the accounts required by the initialize_level_one instruction
+#[derive(Accounts)]
+pub struct InitializeLevelOne<'info> {
+    #[account(
+        init_if_needed,
+        seeds = [b"level1"],
+        bump,
+        payer = signer,
+        space = 8 + 1
+    )]
+    pub new_game_data_account: Account<'info, GameDataAccount>,
+    #[account(
+        init_if_needed,
+        seeds = [b"chestVault"],
+        bump,
+        payer = signer,
+        space = 8
+    )]
+    pub chest_vault: Account<'info, ChestVaultAccount>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+...
+```
+
+Both the `GameDataAccount` and `ChestVaultAccount` are created using a Program
+Derived Address (PDA) as the address of the account, allowing us to
+deterministically locate the address later. The `init_if_needed` constraint
+ensures that the accounts are only initialized if they don't already exist.
+Since the PDAs for both accounts in this instruction use a single fixed seed,
+our program can only create one of each type of account. In effect, the
+instruction would only ever need to be invoked one time.
+
+It's worth noting that the current implementation does not have any restrictions
+on who can modify the `GameDataAccount`, effectively turning the game into a
+multiplayer experience where everyone can control the player's movement.
+
+Alternatively, you can use the signer's address as an extra seed in the
+`initialize` instruction, allowing each player to create their own
+`GameDataAccount`.
+
+### Reset Level and Spawn Chest Instruction
+
+Next, let's implement the `reset_level_and_spawn_chest` instruction, which
+resets the player's position to the start and fills up the chest with a reward
+of 0.1 SOL.
+
+The `reset_level_and_spawn_chest` instruction requires 4 accounts:
+
+- `new_game_data_account` - the `GameDataAccount` storing the player's position
+- `chest_vault` - the `ChestVaultAccount` storing the SOL reward
+- `signer` - the player providing the SOL reward for the chest
+- `system_program` - the program we'll be invoking to transfer SOL using a
+  cross-program invocation (CPI), more on this shortly
+
+```rust
+#[program]
+pub mod tiny_adventure_two {
+    use super::*;
+    ...
+
+    pub fn reset_level_and_spawn_chest(ctx: Context<SpawnChest>) -> Result<()> {
+        ctx.accounts.game_data_account.player_position = 0;
+
+        let cpi_context = CpiContext::new(
+            ctx.accounts.system_program.to_account_info(),
+            system_program::Transfer {
+                from: ctx.accounts.payer.to_account_info().clone(),
+                to: ctx.accounts.chest_vault.to_account_info().clone(),
+            },
+        );
+        system_program::transfer(cpi_context, CHEST_REWARD)?;
+
+        msg!("Level Reset and Chest Spawned at position 3");
+
+        Ok(())
+    }
+
+    ...
+}
+
+// Specify the accounts required by the reset_level_and_spawn_chest instruction
+#[derive(Accounts)]
+pub struct SpawnChest<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(mut, seeds = [b"chestVault"], bump)]
+    pub chest_vault: Account<'info, ChestVaultAccount>,
+    #[account(mut)]
+    pub game_data_account: Account<'info, GameDataAccount>,
+    pub system_program: Program<'info, System>,
+}
+
+...
+```
+
+This instruction includes a cross-program invocation (CPI) to transfer SOL from
+the payer to the `ChestVaultAccount`. A cross-program invocation is when one
+program invokes an instruction on another program. In this case, we use a CPI to
+invoke the `Transfer` instruction from the `system_program` to transfer SOL from
+the payer to the `ChestVaultAccount`.
+
+Cross-program invocations are a key concept in the Solana programming model,
+enabling programs to directly interact with instructions from other programs.
+For a deeper dive into of CPIs, feel free to explore the
+[CPI guide](https://solana.com/docs/core/cpi?q=cpi).
+
+### Move Right Instruction
+
+Finally, let's implement the `move_right` instruction which includes the logic
+for collecting the chest reward. When a player reaches position 3 and inputs the
+correct “password”, the reward is transferred from the **`ChestVaultAccount`**
+to the player's account. If an incorrect password is entered, a custom Anchor
+Error is returned. If the player is already at position 3, a message will be
+logged. Otherwise, the position will be incremented by 1 to represent moving to
+the right.
+
+The main purpose of this "password" functionality is to demonstrate how to
+incorporate parameters into an instruction and the implementation of custom
+Anchor Errors for improved error handling. In this example, the correct password
+will be "gib".
+
+The `move_right` instruction requires 3 accounts:
+
+- `new_game_data_account` - the `GameDataAccount` storing the player's position
+- `chest_vault` - the `ChestVaultAccount` storing the SOL reward
+- `player_wallet` - the wallet of the player invoking the instruction and the
+  potential recipient of SOL reward
+
+```rust
+#[program]
+pub mod tiny_adventure_two {
+    use super::*;
+    ...
+
+    // Instruction to move right
+    pub fn move_right(ctx: Context<MoveRight>, password: String) -> Result<()> {
+        let game_data_account = &mut ctx.accounts.game_data_account;
+        if game_data_account.player_position == 3 {
+            msg!("You have reached the end! Super!");
+        } else if game_data_account.player_position == 2 {
+            if password != "gib" {
+                return err!(MyError::WrongPassword);
+            }
+
+            game_data_account.player_position = game_data_account.player_position + 1;
+
+            msg!(
+                "You made it! Here is your reward {0} lamports",
+                CHEST_REWARD
+            );
+
+            **ctx
+                .accounts
+                .chest_vault
+                .to_account_info()
+                .try_borrow_mut_lamports()? -= CHEST_REWARD;
+            **ctx
+                .accounts
+                .player
+                .to_account_info()
+                .try_borrow_mut_lamports()? += CHEST_REWARD;
+        } else {
+            game_data_account.player_position = game_data_account.player_position + 1;
+            print_player(game_data_account.player_position);
+        }
+        Ok(())
+    }
+
+    ...
+}
+
+// Specify the accounts required by the move_right instruction
+#[derive(Accounts)]
+pub struct MoveRight<'info> {
+    #[account(mut, seeds = [b"chestVault"], bump)]
+    pub chest_vault: Account<'info, ChestVaultAccount>,
+    #[account(mut)]
+    pub game_data_account: Account<'info, GameDataAccount>,
+    #[account(mut)]
+    pub player: Signer<'info>,
+}
+
+// Custom Anchor Error
+#[error_code]
+pub enum MyError {
+    #[msg("Password was wrong")]
+    WrongPassword,
+}
+
+...
+```
+
+To transfer lamports from the reward chest to the player account, we can't use a
+Cross-Program Invocation (CPI) as we did previously, since the
+`ChestVaultAccount` isn't owned by the system program. Instead, we directly
+modify the lamports within the accounts by using `try_borrow_mut_lamports`. Keep
+in mind that the account you deduct lamports from must be a signer, and the
+runtime always makes sure that the total account balances stay equal after a
+transaction.
+
+Note that Program Derived Accounts (PDAs) offer two main features:
+
+1. Provide a deterministic way to find an account's address
+2. Allow the program from which a PDA is derived to "sign" for them
+
+This is the reason we are able to deduct lamports from the `ChestVaultAccount`
+without explicitly requiring an extra signer for the instruction.
+
+### Build and Deploy
+
+Great job! You've now completed part two of the Tiny Adventure program! Your
+final program should look like this:
+
+```rust
+use anchor_lang::prelude::*;
+use anchor_lang::solana_program::native_token::LAMPORTS_PER_SOL;
+use anchor_lang::system_program;
+
+// This is your program's public key and it will update
+// automatically when you build the project.
+declare_id!("7gZTdZg86YsYbs92Rhv63kZUAkoww1kLexJg8sNpgVQ3");
+
+#[program]
+mod tiny_adventure_two {
+    use super::*;
+
+    // The amount of lamports that will be put into chests and given out as rewards.
+    const CHEST_REWARD: u64 = LAMPORTS_PER_SOL / 10; // 0.1 SOL
+
+    pub fn initialize_level_one(_ctx: Context<InitializeLevelOne>) -> Result<()> {
+        // Usually in your production code you would not print lots of text because it cost compute units.
+        msg!("A Journey Begins!");
+        msg!("o.......💎");
+        Ok(())
+    }
+
+    pub fn reset_level_and_spawn_chest(ctx: Context<SpawnChest>) -> Result<()> {
+        ctx.accounts.game_data_account.player_position = 0;
+
+        let cpi_context = CpiContext::new(
+            ctx.accounts.system_program.to_account_info(),
+            system_program::Transfer {
+                from: ctx.accounts.payer.to_account_info().clone(),
+                to: ctx.accounts.chest_vault.to_account_info().clone(),
+            },
+        );
+        system_program::transfer(cpi_context, CHEST_REWARD)?;
+
+        msg!("Level Reset and Chest Spawned at position 3");
+
+        Ok(())
+    }
+
+    pub fn move_right(ctx: Context<MoveRight>, password: String) -> Result<()> {
+        let game_data_account = &mut ctx.accounts.game_data_account;
+        if game_data_account.player_position == 3 {
+            msg!("You have reached the end! Super!");
+        } else if game_data_account.player_position == 2 {
+            if password != "gib" {
+                return err!(MyError::WrongPassword);
+            }
+
+            game_data_account.player_position = game_data_account.player_position + 1;
+
+            msg!(
+                "You made it! Here is your reward {0} lamports",
+                CHEST_REWARD
+            );
+
+            **ctx
+                .accounts
+                .chest_vault
+                .to_account_info()
+                .try_borrow_mut_lamports()? -= CHEST_REWARD;
+            **ctx
+                .accounts
+                .player
+                .to_account_info()
+                .try_borrow_mut_lamports()? += CHEST_REWARD;
+        } else {
+            game_data_account.player_position = game_data_account.player_position + 1;
+            print_player(game_data_account.player_position);
+        }
+        Ok(())
+    }
+}
+
+fn print_player(player_position: u8) {
+    if player_position == 0 {
+        msg!("A Journey Begins!");
+        msg!("o.........💎");
+    } else if player_position == 1 {
+        msg!("..o.......💎");
+    } else if player_position == 2 {
+        msg!("....o.....💎");
+    } else if player_position == 3 {
+        msg!("........\\o/💎");
+        msg!("..........\\o/");
+        msg!("You have reached the end! Super!");
+    }
+}
+
+#[derive(Accounts)]
+pub struct InitializeLevelOne<'info> {
+    // We must specify the space in order to initialize an account.
+    // First 8 bytes are default account discriminator,
+    // next 1 byte come from NewAccount.data being type u8.
+    // (u8 = 8 bits unsigned integer = 8 bytes)
+    // You can also use the signer as seed [signer.key().as_ref()],
+    #[account(
+        init_if_needed,
+        seeds = [b"level1"],
+        bump,
+        payer = signer,
+        space = 8 + 1
+    )]
+    pub new_game_data_account: Account<'info, GameDataAccount>,
+    // This is the PDA in which we will deposit the reward SOL and
+    // from where we send it back to the first player reaching the chest.
+    #[account(
+        init_if_needed,
+        seeds = [b"chestVault"],
+        bump,
+        payer = signer,
+        space = 8
+    )]
+    pub chest_vault: Account<'info, ChestVaultAccount>,
+    #[account(mut)]
+    pub signer: Signer<'info>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct SpawnChest<'info> {
+    #[account(mut)]
+    pub payer: Signer<'info>,
+    #[account(mut, seeds = [b"chestVault"], bump)]
+    pub chest_vault: Account<'info, ChestVaultAccount>,
+    #[account(mut)]
+    pub game_data_account: Account<'info, GameDataAccount>,
+    pub system_program: Program<'info, System>,
+}
+
+#[derive(Accounts)]
+pub struct MoveRight<'info> {
+    #[account(mut, seeds = [b"chestVault"], bump)]
+    pub chest_vault: Account<'info, ChestVaultAccount>,
+    #[account(mut)]
+    pub game_data_account: Account<'info, GameDataAccount>,
+    #[account(mut)]
+    pub player: Signer<'info>,
+}
+
+#[account]
+pub struct GameDataAccount {
+    player_position: u8,
+}
+
+#[account]
+pub struct ChestVaultAccount {}
+
+#[error_code]
+pub enum MyError {
+    #[msg("Password was wrong")]
+    WrongPassword,
+}
+```
+
+Now that the program is complete, let's build and deploy it using the Solana
+Playground!
+
+If you're new to the Solana Playground, start by creating a Playground wallet
+and make sure you're connected to a Devnet endpoint. Next,
+run `solana airdrop 2` until you have 6 SOL. Once you have enough SOL, build and
+deploy the program. If your airdrop fails you can find other way
+[how to get Devnet Sol](https://solana.com/developers/cookbook/development/airdrops-and-faucets).
+
+### Get Started with the Client
+
+In this section, we'll walk through a simple client-side implementation for
+interacting with the game. We will break down the code and provide detailed
+explanations for each step. To get started, navigate to the `client.ts` file in
+Solana Playground, remove the placeholder code, and add the code snippets from
+the following sections.
+
+First, let's derive the PDAs (Program Derived Addresses) for the
+`GameDataAccount` and `ChestVaultAccount`. A PDA is a unique address in the
+format of a public key, derived using the program's ID and additional seeds.
+
+```js
+// The PDA address everyone will be able to control the character if the interact with your program
+const [globalLevel1GameDataAccount, bump] =
+  await anchor.web3.PublicKey.findProgramAddress(
+    [Buffer.from("level1", "utf8")],
+    //[pg.wallet.publicKey.toBuffer()], <- You could also add the player wallet as a seed, then you would have one instance per player. Need to also change the seed in the rust part
+    pg.program.programId
+  );
+
+// This is where the program will save the SOL reward for the chests and from which the reward will be payed out again
+const [chestVaultAccount, chestBump] =
+  await anchor.web3.PublicKey.findProgramAddress(
+    [Buffer.from("chestVault", "utf8")],
+    pg.program.programId
+  );
+```
+
+Next, we'll call the `initializeLevelOne` instruction to set up the
+`GameDataAccount` and `ChestVaultAccount`.
+
+```js
+// Initialize level
+let txHash = await pg.program.methods
+  .initializeLevelOne()
+  .accounts({
+    chestVault: chestVaultAccount,
+    newGameDataAccount: globalLevel1GameDataAccount,
+    signer: pg.wallet.publicKey,
+    systemProgram: web3.SystemProgram.programId
+  })
+  .signers([pg.wallet.keypair])
+  .rpc();
+
+console.log(`Use 'solana confirm -v ${txHash}' to see the logs`);
+await pg.connection.confirmTransaction(txHash);
+
+let balance = await pg.connection.getBalance(pg.wallet.publicKey);
+console.log(
+  `My balance before spawning a chest: ${balance / web3.LAMPORTS_PER_SOL} SOL`
+);
+```
+
+After that, we'll use the `resetLevelAndSpawnChest` instruction to set the
+player's position to 0 and fill the `ChestVaultAccount` with 0.1 SOL.
+
+```js
+// Set the player position back to 0 and pay to fill up the chest with sol
+txHash = await pg.program.methods
+  .resetLevelAndSpawnChest()
+  .accounts({
+    chestVault: chestVaultAccount,
+    gameDataAccount: globalLevel1GameDataAccount,
+    payer: pg.wallet.publicKey,
+    systemProgram: web3.SystemProgram.programId
+  })
+  .signers([pg.wallet.keypair])
+  .rpc();
+
+console.log(`Use 'solana confirm -v ${txHash}' to see the logs`);
+await pg.connection.confirmTransaction(txHash);
+
+console.log("Level reset and chest spawned 💎");
+console.log("o........💎");
+```
+
+Now we can interact with the game by calling the `moveRight` instruction. In
+this example, we'll loop through this instruction until the player reaches the
+position to collect the reward from the `ChestVaultAccount`.
+
+```js
+// Here we move to the right three times and collect the chest at the end of the level
+for (let i = 0; i < 3; i++) {
+  txHash = await pg.program.methods
+    .moveRight("gib")
+    .accounts({
+      chestVault: chestVaultAccount,
+      gameDataAccount: globalLevel1GameDataAccount,
+      player: pg.wallet.publicKey
+    })
+    .signers([pg.wallet.keypair])
+    .rpc();
+
+  console.log(`Use 'solana confirm -v ${txHash}' to see the logs`);
+  await pg.connection.confirmTransaction(txHash);
+  let balance = await pg.connection.getBalance(pg.wallet.publicKey);
+  console.log(`My balance: ${balance / web3.LAMPORTS_PER_SOL} SOL`);
+
+  let gameDateAccount = await pg.program.account.gameDataAccount.fetch(
+    globalLevel1GameDataAccount
+  );
+
+  console.log("Player position is:", gameDateAccount.playerPosition.toString());
+
+  switch (gameDateAccount.playerPosition) {
+    case 0:
+      console.log("A journey begins...");
+      console.log("o........💎");
+      break;
+    case 1:
+      console.log("....o....💎");
+      break;
+    case 2:
+      console.log("......o..💎");
+      break;
+    case 3:
+      console.log(".........\\o/💎");
+      console.log("...........\\o/");
+      break;
+  }
+}
+```
+
+Finally, press the "Run" button in the Solana Playground to execute the client.
+When you input anything other than "gib" as the password for the **`moveRight`**
+instruction, you should encounter the following error message upon reaching the
+position to claim the chest reward:
+
+```
+Error Code: WrongPassword. Error Number: 6000. Error Message: Password was wrong.
+```
+
+However, if you enter the correct password, the output should resemble the
+following:
+
+```
+Running client...
+  client.ts:
+    Use 'solana confirm -v CX8VWV5Jp1kXDkZrTdeeyibgZg3B3cXAzchzCfNHvJoqARSGHeEU5injypxFwiKFcHPcWFG9BeNSrqZAdENtL2t' to see the logs
+    My balance before spawning a chest: 6.396630254 SOL
+    Use 'solana confirm -v 3HwAS1RK7beL3mGoNdFYWteJXF3NdJXiEskJrHtuJ6Tu9ow67Zo3yScQBEPQyish33hP8WyuVanmq93wEFJ2LQcx' to see the logs
+    Level reset and chest spawned 💎
+    o........💎
+    Use 'solana confirm -v 43KnGrx5VQYd8LctsNaNqN1hg69vE6wiiTbdxTC1uM3Hasnq7ZdM9zWx4JS39AKNz2FpQr9a3ZnEA7XscEzmXQ5U' to see the logs
+    My balance: 6.296620254 SOL
+    Player position is: 1
+    ....o....💎
+    Use 'solana confirm -v AGxYWDw49d4y5dLon5M42eu1qG8g2Yf7FeTr3Dpbf1uFXnMeUzp4XWmHyQP1YRNpT8acz4aTJU9f2FQpL6BSAkY' to see the logs
+    My balance: 6.296615254 SOL
+    Player position is: 2
+    ......o..💎
+    Use 'solana confirm -v 5pjAU5NrS4u91QLWZTvo9aXBtR3c6g981UGSxrWDoDW5MehXnx5LnAxu4jKLp1p75RKpVSgMBgg2zHX3WDyci7AK' to see the logs
+    My balance: 6.396610254 SOL
+    Player position is: 3
+    .........\o/💎
+    ...........\o/
+```
+
+Well done! You have successfully created, deployed, and interacted with Tiny
+Adventure Two from the client side. You've incorporated a new feature that
+allows players to collect rewards by reaching the chest at the end of the level.
+Moreover, you've learned how to transfer SOL within an Anchor program using
+cross-program invocations and by directly modifying lamports in accounts.
+
+Feel free to continue building independently and enhance the game with
+additional features like new levels or alternative rewards!
+
+For more advanced examples you can check out the
+[Solana Game Examples](/developers/cookbook/games/game-examples)

--- a/apps/docs/content/cookbook/index.mdx
+++ b/apps/docs/content/cookbook/index.mdx
@@ -16,13 +16,13 @@ details and usage examples.
 Development guides help developers set up and interact with the Solana ecosystem
 using various tools and clients.
 
-| Guide                                                                                                   | Client             | Description                                |
-| ------------------------------------------------------------------------------------------------------- | ------------------ | ------------------------------------------ |
-| [How to Start a Local Validator](/developers/cookbook/development/start-local-validator)                | Solana CLI         | Set up and run a local Solana validator    |
-| [Connecting to a Solana Environment](/developers/cookbook/development/connect-environment)              | JavaScript, Python | Connect to different Solana networks       |
-| [Getting Test SOL](/developers/cookbook/development/test-sol)                                           | JavaScript, Python | Obtain SOL tokens for testing              |
-| [Subscribing to Events](/developers/cookbook/development/subscribing-events)                            | JavaScript, Python | Listen to Solana program events            |
-| [Using Mainnet Accounts and Programs](/developers/cookbook/development/using-mainnet-accounts-programs) | Solana CLI         | Work with production accounts and programs |
+| Guide                                                                                      | Client             | Description                                |
+| ------------------------------------------------------------------------------------------ | ------------------ | ------------------------------------------ |
+| [How to Start a Local Validator](/docs/intro/installation/surfpool-cli-basics)             | Solana CLI         | Set up and run a local Solana validator    |
+| [Connecting to a Solana Environment](/developers/cookbook/development/connect-environment) | JavaScript, Python | Connect to different Solana networks       |
+| [Getting Test SOL](/developers/cookbook/development/test-sol)                              | JavaScript, Python | Obtain SOL tokens for testing              |
+| [Subscribing to Events](/developers/cookbook/development/subscribing-events)               | JavaScript, Python | Listen to Solana program events            |
+| [Using Mainnet Accounts and Programs](/docs/tools/surfpool)                                | Solana CLI         | Work with production accounts and programs |
 
 ## Wallet Management
 
@@ -48,7 +48,7 @@ Explore various transaction-related operations on the Solana blockchain.
 | Guide                                                                                            | Client             | Description                    |
 | ------------------------------------------------------------------------------------------------ | ------------------ | ------------------------------ |
 | [How to Send SOL](/developers/cookbook/transactions/send-sol)                                    | JavaScript, Python | Transfer SOL between accounts  |
-| [How to Send Tokens](/developers/cookbook/transactions/send-tokens)                              | JavaScript, Python | Transfer SPL tokens            |
+| [How to Send Tokens](/docs/tokens/basics/transfer-tokens)                                        | JavaScript, Python | Transfer SPL tokens            |
 | [How to Calculate Transaction Cost](/developers/cookbook/transactions/calculate-cost)            | JavaScript, Python | Estimate transaction fees      |
 | [How to Add a Memo to a Transaction](/developers/cookbook/transactions/add-memo)                 | JavaScript, Python | Include memos in transactions  |
 | [How to Add Priority Fees to a Transaction](/developers/cookbook/transactions/add-priority-fees) | JavaScript, Python | Set transaction priorities     |
@@ -63,9 +63,9 @@ Learn how to manage Solana accounts effectively.
 | -------------------------------------------------------------------------------------- | ------------------ | -------------------------- |
 | [How to Create an Account](/developers/cookbook/accounts/create-account)               | JavaScript, Python | Create new Solana accounts |
 | [How to Calculate Account Creation Cost](/developers/cookbook/accounts/calculate-rent) | JavaScript, Python | Estimate account costs     |
-| [How to Create a PDA's Account](/developers/cookbook/accounts/create-pda-account)      | JavaScript, Rust   | Work with PDAs             |
-| [How to Sign with a PDA's Account](/developers/cookbook/accounts/sign-with-pda)        | Rust               | PDA signing operations     |
-| [How to Close an Account](/developers/cookbook/accounts/close-account)                 | Rust               | Remove accounts            |
+| [How to Create a PDA's Account](/docs/core/pda)                                        | JavaScript, Rust   | Work with PDAs             |
+| [How to Sign with a PDA's Account](/docs/core/cpi)                                     | Rust               | PDA signing operations     |
+| [How to Close an Account](/docs/core/accounts)                                         | Rust               | Remove accounts            |
 | [How to Get Account Balance](/developers/cookbook/accounts/get-account-balance)        | JavaScript, Python | Check account balances     |
 
 ## Token Program Instructions

--- a/apps/docs/content/cookbook/meta.json
+++ b/apps/docs/content/cookbook/meta.json
@@ -1,5 +1,13 @@
 {
   "title": "Solana Cookbook",
   "defaultOpen": false,
-  "pages": ["development", "wallets", "transactions", "accounts", "tokens"]
+  "pages": [
+    "development",
+    "wallets",
+    "transactions",
+    "accounts",
+    "tokens",
+    "games",
+    "depin"
+  ]
 }

--- a/apps/docs/content/cookbook/transactions/confirmation.mdx
+++ b/apps/docs/content/cookbook/transactions/confirmation.mdx
@@ -1,0 +1,398 @@
+---
+title: Confirmation & Expiration
+seoTitle: "Transaction Confirmation & Expiration"
+description:
+  "Understand how Solana transaction confirmation and when a transaction expires
+  (including recent blockhash checks)."
+h1: Transaction Confirmation & Expiration
+---
+
+Problems relating to
+[transaction confirmation](/docs/references/terminology#transaction-confirmations)
+are common with many newer developers while building applications. This article
+aims to boost the overall understanding of the confirmation mechanism used on
+the Solana blockchain, including some recommended best practices.
+
+## Brief background on transactions
+
+Before diving into how Solana transaction confirmation and expiration works,
+let's briefly set the base understanding of a few things:
+
+- what a transaction is
+- the lifecycle of a transaction
+- what a blockhash is
+- and a brief understanding of Proof of History (PoH) and how it relates to
+  blockhashes
+
+### What is a transaction?
+
+Transactions consist of two components: a
+[message](/docs/references/terminology#message) and a
+[list of signatures](/docs/references/terminology#signature). The transaction
+message is where the magic happens and at a high level it consists of four
+components:
+
+- a **header** with metadata about the transaction,
+- a **list of instructions** to invoke,
+- a **list of accounts** to load, and
+- a **“recent blockhash.”**
+
+In this article, we're going to be focusing a lot on a transaction's
+[recent blockhash](/docs/references/terminology#blockhash) because it plays a
+big role in transaction confirmation.
+
+### Transaction lifecycle refresher
+
+Below is a high level view of the lifecycle of a transaction. This article will
+touch on everything except steps 1 and 4.
+
+1. Create a header and a list of instructions along with the list of accounts
+   that instructions need to read and write
+2. Fetch a recent blockhash and use it to prepare a transaction message
+3. Simulate the transaction to ensure it behaves as expected
+4. Prompt user to sign the prepared transaction message with their private key
+5. Send the transaction to an RPC node which attempts to forward it to the
+   current block producer
+6. Hope that a block producer validates and commits the transaction into their
+   produced block
+7. Confirm the transaction has either been included in a block or detect when it
+   has expired
+
+### What is a Blockhash?
+
+A [“blockhash”](/docs/references/terminology#blockhash) refers to the last Proof
+of History (PoH) hash for a [“slot”](/docs/references/terminology#slot)
+(description below). Since Solana uses PoH as a trusted clock, a transaction's
+recent blockhash can be thought of as a **timestamp**.
+
+### Proof of History refresher
+
+Solana's Proof of History mechanism uses a very long chain of recursive SHA-256
+hashes to build a trusted clock. The “history” part of the name comes from the
+fact that block producers hash transaction id's into the stream to record which
+transactions were processed in their block.
+
+[PoH hash calculation](https://github.com/anza-xyz/agave/blob/aa0922d6845e119ba466f88497e8209d1c82febc/entry/src/poh.rs#L79):
+`next_hash = hash(prev_hash, hash(transaction_ids))`
+
+PoH can be used as a trusted clock because each hash must be produced
+sequentially. Each produced block contains a blockhash and a list of hash
+checkpoints called “ticks” so that validators can verify the full chain of
+hashes in parallel and prove that some amount of time has actually passed.
+
+## Transaction Expiration
+
+By default, all Solana transactions will expire if not committed to a block in a
+certain amount of time. The **vast majority** of transaction confirmation issues
+are related to how RPC nodes and validators detect and handle **expired**
+transactions. A solid understanding of how transaction expiration works should
+help you diagnose the bulk of your transaction confirmation issues.
+
+### How does transaction expiration work?
+
+Each transaction includes a “recent blockhash” which is used as a PoH clock
+timestamp and expires when that blockhash is no longer “recent enough”.
+
+As each block is finalized (i.e. the maximum tick height
+[is reached](https://github.com/anza-xyz/agave/blob/0588ecc6121ba026c65600d117066dbdfaf63444/runtime/src/bank.rs#L3269-L3271),
+reaching the "block boundary"), the final hash of the block is added to the
+`BlockhashQueue` which stores a maximum of the
+[300 most recent blockhashes](https://github.com/anza-xyz/agave/blob/e0b0bcc80380da34bb63364cc393801af1e1057f/sdk/program/src/clock.rs#L123-L126).
+During transaction processing, Solana Validators will check if each
+transaction's recent blockhash is recorded within the most recent 151 stored
+hashes (aka "max processing age"). If the transaction's recent blockhash is
+[older than this](https://github.com/anza-xyz/agave/blob/cb2fd2b632f16a43eff0c27af7458e4e97512e31/runtime/src/bank.rs#L3570-L3571)
+max processing age, the transaction is not processed.
+
+> Due to the current
+> [max processing age of 150](https://github.com/anza-xyz/agave/blob/cb2fd2b632f16a43eff0c27af7458e4e97512e31/sdk/program/src/clock.rs#L129-L131)
+> and the "age" of a blockhash in the queue being
+> [0-indexed](https://github.com/anza-xyz/agave/blob/992a398fe8ea29ec4f04d081ceef7664960206f4/accounts-db/src/blockhash_queue.rs#L248-L274),
+> there are actually 151 blockhashes that are considered "recent enough" and
+> valid for processing.
+
+Since [slots](/docs/references/terminology#slot) (aka the time period a
+validator can produce a block) are configured to last about
+[400ms](https://github.com/anza-xyz/agave/blob/cb2fd2b632f16a43eff0c27af7458e4e97512e31/sdk/program/src/clock.rs#L107-L109),
+but may fluctuate between 400ms and 600ms, a given blockhash can only be used by
+transactions for about 60 to 90 seconds before it will be considered expired by
+the runtime.
+
+### Example of transaction expiration
+
+Let's walk through a quick example:
+
+1. A validator is actively producing a new block for the current slot
+2. The validator receives a transaction from a user with the recent blockhash
+   `abcd...`
+3. The validator checks this blockhash `abcd...` against the list of recent
+   blockhashes in the `BlockhashQueue` and discovers that it was created 151
+   blocks ago
+4. Since it is exactly 151 blockhashes old, the transaction has not expired yet
+   and can still be processed!
+5. But wait: before actually processing the transaction, the validator finished
+   creating the next block and added it to the `BlockhashQueue`. The validator
+   then starts producing the block for the next slot (validators get to produce
+   blocks for 4 consecutive slots)
+6. The validator checks that same transaction again and finds it is now 152
+   blockhashes old and rejects it because it's too old :(
+
+## Why do transactions expire?
+
+There's a very good reason for this actually, it's to help validators avoid
+processing the same transaction twice.
+
+A naive brute force approach to prevent double processing could be to check
+every new transaction against the blockchain's entire transaction history. But
+by having transactions expire after a short amount of time, validators only need
+to check if a new transaction is in a relatively small set of _recently_
+processed transactions.
+
+### Other blockchains
+
+Solana's approach to prevent double processing is quite different from other
+blockchains. For example, Ethereum tracks a counter (nonce) for each transaction
+sender and will only process transactions that use the next valid nonce.
+
+Ethereum's approach is simple for validators to implement, but it can be
+problematic for users. Many people have encountered situations when their
+Ethereum transactions got stuck in a _pending_ state for a long time and all the
+later transactions, which used higher nonce values, were blocked from
+processing.
+
+### Advantages on Solana
+
+There are a few advantages to Solana's approach:
+
+1. A single fee payer can submit multiple transactions at the same time that are
+   allowed to be processed in any order. This might happen if you're using
+   multiple applications at the same time.
+2. If a transaction doesn't get committed to a block and expires, users can try
+   again knowing that their previous transaction will NOT ever be processed.
+
+By not using counters, the Solana wallet experience may be easier for users to
+understand because they can get to success, failure, or expiration states
+quickly and avoid annoying pending states.
+
+### Disadvantages on Solana
+
+Of course there are some disadvantages too:
+
+1. Validators have to actively track a set of all processed transaction id's to
+   prevent double processing.
+2. If the expiration time period is too short, users might not be able to submit
+   their transaction before it expires.
+
+These disadvantages highlight a tradeoff in how transaction expiration is
+configured. If the expiration time of a transaction is increased, validators
+need to use more memory to track more transactions. If expiration time is
+decreased, users don't have enough time to submit their transaction.
+
+Currently, Solana clusters require that transactions use blockhashes that are no
+more than 151 blocks old.
+
+> This [GitHub issue](https://github.com/solana-labs/solana/issues/23582)
+> contains some calculations that estimate that mainnet validators need about
+> 150MB of memory to track transactions. This could be slimmed down in the
+> future if necessary without decreasing expiration time as are detailed in that
+> issue.
+
+## Transaction confirmation tips
+
+As mentioned before, blockhashes expire after a time period of only 151 blocks
+which can pass as quickly as **one minute** when slots are processed within the
+target time of 400ms.
+
+One minute is not a lot of time considering that a client needs to fetch a
+recent blockhash, wait for the user to sign, and finally hope that the
+broadcasted transaction reaches a leader that is willing to accept it. Let's go
+through some tips to help avoid confirmation failures due to transaction
+expiration!
+
+### Fetch blockhashes with the appropriate commitment level
+
+Given the short expiration time frame, it's imperative that clients and
+applications help users create transactions with a blockhash that is as recent
+as possible.
+
+When fetching blockhashes, the current recommended RPC API is called
+[`getLatestBlockhash`](/docs/rpc/http/getlatestblockhash). By default, this API
+uses the `finalized` commitment level to return the most recently finalized
+block's blockhash. However, you can override this behavior by
+[setting the `commitment` parameter](/docs/rpc/#configuring-state-commitment) to
+a different commitment level.
+
+**Recommendation**
+
+The `confirmed` commitment level should almost always be used for RPC requests
+because it's usually only a few slots behind the `processed` commitment and has
+a very low chance of belonging to a dropped
+[fork](https://docs.anza.xyz/consensus/fork-generation).
+
+But feel free to consider the other options:
+
+- Choosing `processed` will let you fetch the most recent blockhash compared to
+  other commitment levels and therefore gives you the most time to prepare and
+  process a transaction. But due to the prevalence of forking in the Solana
+  blockchain, roughly 5% of blocks don't end up being finalized by the cluster
+  so there's a real chance that your transaction uses a blockhash that belongs
+  to a dropped fork. Transactions that use blockhashes for abandoned blocks
+  won't ever be considered recent by any blocks that are in the finalized
+  blockchain.
+- Using the [default commitment](/docs/rpc#configuring-state-commitment) level
+  `finalized` will eliminate any risk that the blockhash you choose will belong
+  to a dropped fork. The tradeoff is that there is typically at least a 32 slot
+  difference between the most recent confirmed block and the most recent
+  finalized block. This tradeoff is pretty severe and effectively reduces the
+  expiration of your transactions by about 13 seconds but this could be even
+  more during unstable cluster conditions.
+
+### Use an appropriate preflight commitment level
+
+If your transaction uses a blockhash that was fetched from one RPC node then you
+send, or simulate, that transaction with a different RPC node, you could run
+into issues due to one node lagging behind the other.
+
+When RPC nodes receive a `sendTransaction` request, they will attempt to
+determine the expiration block of your transaction using the most recent
+finalized block or with the block selected by the `preflightCommitment`
+parameter. A **VERY** common issue is that a received transaction's blockhash
+was produced after the block used to calculate the expiration for that
+transaction. If an RPC node can't determine when your transaction expires, it
+will only forward your transaction **one time** and afterwards will then
+**drop** the transaction.
+
+Similarly, when RPC nodes receive a `simulateTransaction` request, they will
+simulate your transaction using the most recent finalized block or with the
+block selected by the `preflightCommitment` parameter. If the block chosen for
+simulation is older than the block used for your transaction's blockhash, the
+simulation will fail with the dreaded “blockhash not found” error.
+
+**Recommendation**
+
+Even if you use `skipPreflight`, **ALWAYS** set the `preflightCommitment`
+parameter to the same commitment level used to fetch your transaction's
+blockhash for both `sendTransaction` and `simulateTransaction` requests.
+
+### Be wary of lagging RPC nodes when sending transactions
+
+When your application uses an RPC pool service or when the RPC endpoint differs
+between creating a transaction and sending a transaction, you need to be wary of
+situations where one RPC node is lagging behind the other. For example, if you
+fetch a transaction blockhash from one RPC node then you send that transaction
+to a second RPC node for forwarding or simulation, the second RPC node might be
+lagging behind the first.
+
+**Recommendation**
+
+For `sendTransaction` requests, clients should keep resending a transaction to a
+RPC node on a frequent interval so that if an RPC node is slightly lagging
+behind the cluster, it will eventually catch up and detect your transaction's
+expiration properly.
+
+For `simulateTransaction` requests, clients should use the
+[`replaceRecentBlockhash`](/docs/rpc/http/simulatetransaction) parameter to tell
+the RPC node to replace the simulated transaction's blockhash with a blockhash
+that will always be valid for simulation.
+
+### Avoid reusing stale blockhashes
+
+Even if your application has fetched a very recent blockhash, be sure that
+you're not reusing that blockhash in transactions for too long. The ideal
+scenario is that a recent blockhash is fetched right before a user signs their
+transaction.
+
+**Recommendation for applications**
+
+Poll for new recent blockhashes on a frequent basis to ensure that whenever a
+user triggers an action that creates a transaction, your application already has
+a fresh blockhash that's ready to go.
+
+**Recommendation for wallets**
+
+Poll for new recent blockhashes on a frequent basis and replace a transaction's
+recent blockhash right before they sign the transaction to ensure the blockhash
+is as fresh as possible.
+
+### Use healthy RPC nodes when fetching blockhashes
+
+By fetching the latest blockhash with the `confirmed` commitment level from an
+RPC node, it's going to respond with the blockhash for the latest confirmed
+block that it's aware of. Solana's block propagation protocol prioritizes
+sending blocks to staked nodes so RPC nodes naturally lag about a block behind
+the rest of the cluster. They also have to do more work to handle application
+requests and can lag a lot more under heavy user traffic.
+
+Lagging RPC nodes can therefore respond to
+[`getLatestBlockhash`](/docs/rpc/http/getlatestblockhash) requests with
+blockhashes that were confirmed by the cluster quite awhile ago. By default, a
+lagging RPC node detects that it is more than 150 slots behind the cluster will
+stop responding to requests, but just before hitting that threshold they can
+still return a blockhash that is just about to expire.
+
+**Recommendation**
+
+Monitor the health of your RPC nodes to ensure that they have an up-to-date view
+of the cluster state with one of the following methods:
+
+1. Fetch your RPC node's highest processed slot by using the
+   [`getSlot`](/docs/rpc/http/getslot) RPC API with the `processed` commitment
+   level and then call the
+   [`getMaxShredInsertSlot`](/docs/rpc/http/getmaxshredinsertslot) RPC API to
+   get the highest slot that your RPC node has received a “shred” of a block
+   for. If the difference between these responses is very large, the cluster is
+   producing blocks far ahead of what the RPC node has processed.
+2. Call the `getLatestBlockhash` RPC API with the `confirmed` commitment level
+   on a few different RPC API nodes and use the blockhash from the node that
+   returns the highest slot for its
+   [context slot](/docs/rpc/http/getlatestblockhash).
+
+### Wait long enough for expiration
+
+**Recommendation**
+
+When calling the [`getLatestBlockhash`](/docs/rpc/http/getlatestblockhash) RPC
+API to get a recent blockhash for your transaction, take note of the
+`lastValidBlockHeight` in the response.
+
+Then, poll the [`getBlockHeight`](/docs/rpc/http/getblockheight) RPC API with
+the `confirmed` commitment level until it returns a block height greater than
+the previously returned last valid block height.
+
+### Consider using “durable” transactions
+
+Sometimes transaction expiration issues are really hard to avoid (e.g. offline
+signing, cluster instability). If the previous tips are still not sufficient for
+your use-case, you can switch to using durable transactions (they just require a
+bit of setup).
+
+To start using durable transactions, a user first needs to submit a transaction
+that
+[invokes instructions that create a special onchain “nonce” account](https://docs.rs/solana-program/latest/solana_program/system_instruction/fn.create_nonce_account.html)
+and stores a “durable blockhash” inside of it. At any point in the future (as
+long as the nonce account hasn't been used yet), the user can create a durable
+transaction by following these 2 rules:
+
+1. The instruction list must start with an
+   [“advance nonce” system instruction](https://docs.rs/solana-program/latest/solana_program/system_instruction/fn.advance_nonce_account.html)
+   which loads their onchain nonce account
+2. The transaction's blockhash must be equal to the durable blockhash stored by
+   the onchain nonce account
+
+Here's how these durable transactions are processed by the Solana runtime:
+
+1. If the transaction's blockhash is no longer “recent”, the runtime checks if
+   the transaction's instruction list begins with an “advance nonce” system
+   instruction
+2. If so, it then loads the nonce account specified by the “advance nonce”
+   instruction
+3. Then it checks that the stored durable blockhash matches the transaction's
+   blockhash
+4. Lastly it makes sure to advance the nonce account's stored blockhash to the
+   latest recent blockhash to ensure that the same transaction can never be
+   processed again
+
+For more details about how these durable transactions work, you can read the
+[original proposal](https://docs.anza.xyz/implemented-proposals/durable-tx-nonces)
+and [check out an example](/developers/cookbook/transactions/durable-nonces) in
+the Solana docs.

--- a/apps/docs/content/cookbook/transactions/durable-nonces.mdx
+++ b/apps/docs/content/cookbook/transactions/durable-nonces.mdx
@@ -1,0 +1,621 @@
+---
+date: 2024-06-29T00:00:00Z
+difficulty: advanced
+title: "Durable & Offline Transaction Signing using Nonces"
+description:
+  "One-stop shop for Solana's Durable Nonces: an easy way to power your Solana
+  dapps"
+tags:
+  - cli
+  - web3js
+keywords:
+  - tutorial
+  - durable nonces
+  - offline signing
+  - transactions
+  - intro to solana development
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+---
+
+This guide is meant to be a one-stop shop for Solana's Durable Nonces: a highly
+under-utilized and under-appreciated way to power your Solana dapps and make
+your user's experience more reliable and deterministic.
+
+> The code for this guide can be found in
+> [this repository](https://github.com/0xproflupin/solana-durable-nonces), and
+> it's advisable to follow along and run the examples locally to get a better
+> grasp of Durable Nonces
+
+## Durable Nonce Applications
+
+Before we dive deep into Durable Nonces, its important to understand that
+durable nonces provide an opportunity to create and sign a transaction that can
+be submitted at any point in the future, and much more. This opens up a wide
+range of use cases that are otherwise not possible or too difficult to
+implement:
+
+1. **Scheduled Transactions**: One of the most apparent applications of Durable
+   Nonces is the ability to schedule transactions. Users can pre-sign a
+   transaction and then submit it at a later date, allowing for planned
+   transfers, contract interactions, or even executing pre-determined investment
+   strategies.
+
+2. **Multisig Wallets**: Durable Nonces are very useful for multi-signature
+   wallets where one party signs a transaction, and others may confirm at a
+   later time. This feature enables the proposal, review, and later execution of
+   a transaction within a trustless system.
+
+3. **Programs Requiring Future Interaction**: If a program on Solana requires
+   interaction at a future point (such as a vesting contract or a timed release
+   of funds), a transaction can be pre-signed using a Durable Nonce. This
+   ensures the contract interaction happens at the correct time without
+   necessitating the presence of the transaction creator.
+
+4. **Cross-chain Interactions**: When you need to interact with another
+   blockchain, and it requires waiting for confirmations, you could sign the
+   transaction with a Durable Nonce and then execute it once the required
+   confirmations are received.
+
+5. **Decentralized Derivatives Platforms**: In a decentralized derivatives
+   platform, complex transactions might need to be executed based on specific
+   triggers. With Durable Nonces, these transactions can be pre-signed and
+   executed when the trigger condition is met.
+
+## Introduction to Durable Nonces
+
+### Double Spend
+
+Imagine you're buying an NFT on MagicEden or Tensor. You have to sign a
+transaction that allows the marketplace's program to extract some SOL from your
+wallets.
+
+What is stopping them from reusing your signature to extract SOL again? Without
+a way to check if the transaction was already submitted once, they can keep
+submitting the signed transaction until there's no SOL left in their wallet.
+
+This is known as the problem of Double-Spend and is one of the core issues that
+blockchains like Solana solve.
+
+A naive solution could be to crosscheck all transactions made in the past and
+see if we find the signature there. This is not practically possible, as the
+size of the Solana ledger is >80 TB.
+
+### Recent Blockhashes
+
+Solution: Crosscheck signatures within only a set period of recent time, and
+discard the transaction if it gets "too" old.
+
+Recent Blockhashes are used to achieve this. A blockhash contains a 32-byte
+SHA-256 hash. It is used to indicate when a client last observed the ledger.
+Using recent blockhashes, transactions are checked in the last 150 blocks. If
+they are found, they are rejected. They are also rejected if they get older than
+150 blocks. The only case they are accepted is if they are unique and the
+blockhash is more recent than 150 blocks (~80-90 seconds).
+
+As you can imagine, a side-effect of using recent blockhashes is the forced
+mortality of a transaction even before its submission.
+
+Another issue with blockhashes is the forced non-uniqueness of signed
+transactions in very small timeframes. In some cases, if the transactions are
+executed very quickly in succession, some get the same recent blockhashes with
+high probability, thus
+[making them duplicate and avoid their execution](https://solana.stackexchange.com/questions/1161/how-to-avoid-sendtransactionerror-this-transaction-has-already-been-processed?rq=1).
+
+To summarize:
+
+1. What if I don't want to send the transaction right away?
+2. What if I want to sign the transaction offline as I don't want to keep my
+   keys on a device that is connected to the net?
+3. What if I want to co-sign the transaction from multiple devices owned by
+   multiple people, and the co-signing takes more than 90 seconds, like in a
+   case of a multi-sig operated by a DAO?
+4. What if I want to sign and send a burst of transactions and don't want them
+   to fail due to duplication?
+
+The solution lies with Durable Nonces⚡️
+
+### Durable Nonces
+
+Durable Transaction Nonces, which are 32-byte in length (usually represented as
+base58 encoded strings), are used in place of recent blockhashes to make every
+transaction unique (to avoid double-spending) while removing the mortality on
+the unexecuted transaction.
+
+> How do they make transactions unique to avoid double spending?
+>
+> If nonces are used in place of recent blockhashes, the first instruction of
+> the transaction needs to be a `nonceAdvance` instruction, which changes or
+> advances the nonce. This ensures that every transaction which is signed using
+> the nonce as the recent blockhash, irrespective of being successfully
+> submitted or not, will be unique.
+
+Let's look at a couple of accounts that are important for using durable nonces
+with Solana transactions.
+
+### Nonce Account
+
+The Nonce Account is the account that stores the value of the nonce. This
+account is owned by the `SystemProgram` and is rent-exempt; thus needs to
+maintain the minimum balance for rent exemption (around 0.0015 SOL).
+
+### Nonce Authority
+
+Nonce authority is the account that controls the Nonce Account. It has the
+authority to generate a new nonce, advance the nonce or withdraw SOL from the
+Nonce Account. By default, the account that creates the Nonce Account is
+delegated as the Nonce Authority, but it's possible to transfer the authority
+onto a different keypair account.
+
+## Durable Nonces with Solana CLI
+
+Now that we know what Durable Nonces are, it's time to use them to send durable
+transactions.
+
+> If you do not have the Solana CLI installed, please go through
+> [this tutorial](/docs/intro/installation) and set up the Solana CLI and create
+> a keypair with some airdropped SOL on devnet
+
+### Create Nonce Authority
+
+Let's start with creating a new keypair which we will use as our Nonce
+authority. We can use the keypair currently configured in our Solana CLI, but
+it's better to make a fresh one (make sure you're on devnet).
+
+```shell
+solana-keygen new -o nonce-authority.json
+```
+
+Set the current Solana CLI keypair to `nonce-authority.json` and airdrop some
+SOL in it.
+
+```shell
+solana config set -k ~/<path>/nonce-authority.json
+solana airdrop 2
+```
+
+Okay, we're set. Let's create our nonce account.
+
+### Create Nonce Account
+
+Create a new keypair `nonce-account` and use the `create-nonce-account`
+instruction to delegate this keypair as the Nonce Account. We will also transfer
+0.0015 SOL to the Nonce Account from the Nonce Authority, which is usually just
+above the minimum quantity needed for rent exemption.
+
+```shell
+solana-keygen new -o nonce-account.json
+solana create-nonce-account nonce-account.json 0.0015
+```
+
+Output
+
+```shell
+Signature: skkfzUQrZF2rcmrhAQV6SuLa7Hj3jPFu7cfXAHvkVep3Lk3fNSVypwULhqMRinsa6Zj5xjj8zKZBQ1agMxwuABZ
+```
+
+Upon searching the
+[signature](https://solscan.io/tx/skkfzUQrZF2rcmrhAQV6SuLa7Hj3jPFu7cfXAHvkVep3Lk3fNSVypwULhqMRinsa6Zj5xjj8zKZBQ1agMxwuABZ?cluster=devnet)
+on the explorer, we can see that the Nonce Account was created and the
+`InitializeNonce` instruction was used to initialize a nonce within the account.
+
+### Fetch Nonce
+
+We can query the value of the stored Nonce as follows.
+
+```shell
+solana nonce nonce-account.json
+```
+
+Output
+
+```shell
+AkrQn5QWLACSP5EMT2R1ZHyKaGWVFrDHJ6NL89HKtwjQ
+```
+
+This is the base58 encoded hash that will be used in place of recent blockhashes
+while signing a transaction.
+
+### Display Nonce Account
+
+We can inspect the details of a Nonce Account in a prettier formatted version
+
+```shell
+solana nonce-account nonce-account.json
+```
+
+Output
+
+```shell
+Balance: 0.0015 SOL
+Minimum Balance Required: 0.00144768 SOL
+Nonce blockhash: AkrQn5QWLACSP5EMT2R1ZHyKaGWVFrDHJ6NL89HKtwjQ
+Fee: 5000 lamports per signature
+Authority: 5CZKcm6PakaRWGK8NogzXvj8CjA71uSofKLohoNi4Wom
+```
+
+### Advancing Nonce
+
+As discussed before, advancing the Nonce or changing the value of the nonce is
+an important step for making subsequent transactions unique. The Nonce Authority
+needs to sign the transaction with the `nonceAdvance` instruction.
+
+```shell
+solana new-nonce nonce-account.json
+```
+
+Output
+
+```shell
+Signature: 4nMHnedguiEtHshuMEm3NsuTQaeV8AdcDL6QSndTZLK7jcLUag6HCiLtUq6kv21yNSVQLoFj44aJ5sZrTXoYYeyS
+```
+
+If we check the nonce again, the value of the nonce has changed or advanced.
+
+```shell
+solana nonce nonce-account.json
+```
+
+Output
+
+```shell
+DA8ynAQTGctqQXNS2RNTGpag6s5p5RcrBm2DdHhvpRJ8
+```
+
+### Withdraw from Nonce Account
+
+We transferred 0.0015 SOL when creating the Nonce Account. The Nonce Authority
+can transfer these funds back to itself or some other account.
+
+```shell
+solana withdraw-from-nonce-account nonce-account.json nonce-authority.json 0.0000001
+```
+
+Output
+
+```shell
+Signature: 5zuBmrUpqnubdePHVgzSNThbocruJZLJK5Dut7DM6WyoqW4Qbrc26uCw3nq6jRocR9XLMwZZ79U54HDnGhDJVNfF
+```
+
+We can check the status of the Nonce Account after the withdrawal; the balance
+should have changed.
+
+```shell
+solana nonce-account nonce-account.json
+```
+
+Output
+
+```shell
+Balance: 0.0014999 SOL
+Minimum Balance Required: 0.00144768 SOL
+Nonce blockhash: DA8ynAQTGctqQXNS2RNTGpag6s5p5RcrBm2DdHhvpRJ8
+Fee: 5000 lamports per signature
+Authority: 5CZKcm6PakaRWGK8NogzXvj8CjA71uSofKLohoNi4Wom
+```
+
+## Live Example: DAO Offline Co-Signing
+
+We will use an example where a DAO committee needs to transfer some SOL to a new
+wallet. Two co-signers are needed before sending the SOL, where `co-sender` pays
+for the transaction and `sender` sends the SOL. To add to this, the `co-sender`
+is very careful when it comes to connecting his device to the internet and thus
+wants to sign the transaction offline.
+
+Let's create three new keypairs, which will act as the two members of the DAO
+and the receiver. Although, for this example, we are creating the keypairs in
+the same system, we will assume that these accounts are on different systems to
+replicate an IRL scenario.
+
+```shell
+solana-keygen new -o sender.json
+# pubkey: H8BHbivzT4DtJxL4J4X53CgnqzTUAEJfptSaEHsCvg51
+
+solana-keygen new -o co-sender.json
+# pubkey: HDx43xY4piU3xMxNyRQkj89cqiF15hz5FVW9ergTtZ7S
+
+solana-keygen new -o receiver.json
+# pubkey: D3RAQxwQBhMLum2WK7eCn2MpRWgeLtDW7fqXTcqtx9uC
+```
+
+Let's add some SOL to the member wallets.
+
+```shell
+solana airdrop -k sender.json 0.5
+solana airdrop -k co-sender.json 0.5
+```
+
+### Using Recent Blockhashes
+
+Before we try to sign and send a durable transaction, let's see how transactions
+are normally submitted using recent blockhashes.
+
+> Its important to note that although we'll attempt to achieve the above using
+> recent blockhashes, the expected outcome is failure, which will help us
+> appreciate why durable nonces are necessary here.
+
+The first step is to build a transfer transaction from `sender` to `receiver`
+and sign it with `co-sender`'s wallet.
+
+To sign an offline transaction, we need to use:
+
+1. `--sign-only`: which prevents clients from sending the transaction.
+2. `--blockhash`: which lets us specify a recent blockhash so that the client
+   does not try to fetch for it in an offline setting.
+
+- We can get a recent blockhash from
+  [solscan](https://solscan.io/blocks?cluster=devnet). Just copy the first
+  blockhash from the list.
+- We will also need the pubkey of `sender`:
+  `H8BHbivzT4DtJxL4J4X53CgnqzTUAEJfptSaEHsCvg51`
+- You can even turn off your internet when you sign this transaction using the
+  `co-sender`'s wallet :).
+
+```shell
+solana transfer receiver.json 0.1 \
+  --sign-only \
+  --blockhash F13BkBgNTyyuruUQFSgUkXPMJCfPvKhhrr217eiqGfVE \
+  --fee-payer co-sender.json \
+  --from H8BHbivzT4DtJxL4J4X53CgnqzTUAEJfptSaEHsCvg51 \
+  --keypair co-sender.json
+```
+
+Output
+
+```shell
+Blockhash: F13BkBgNTyyuruUQFSgUkXPMJCfPvKhhrr217eiqGfVE
+Signers (Pubkey=Signature):
+ HDx43xY4piU3xMxNyRQkj89cqiF15hz5FVW9ergTtZ7S=2gUmcb4Xwm3Dy9xH3a3bePsWVKCRMtUghqDS9pnGZDmX6hqtWMfpubEbgcai5twncoAJzyr9FRn3yuXVeSvYD4Ni
+Absent Signers (Pubkey):
+ H8BHbivzT4DtJxL4J4X53CgnqzTUAEJfptSaEHsCvg51
+```
+
+The transaction is signed by `co-sender`'s wallet, who will pay the tx fee.
+Also, we are notified about the pending signature from the `sender`'s wallet
+(`H8BHbivzT4DtJxL4J4X53CgnqzTUAEJfptSaEHsCvg51`).
+
+In a real-world scenario, `co-sender` can share their `Pubkey=Signature` pair
+with the `sender` who will need this sign and submit the transaction. This share
+may take more than a minute to happen. Once the `sender` receives this pair,
+they can initiate the transfer.
+
+```shell
+solana transfer receiver.json 0.1 \
+  --allow-unfunded-recipient \
+  --blockhash F13BkBgNTyyuruUQFSgUkXPMJCfPvKhhrr217eiqGfVE \
+  --from sender.json \
+  --keypair sender.json \
+  --signer HDx43xY4piU3xMxNyRQkj89cqiF15hz5FVW9ergTtZ7S=2gUmcb4Xwm3Dy9xH3a3bePsWVKCRMtUghqDS9pnGZDmX6hqtWMfpubEbgcai5twncoAJzyr9FRn3yuXVeSvYD4Ni
+```
+
+Output
+
+```shell
+Error: Hash has expired F13BkBgNTyyuruUQFSgUkXPMJCfPvKhhrr217eiqGfVE
+```
+
+The transfer is not successful because the hash has expired. How do we overcome
+this issue of expired blockhashes? Using Durable Nonces!
+
+### Using Durable Nonces
+
+We will use the `nonce-account.json` and `nonce-authority.json` keypairs that we
+created earlier. We already have a nonce initialized in the `nonce-account`.
+Let's advance it to get a new one first, just to be sure that the `nonce` isn't
+already used.
+
+```shell
+solana new-nonce nonce-account.json
+solana nonce-account nonce-account.json
+```
+
+Output
+
+```shell
+Signature: 3z1sSU7fmdRoBZynVLiJEqa97Ja481nb3r1mLu8buAgwMnaKdF4ZaiBkzrLjPRzn1HV2rh4AHQTJHAQ3DsDiYVpF
+
+Balance: 0.0014999 SOL
+Minimum Balance Required: 0.00144768 SOL
+Nonce blockhash: HNUi6La2QpGJdfcAR6yFFmdgYoCvFZREkve2haMBxXVz
+Fee: 5000 lamports per signature
+Authority: 5CZKcm6PakaRWGK8NogzXvj8CjA71uSofKLohoNi4Wom
+```
+
+Perfect, now let's start with offline co-signing the transaction with
+`co-signer`'s wallet, but this time, we'll use the `Nonce blockhash` printed
+above, which is basically the `nonce` stored in the `nonce-account` as the
+blockhash for the transfer transaction.
+
+```shell
+solana transfer receiver.json 0.1 \
+  --sign-only \
+  --nonce nonce-account.json \
+  --blockhash HNUi6La2QpGJdfcAR6yFFmdgYoCvFZREkve2haMBxXVz \
+  --fee-payer co-sender.json \
+  --from H8BHbivzT4DtJxL4J4X53CgnqzTUAEJfptSaEHsCvg51 \
+  --keypair co-sender.json
+```
+
+Output
+
+```shell
+Blockhash: HNUi6La2QpGJdfcAR6yFFmdgYoCvFZREkve2haMBxXVz
+Signers (Pubkey=Signature):
+ HDx43xY4piU3xMxNyRQkj89cqiF15hz5FVW9ergTtZ7S=5tfuPxsXchbVFU745658nsQr5Gqhb5nRnZKLnnovJ2PZBHbqUbe7oB5kDbnq7tjeJ2V8Mywa4gujUjT4BWKRcAdi
+Absent Signers (Pubkey):
+ H8BHbivzT4DtJxL4J4X53CgnqzTUAEJfptSaEHsCvg51
+```
+
+This is very similar to the one we signed using the recent blockhash. Now we'll
+sign and send the transaction with the `sender`'s wallet.
+
+```shell
+solana transfer receiver.json 0.1 \
+  --nonce nonce-account.json \
+  --nonce-authority nonce-authority.json \
+  --blockhash HNUi6La2QpGJdfcAR6yFFmdgYoCvFZREkve2haMBxXVz \
+  --from sender.json \
+  --keypair sender.json \
+  --signer HDx43xY4piU3xMxNyRQkj89cqiF15hz5FVW9ergTtZ7S=5tfuPxsXchbVFU745658nsQr5Gqhb5nRnZKLnnovJ2PZBHbqUbe7oB5kDbnq7tjeJ2V8Mywa4gujUjT4BWKRcAdi
+```
+
+Output
+
+```shell
+Signature: anQ8VtQgeSMoKTnQCubTenq1J7WKxAa1dbFMDLsbDWgV6GGL135G1Ydv4QTNd6GptP3TxDQ2ZWi3Y5qnEtjM7yg
+```
+
+The transaction is successfully submitted!
+
+If we check it on the
+[explorer](https://solscan.io/tx/anQ8VtQgeSMoKTnQCubTenq1J7WKxAa1dbFMDLsbDWgV6GGL135G1Ydv4QTNd6GptP3TxDQ2ZWi3Y5qnEtjM7yg?cluster=devnet),
+we can see that an `AdvanceNonce` instruction was prepended to the transaction,
+as we discussed before. This is done to avoid using the same nonce again.
+
+Voila, we've gone through a very real-life use case of Durable Nonces. Now let's
+see how to use them in transactions using JavaScript and the
+[`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/v1.x/) package.
+
+## Durable Nonces with Solana Web3.js
+
+We'll use a similar example of making a simple transfer to demonstrate how to
+send transactions using durable nonces.
+
+### Create Nonce Authority (Web3.js)
+
+```ts
+const nonceAuthKP = Keypair.generate();
+```
+
+_If you need SOL, you can use the
+[faucet.solana.com](https://faucet.solana.com/)_ to get some.
+
+### Create Nonce Accounts (Web3.js)
+
+```ts
+const nonceKeypair = Keypair.generate();
+const tx = new Transaction();
+
+// the fee payer can be any account
+tx.feePayer = nonceAuthKP.publicKey;
+
+// to create the nonce account, you can use fetch the recent blockhash
+// or use a nonce from a different, pre-existing nonce account
+tx.recentBlockhash = (await connection.getLatestBlockhash()).blockhash;
+
+tx.add(
+  // create system account with the minimum amount needed for rent exemption.
+  // NONCE_ACCOUNT_LENGTH is the space a nonce account takes
+  SystemProgram.createAccount({
+    fromPubkey: nonceAuthKP.publicKey,
+    newAccountPubkey: nonceKeypair.publicKey,
+    lamports: 0.0015 * LAMPORTS_PER_SOL,
+    space: NONCE_ACCOUNT_LENGTH,
+    programId: SystemProgram.programId
+  }),
+  // initialise nonce with the created nonceKeypair's pubkey as the noncePubkey
+  // also specify the authority of the nonce account
+  SystemProgram.nonceInitialize({
+    noncePubkey: nonceKeypair.publicKey,
+    authorizedPubkey: nonceAuthKP.publicKey
+  })
+);
+
+// sign the transaction with both the nonce keypair and the authority keypair
+tx.sign(nonceKeypair, nonceAuthKP);
+
+// send the transaction
+const sig = await sendAndConfirmRawTransaction(
+  connection,
+  tx.serialize({ requireAllSignatures: false })
+);
+console.log("Nonce initiated: ", sig);
+```
+
+### Fetch Nonce Account (Web3.js)
+
+```ts
+const accountInfo = await connection.getAccountInfo(nonceKeypair.publicKey);
+const nonceAccount = NonceAccount.fromAccountData(accountInfo.data);
+```
+
+### Sign Transaction using Durable Nonce
+
+```ts
+// make a system transfer instruction
+const ix = SystemProgram.transfer({
+  fromPubkey: publicKey,
+  toPubkey: publicKey,
+  lamports: 100
+});
+
+// make a nonce advance instruction
+const advanceIX = SystemProgram.nonceAdvance({
+  authorizedPubkey: nonceAuthKP.publicKey,
+  noncePubkey: noncePubKey
+});
+
+// add them to a transaction
+const tx = new Transaction();
+tx.add(advanceIX);
+tx.add(ix);
+
+// use the nonceAccount's stored nonce as the recentBlockhash
+tx.recentBlockhash = nonceAccount.nonce;
+tx.feePayer = publicKey;
+
+// sign the tx with the nonce authority's keypair
+tx.sign(nonceAuthKP);
+
+// make the owner of the publicKey sign the transaction
+// this should open a wallet popup and let the user sign the tx
+const signedTx = await signTransaction(tx);
+
+// once you have the signed tx, you can serialize it and store it
+// in a database, or send it to another device. You can submit it
+// at a later point, without the tx having a mortality
+const serialisedTx = bs58.encode(
+  signedTx.serialize({ requireAllSignatures: false })
+);
+console.log("Signed Durable Transaction: ", serialisedTx);
+```
+
+## Live Example: Poll Simulation App
+
+The Poll Simulation app simulates a real-life poll mechanism, wherein voters are
+allowed to vote for a given set of times. Once the time comes for determining
+the results of the poll: the votes are counted, the count is publicly announced
+to everyone, and the winner is declared.
+
+This is tough to build onchain, as changing the state of an account onchain is a
+public action, and hence if a user votes for someone, others would know, and
+hence the count won't be hidden from the public until the voting has been
+completed.
+
+Durable nonces can be used to partially fix this. Instead of signing and sending
+the transaction when voting for your candidate, the dapp can let the user sign
+the transaction using durable nonces, serialize the transaction as shown above
+in the web3.js example, and save the serialized transactions in a database until
+the time comes for counting.
+
+For counting the votes, the dapp then needs to sync, send, or submit all the
+signed transactions one by one. With each submitted transaction, the state
+change will happen onchain, and the winner can be decided.
+
+### Live App
+
+- The app is live on:
+  [**https://durable-nonces-demo.vercel.app/**](https://durable-nonces-demo.vercel.app/)
+
+- Information on how to use the dapp can be found
+  [here](https://github.com/0xproflupin/solana-durable-nonces/blob/main/durable-nonces-demo/README.md#how-to-use-the-dapp)
+
+- Information on how to build the dapp locally can be found
+  [here](https://github.com/0xproflupin/solana-durable-nonces/blob/main/durable-nonces-demo/README.md#how-to-build-the-dapp-locally)
+
+## References
+
+- [Neodyme Blog: Nonce Upon a Time, or a Total Loss of Funds](https://neodyme.io/blog/nonce-upon-a-time/)
+- [Solana Durable Nonces CLI](https://docs.anza.xyz/cli/examples/durable-nonce)
+- [Solana Durable Transaction Nonces Proposal](https://docs.anza.xyz/implemented-proposals/durable-tx-nonces)

--- a/apps/docs/content/cookbook/transactions/lookup-tables.mdx
+++ b/apps/docs/content/cookbook/transactions/lookup-tables.mdx
@@ -1,0 +1,192 @@
+---
+title: Address Lookup Tables
+description:
+  Learn how to use Solana Address Lookup Tables (ALTs) to efficiently handle up
+  to 64 addresses per transaction. Create, extend, and utilize lookup tables
+  using web3.js.
+---
+
+Address Lookup Tables, commonly referred to as "_lookup tables_" or "_ALTs_" for
+short, allow developers to create a collection of related addresses to
+efficiently load more addresses in a single transaction.
+
+Since each transaction on the Solana blockchain requires a listing of every
+address that is interacted with as part of the transaction, this listing would
+effectively be capped at 32 addresses per transaction. With the help of
+[Address Lookup Tables](/developers/cookbook/transactions/lookup-tables), a
+transaction would now be able to raise that limit to 64 addresses per
+transaction.
+
+## Compressing onchain addresses
+
+After all the desired addresses have been stored onchain in an Address Lookup
+Table, each address can be referenced inside a transaction by its 1-byte index
+within the table (instead of their full 32-byte address). This lookup method
+effectively "_compresses_" a 32-byte address into a 1-byte index value.
+
+This "_compression_" enables storing up to 256 addresses in a single lookup
+table for use inside any given transaction.
+
+## Versioned Transactions
+
+To utilize an Address Lookup Table inside a transaction, developers must use v0
+transactions that were introduced with the new
+[Versioned Transaction format](/developers/cookbook/transactions/versions).
+
+## How to create an address lookup table
+
+Creating a new lookup table with the `@solana/web3.js` library is similar to the
+older `legacy` transactions, but with some differences.
+
+Using the `@solana/web3.js` library, you can use the
+[`createLookupTable`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/AddressLookupTableProgram.html#createLookupTable)
+function to construct the instruction needed to create a new lookup table, as
+well as determine its address:
+
+```js
+const web3 = require("@solana/web3.js");
+
+// connect to a cluster and get the current `slot`
+const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+const slot = await connection.getSlot();
+
+// Assumption:
+// `payer` is a valid `Keypair` with enough SOL to pay for the execution
+
+const [lookupTableInst, lookupTableAddress] =
+  web3.AddressLookupTableProgram.createLookupTable({
+    authority: payer.publicKey,
+    payer: payer.publicKey,
+    recentSlot: slot
+  });
+
+console.log("lookup table address:", lookupTableAddress.toBase58());
+
+// To create the Address Lookup Table onchain:
+// send the `lookupTableInst` instruction in a transaction
+```
+
+> NOTE: Address lookup tables can be **created** with either a `v0` transaction
+> or a `legacy` transaction. But the Solana runtime can only retrieve and handle
+> the additional addresses within a lookup table while using
+> [v0 Versioned Transactions](/developers/cookbook/transactions/versions#current-transaction-versions).
+
+## Add addresses to a lookup table
+
+Adding addresses to a lookup table is known as "_extending_". Using the
+`@solana/web3.js` library, you can create a new _extend_ instruction using the
+[`extendLookupTable`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/AddressLookupTableProgram.html#extendLookupTable)
+method:
+
+```js
+// add addresses to the `lookupTableAddress` table via an `extend` instruction
+const extendInstruction = web3.AddressLookupTableProgram.extendLookupTable({
+  payer: payer.publicKey,
+  authority: payer.publicKey,
+  lookupTable: lookupTableAddress,
+  addresses: [
+    payer.publicKey,
+    web3.SystemProgram.programId
+    // list more `publicKey` addresses here
+  ]
+});
+
+// Send this `extendInstruction` in a transaction to the cluster
+// to insert the listing of `addresses` into your lookup table with address `lookupTableAddress`
+```
+
+> NOTE: Due to the same memory limits of `legacy` transactions, any transaction
+> used to _extend_ an Address Lookup Table is also limited in how many addresses
+> can be added at a time. Because of this, you will need to use multiple
+> transactions to _extend_ any table with more addresses (~20) that can fit
+> within a single transaction's memory limits.
+
+Once these addresses have been inserted into the table, and stored onchain, you
+will be able to utilize the Address Lookup Table in future transactions.
+Enabling up to 64 addresses in those future transactions.
+
+## Fetch an Address Lookup Table
+
+Similar to requesting another account (or PDA) from the cluster, you can fetch a
+complete Address Lookup Table with the
+[`getAddressLookupTable`](https://solana-labs.github.io/solana-web3.js/v1.x/classes/Connection.html#getAddressLookupTable)
+method:
+
+```js
+// define the `PublicKey` of the lookup table to fetch
+const lookupTableAddress = new web3.PublicKey("");
+
+// get the table from the cluster
+const lookupTableAccount = (
+  await connection.getAddressLookupTable(lookupTableAddress)
+).value;
+
+// `lookupTableAccount` will now be an `AddressLookupTableAccount` object
+
+console.log("Table address from cluster:", lookupTableAccount.key.toBase58());
+```
+
+Our `lookupTableAccount` variable will now be an `AddressLookupTableAccount`
+object which we can parse to read the listing of all the addresses stored on
+chain in the lookup table:
+
+```js
+// loop through and parse all the addresses stored in the table
+for (let i = 0; i < lookupTableAccount.state.addresses.length; i++) {
+  const address = lookupTableAccount.state.addresses[i];
+  console.log(i, address.toBase58());
+}
+```
+
+## How to use an address lookup table in a transaction
+
+After you have created your lookup table, and stored your needed address on
+chain (via extending the lookup table), you can create a `v0` transaction to
+utilize the onchain lookup capabilities.
+
+Just like older `legacy` transactions, you can create all the
+[instructions](/docs/references/terminology#instruction) your transaction will
+execute onchain. You can then provide an array of these instructions to the
+[Message](/docs/references/terminology#message) used in the `v0` transaction.
+
+> NOTE: The instructions used inside a `v0` transaction can be constructed using
+> the same methods and functions used to create the instructions in the past.
+> There is no required change to the instructions used involving an Address
+> Lookup Table.
+
+```js
+// Assumptions:
+// - `arrayOfInstructions` has been created as an `array` of `TransactionInstruction`
+// - we are using the `lookupTableAccount` obtained above
+
+// construct a v0 compatible transaction `Message`
+const messageV0 = new web3.TransactionMessage({
+  payerKey: payer.publicKey,
+  recentBlockhash: blockhash,
+  instructions: arrayOfInstructions // note this is an array of instructions
+}).compileToV0Message([lookupTableAccount]);
+
+// create a v0 transaction from the v0 message
+const transactionV0 = new web3.VersionedTransaction(messageV0);
+
+// sign the v0 transaction using the file system wallet we created named `payer`
+transactionV0.sign([payer]);
+
+// send and confirm the transaction
+// (NOTE: There is NOT an array of Signers here; see the note below...)
+const txid = await web3.sendAndConfirmTransaction(connection, transactionV0);
+
+console.log(
+  `Transaction: https://explorer.solana.com/tx/${txid}?cluster=devnet`
+);
+```
+
+> NOTE: When sending a `VersionedTransaction` to the cluster, it must be signed
+> BEFORE calling the `sendAndConfirmTransaction` method. If you pass an array of
+> `Signer` (like with `legacy` transactions) the method will trigger an error!
+
+## More Resources
+
+- Read the [proposal](https://docs.anza.xyz/proposals/versioned-transactions)
+  for Address Lookup Tables and Versioned transactions
+- [Example Rust program using Address Lookup Tables](https://github.com/TeamRaccoons/address-lookup-table-multi-swap)

--- a/apps/docs/content/cookbook/transactions/meta.json
+++ b/apps/docs/content/cookbook/transactions/meta.json
@@ -11,6 +11,11 @@
     "add-priority-fees",
     "optimize-compute",
     "offline-transactions",
+    "durable-nonces",
+    "versions",
+    "lookup-tables",
+    "confirmation",
+    "retry",
     "mev-protection"
   ]
 }

--- a/apps/docs/content/cookbook/transactions/optimize-compute.mdx
+++ b/apps/docs/content/cookbook/transactions/optimize-compute.mdx
@@ -68,7 +68,7 @@ async def get_simulation_compute_units(rpc, instructions, payer_pubkey, lookup_t
 async def build_optimal_transaction(rpc, instructions, signer, lookup_tables=[]):
     """Build optimal transaction similar to JavaScript version"""
     # See the equivalent JavaScript guide for context here:
-    # https://solana.com/zh/developers/guides/advanced/how-to-request-optimal-compute
+    # https://solana.com/zh/developers/cookbook/transactions/optimize-compute
     micro_lamports = 100  # Get optimal priority fees
     units = await get_simulation_compute_units(rpc, instructions, signer.pubkey(), lookup_tables)
     recent_blockhash = await rpc.get_latest_blockhash()

--- a/apps/docs/content/cookbook/transactions/retry.mdx
+++ b/apps/docs/content/cookbook/transactions/retry.mdx
@@ -1,0 +1,324 @@
+---
+title: Retrying Transactions
+description:
+  Learn how to handle dropped transactions and implement custom retry logic on
+  Solana. This guide covers transaction rebroadcasting, preflight checks, and
+  best practices for managing transaction retries to ensure reliable transaction
+  processing on the Solana blockchain.
+---
+
+# Retrying Transactions
+
+On some occasions, a seemingly valid transaction may be dropped before it is
+included in a block. This most often occurs during periods of network
+congestion, when an RPC node fails to rebroadcast the transaction to the
+[leader](/docs/references/terminology#leader). To an end-user, it may appear as
+if their transaction disappears entirely. While RPC nodes are equipped with a
+generic rebroadcasting algorithm, application developers are also capable of
+developing their own custom rebroadcasting logic.
+
+## TLDR;
+
+- RPC nodes will attempt to rebroadcast transactions using a generic algorithm
+- Application developers can implement their own custom rebroadcasting logic
+- Developers should take advantage of the `maxRetries` parameter on the
+  `sendTransaction` JSON-RPC method
+- Developers should enable preflight checks to raise errors before transactions
+  are submitted
+- Before re-signing any transaction, it is **very important** to ensure that the
+  initial transaction's blockhash has expired
+
+## The Journey of a Transaction
+
+### How Clients Submit Transactions
+
+In Solana, there is no concept of a mempool. All transactions, whether they are
+initiated programmatically or by an end-user, are efficiently routed to leaders
+so that they can be processed into a block. There are two main ways in which a
+transaction can be sent to leaders:
+
+1. By proxy via an RPC server and the
+   [sendTransaction](/docs/rpc/http/sendtransaction) JSON-RPC method
+2. Directly to leaders via a
+   [TPU Client](https://docs.rs/solana-client/latest/solana_client/tpu_client/index.html)
+
+The vast majority of end-users will submit transactions via an RPC server. When
+a client submits a transaction, the receiving RPC node will in turn attempt to
+broadcast the transaction to both the current and next leaders. Until the
+transaction is processed by a leader, there is no record of the transaction
+outside of what the client and the relaying RPC nodes are aware of. In the case
+of a TPU client, rebroadcast and leader forwarding is handled entirely by the
+client software.
+
+![Overview of a transactions journey, from client to leader](/assets/docs/rt-tx-journey.png)
+
+### How RPC Nodes Broadcast Transactions
+
+After an RPC node receives a transaction via `sendTransaction`, it will convert
+the transaction into a
+[UDP](https://en.wikipedia.org/wiki/User_Datagram_Protocol) packet before
+forwarding it to the relevant leaders. UDP allows validators to quickly
+communicate with one another, but does not provide any guarantees regarding
+transaction delivery.
+
+Because Solana's leader schedule is known in advance of every
+[epoch](/docs/references/terminology#epoch) (~2 days), an RPC node will
+broadcast its transaction directly to the current and next leaders. This is in
+contrast to other gossip protocols such as Ethereum that propagate transactions
+randomly and broadly across the entire network. By default, RPC nodes will try
+to forward transactions to leaders every two seconds until either the
+transaction is finalized or the transaction's blockhash expires (150 blocks or
+~1 minute 19 seconds as of the time of this writing). If the outstanding
+rebroadcast queue size is greater than
+[10,000 transactions](https://github.com/solana-labs/solana/blob/bfbbc53dac93b3a5c6be9b4b65f679fdb13e41d9/send-transaction-service/src/send_transaction_service.rs#L20),
+newly submitted transactions are dropped. There are command-line
+[arguments](https://github.com/solana-labs/solana/blob/bfbbc53dac93b3a5c6be9b4b65f679fdb13e41d9/validator/src/main.rs#L1172)
+that RPC operators can adjust to change the default behavior of this retry
+logic.
+
+When an RPC node broadcasts a transaction, it will attempt to forward the
+transaction to a leader's
+[Transaction Processing Unit (TPU)](https://github.com/solana-labs/solana/blob/cd6f931223181d5a1d47cba64e857785a175a760/core/src/validator.rs#L867).
+The TPU processes transactions in five distinct phases:
+
+- [Fetch Stage](https://github.com/solana-labs/solana/blob/cd6f931223181d5a1d47cba64e857785a175a760/core/src/fetch_stage.rs#L21)
+- [SigVerify Stage](https://github.com/solana-labs/solana/blob/cd6f931223181d5a1d47cba64e857785a175a760/core/src/tpu.rs#L91)
+- [Banking Stage](https://github.com/solana-labs/solana/blob/cd6f931223181d5a1d47cba64e857785a175a760/core/src/banking_stage.rs#L249)
+- [Proof of History Service](https://github.com/solana-labs/solana/blob/cd6f931223181d5a1d47cba64e857785a175a760/poh/src/poh_service.rs)
+- [Broadcast Stage](https://github.com/solana-labs/solana/blob/cd6f931223181d5a1d47cba64e857785a175a760/core/src/tpu.rs#L136)
+
+![Overview of the Transaction Processing Unit (TPU)](/assets/docs/rt-tpu-jito-labs.png)
+
+Of these five phases, the Fetch Stage is responsible for receiving transactions.
+Within the Fetch Stage, validators will categorize incoming transactions
+according to three ports:
+
+- [tpu](https://github.com/solana-labs/solana/blob/cd6f931223181d5a1d47cba64e857785a175a760/gossip/src/contact_info.rs#L27)
+  handles regular transactions such as token transfers, NFT mints, and program
+  instructions
+- [tpu_vote](https://github.com/solana-labs/solana/blob/cd6f931223181d5a1d47cba64e857785a175a760/gossip/src/contact_info.rs#L31)
+  focuses exclusively on voting transactions
+- [tpu_forwards](https://github.com/solana-labs/solana/blob/cd6f931223181d5a1d47cba64e857785a175a760/gossip/src/contact_info.rs#L29)
+  forwards unprocessed packets to the next leader if the current leader is
+  unable to process all transactions
+
+For more information on the TPU, please refer to
+[this excellent writeup by Jito Labs](https://jito-labs.medium.com/solana-validator-101-transaction-processing-90bcdc271143).
+
+## How Transactions Get Dropped
+
+Throughout a transaction's journey, there are a few scenarios in which the
+transaction can be unintentionally dropped from the network.
+
+### Before a transaction is processed
+
+If the network drops a transaction, it will most likely do so before the
+transaction is processed by a leader. UDP
+[packet loss](https://en.wikipedia.org/wiki/Packet_loss) is the simplest reason
+why this might occur. During times of intense network load, it's also possible
+for validators to become overwhelmed by the sheer number of transactions
+required for processing. While validators are equipped to forward surplus
+transactions via `tpu_forwards`, there is a limit to the amount of data that can
+be
+[forwarded](https://github.com/solana-labs/solana/blob/master/core/src/banking_stage.rs#L389).
+Furthermore, each forward is limited to a single hop between validators. That
+is, transactions received on the `tpu_forwards` port are not forwarded on to
+other validators.
+
+There are also two lesser known reasons why a transaction may be dropped before
+it is processed. The first scenario involves transactions that are submitted via
+an RPC pool. Occasionally, part of the RPC pool can be sufficiently ahead of the
+rest of the pool. This can cause issues when nodes within the pool are required
+to work together. In this example, the transaction's
+[recentBlockhash](/docs/core/transactions/transaction-structure#recent-blockhash)
+is queried from the advanced part of the pool (Backend A). When the transaction
+is submitted to the lagging part of the pool (Backend B), the nodes will not
+recognize the advanced blockhash and will drop the transaction. This can be
+detected upon transaction submission if developers enable
+[preflight checks](/docs/rpc/http/sendtransaction) on `sendTransaction`.
+
+![Transaction dropped via an RPC Pool](/assets/docs/rt-dropped-via-rpc-pool.png)
+
+Temporary network forks can also result in dropped transactions. If a validator
+is slow to replay its blocks within the Banking Stage, it may end up creating a
+minority fork. When a client builds a transaction, it's possible for the
+transaction to reference a `recentBlockhash` that only exists on the minority
+fork. After the transaction is submitted, the cluster can then switch away from
+its minority fork before the transaction is processed. In this scenario, the
+transaction is dropped due to the blockhash not being found.
+
+![Transaction dropped due to minority fork (before processed)](/assets/docs/rt-dropped-minority-fork-pre-process.png)
+
+### After a transaction is processed and before it is finalized
+
+In the event a transaction references a `recentBlockhash` from a minority fork,
+it's still possible for the transaction to be processed. In this case, however,
+it would be processed by the leader on the minority fork. When this leader
+attempts to share its processed transactions with the rest of the network, it
+would fail to reach consensus with the majority of validators that do not
+recognize the minority fork. At this time, the transaction would be dropped
+before it could be finalized.
+
+![Transaction dropped due to minority fork (after processed)](/assets/docs/rt-dropped-minority-fork-post-process.png)
+
+## Handling Dropped Transactions
+
+While RPC nodes will attempt to rebroadcast transactions, the algorithm they
+employ is generic and often ill-suited for the needs of specific applications.
+To prepare for times of network congestion, application developers should
+customize their own rebroadcasting logic.
+
+### An In-Depth Look at sendTransaction
+
+When it comes to submitting transactions, the `sendTransaction` RPC method is
+the primary tool available to developers. `sendTransaction` is only responsible
+for relaying a transaction from a client to an RPC node. If the node receives
+the transaction, `sendTransaction` will return the transaction id that can be
+used to track the transaction. A successful response does not indicate whether
+the transaction will be processed or finalized by the cluster.
+
+### Request Parameters
+
+- `transaction`: `string` - fully-signed Transaction, as encoded string
+- (optional) `configuration object`: `object`
+  - `skipPreflight`: `boolean` - if true, skip the preflight transaction checks
+    (default: false)
+  - (optional) `preflightCommitment`: `string` -
+    [Commitment](/docs/rpc/#configuring-state-commitment) level to use for
+    preflight simulations against the bank slot (default: "finalized").
+  - (optional) `encoding`: `string` - Encoding used for the transaction data.
+    Either "base58" (slow), or "base64". (default: "base58").
+  - (optional) `maxRetries`: `usize` - Maximum number of times for the RPC node
+    to retry sending the transaction to the leader. If this parameter is not
+    provided, the RPC node will retry the transaction until it is finalized or
+    until the blockhash expires.
+
+**Response:**
+
+- `transaction id`: `string` - First transaction signature embedded in the
+  transaction, as base-58 encoded string. This transaction id can be used with
+  [`getSignatureStatuses`](/docs/rpc/http/getsignaturestatuses) to poll for
+  status updates.
+
+## Customizing Rebroadcast Logic
+
+In order to develop their own rebroadcasting logic, developers should take
+advantage of `sendTransaction`'s `maxRetries` parameter. If provided,
+`maxRetries` will override an RPC node's default retry logic, allowing
+developers to manually control the retry process
+[within reasonable bounds](https://github.com/solana-labs/solana/blob/98707baec2385a4f7114d2167ef6dfb1406f954f/validator/src/main.rs#L1258-L1274).
+
+A common pattern for manually retrying transactions involves temporarily storing
+the `lastValidBlockHeight` that comes from
+[getLatestBlockhash](/docs/rpc/http/getlatestblockhash). Once stashed, an
+application can then
+[poll the cluster's blockheight](/docs/rpc/http/getblockheight) and manually
+retry the transaction at an appropriate interval. In times of network
+congestion, it's advantageous to set `maxRetries` to 0 and manually rebroadcast
+via a custom algorithm. While some applications may employ an
+[exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff)
+algorithm, others such as [Mango](https://www.mango.markets/) opt to
+[continuously resubmit](https://github.com/blockworks-foundation/mango-ui/blob/b6abfc6c13b71fc17ebbe766f50b8215fa1ec54f/src/utils/send.tsx#L713)
+transactions at a constant interval until some timeout has occurred.
+
+```ts
+import {
+  Keypair,
+  Connection,
+  LAMPORTS_PER_SOL,
+  SystemProgram,
+  Transaction
+} from "@solana/web3.js";
+import * as nacl from "tweetnacl";
+
+const sleep = async (ms: number) => {
+  return new Promise((r) => setTimeout(r, ms));
+};
+
+(async () => {
+  const payer = Keypair.generate();
+  const toAccount = Keypair.generate().publicKey;
+
+  const connection = new Connection("http://127.0.0.1:8899", "confirmed");
+
+  const airdropSignature = await connection.requestAirdrop(
+    payer.publicKey,
+    LAMPORTS_PER_SOL
+  );
+
+  await connection.confirmTransaction({ signature: airdropSignature });
+
+  const blockhashResponse = await connection.getLatestBlockhash();
+  const lastValidBlockHeight = blockhashResponse.lastValidBlockHeight - 150;
+
+  const transaction = new Transaction({
+    feePayer: payer.publicKey,
+    blockhash: blockhashResponse.blockhash,
+    lastValidBlockHeight: lastValidBlockHeight
+  }).add(
+    SystemProgram.transfer({
+      fromPubkey: payer.publicKey,
+      toPubkey: toAccount,
+      lamports: 1000000
+    })
+  );
+  const message = transaction.serializeMessage();
+  const signature = nacl.sign.detached(message, payer.secretKey);
+  transaction.addSignature(payer.publicKey, Buffer.from(signature));
+  const rawTransaction = transaction.serialize();
+  let blockheight = await connection.getBlockHeight();
+
+  while (blockheight < lastValidBlockHeight) {
+    connection.sendRawTransaction(rawTransaction, {
+      skipPreflight: true
+    });
+    await sleep(500);
+    blockheight = await connection.getBlockHeight();
+  }
+})();
+```
+
+When polling via `getLatestBlockhash`, applications should specify their
+intended [commitment](/docs/rpc/#configuring-state-commitment) level. By setting
+its commitment to `confirmed` (voted on) or `finalized` (~30 blocks after
+`confirmed`), an application can avoid polling a blockhash from a minority fork.
+
+If an application has access to RPC nodes behind a load balancer, it can also
+choose to divide its workload amongst specific nodes. RPC nodes that serve
+data-intensive requests such as
+[getProgramAccounts](/docs/rpc/http/getprogramaccounts) may be prone to falling
+behind and can be ill-suited for also forwarding transactions. For applications
+that handle time-sensitive transactions, it may be prudent to have dedicated
+nodes that only handle `sendTransaction`.
+
+### The Cost of Skipping Preflight
+
+By default, `sendTransaction` will perform three preflight checks prior to
+submitting a transaction. Specifically, `sendTransaction` will:
+
+- Verify that all signatures are valid
+- Check that the referenced blockhash is within the last 150 blocks
+- Simulate the transaction against the bank slot specified by the
+  `preflightCommitment`
+
+In the event that any of these three preflight checks fail, `sendTransaction`
+will raise an error prior to submitting the transaction. Preflight checks can
+often be the difference between losing a transaction and allowing a client to
+gracefully handle an error. To ensure that these common errors are accounted
+for, it is recommended that developers keep `skipPreflight` set to `false`.
+
+### When to Re-Sign Transactions
+
+Despite all attempts to rebroadcast, there may be times in which a client is
+required to re-sign a transaction. Before re-signing any transaction, it is
+**very important** to ensure that the initial transaction's blockhash has
+expired. If the initial blockhash is still valid, it is possible for both
+transactions to be accepted by the network. To an end-user, this would appear as
+if they unintentionally sent the same transaction twice.
+
+In Solana, a dropped transaction can be safely discarded once the blockhash it
+references is older than the `lastValidBlockHeight` received from
+`getLatestBlockhash`. Developers should keep track of this
+`lastValidBlockHeight` by querying [`getEpochInfo`](/docs/rpc/http/getepochinfo)
+and comparing with `blockHeight` in the response. Once a blockhash is
+invalidated, clients may re-sign with a newly-queried blockhash.

--- a/apps/docs/content/cookbook/transactions/versions.mdx
+++ b/apps/docs/content/cookbook/transactions/versions.mdx
@@ -1,0 +1,188 @@
+---
+title: Versioned Transactions
+description:
+  "Explore the core Solana concepts: transactions, versioned transactions,
+  enabling additional functionality in the Solana runtime, address lookup
+  tables, and more."
+---
+
+Versioned Transactions are the new transaction format that allow for additional
+functionality in the Solana runtime, including
+[Address Lookup Tables](/developers/cookbook/transactions/lookup-tables).
+
+While changes to onchain programs are **NOT** required to support the new
+functionality of versioned transactions (or for backwards compatibility),
+developers **WILL** need update their client side code to prevent
+[errors due to different transaction versions](#max-supported-transaction-version).
+
+## Current Transaction Versions
+
+The Solana runtime supports two transaction versions:
+
+- `legacy` - older transaction format with no additional benefit
+- `0` - added support for
+  [Address Lookup Tables](/developers/cookbook/transactions/lookup-tables)
+
+## Max supported transaction version
+
+All RPC requests that return a transaction **_should_** specify the highest
+version of transactions they will support in their application using the
+`maxSupportedTransactionVersion` option, including
+[`getBlock`](/docs/rpc/http/getblock) and
+[`getTransaction`](/docs/rpc/http/gettransaction).
+
+An RPC request will fail if a Versioned Transaction is returned that is higher
+than the set `maxSupportedTransactionVersion`. (i.e. if a version `0`
+transaction is returned when `legacy` is selected)
+
+> WARNING: If no `maxSupportedTransactionVersion` value is set, then only
+> `legacy` transactions will be allowed in the RPC response. Therefore, your RPC
+> requests **WILL** fail if any version `0` transactions are returned.
+
+## How to set max supported version
+
+You can set the `maxSupportedTransactionVersion` using both the
+[`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/v1.x/) library
+and JSON formatted requests directly to an RPC endpoint.
+
+### Using web3.js
+
+Using the
+[`@solana/web3.js`](https://solana-labs.github.io/solana-web3.js/v1.x/) library,
+you can retrieve the most recent block or get a specific transaction:
+
+```js
+// connect to the `devnet` cluster and get the current `slot`
+const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+const slot = await connection.getSlot();
+
+// get the latest block (allowing for v0 transactions)
+const block = await connection.getBlock(slot, {
+  maxSupportedTransactionVersion: 0
+});
+
+// get a specific transaction (allowing for v0 transactions)
+const getTx = await connection.getTransaction(
+  "3jpoANiFeVGisWRY5UP648xRXs3iQasCHABPWRWnoEjeA93nc79WrnGgpgazjq4K9m8g2NJoyKoWBV1Kx5VmtwHQ",
+  {
+    maxSupportedTransactionVersion: 0
+  }
+);
+```
+
+### JSON requests to the RPC
+
+Using a standard JSON formatted POST request, you can set the
+`maxSupportedTransactionVersion` when retrieving a specific block:
+
+```shell
+curl https://api.devnet.solana.com -X POST -H "Content-Type: application/json" -d \
+'{"jsonrpc": "2.0", "id":1, "method": "getBlock", "params": [430, {
+  "encoding":"json",
+  "maxSupportedTransactionVersion":0,
+  "transactionDetails":"full",
+  "rewards":false
+}]}'
+```
+
+## How to create a Versioned Transaction
+
+Versioned transactions can be created similar to the older method of creating
+transactions. There are differences in using certain libraries that should be
+noted.
+
+Below is an example of how to create a Versioned Transaction, using the
+`@solana/web3.js` library, to send perform a SOL transfer between two accounts.
+
+#### Notes:
+
+- `payer` is a valid `Keypair` wallet, funded with SOL
+- `toAccount` a valid `Keypair`
+
+Firstly, import the web3.js library and create a `connection` to your desired
+cluster.
+
+We then define the recent `blockhash` and `minRent` we will need for our
+transaction and the account:
+
+```js
+const web3 = require("@solana/web3.js");
+
+// connect to the cluster and get the minimum rent for rent exempt status
+const connection = new web3.Connection(web3.clusterApiUrl("devnet"));
+let minRent = await connection.getMinimumBalanceForRentExemption(0);
+let blockhash = await connection
+  .getLatestBlockhash()
+  .then((res) => res.blockhash);
+```
+
+Create an `array` of all the `instructions` you desire to send in your
+transaction. In this example below, we are creating a simple SOL transfer
+instruction:
+
+```js
+// create an array with your desired `instructions`
+const instructions = [
+  web3.SystemProgram.transfer({
+    fromPubkey: payer.publicKey,
+    toPubkey: toAccount.publicKey,
+    lamports: minRent
+  })
+];
+```
+
+Next, construct a `MessageV0` formatted transaction message with your desired
+`instructions`:
+
+```js
+// create v0 compatible message
+const messageV0 = new web3.TransactionMessage({
+  payerKey: payer.publicKey,
+  recentBlockhash: blockhash,
+  instructions
+}).compileToV0Message();
+```
+
+Then, create a new `VersionedTransaction`, passing in our v0 compatible message:
+
+```js
+const transaction = new web3.VersionedTransaction(messageV0);
+
+// sign your transaction with the required `Signers`
+transaction.sign([payer]);
+```
+
+You can sign the transaction by either:
+
+- passing an array of `signatures` into the `VersionedTransaction` method, or
+- call the `transaction.sign()` method, passing an array of the required
+  `Signers`
+
+> NOTE: After calling the `transaction.sign()` method, all the previous
+> transaction `signatures` will be fully replaced by new signatures created from
+> the provided in `Signers`.
+
+After your `VersionedTransaction` has been signed by all required accounts, you
+can send it to the cluster and `await` the response:
+
+```js
+// send our v0 transaction to the cluster
+const txId = await connection.sendTransaction(transaction);
+console.log(`https://explorer.solana.com/tx/${txId}?cluster=devnet`);
+```
+
+> NOTE: Unlike `legacy` transactions, sending a `VersionedTransaction` via
+> `sendTransaction` does **NOT** support transaction signing via passing in an
+> array of `Signers` as the second parameter. You will need to sign the
+> transaction before calling `connection.sendTransaction()`.
+
+## More Resources
+
+- using
+  [Versioned Transactions for Address Lookup Tables](/developers/cookbook/transactions/lookup-tables#how-to-create-an-address-lookup-table)
+- view an
+  [example of a v0 transaction](https://explorer.solana.com/tx/h9WQsqSUYhFvrbJWKFPaXximJpLf6Z568NW1j6PBn3f7GPzQXe9PYMYbmWSUFHwgnUmycDNbEX9cr6WjUWkUFKx/?cluster=devnet)
+  on Solana Explorer
+- read the
+  [accepted proposal](https://docs.anza.xyz/proposals/versioned-transactions)
+  for Versioned Transaction and Address Lookup Tables

--- a/apps/docs/content/cookbook/wallets/auto-approve.mdx
+++ b/apps/docs/content/cookbook/wallets/auto-approve.mdx
@@ -1,0 +1,91 @@
+---
+date: 2024-04-25T00:00:00Z
+difficulty: beginner
+title: How to auto approve transactions
+seoTitle: How to auto approve transactions on Solana
+description:
+  By auto approving transactions dApps and games can create a more fluid user
+  experience. This is especially interesting for onchain games.
+tags:
+  - games
+  - wallets
+  - transactions
+  - unity
+keywords:
+  - tutorial
+  - auto approve
+  - transactions
+  - blockchain developer
+  - blockchain tutorial
+  - web3 developer
+---
+
+Auto approving transactions means that the user does not have to manually
+confirm every transaction. This is especially useful for onchain games where you
+want to have fluid game play. Here are some options on how this can be achieved.
+
+## Wallet Auto Approve
+
+A few popular Solana wallet applications have transaction "auto approve"
+functionality directly with in them. Some accomplish this with burner wallets.
+This is a very convenient solution, but it may limit your players to using one
+of these wallets. Players may also be resistant to activate the feature since it
+may be seen as a security risk.
+
+- [Solflare auto approve](https://twitter.com/solflare_wallet/status/1625950688709644324)
+- [Phantom auto approve](https://phantom.app/learn/blog/auto-confirm)
+
+## Local Keypair
+
+Another way to add transaction auto approval is to create a keypair in your
+game/dApp and let the player transfer some SOL to that wallet and then use it to
+pay for transaction fees. The only problem with this is that you need to handle
+the security for this wallet and the keys can get lost if the users clear their
+browser cache.
+
+Here, you can find some example source code on how to implement transaction auto
+approval using local keypairs:
+
+- [Example Source Code](https://github.com/solana-developers/solana-game-examples/blob/main/seven-seas/unity/Assets/SolPlay/Scripts/Services/WalletHolderService.cs)
+- [Example Game Seven seas](https://solplay.de/sevenseas/)
+
+## Server Backend
+
+Using a server backend for your game or dApp, you can configure a system that
+will allow your backend to handle paying the [Solana fees](/docs/core/fees)
+yourself. This backend would allow you to create and sign transactions for the
+user, marking your secure backend keypair the `fee payer`, and enabling your
+application to interact with it via an API endpoint.
+
+To accomplish this, your client application (i.e. game or dApp) would send
+parameters to your backend server. The backend server would then authenticate
+that request and the build a transaction with the required data from the user.
+The backend would then sign and send this transaction to the Solana blockchain,
+confirm the transaction was successful, and send a confirmation message to the
+client.
+
+This server backend method is an easy and convenient solution, but you need to
+handle the user's authentication and security. So that could add complexity to
+your application's infrastructure and architecture.
+
+## Session Keys
+
+Session Keys are ephemeral (short lived) keypairs with fine-grained
+program/instruction scoping for tiered access in your Solana programs. They
+allow users to interact with apps by signing transactions locally using a
+temporary keypair. The temporary keypair acts a bit like an oauth token from web
+2, allowing access for a certain amount of time.
+
+Session keys make for a really great user experience, but they do need some
+extra work to implement in the onchain program. You can use the `session-keys`
+crate maintained by [Magic Block](https://www.magicblock.gg/) using their
+[official documentation](https://docs.magicblock.gg/Onboarding/Session%20Keys/integrating-sessions-in-your-program).
+
+## Shadow Signer
+
+Shadow signer is a feature within the
+[Honeycomb Protocol](https://twitter.com/honeycomb_prtcl) that allows you to
+sign transactions.
+
+- [How Shadow Signer works](https://twitter.com/honeycomb_prtcl/status/1777807635795919038)
+- [Docs](https://docs.honeycombprotocol.com/services/)

--- a/apps/docs/content/cookbook/wallets/meta.json
+++ b/apps/docs/content/cookbook/wallets/meta.json
@@ -11,6 +11,8 @@
     "generate-vanity-address",
     "sign-message",
     "sign-with-keychain",
-    "connect-wallet-react"
+    "connect-wallet-react",
+    "auto-approve",
+    "supabase-auth"
   ]
 }

--- a/apps/docs/content/cookbook/wallets/supabase-auth.mdx
+++ b/apps/docs/content/cookbook/wallets/supabase-auth.mdx
@@ -1,0 +1,681 @@
+---
+date: 2025-01-22T00:00:00Z
+difficulty: beginner
+title: "How to Authenticate Users with Solana Wallets Using Supabase"
+seoTitle: "How to Authenticate Users with Solana Wallets Using Supabase"
+description:
+  "Step-by-step guide to implement Solana wallet authentication in your Next.js
+  application using Supabase. Learn how to connect Phantom or Solflare wallets,
+  authenticate users with wallet signatures, and protect routes. Perfect for
+  developers building Solana dApps who want secure, passwordless authentication."
+tags:
+  - auth
+  - supabase
+  - wallet
+  - nextjs
+keywords:
+  - authentication
+  - supabase
+  - wallet authentication
+  - wallet authentication
+  - solana wallet
+  - next.js
+  - protected routes
+---
+
+# How to Authenticate Users with Solana Wallets Using Supabase
+
+## 1. Introduction
+
+This guide shows you how to build a Solana app with wallet authentication using
+[Supabase](https://supabase.com). Users sign in with their Phantom or Solflare
+wallet. No email. No passwords. Just a wallet signature.
+
+You'll be working with the
+[Supabase authentication template](https://templates.solana.com/supabase-auth),
+which provides a complete starting point for Solana applications with
+wallet-based authentication.
+
+Traditional authentication means managing user accounts, password resets, and
+email verification. With Solana wallet authentication, users prove they control
+a wallet address. That's it. It's simpler for them. It's simpler for you.
+
+The template uses Supabase's wallet authentication. Supabase handles the
+cryptographic verification. You get a managed
+[PostgreSQL](https://www.postgresql.org/) database, session management, and
+protected routes. No local database setup. Everything runs through Supabase's
+hosted services.
+
+This guide is based directly on the code in the template. Every code snippet
+comes from the actual implementation. Every file path is real. If you see
+something here, you can find it in the template.
+
+What you'll learn:
+
+- How to set up Supabase wallet authentication for Solana wallets
+- How wallet connection works separately from Supabase authentication
+- How to protect routes so only authenticated users can access them
+- How the authentication flow works under the hood
+
+By the end, you'll understand why each piece exists. You'll know how to extend
+it for your own needs. If you see an error message you don't recognize, don't
+stress. We'll cover the common ones and how to fix them.
+
+## 2. What You'll Build
+
+After following this guide, you'll have a working [Next.js](https://nextjs.org)
+app with wallet authentication built from the
+[Supabase authentication template](https://templates.solana.com/supabase-auth).
+The app includes a home page with wallet connection, a protected account page,
+and a complete authentication system using Supabase.
+
+## 3. Why This Matters
+
+Building your own Solana authentication system requires handling message
+signing, signature verification, session management, and database storage. This
+template uses Supabase's wallet authentication, so you just call
+`supabase.auth.signInWithWeb3()` and it works. With Solana wallet
+authentication, users sign in with their wallet, no passwords, no email
+verification, just one click.
+
+## 4. Prerequisites
+
+Before you start, make sure you have these installed. If you're missing
+something, the app won't run. Don't worry, we'll check each one.
+
+**Node.js v24 (LTS)**
+
+The template uses Next.js. It requires Node.js v24 (LTS) or later. Check your
+version:
+
+```bash
+node --version
+```
+
+If you see Node.js v24 or later, you're good. If not, install
+[Node.js](https://nodejs.org) from [nodejs.org](https://nodejs.org). Use the LTS
+version. It's the most stable.
+
+Next.js runs on Node.js. It handles server-side rendering, API routes, and the
+build process. Without it, `npm install` won't work.
+
+**A Supabase account**
+
+You need a Supabase account to use wallet authentication. The free tier works
+fine for development. Sign up at [supabase.com](https://supabase.com). It takes
+about two minutes.
+
+The template uses Supabase's wallet authentication feature. You'll create a
+project and get credentials. Those credentials go in your `.env.local` file.
+Without them, authentication won't work.
+
+You'll need two things from your Supabase project:
+
+- Project URL (looks like `https://xxxxx.supabase.co`)
+- Anon key (the public key, not the service role key)
+
+You can find both in your Supabase dashboard under Settings → API. Don't stress
+if you don't have them yet. We'll get them during setup.
+
+**A Solana wallet extension**
+
+You need a Solana wallet installed in your browser. Phantom, Solflare, or
+Backpack all work. Install one from their official websites. Make sure it's the
+browser extension, not a mobile app.
+
+Users sign in with their wallet. The template detects `window.solana` to
+connect. Without a wallet extension, the "Connect Wallet" button won't work. You
+can't test authentication without it.
+
+**Optional: A code editor**
+
+Use VS Code, Cursor, or any editor you prefer. The template uses TypeScript, so
+an editor with [TypeScript](https://www.typescriptlang.org/) support helps. But
+it's not required. You can use any text editor.
+
+That's it. If you have Node.js v24 (LTS) or later, a Supabase account, and a
+Solana wallet, you're ready. If you're missing something, install it now. We'll
+wait.
+
+## 5. Setting Up the Project
+
+Follow these steps in order. If you skip a step, something will break. Don't
+worry, we'll check each step as we go.
+
+<Steps>
+<Step>
+
+1. Create the project
+
+Create a new project using the Supabase authentication template:
+
+```bash
+npx -y create-solana-dapp@latest -t solana-foundation/templates/community/supabase-auth
+```
+
+![Click "Use This Template"](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763757062/Screenshot_2025-11-21_at_5.17.20_PM_uygpei.png)
+
+![Copy The Command](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763757064/Screenshot_2025-11-21_at_5.16.10_PM_zintc3.png)
+
+This creates a new project directory with all the template code. You can find
+the template at
+[templates.solana.com/supabase-auth](https://templates.solana.com/supabase-auth).
+
+Navigate into the project directory:
+
+```bash
+cd supabase-auth
+```
+
+You need to be in this directory for all the commands below.
+
+</Step>
+
+<Step>
+2. Install dependencies
+
+```bash
+npm install
+```
+
+</Step>
+
+<Step>
+3. Create your Supabase project
+
+You need a Supabase project before you can authenticate. Here's how to create
+one:
+
+1. Go to [supabase.com](https://supabase.com)
+   ![Go To Supabase](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763816332/Screenshot_2025-11-22_at_9.46.54_AM_gt6tz1.png)
+
+2. Sign in with using your preferred Sign In Method.
+   ![Sign In With Github or Email](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763816333/Screenshot_2025-11-22_at_9.47.10_AM_g1yror.png)
+
+3. Click "New Project".
+   ![Click On New Project](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763816333/Screenshot_2025-11-22_at_9.48.10_AM_cphnl1.png)
+
+4. Fill in your project details:
+   - Name it something memorable (like "solana-auth-test")
+   - Set a database password (save this somewhere safe)
+   - Choose a region close to you
+     ![Create Your Project](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763816333/Screenshot_2025-11-22_at_9.48.35_AM_quesek.png)
+
+5. Wait for the project to finish provisioning (about 2 minutes)
+
+Once your project is ready, you'll see the project dashboard. Don't close this
+tab. You'll need it for the next steps.
+
+Supabase needs a project to store user sessions and handle authentication. Each
+project has its own database and API keys. The free tier gives you everything
+you need for development.
+
+</Step>
+
+<Step>
+4. Enable Web3 Authentication in Supabase
+
+<Callout type="warn">
+
+This step is critical. Without it, authentication will fail with a 422 error.
+Don't skip this.
+
+</Callout>
+
+1. In your Supabase dashboard, go to **Authentication** → **Providers**
+2. Scroll down to find **Web3** (it may be under "Additional Providers" or
+   "Additional")
+3. Toggle **Web3** to enabled
+4. Save the changes
+
+![Supabase Web3 authentication toggle enabled](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763204891/Screenshot_2025-11-15_at_8.06.58_AM_tnivte.png)
+
+If you don't see Web3 as an option, your Supabase project might not support it
+yet. Wallet authentication is still in beta for some projects. Try creating a
+new project or check the Supabase documentation for the latest status.
+
+The template uses `supabase.auth.signInWithWeb3()`. This method only works if
+wallet authentication is enabled in your project. If it's disabled, you'll get a
+422 error when trying to sign in. The error message will say "Web3 provider is
+disabled". If you see that, come back to this step.
+
+</Step>
+
+<Step>
+5. Get your Supabase credentials
+
+You need two values from your Supabase project:
+
+1. In your Supabase dashboard, go to **Settings** → **API**
+2. Copy your **Project URL** (looks like `https://xxxxx.supabase.co`)
+3. Copy your **anon/public key** (the `anon` key, not the `service_role` key)
+
+Keep these handy. You'll paste them into a file in the next step.
+
+The Project URL tells the Supabase client where to connect. The anon key is the
+public key that allows client-side access. The service role key is more powerful
+and should never be used in client-side code. That's why we use the anon key.
+
+</Step>
+
+<Step>
+6. Configure environment variables
+
+Create a `.env.local` file from the example:
+
+```bash
+cp .env.example .env.local
+```
+
+Open `.env.local` in your editor. You'll see:
+
+```env
+NEXT_PUBLIC_SUPABASE_URL="https://your-project.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-anon-key-here"
+```
+
+Replace the placeholder values with your actual Supabase credentials:
+
+```env
+NEXT_PUBLIC_SUPABASE_URL="https://xxxxx.supabase.co"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="your-actual-anon-key-here"
+```
+
+Make sure the URL is in quotes. Make sure the key is in quotes. Don't add any
+extra spaces.
+
+Next.js automatically loads `.env.local`. It ignores it in git, so your secrets
+stay local. Never commit `.env.local` to version control. The `.env.example`
+file is safe to commit because it has placeholder values.
+
+</Step>
+
+<Step>
+7. Run the project
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+This starts Next.js with Turbopack (faster than the default webpack). You should
+see output like:
+
+```text
+▲ Next.js 16
+- Local:        http://localhost:3000
+```
+
+Open [http://localhost:3000](http://localhost:3000) in your browser. You should
+see a "gm" screen with a dashboard. That's how you know it's working.
+
+If the page loads but shows errors in the browser console, don't stress. We'll
+cover common errors in the Troubleshooting section. For now, if you see the "gm"
+screen, you're good to go.
+
+</Step>
+</Steps>
+
+## 6. Connecting Your Wallet
+
+<Callout type="warn">
+
+Make sure you have a Solana wallet extension installed (Phantom, Solflare, or
+Backpack) before continuing. Without a wallet, you won't be able to connect or
+authenticate.
+
+</Callout>
+
+Wallet connection happens before authentication. You connect your wallet to read
+blockchain data. Then you authenticate with Supabase to create a session.
+They're separate steps.
+
+### Finding the wallet dropdown
+
+Look at the header of the page. You'll see a button that says "Select Wallet" or
+"Connect Wallet". That's the wallet dropdown. It's in
+`src/components/wallet-dropdown.tsx`.
+
+![Wallet dropdown in the header](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763205080/Screenshot_2025-11-15_at_8.11.08_AM_dyci3x.png)
+
+If you don't see it, check that your wallet extension is installed. The wallet
+dropdown detects installed wallets automatically. If no wallets are detected,
+the dropdown shows a link to get a Solana wallet.
+
+### Connecting your wallet
+
+Click the "Select Wallet" button. A dropdown menu appears. It lists all detected
+wallets. You'll see options like:
+
+- Phantom
+- Solflare
+- Backpack
+- Other installed wallets
+
+Click on your wallet. Your wallet extension will open a popup. It asks you to
+approve the connection. Click "Approve" or "Connect" in the popup.
+
+Once connected, the button in the header changes. It shows your wallet address
+truncated (like `J4AJ...MAAP`). That's how you know it's connected.
+
+![Connected wallet showing truncated address](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763205189/Screenshot_2025-11-15_at_8.12.57_AM_afhpjb.png)
+
+**What happens behind the scenes:** The wallet dropdown uses the
+`useWalletConnection()` hook from `@solana/react-hooks`. When you click a wallet
+in the dropdown, it calls `connect(connectorId)` to establish the connection.
+The hook manages the connection state automatically and exposes it to your
+components through `connected`, `status`, and other properties.
+
+## 7. Signing In with Solana
+
+Once your wallet is connected, you can authenticate with Supabase. This creates
+a session that persists across page refreshes. You'll be able to access
+protected routes.
+
+Authentication creates a Supabase session that lets you access protected routes
+and store user data. Without authentication, you can't access `/account` or
+other protected pages.
+
+### Finding the sign-in card
+
+Scroll down on the home page. You'll see a card titled "Sign in with Solana".
+It's in the dashboard section. The component is
+`src/components/auth/wallet-login.tsx`.
+
+If you haven't connected your wallet yet, the card shows "Connect Wallet First"
+and the button is disabled. Connect your wallet first, then come back to this
+card.
+
+![Sign in with Solana card](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763205326/Screenshot_2025-11-15_at_8.15.12_AM_crhf6r.png)
+
+### The authentication flow
+
+Once your wallet is connected, the card shows "Wallet Connected: [your address]"
+in green text. Click the **Sign in with Solana** button.
+
+Your wallet extension will open a popup. It asks you to sign a message. The
+message says "Please sign this message to authenticate with your wallet." This
+is the authentication challenge.
+
+Click "Approve" or "Sign" in your wallet popup. The wallet signs the message
+cryptographically. This proves you control the wallet address.
+
+**How it works:** Your wallet signs a message that Supabase verifies. If the
+signature matches your wallet address, Supabase creates a session and you're
+authenticated.
+
+![Authentication flow diagram](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763808852/Screenshot_2025-11-22_at_7.50.13_AM_tsggmv.png)
+
+![Wallet popup asking to sign authentication message](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763205749/Screenshot_2025-11-15_at_8.18.19_AM_dqjptf.png)
+
+If authentication succeeds, you'll see "Wallet authenticated successfully!" in
+green text. The card updates automatically to show a welcome message with your
+wallet address and buttons to view account details or sign out. The UI updates
+via the `AuthProvider` state changes - no manual navigation is needed.
+
+### Verifying authentication
+
+After signing in, check the card. It should show "Welcome Back!" with your
+wallet address. You'll see two buttons: "View Account Details" and "Sign Out".
+
+The `AuthProvider` component automatically updates the UI when authentication
+state changes. Any component using `useAuth` gets the updated state.
+
+### Session persistence
+
+The session persists across page refreshes. Users don't have to sign in every
+time they visit. The session lasts until they sign out or it expires.
+
+### Accessing protected routes
+
+Once authenticated, you can access protected routes. Try clicking "View Account
+Details" in the welcome card. It takes you to `/account`. Or navigate to
+`/account` directly in your browser.
+
+If you're not authenticated and try to access `/account`, the `ProtectedRoute`
+component redirects you to the home page. It checks `useAuth()` for the user. If
+`user` is null, it redirects.
+
+The protected route logic is in `src/components/auth/protected-route.tsx`. It
+wraps the `/account` page content. You can use it to protect any route you want.
+
+### Signing out
+
+To sign out, click the "Sign Out" button in the welcome card. This signs you out
+from Supabase and disconnects your wallet, giving you a clean slate.
+
+### Common authentication errors
+
+**"Authentication failed: Web3 provider is disabled"**
+
+This means wallet authentication isn't enabled in your Supabase project. Don't
+stress. Go back to your Supabase dashboard. Navigate to **Authentication** →
+**Providers**. Find **Web3** and toggle it to enabled. Save the changes. Then
+try signing in again.
+
+**"Authentication failed: [422 error]"**
+
+A 422 error usually means one of these:
+
+- Wallet authentication isn't enabled (see above)
+- Your Supabase project doesn't support wallet authentication (check if you're
+  on a supported plan)
+- The wallet connection wasn't established properly
+
+If you see a 422 error, check the browser console. You might see more details
+about what went wrong. The error message from Supabase usually tells you what's
+missing.
+
+**"No wallet connectors available"**
+
+This means no wallet extensions were detected. Make sure you have a Solana
+wallet extension installed and enabled. The template uses `@solana/react-hooks`
+to auto-discover available wallet connectors. Make sure you've connected your
+wallet before trying to authenticate.
+
+**"Please connect a wallet first"**
+
+This message appears if you try to sign in without connecting your wallet.
+Connect your wallet using the dropdown in the header first. Then come back to
+the sign-in card.
+
+**"Failed to authenticate with wallet. Please try again."**
+
+This is a generic error. Check the browser console for more details. It might be
+a network issue or a problem with the Supabase connection. Make sure your
+`.env.local` file has the correct Supabase credentials.
+
+### Understanding the authentication state
+
+The `useAuth` hook gives you access to authentication state (`user`, `session`,
+`loading`, `signOut`). You can use this hook in any component to check
+authentication status.
+
+## 8. Exploring Protected Routes
+
+Protected routes require authentication. Unauthenticated users can't access
+them. The template includes a `ProtectedRoute` component that handles this. (See
+[Architecture Overview](#understanding-the-protectedroute-component) for how it
+works.)
+
+### Understanding the ProtectedRoute component
+
+The `ProtectedRoute` component is in `src/components/auth/protected-route.tsx`.
+It wraps any content you want to protect. It checks authentication status and
+handles redirects.
+
+Here's how it works:
+
+1. It uses the `useAuth` hook to get the current user
+2. If `loading` is true, it shows a loading spinner
+3. If `user` is null (not authenticated), it redirects to home
+4. If authenticated, it renders the children
+
+The component uses `router.replace('/')` to redirect. This replaces the current
+URL in history. Users can't go back to the protected page after being
+redirected.
+
+### The /account route
+
+The `/account` route is protected. The page file is `src/app/account/page.tsx`.
+It wraps the account content with `ProtectedRoute`:
+
+```tsx
+<ProtectedRoute>
+  <AccountFeatureIndex />
+</ProtectedRoute>
+```
+
+If you're not authenticated and try to visit `/account`, you'll be redirected to
+the home page. The redirect happens automatically. You'll see a brief loading
+state, then the redirect.
+
+Redirecting is better UX than showing an error. Users know they need to sign in.
+They're taken to a place where they can sign in. The redirect is instant, so it
+doesn't feel broken.
+
+### The account page flow
+
+The account page has two parts:
+
+1. **Index page** (`/account`) - Redirects to the detail page if a wallet is
+   connected
+2. **Detail page** (`/account/[address]`) - Shows account details for a specific
+   address
+
+Both routes are protected. The `/account/[address]` route
+(`src/app/account/[address]/page.tsx`) is also wrapped with `ProtectedRoute`.
+You can navigate directly to `/account/[address]` if you know the address, but
+you must be authenticated first.
+
+The index page (`src/features/account/account-feature-index.tsx`) checks if a
+wallet is connected. If `account` exists, it redirects to `/account/[address]`.
+If not, it shows a wallet dropdown so you can connect.
+
+This flow ensures you always see account details for a connected wallet. If
+you're authenticated but don't have a wallet connected, you can still connect
+one.
+
+### What you'll see on the account page
+
+Once authenticated and on `/account/[address]`, you'll see:
+
+- **Account balance** - Shows SOL balance for the address
+- **Account buttons** - Actions like send and receive
+- **Token list** - Shows SPL tokens held by the address
+- **Transaction history** - Shows recent transactions for the address
+
+![Account page showing balance, tokens, and transactions](https://res.cloudinary.com/resourcefulmind-inc/image/upload/v1763205913/Screenshot_2025-11-15_at_8.24.57_AM_cfgmwf.png)
+
+The page uses React hooks with `@solana/react-hooks` to fetch data from the
+Solana network.
+
+The account detail component is in
+`src/features/account/account-feature-detail.tsx`. It extracts the address from
+the URL params. It validates the address using `toAddress` from
+`@solana/client`. If the address is invalid, it shows an error.
+
+### Testing protected routes
+
+To test the protection, try this:
+
+1. Sign out (if you're signed in)
+2. Try to navigate to `/account` directly in your browser
+3. You should be redirected to the home page
+
+You can also check the browser console. You'll see a log message: "Protected
+route: User not authenticated, redirecting to home". This confirms the
+protection is working.
+
+If you're authenticated and visit `/account`, you'll see the account page. The
+`ProtectedRoute` component checks authentication and renders the content.
+
+### Creating your own protected routes
+
+You can protect any route by wrapping it with `ProtectedRoute`. For example, to
+protect a `/dashboard` route:
+
+```tsx
+// src/app/dashboard/page.tsx
+import { ProtectedRoute } from "@/components/auth/protected-route";
+
+export default function DashboardPage() {
+  return (
+    <ProtectedRoute>
+      <div>Your protected content here</div>
+    </ProtectedRoute>
+  );
+}
+```
+
+The component handles all the authentication checks. You don't need to write
+redirect logic yourself.
+
+You can also provide a custom fallback:
+
+```tsx
+<ProtectedRoute fallback={<div>Custom "please sign in" message</div>}>
+  <YourContent />
+</ProtectedRoute>
+```
+
+The fallback renders instead of the default "Authentication Required" card. Use
+this if you want custom messaging or styling.
+
+### Understanding the loading state
+
+The `ProtectedRoute` component shows a loading state while checking
+authentication. This happens on the first render. The `AuthProvider` calls
+`supabase.auth.getSession()` on mount. Until that completes, `loading` is true.
+
+Without a loading state, unauthenticated users might briefly see protected
+content. The loading state prevents that flash. It's a better UX.
+
+The loading state is a spinner in a card. It says "Loading..." and "Checking
+authentication status". It's centered on the screen. Once authentication is
+checked, it either redirects or shows the content.
+
+### Common issues with protected routes
+
+**Redirect loop**
+
+If you see a redirect loop, check that your home page doesn't redirect to a
+protected route. The home page should be accessible without authentication. If
+it's protected, you'll get stuck in a loop.
+
+**Loading state never ends**
+
+If the loading spinner never goes away, check the browser console. You might see
+an error from Supabase. Make sure your `.env.local` file has the correct
+Supabase credentials. The `AuthProvider` can't check sessions without valid
+credentials.
+
+**Can't access protected route even when authenticated**
+
+If you're signed in but still get redirected, check the browser console. You
+might see an error about the session. Try signing out and signing back in. The
+session might be invalid or expired.
+
+**Protected route shows content but user is null**
+
+This shouldn't happen, but if it does, there's a race condition. The
+`ProtectedRoute` checks `user` from `useAuth`. If the auth state updates after
+the check, you might see content briefly. This is rare, but if you see it,
+refresh the page.
+
+### Why this pattern works
+
+The `ProtectedRoute` pattern is simple and reusable. Wrap any content you want
+to protect. The component handles all the logic. It works with Next.js App
+Router as a client component that can use hooks. For larger apps, you might want
+middleware, but for most cases, this component is enough.
+
+## 9. Conclusion
+
+You've successfully set up a Solana application with wallet authentication using
+Supabase. You can now connect wallets, authenticate users, and protect routes.
+
+Start building your features and customize the template to fit your needs. The
+template provides a solid foundation for Solana applications with wallet-based
+authentication.


### PR DESCRIPTION
Part 1 of 6 in the docs restructure stack.

## Summary

- adds task-oriented development, game, transaction, wallet, and DePIN guides to the Cookbook
- updates Cookbook indexes and section metadata so the new recipes are discoverable
- leaves legacy guide routes intact until the destination sections land in the next PR

## Review scope

Most guide bodies are existing content moved into the Cookbook. Please focus on placement, navigation, and links rather than unchanged copy.