### PR TITLE
fix(media): align Keystatic staging branch workflow

### DIFF
--- a/apps/media/DEPLOYMENT.md
+++ b/apps/media/DEPLOYMENT.md
@@ -209,6 +209,19 @@ paths—no URL rewriting needed.
 
 ## Troubleshooting
 
+### Issue: The New branch button does not open or create a branch
+
+**Solution:**
+
+1. Keep `@keystatic/core` 0.6.x paired with `@keystar/ui` 0.8.x. Keystatic 0.6
+   updates the UI and React Aria stack used by the branch dialog.
+2. Run `pnpm --filter solana-com-media test:keystatic-branches` to verify that
+   the dialog opens, non-`staging-*` branches are filtered out, and the GitHub
+   `createRef` request starts from `main`.
+3. If the dialog opens but GitHub rejects the request, verify the GitHub App
+   installation and writer permissions described above, then have the writer
+   sign out and authorize the app again.
+
 ### Issue: 404 on solana.com/news or solana.com/podcasts
 
 **Solution:** Check that:

--- a/apps/media/DEPLOYMENT.md
+++ b/apps/media/DEPLOYMENT.md
@@ -75,14 +75,34 @@ access the site through `solana.com`.
    KEYSTATIC_GITHUB_CLIENT_ID=your_client_id
    KEYSTATIC_GITHUB_CLIENT_SECRET=your_client_secret
    KEYSTATIC_SECRET=your_random_secret
-
-   # Or use local mode
-   NEXT_PUBLIC_KEYSTATIC_LOCAL=true
+   NEXT_PUBLIC_KEYSTATIC_GITHUB_APP_SLUG=your_app_slug
 
    # Vercel (auto-set)
    VERCEL_ENV=production
    VERCEL_URL=solana-com-media.vercel.app
    ```
+
+   Do not set `NEXT_PUBLIC_KEYSTATIC_LOCAL=true` in Vercel. That flag is for
+   local filesystem development only.
+
+4. **Verify the Keystatic GitHub App:**
+   - The app is installed for `solana-foundation/solana-com`.
+   - Repository permissions include **Contents: Read and write**, **Pull
+     requests: Read and write**, and **Metadata: Read-only**.
+   - The production callback URL is
+     `https://solana-com-media.vercel.app/api/keystatic/github/oauth/callback`.
+   - Content writers have the repository's **Write** role. Read or Triage access
+     cannot create branches.
+   - Repository rules allow creation of `staging-*` branches while requiring
+     Pull Requests for changes to `main`.
+   - For production ownership continuity, the GitHub App registration is owned
+     by `solana-foundation` and has designated App managers rather than
+     depending on one person's account.
+
+   If permissions, repository access, or organization integration policies
+   change, an organization owner may need to approve the updated installation.
+   After approval, writers should log out of Keystatic and authorize the app
+   again so their user token reflects the current access.
 
 ### Deploying Updates
 

--- a/apps/media/__tests__/keystatic-config.test.ts
+++ b/apps/media/__tests__/keystatic-config.test.ts
@@ -3,11 +3,11 @@ import { describe, expect, it } from "vitest";
 import { githubStorage } from "../keystatic.config";
 
 describe("Keystatic GitHub storage", () => {
-  it("creates and filters dedicated staging branches", () => {
-    expect(githubStorage.kind).toBe("github");
-    expect(githubStorage.branchPrefix).toBe("staging-");
-    expect(`${githubStorage.branchPrefix}editor-article-name`).toBe(
-      "staging-editor-article-name",
-    );
+  it("passes the dedicated staging branch policy to Keystatic", () => {
+    expect(githubStorage).toMatchObject({
+      kind: "github",
+      branchPrefix: "staging-",
+      pathPrefix: "apps/media",
+    });
   });
 });

--- a/apps/media/__tests__/keystatic-config.test.ts
+++ b/apps/media/__tests__/keystatic-config.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { githubStorage } from "../keystatic.config";
+
+describe("Keystatic GitHub storage", () => {
+  it("creates and filters dedicated staging branches", () => {
+    expect(githubStorage.kind).toBe("github");
+    expect(githubStorage.branchPrefix).toBe("staging-");
+    expect(`${githubStorage.branchPrefix}editor-article-name`).toBe(
+      "staging-editor-article-name",
+    );
+  });
+});

--- a/apps/media/docs/authoring-posts-with-branching.md
+++ b/apps/media/docs/authoring-posts-with-branching.md
@@ -5,39 +5,39 @@
 
 ## When To Use This
 
-Use this flow when you are creating or updating a post and do not want to work
-directly on the shared `staging` branch.
+Use this flow for every content change. Each article or related content batch
+gets its own `staging-*` branch.
 
 The goal is simple:
 
-1. Create a dedicated branch from `staging`
+1. Create a dedicated `staging-*` branch from `main`
 2. Write and save the post there
-3. Open the pull request flow from that branch
-4. Review, approve, merge, and publish through GitHub
+3. Open a Pull Request from that branch to `main`
+4. Review, approve, and merge the Pull Request
 
-## Step 1: Start from `staging`
+## Step 1: Start from `main`
 
 Open the hosted Keystatic admin:
 
 - `https://solana-com-media.vercel.app/keystatic`
 
-On the dashboard, confirm the branch selector is set to `staging`.
+On the dashboard, confirm the branch selector is set to `main`. Starting from
+`main` ensures the new content branch contains the latest published content.
 
 Then click `New branch...`.
 
-![Create New Branch](screenshots/17-create-new-branch.webp)
-
 ## Step 2: Name the Branch
 
-Use a descriptive branch name for the article you are creating.
+Keystatic adds the required `staging-` prefix. Enter a descriptive suffix for
+the article you are creating.
 
 Example:
 
-- `staging-ek-article-name`
+- Enter `ek-article-name`
+- Keystatic creates `staging-ek-article-name`
 
-Keep `Based on` set to `staging`, then click `Create`.
-
-![Name Branch](screenshots/18-name-branch.webp)
+Because you started on `main`, Keystatic uses `main` as the base automatically.
+Click `Create`.
 
 ## Step 3: Open Posts and Draft on Your Branch
 
@@ -64,15 +64,12 @@ Keystatic opens the GitHub PR screen for the current branch.
 In GitHub, review the branch comparison, add the PR title and description, and
 create the pull request.
 
-The flow in the screenshots shows:
+Confirm the GitHub comparison shows:
 
 - `base`: `main`
 - `compare`: your content branch, for example `staging-ek-article-name`
 
 ![Open Pull Request in GitHub](screenshots/20-action-in-github.webp)
-
-If your team wants an intermediate merge into shared `staging` before release,
-adjust the GitHub base branch there before creating the PR.
 
 ## Step 6: Wait for the Vercel Preview Build
 
@@ -115,11 +112,10 @@ passed.
 
 ## Quick Rules
 
-- Do not draft directly on shared `staging` when the article should live on its
-  own branch first
+- Start each content branch from `main`
+- Use a branch beginning with `staging-`; Keystatic adds this prefix for you
 - Use one dedicated branch per article or content batch
-- Review the GitHub base and compare branches before clicking
-  `Create pull request`
+- Open the Pull Request directly from the content branch to `main`
 - Wait for the Vercel preview build and review the preview link from the PR
 - Approve the GitHub PR only after the preview and content diff have been
   checked

--- a/apps/media/docs/keystatic-walkthrough.md
+++ b/apps/media/docs/keystatic-walkthrough.md
@@ -11,8 +11,8 @@ Keystatic uses GitHub for authentication and version control. Before you start,
 make sure you have:
 
 1. A GitHub account.
-2. Access to the `solana-foundation/solana-com` repository.
-3. Permission to work in Keystatic on the shared `staging` branch.
+2. **Write** access to the `solana-foundation/solana-com` repository.
+3. Access to the Solana Media Keystatic GitHub App.
 
 If you do not have repository access yet:
 
@@ -31,26 +31,27 @@ If you do not have repository access yet:
 
 There are two separate stages in the workflow:
 
-| Stage                  | Where the change lives                | What it means                               |
-| ---------------------- | ------------------------------------- | ------------------------------------------- |
-| **Drafting / editing** | `staging` branch                      | Safe working copy for content updates       |
-| **Publishing**         | Pull Request from `staging` to `main` | Review and release process for live content |
+| Stage                  | Where the change lives                          | What it means                               |
+| ---------------------- | ----------------------------------------------- | ------------------------------------------- |
+| **Drafting / editing** | A dedicated `staging-*` branch made from `main` | Safe working copy for one content change    |
+| **Publishing**         | Pull Request from that branch to `main`         | Review and release process for live content |
 
-The `staging` branch has its own preview deployment at
-[https://solana-com-media-git-staging-solana-foundation.vercel.app/](https://solana-com-media-git-staging-solana-foundation.vercel.app/).
-Use this link to verify how your content looks before opening a Pull Request.
+Each Pull Request gets a Vercel preview deployment. Open the preview link from
+the Pull Request checks to verify the content before merging.
 
-> **Note:** After saving a change to `staging`, allow 1–2 minutes for the
-> preview to update. Vercel needs to rebuild the site before new content
-> appears.
+> **Note:** After saving a change, allow 1–2 minutes for the branch preview to
+> update. Vercel needs to rebuild the site before new content appears.
 
 Important rules:
 
-- Always select the `staging` branch before you create or edit content.
-- Saving in Keystatic writes a commit to `staging`, not to the live site.
-- Setting a post to **Published** only marks it ready on `staging`.
-- Content goes live only after a Pull Request from `staging` to `main` is
-  reviewed and merged.
+- Start from `main`, then create a new branch for the article or content batch.
+- Branch names must start with `staging-`. Keystatic adds this prefix for you.
+- Do not edit content directly on `main` or on the old shared `staging` branch.
+- Saving in Keystatic writes a commit to the selected `staging-*` branch, not to
+  the live site.
+- Setting a post to **Published** only marks it ready on that branch.
+- Content goes live only after a Pull Request from the content branch to `main`
+  is reviewed and merged.
 - Posts and reports now use **Publish Date** with both date and time.
 - Enter **Publish Date** in UTC.
 - Published posts and reports remain hidden until their **Publish Date** has
@@ -69,22 +70,40 @@ Important rules:
 2. Click **Log in with GitHub**.
 3. Authorize the GitHub prompt if asked.
 4. After Keystatic loads, use the branch selector in the left sidebar and
-   confirm it is set to **`staging`** before doing any work.
+   confirm it is set to **`main`**.
+5. Click **New branch...**.
+6. Enter a descriptive suffix such as `ek-article-name`. Keystatic displays the
+   fixed `staging-` prefix and creates `staging-ek-article-name`.
+7. Because you started on `main`, Keystatic uses `main` as the base
+   automatically. Click **Create**.
 
 ### Dashboard
 
 The dashboard shows all collections and singletons you can manage, plus the
 current branch and the **Create pull request** action.
 
-![Dashboard](screenshots/01-dashboard.webp)
-
 On the dashboard:
 
-- The branch selector in the left sidebar should read `staging`.
+- The branch selector should show your dedicated `staging-*` branch before you
+  edit content.
 - The **Create pull request** button is used later when content is ready to
   publish.
 - The collection cards take you to Posts, Podcasts, Authors, Categories, Tags,
   CTAs, Switchbacks, and Links.
+
+### If Branch Creation Fails
+
+1. Confirm you opened the branch dialog from `main`.
+2. Enter only the branch suffix. The `staging-` prefix is already supplied by
+   Keystatic.
+3. Log out of Keystatic, log in again, and reauthorize the GitHub App.
+4. Ask a repository admin to confirm that:
+   - you have the **Write** role,
+   - the Solana Media Keystatic App is installed for
+     `solana-foundation/solana-com`,
+   - the installation is not suspended or awaiting approval, and
+   - its repository permissions include write access to Contents and Pull
+     Requests.
 
 ---
 
@@ -92,13 +111,14 @@ On the dashboard:
 
 This is the most common workflow.
 
-### Step 1: Confirm You Are on `staging`
+### Step 1: Confirm You Are on Your `staging-*` Branch
 
 Before editing anything, check the branch selector in the left sidebar. It
-should show **`staging`**.
+should show the dedicated branch you just created, such as
+**`staging-ek-article-name`**.
 
-If it shows `main`, switch it to `staging` first. Drafts and edits should be
-made on staging, not directly on `main`.
+If it shows `main`, create or select the correct `staging-*` branch first.
+Drafts and edits must not be made directly on `main`.
 
 ### Step 2: Open the Posts Collection
 
@@ -140,18 +160,17 @@ the TeX expression without `$` or `$$` delimiters. For example, enter `E = mc^2`
 or `\frac{a}{b}` directly in the LaTeX field. The editor preview shows the
 rendered formula before you save.
 
-### Step 4: Save the Post as a Draft on `staging`
+### Step 4: Save the Post as a Draft on Your Branch
 
 When the article is still in progress:
 
 1. Leave **Status** set to **Draft**.
 2. Click **Create**.
-3. Keystatic saves the new post to the current **`staging`** branch.
+3. Keystatic saves the new post to the selected **`staging-*`** branch.
 
-This does **not** publish the article to the live site. You can preview your
-draft on the staging site at
-[https://solana-com-media-git-staging-solana-foundation.vercel.app/](https://solana-com-media-git-staging-solana-foundation.vercel.app/).
-Allow 1–2 minutes after saving for the preview to update while Vercel rebuilds.
+This does **not** publish the article to the live site. After you open the Pull
+Request, use its Vercel preview link to review the draft. Allow 1–2 minutes
+after saving for the preview to update while Vercel rebuilds.
 
 ### Step 5: Mark the Post Ready for Publishing
 
@@ -163,30 +182,29 @@ When the article is approved and finalized:
    visible in UTC.
 4. Click **Save**.
 
-This still saves only to `staging`. The article is not live yet.
+This still saves only to your `staging-*` branch. The article is not live yet.
 
 ---
 
 ## Section 5: Opening a Pull Request to Publish
 
-Publishing happens after the content is already saved on `staging`.
+Publishing happens after the content is already saved on its dedicated branch.
 
 1. Return to the dashboard.
-2. Confirm the current branch is still **`staging`**.
+2. Confirm the current branch is your **`staging-*`** content branch.
 3. Click **Create pull request**.
 4. In GitHub, open a Pull Request with:
    - **base:** `main`
-   - **compare:** `staging`
-5. Review the diff and create the Pull Request.
-6. Wait for the preview deployment to finish building. You can also verify
-   content on the staging preview at
-   [https://solana-com-media-git-staging-solana-foundation.vercel.app/](https://solana-com-media-git-staging-solana-foundation.vercel.app/)
-   before merging.
+   - **compare:** your `staging-*` branch
+5. Review the diff, confirm it contains only the intended content change, and
+   create the Pull Request.
+6. Wait for the Vercel preview deployment to finish and verify the preview link
+   from the Pull Request checks.
 7. After review and approval, merge the Pull Request into `main`.
 
 > **Important:** A post with **Status = Published** is still not live until the
-> `staging` to `main` Pull Request is merged, and it remains hidden until the
-> **Publish Date** timestamp has passed.
+> content branch is merged to `main`, and it remains hidden until the **Publish
+> Date** timestamp has passed.
 >
 > Example: if you want a post to go live at `6:00 PM` in Auckland on March 20,
 > 2026, enter the equivalent UTC time, not `2026-03-20 18:00`.
@@ -217,8 +235,8 @@ Click **Add** to create a new link.
 | **Tags**        | Related tags                                            |
 | **Featured**    | Whether the link should be featured                     |
 
-Save link changes on `staging`, then publish them through the same Pull Request
-flow described above.
+Save link changes on a dedicated `staging-*` branch, then publish them through
+the same Pull Request flow described above.
 
 ---
 
@@ -282,7 +300,8 @@ To schedule a report:
 2. Enable **Use As Report** if needed.
 3. Set **Report Status** to **Published**.
 4. Set **Publish Date** to the exact release date and time in UTC.
-5. Save on `staging` and publish through the normal Pull Request flow.
+5. Save on a dedicated `staging-*` branch and publish through the normal Pull
+   Request flow.
 
 ---
 
@@ -335,16 +354,17 @@ Global Settings controls site-wide theme options.
 
 ## Section 12: Quick Reference
 
-| Task                     | Branch                                | Final step                               |
-| ------------------------ | ------------------------------------- | ---------------------------------------- |
-| Start a new draft        | `staging`                             | Click **Create**                         |
-| Update an existing draft | `staging`                             | Click **Save**                           |
-| Mark a post ready        | `staging`                             | Set **Status** to **Published** and save |
-| Publish to the live site | Pull Request from `staging` to `main` | Merge the PR                             |
+| Task                     | Branch                                       | Final step                               |
+| ------------------------ | -------------------------------------------- | ---------------------------------------- |
+| Start a new draft        | New `staging-*` branch based on `main`       | Click **Create**                         |
+| Update an existing draft | That content change's `staging-*` branch     | Click **Save**                           |
+| Mark a post ready        | That content change's `staging-*` branch     | Set **Status** to **Published** and save |
+| Publish to the live site | Pull Request from the content branch to main | Merge the PR                             |
 
 ### Remember
 
-- Work in **`staging`**.
-- Drafts stay in **`staging`**.
+- Start from **`main`**, then create a fresh **`staging-*`** branch.
+- Keep one article or related content batch per branch.
 - **Published** status alone does not make content live.
-- A **Pull Request from `staging` to `main`** is what publishes the content.
+- A **Pull Request from the content branch to `main`** is what publishes the
+  content.

--- a/apps/media/e2e/keystatic-branch-workflow.spec.ts
+++ b/apps/media/e2e/keystatic-branch-workflow.spec.ts
@@ -1,0 +1,187 @@
+import { expect, test } from "@playwright/test";
+
+type CreateRefInput = {
+  name: string;
+  oid: string;
+  repositoryId: string;
+};
+
+const repositoryId = "repository-id";
+const mainCommit = "main-commit";
+const mainTree = "main-tree";
+
+function githubRef(name: string, oid: string, treeOid: string) {
+  return {
+    __typename: "Ref",
+    id: `ref-${name}`,
+    name,
+    target: {
+      __typename: "Commit",
+      id: `commit-${name}`,
+      oid,
+      tree: {
+        __typename: "Tree",
+        id: `tree-${name}`,
+        oid: treeOid,
+      },
+    },
+  };
+}
+
+test("filters branches and creates a staging branch from main", async ({
+  context,
+  page,
+}) => {
+  test.skip(
+    process.env.NEXT_PUBLIC_KEYSTATIC_LOCAL !== "false",
+    "This test exercises Keystatic's GitHub storage mode.",
+  );
+
+  let createRefInput: CreateRefInput | undefined;
+
+  await context.addCookies([
+    {
+      name: "keystatic-gh-access-token",
+      value: "test-token",
+      url: "http://127.0.0.1:3002",
+    },
+  ]);
+
+  await page.route(
+    "https://api.github.com/repos/solana-foundation/solana-com/git/trees/**",
+    async (route) => {
+      await route.fulfill({
+        contentType: "application/json",
+        json: {
+          sha: mainTree,
+          truncated: false,
+          tree: [],
+        },
+      });
+    },
+  );
+
+  await page.route("https://api.github.com/graphql", async (route) => {
+    const body = route.request().postDataJSON() as {
+      query: string;
+      variables?: { input?: CreateRefInput };
+    };
+
+    if (body.query.includes("mutation CreateBranch")) {
+      createRefInput = body.variables?.input;
+      await route.fulfill({
+        contentType: "application/json",
+        json: {
+          data: {
+            createRef: {
+              __typename: "CreateRefPayload",
+              ref: githubRef(
+                "staging-editor-article-name",
+                mainCommit,
+                mainTree,
+              ),
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    if (body.query.includes("query GitHubAppShell")) {
+      await route.fulfill({
+        contentType: "application/json",
+        json: {
+          data: {
+            repository: {
+              __typename: "Repository",
+              id: repositoryId,
+              isPrivate: false,
+              owner: {
+                __typename: "Organization",
+                id: "owner-id",
+                login: "solana-foundation",
+              },
+              name: "solana-com",
+              defaultBranchRef: {
+                __typename: "Ref",
+                id: "ref-main",
+                name: "main",
+              },
+              refs: {
+                __typename: "RefConnection",
+                nodes: [
+                  githubRef("main", mainCommit, mainTree),
+                  githubRef(
+                    "staging-existing-article",
+                    "staging-commit",
+                    "staging-tree",
+                  ),
+                  githubRef(
+                    "unrelated-feature",
+                    "feature-commit",
+                    "feature-tree",
+                  ),
+                ],
+                pageInfo: {
+                  __typename: "PageInfo",
+                  hasNextPage: false,
+                  endCursor: null,
+                },
+              },
+              viewerPermission: "WRITE",
+              forks: {
+                __typename: "RepositoryConnection",
+                nodes: [],
+              },
+            },
+            viewer: {
+              __typename: "User",
+              id: "viewer-id",
+              name: "Editor",
+              login: "editor",
+              avatarUrl: "https://example.com/avatar.png",
+              databaseId: 1,
+            },
+          },
+        },
+      });
+      return;
+    }
+
+    throw new Error(`Unexpected GraphQL operation: ${body.query}`);
+  });
+
+  await page.goto("/keystatic/branch/main");
+  await expect(page.getByRole("heading", { name: "Dashboard" })).toBeVisible();
+
+  const branchPicker = page.getByRole("combobox", {
+    name: "Current branch",
+  });
+  await branchPicker.click();
+  await expect(page.getByRole("option", { name: /main/ })).toBeVisible();
+  await expect(
+    page.getByRole("option", { name: "staging-existing-article" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("option", { name: "unrelated-feature" }),
+  ).toHaveCount(0);
+  await page.keyboard.press("Escape");
+
+  await page.getByRole("button", { name: /New branch/ }).click();
+  await expect(page.getByText("staging-", { exact: true })).toBeVisible();
+  await page
+    .getByRole("textbox", { name: "Branch name" })
+    .fill("editor-article-name");
+  await page.getByRole("button", { name: "Create", exact: true }).click();
+
+  await expect
+    .poll(() => createRefInput)
+    .toEqual({
+      name: "refs/heads/staging-editor-article-name",
+      oid: mainCommit,
+      repositoryId,
+    });
+  await expect(page).toHaveURL(
+    /\/keystatic\/branch\/staging-editor-article-name$/,
+  );
+});

--- a/apps/media/e2e/walkthrough-screenshots.spec.ts
+++ b/apps/media/e2e/walkthrough-screenshots.spec.ts
@@ -12,7 +12,7 @@ async function snap(page: Page, name: string) {
 
 /** Bootstrap the Keystatic SPA and wait for sidebar nav to render. */
 async function gotoKeystatic(page: Page) {
-  await page.goto("/keystatic/branch/staging", {
+  await page.goto("/keystatic/branch/main", {
     waitUntil: "domcontentloaded",
   });
   await page.waitForSelector('nav a:has-text("Posts")', { timeout: 30_000 });

--- a/apps/media/keystatic.config.tsx
+++ b/apps/media/keystatic.config.tsx
@@ -24,13 +24,16 @@ const localStorage: LocalConfig["storage"] = {
   kind: "local",
 };
 
-const githubStorage: GitHubConfig["storage"] = {
+export const githubStorage: GitHubConfig["storage"] = {
   kind: "github",
   repo: {
     owner: "solana-foundation",
     name: "solana-com",
   },
-  branchPrefix: "staging",
+  // Keep content work isolated to one branch per article or content batch.
+  // Keystatic prepends this value when creating a branch and only lists
+  // matching branches (plus the repository's default branch).
+  branchPrefix: "staging-",
   pathPrefix: "apps/media",
 };
 

--- a/apps/media/package.json
+++ b/apps/media/package.json
@@ -17,12 +17,14 @@
     "check-types": "next typegen && tsc --noEmit",
     "typecheck": "pnpm run check-types",
     "test": "vitest run",
+    "test:keystatic-branches": "NEXT_PUBLIC_KEYSTATIC_LOCAL=false playwright test e2e/keystatic-branch-workflow.spec.ts",
     "screenshots": "playwright test e2e/walkthrough-screenshots.spec.ts"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.10",
-    "@keystatic/core": "^0.5.50",
+    "@keystatic/core": "^0.6.0",
     "@keystatic/next": "^5.0.4",
+    "@keystar/ui": "0.8.0",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-slot": "^1.2.4",
     "@sentry/nextjs": "^10.11.0",

--- a/apps/media/playwright.config.ts
+++ b/apps/media/playwright.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "@playwright/test";
 
-const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://localhost:3002";
+const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? "http://127.0.0.1:3002";
 const storageState = process.env.PLAYWRIGHT_STORAGE_STATE;
 const isLocalKeystatic =
   (process.env.NEXT_PUBLIC_KEYSTATIC_LOCAL ?? "true") === "true";
+const shouldStartServer = !process.env.PLAYWRIGHT_BASE_URL;
 
 export default defineConfig({
   testDir: "./e2e",
@@ -19,10 +20,10 @@ export default defineConfig({
     trace: "off",
     ...(storageState ? { storageState } : {}),
   },
-  ...(isLocalKeystatic
+  ...(shouldStartServer
     ? {
         webServer: {
-          command: "NEXT_PUBLIC_KEYSTATIC_LOCAL=true pnpm dev",
+          command: `NEXT_PUBLIC_KEYSTATIC_LOCAL=${isLocalKeystatic} pnpm dev`,
           url: "http://127.0.0.1:3002/keystatic",
           reuseExistingServer: true,
           timeout: 120_000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -486,12 +486,15 @@ importers:
       "@headlessui/react":
         specifier: ^2.2.10
         version: 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@keystar/ui":
+        specifier: 0.8.0
+        version: 0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
       "@keystatic/core":
-        specifier: ^0.5.50
-        version: 0.5.50(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        specifier: ^0.6.0
+        version: 0.6.0(@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
       "@keystatic/next":
         specifier: ^5.0.4
-        version: 5.0.4(@keystatic/core@0.5.50(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 5.0.4(@keystatic/core@0.6.0(@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@radix-ui/react-avatar":
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3627,40 +3630,16 @@ packages:
         integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==,
       }
 
-  "@formatjs/ecma402-abstract@2.3.4":
-    resolution:
-      {
-        integrity: sha512-qrycXDeaORzIqNhBOx0btnhpD1c+/qFIHAN9znofuMJX6QBwtbrmlpWfD4oiUUD2vJUOIYFA/gYtg2KAMGG7sA==,
-      }
-
-  "@formatjs/fast-memoize@2.2.7":
-    resolution:
-      {
-        integrity: sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==,
-      }
-
   "@formatjs/fast-memoize@3.1.6":
     resolution:
       {
         integrity: sha512-H5aexk1Le7T9TPmscacZ+1pR6CTa2n1wq+HDVGXhH8TzUlQQpeXzZs91dRtmFHrbeNbjPFPfQujUqm7MHgVoXQ==,
       }
 
-  "@formatjs/icu-messageformat-parser@2.11.2":
-    resolution:
-      {
-        integrity: sha512-AfiMi5NOSo2TQImsYAg8UYddsNJ/vUEv/HaNqiFjnI3ZFfWihUtD5QtuX6kHl8+H+d3qvnE/3HZrfzgdWpsLNA==,
-      }
-
   "@formatjs/icu-messageformat-parser@3.5.11":
     resolution:
       {
         integrity: sha512-NVsuNsc2dUVG9+4HBJ/srScxtA/18LqGgwtop/tuN/OIBjVl6QA+0KhfZQddDD9sEh2LeVjLFPGVU3ixa3blcA==,
-      }
-
-  "@formatjs/icu-skeleton-parser@1.8.14":
-    resolution:
-      {
-        integrity: sha512-i4q4V4qslThK4Ig8SxyD76cp3+QJ3sAqr7f6q9VVfeGtxG9OhiAk3y9XF6Q41OymsKzsGQ6OQQoJNY4/lI8TcQ==,
       }
 
   "@formatjs/icu-skeleton-parser@2.1.10":
@@ -4221,40 +4200,16 @@ packages:
       "@types/node":
         optional: true
 
-  "@internationalized/date@3.11.0":
-    resolution:
-      {
-        integrity: sha512-BOx5huLAWhicM9/ZFs84CzP+V3gBW6vlpM02yzsdYC7TGlZJX1OJiEEHcSayF00Z+3jLlm4w79amvSt6RqKN3Q==,
-      }
-
   "@internationalized/date@3.12.2":
     resolution:
       {
         integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==,
       }
 
-  "@internationalized/message@3.1.8":
-    resolution:
-      {
-        integrity: sha512-Rwk3j/TlYZhn3HQ6PyXUV0XP9Uv42jqZGNegt0BXlxjE6G3+LwHjbQZAGHhCnCPdaA6Tvd3ma/7QzLlLkJxAWA==,
-      }
-
-  "@internationalized/number@3.6.5":
-    resolution:
-      {
-        integrity: sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==,
-      }
-
   "@internationalized/number@3.6.7":
     resolution:
       {
         integrity: sha512-3ji1fcrT+FPAK86UqEhB/psHixYo6niWPJtt7+qRaYFynt/BaJG8GhAPimtWUpEiVSTq8ZM8L5psMxGquiB/Vg==,
-      }
-
-  "@internationalized/string@3.2.7":
-    resolution:
-      {
-        integrity: sha512-D4OHBjrinH+PFZPvfCXvG28n2LSykWcJ7GIioQL+ok0LON15SdfoUssoHzzOUmVZLbRoREsQXVzA6r8JKsbP6A==,
       }
 
   "@internationalized/string@3.2.9":
@@ -4319,27 +4274,43 @@ packages:
         integrity: sha512-dfLbk+PwWvFzSxwk3n5ySL0hfBog779o8h68wK/7/APo/7cgyWp5jcXockbxdk5kFRkbeXWm4Fbi9FrdN381sA==,
       }
 
-  "@keystar/ui@0.7.21":
+  "@keystar/ui@0.8.0":
     resolution:
       {
-        integrity: sha512-DgAfdtcieYMMG5S0EaGf/F8T8e5nol9iLfZqIZOXHkjnc7UBHY3qHea2Zzd0hUrIoAcXiv4JyCtAND0vNKjJYA==,
+        integrity: sha512-LkF98QS5SrQ1hvbFknfwba3uEfjPmN8NXdbA1Odra0NTMs7ZzdeREUHtxK2LIpNJPxZLC1hnrQxcguCjrQVQwg==,
       }
     peerDependencies:
       next: ">=14"
       react: ^18.2.0 || ^19.0.0
+      react-aria: 3.50.0
       react-dom: ^18.2.0 || ^19.0.0
+      react-stately: 3.48.0
     peerDependenciesMeta:
       next:
         optional: true
+      react-aria:
+        optional: true
+      react-stately:
+        optional: true
 
-  "@keystatic/core@0.5.50":
+  "@keystatic/core@0.6.0":
     resolution:
       {
-        integrity: sha512-ilgG9hw1iWZsT8iCV+1WFX1VNo6eK+iHIs61x4vRtce6SstKad6ib7BLhXEP41Q8ja6JIKWXvv6qBPVumyy88Q==,
+        integrity: sha512-poJLwfV0RNXImZu9IpdZQNHMHgSiSd1pyIhK3ex+fussh95Nxl0oJmrWzHqLgmiU74GUH2KV5a/1Ox4tyaJQTw==,
       }
     peerDependencies:
+      "@keystar/ui": "*"
       react: ^18.2.0 || ^19.0.0
+      react-aria: 3.50.0
       react-dom: ^18.2.0 || ^19.0.0
+      react-stately: 3.48.0
+    peerDependenciesMeta:
+      "@keystar/ui":
+        optional: true
+      react-aria:
+        optional: true
+      react-stately:
+        optional: true
 
   "@keystatic/next@5.0.4":
     resolution:
@@ -6237,127 +6208,10 @@ packages:
         integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==,
       }
 
-  "@react-aria/actiongroup@3.7.23":
-    resolution:
-      {
-        integrity: sha512-CQyswtH0CWCJPYlAz39TUS3H0eA1Xplx4GalF71BYcFG6U6mbawgtiUHPNj9sXdUSwY3Pb2K2FBk3cEtk/fySQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/breadcrumbs@3.5.31":
-    resolution:
-      {
-        integrity: sha512-j8F2NMHFGT/n3alfFKdO4bvrY/ymtdL04GdclY7Vc6zOmCnWoEZ2UA0sFuV7Rk9dOL8fAtYV1kMD1ZRO/EMcGA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/button@3.14.4":
-    resolution:
-      {
-        integrity: sha512-6mTPiSSQhELnWlnYJ1Tm1B0VL1GGKAs2PGAY3ZGbPGQPPDc6Wu82yIhuAO8TTFJrXkwAiqjQawgDLil/yB0V7Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/calendar@3.9.4":
-    resolution:
-      {
-        integrity: sha512-0BvU8cj6uHn622Vp8Xd21XxXtvp3Bh4Yk1pHloqDNmUvvdBN+ol3Xsm5gG3XKKkZ+6CCEi6asCbLaEg3SZSbyg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/checkbox@3.16.4":
-    resolution:
-      {
-        integrity: sha512-FcZj6/f27mNp2+G5yxyOMRZbZQjJ1cuWvo0PPnnZ4ybSPUmSzI4uUZBk1wvsJVP9F9n+J2hZuYVCaN8pyzLweA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/combobox@3.14.2":
-    resolution:
-      {
-        integrity: sha512-qwBeb8cMgK3xwrvXYHPtcphduD/k+oTcU18JHPvEO2kmR32knB33H81C2/Zoh4x86zTDJXaEtPscXBWuQ/M7AQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/datepicker@3.16.0":
-    resolution:
-      {
-        integrity: sha512-QynYHIHE+wvuGopl/k05tphmDpykpfZ3l3eKnUfGrqvAYJEeCOyS0qoMlw7Vq3NscMLFbJI6ajqBmlmtgFNiSA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/dialog@3.5.33":
-    resolution:
-      {
-        integrity: sha512-C5FpLAMJU6gQU8gztWKlEJ2A0k/JKl0YijNOv3Lizk+vUdF5njROSrmFs16bY5Hd6ycmsK9x/Pqkq3m/OpNFXA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/dnd@3.11.5":
-    resolution:
-      {
-        integrity: sha512-3IGrABfK8Cf6/b/uEmGEDGeubWKMUK3umWunF/tdkWBnIaxpdj4gRkWFMw7siWQYnqir6AN567nrWXtHFcLKsA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   "@react-aria/focus@3.21.4":
     resolution:
       {
         integrity: sha512-6gz+j9ip0/vFRTKJMl3R30MHopn4i19HqqLfSQfElxJD+r9hBnYG1Q6Wd/kl/WRR1+CALn2F+rn06jUnf5sT8Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/form@3.1.4":
-    resolution:
-      {
-        integrity: sha512-GjPS85cE/34zal3vs6MOi7FxUsXwbxN4y6l1LFor2g92UK97gVobp238f3xdMW2T8IuaWGcnHeYFg+cjiZ51pQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/grid@3.14.7":
-    resolution:
-      {
-        integrity: sha512-8eaJThNHUs75Xf4+FQC2NKQtTOVYkkDdA8VbfbqG06oYDAn7ETb1yhbwoqh1jOv7MezCNkYjyFe4ADsz2rBVcw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/gridlist@3.14.3":
-    resolution:
-      {
-        integrity: sha512-t3nr29nU5jRG9MdWe9aiMd02V8o0pmidLU/7c4muWAu7hEH+IYdeDthGDdXL9tXAom/oQ+6yt6sOfLxpsVNmGA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/i18n@3.12.15":
-    resolution:
-      {
-        integrity: sha512-3CrAN7ORVHrckvTmbPq76jFZabqq+rScosGT5+ElircJ5rF5+JcdT99Hp5Xg6R10jk74e8G3xiqdYsUd+7iJMA==,
       }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -6381,147 +6235,6 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  "@react-aria/label@3.7.24":
-    resolution:
-      {
-        integrity: sha512-lcJbUy6xyicWKNgzfrXksrJ2CeCST2rDxGAvHOmUxSbFOm26kK710DjaFvtO4tICWh/TKW5mC3sm77soNcVUGA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/landmark@3.0.9":
-    resolution:
-      {
-        integrity: sha512-YYyluDBCXupnMh91ccE5g27fczjYmzPebHqTkVYjH4B6k45pOoqsMmWBCMnOTl0qOCeioI+daT8W0MamAZzoSw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/link@3.8.8":
-    resolution:
-      {
-        integrity: sha512-hxQEvo5rrn2C0GOSwB/tROe+y//dyhmyXGbm8arDy6WF5Mj0wcjjrAu0/dhGYBqoltJa16iIEvs52xgzOC+f+Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/listbox@3.15.2":
-    resolution:
-      {
-        integrity: sha512-xcrgSediV8MaVmsuDrDPmWywF82/HOv+H+Y/dgr6GLCWl0XDj5Q7PyAhDzUsYdZNIne3B9muGh6IQc3HdkgWqg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/live-announcer@3.4.4":
-    resolution:
-      {
-        integrity: sha512-PTTBIjNRnrdJOIRTDGNifY2d//kA7GUAwRFJNOEwSNG4FW+Bq9awqLiflw0JkpyB0VNIwou6lqKPHZVLsGWOXA==,
-      }
-
-  "@react-aria/menu@3.20.0":
-    resolution:
-      {
-        integrity: sha512-BAsHuf7kTVmawNUkTUd5RB3ZvL6DQQT7hgZ2cYKd/1ZwYq4KO2wWGYdzyTOtK1qimZL0eyHyQwDYv4dNKBH4gw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/meter@3.4.29":
-    resolution:
-      {
-        integrity: sha512-XAhJf8LlYQl+QQXqtpWvzjlrT8MZKEG6c8N3apC5DONgSKlCwfmDm4laGEJPqtuz3QGiOopsfSfyTFYHjWsfZw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/numberfield@3.12.4":
-    resolution:
-      {
-        integrity: sha512-TgKBjKOjyURzbqNR2wF4tSFmQKNK5DqE4QZSlQxpYYo1T6zuztkh+oTOUZ4IWCJymL5qLtuPfGHCZbR7B+DN2w==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/overlays@3.31.1":
-    resolution:
-      {
-        integrity: sha512-U5BedzcXU97U5PWm4kIPnNoVpAs9KjTYfbkGx33vapmTVpGYhQyYW9eg6zW2E8ZKsyFJtQ/jkQnbWGen97aHSQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/progress@3.4.29":
-    resolution:
-      {
-        integrity: sha512-orSaaFLX5LdD9UyxgBrmP1J/ivyEFX+5v4ENPQM5RH5+Hl+0OJa+8ozI0AfVKBqCYc89BOZfG7kzi7wFHACZcQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/radio@3.12.4":
-    resolution:
-      {
-        integrity: sha512-2sjBAE8++EtAAfjwPdrqEVswbzR4Mvcy4n8SvwUxTo02yESa9nolBzCSdAUFUmhrNj3MiMA+zLxQ+KACfUjJOg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/searchfield@3.8.11":
-    resolution:
-      {
-        integrity: sha512-5R0prEC+jRFwPeJsK6G4RN8QG3V/+EaIuw9p79G1gFD+1dY81ZakiZIIJaLWRyO7AzYBGyC/QFHtz0m3KGQT/Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/select@3.17.2":
-    resolution:
-      {
-        integrity: sha512-oMpHStyMluRf67qxrzH5Qfcvw6ETQgZT1Qw2xvAxQVRd5IBb0PfzZS7TGiULOcMLqXAUOC28O/ycUGrGRKLarg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/selection@3.27.1":
-    resolution:
-      {
-        integrity: sha512-8WQ4AtWiBnk9UEeYkqpH12dd8KQW2aFbNZvM4sDfLtz7K7HWyY/MkqMe/snk9IcoSa7t4zr0bnoZJcWSGgn2PQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/separator@3.4.15":
-    resolution:
-      {
-        integrity: sha512-A1aPQhCaE8XeelNJYPjHtA2uh921ROh8PNiZI4o62x80wcziRoctN5PAtNHJAx7VKvX66A8ZVGbOqb7iqS3J5Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/spinbutton@3.7.1":
-    resolution:
-      {
-        integrity: sha512-Nisah6yzxOC6983u/5ck0w+OQoa3sRKmpDvWpTEX0g2+ZIABOl8ttdSd65XKtxXmXHdK8X1zmrfeGOBfBR3sKA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   "@react-aria/ssr@3.9.10":
     resolution:
       {
@@ -6530,87 +6243,6 @@ packages:
     engines: { node: ">= 12" }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/switch@3.7.10":
-    resolution:
-      {
-        integrity: sha512-j7nrYnqX6H9J8GuqD0kdMECUozeqxeG19A2nsvfaTx3//Q7RhgIR9fqhQdVHW/wgraTlEHNH6AhDzmomBg0TNw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/table@3.17.10":
-    resolution:
-      {
-        integrity: sha512-xdEeyOzuETkOfAHhZrX7HOIwMUsCUr4rbPvHqdcNqg7Ngla2ck9iulZNAyvOPfFwELuBEd2rz1I9TYRQ2OzSQQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/tabs@3.11.0":
-    resolution:
-      {
-        integrity: sha512-9Gwo118GHrMXSyteCZL1L/LHLVlGSYkhGgiTL3e/UgnYjHfEfDJVTkV2JikuE2O/4uig52gQRlq5E99axLeE9Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/tag@3.8.0":
-    resolution:
-      {
-        integrity: sha512-sTV6uRKFIFU1aljKb0QjM6fPPnzBuitrbkkCUZCJ0w0RIX1JinZPh96NknNtjFwWmqoROjVNCq51EUd0Hh2SQw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/textfield@3.18.4":
-    resolution:
-      {
-        integrity: sha512-ts3Vdy2qNOzjCVeO+4RH8FSgTYN2USAMcYFeGbHOriCukVOrvgRsqcDniW7xaT60LgFdlWMJsCusvltSIyo6xw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/toast@3.0.2":
-    resolution:
-      {
-        integrity: sha512-iaiHDE1CKYM3BbNEp3A2Ed8YAlpXUGyY6vesKISdHEZ2lJ7r+1hbcFoTNdG8HfbB8Lz5vw8Wd2o+ZmQ2tnDY9Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/toggle@3.12.4":
-    resolution:
-      {
-        integrity: sha512-yVcl8kEFLsV47aCA22EMPcd/KWoYqPIPSzoKjRD/iWmxcP6iGzSxDjdUgMQojNGY8Q6wL8lUxfRqKBjvl/uezQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/toolbar@3.0.0-beta.23":
-    resolution:
-      {
-        integrity: sha512-FzvNf2hWtjEwk8F2MBf4qSs6AAR/p2WFSws6kJ4f0SrWXl4wR9VDEwBEUQcIPbWCK2aUsyOjubCh55Cl4t3MoQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/tooltip@3.9.1":
-    resolution:
-      {
-        integrity: sha512-mvEhqpvF4v/wj9zw3a8bsAEnySutGbxKXXt39s6WvF6dkVfaXfsmV9ahuMCHH//UGh/yidZGLrXX4YVdrgS8lA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   "@react-aria/utils@3.33.0":
     resolution:
@@ -6621,222 +6253,11 @@ packages:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
       react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  "@react-aria/virtualizer@4.1.12":
-    resolution:
-      {
-        integrity: sha512-va0VAD28nq7rk1vHZvnkq591EbWuDKBwh2NzAEn+zz9JjMtpg4utcihNXECJ1DwMRkpaT6q+KpOE7dSdzTxPBQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-aria/visually-hidden@3.8.30":
-    resolution:
-      {
-        integrity: sha512-iY44USEU8sJy0NOJ/sTDn3YlspbhHuVG3nx2YYrzfmxbS3i+lNwkCfG8kJ77dtmbuDLIdBGKENjGkbcwz3kiJg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/calendar@3.9.2":
-    resolution:
-      {
-        integrity: sha512-AQj8/izwb7eY+KFqKcMLI2ygvnbAIwLuQG5KPHgJsMygFqnN4yzXKz5orGqVJnxEXLKiLPteVztx7b5EQobrtw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/checkbox@3.7.4":
-    resolution:
-      {
-        integrity: sha512-oXHMkK22CWLcmNlunDuu4p52QXYmkpx6es9AjWx/xlh3XLZdJzo/5SANioOH1QvBtwPA/c2KQy+ZBqC21NtMHw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/collections@3.12.9":
-    resolution:
-      {
-        integrity: sha512-2jywPMhVgMOh0XtutxPqIxFCIiLOnL/GXIrRKoBEo8M3Q24NoMRBavUrn9RTvjqNnec1i/8w1/8sq8cmCKEohA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/combobox@3.12.2":
-    resolution:
-      {
-        integrity: sha512-h4YRmzA+s3aMwUrXm6jyWLN0BWWXUNiodArB1wC24xNdeI7S8O3mxz6G2r3Ne8AE02FXmZXs9SD30Mx5vVVuqQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/data@3.15.1":
-    resolution:
-      {
-        integrity: sha512-lchubLxCWg1Yswpe9yRYJAjmzP0eTYZe+AQyFJQRIT6axRi9Gs92RIZ7zhwLXxI0vcWpnAWADB9kD4bsos7xww==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/datepicker@3.16.0":
-    resolution:
-      {
-        integrity: sha512-mYtzKXufFVivrHjmxys3ryJFMPIQNhVqaSItmGnWv3ehxw+0HKBrROf3BFiEN4zP20euoP149ZaR4uNx90kMYw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/dnd@3.7.3":
-    resolution:
-      {
-        integrity: sha512-yBtzAimyYvJWnzP80Scx7l559+43TVSyjaMpUR6/s2IjqD3XoPKgPsv7KaFUmygBTkCBGBFJn404rYgMCOsu3g==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   "@react-stately/flags@3.1.2":
     resolution:
       {
         integrity: sha512-2HjFcZx1MyQXoPqcBGALwWWmgFVUk2TuKVIQxCbRq7fPyWXIl6VHcakCLurdtYC2Iks7zizvz0Idv48MQ38DWg==,
       }
-
-  "@react-stately/form@3.2.3":
-    resolution:
-      {
-        integrity: sha512-NPvjJtns1Pq9uvqeRJCf8HIdVmOm2ARLYQ2F/sqXj1w5IChJ4oWL4Xzvj29/zBitgE1vVjDhnrnwSfNlHZGX0g==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/grid@3.11.8":
-    resolution:
-      {
-        integrity: sha512-tCabR5U7ype+uEElS5Chv5n6ntUv3drXa9DwebjO05cFevUmjTkEfYPJWixpgX4UlCCvjdUFgzeQlJF+gCiozg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/layout@4.5.3":
-    resolution:
-      {
-        integrity: sha512-BDYnvO2AKzvWfxxVM96kif3qCynsA+XcNoQC+T77exH+LLT8zlK9oOdarZXTlok/eZmjs6+5wmjq51PeL6eM5w==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/list@3.13.3":
-    resolution:
-      {
-        integrity: sha512-xN0v7rzhIKshhcshOzx+ZgVngXnGCtMPRdhoDLGaHzQy5YfxvKBMNLCnr5Lm4T1U/kIvHbyzxmr5uwmH8WxoIg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/menu@3.9.10":
-    resolution:
-      {
-        integrity: sha512-dY9FzjQ+6iNInVujZPyMklDGoSbaoO0yguUnALAY+yfkPAyStEElfm4aXZgRfNKOTNHe9E34oV7qefSYsclvTg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/numberfield@3.10.4":
-    resolution:
-      {
-        integrity: sha512-EniHHwXOw/Ta0x5j61OvldDAvLoi/8xOo//bzrqwnDvf2/1IKGFMD9CHs7HYhQw+9oNl3Q2V1meOTNPc4PvoMQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/overlays@3.6.22":
-    resolution:
-      {
-        integrity: sha512-sWBnuy5dqVp8d+1e+ABTRVB3YBcOW86/90pF5PWY44au3bUFXVSUBO2QMdR/6JtojDoPRmrjufonI19/Zs/20w==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/radio@3.11.4":
-    resolution:
-      {
-        integrity: sha512-3svsW5VxJA5/p1vO+Qlxv+7Jq9g7f4rqX9Rbqdfd+pH7ykHaV0CUKkSRMaWfcY8Vgaf2xmcc6dvusPRqKX8T1A==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/searchfield@3.5.18":
-    resolution:
-      {
-        integrity: sha512-C3/1wOON5oK0QBljj0vSbHm/IWgd29NxB+7zT1JjZcxtbcFxCj4HOxKdnPCT/d8Pojb0YS26QgKzatLZ0NnhgQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/select@3.9.1":
-    resolution:
-      {
-        integrity: sha512-CJQRqv8Dg+0RRvcig3a2YfY6POJIscDINvidRF31yK6J72rsP01dY3ria9aJjizNDHR9Q5dWFp/z+ii0cOTWIQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/selection@3.20.8":
-    resolution:
-      {
-        integrity: sha512-V1kRN1NLW+i/3Xv+Q0pN9OzuM0zFEW9mdXOOOq7l+YL6hFjqIjttT2/q4KoyiNV3W0hfoRFSTQ7XCgqnqtwEng==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/table@3.15.3":
-    resolution:
-      {
-        integrity: sha512-W1wR0O/PmdD8hCUFIAelHICjUX/Ii6ZldPlH6EILr9olyGpoCaY7XmnyG7kii1aANuQGBeskjJdXvS6LX/gyDw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/tabs@3.8.8":
-    resolution:
-      {
-        integrity: sha512-BZImWT+pHZitImRQkoL7jVhTtpGPSra1Rhh4pi8epzwogeqseEIEpuWpQebjQP74r1kfNi/iT2p5Qb31eWfh1Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/toast@3.1.0":
-    resolution:
-      {
-        integrity: sha512-9W2+evz+EARrjkR1QPLlOL5lcNpVo6PjMAIygRSaCPJ6ftQAZ6B+7xTFGPFabWh83gwXQDUgoSwC3/vosvxZaQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/toggle@3.9.4":
-    resolution:
-      {
-        integrity: sha512-tjWsshRJtHC+PI5NYMlnDlV/BTo1eWq6fmR6x1mXlQfKuKGTJRzhgJyaQ2mc5K+LkifD7fchOhfapHCrRlzwMg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/tooltip@3.5.10":
-    resolution:
-      {
-        integrity: sha512-GauUdc6Of08Np2iUw4xx/DdgpvszS9CxJWYcRnNyAAGPLQrmniVrpJvb0EUKQTP9sUSci1SlmpvJh4SNZx26Bw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-stately/tree@3.9.5":
-    resolution:
-      {
-        integrity: sha512-UpvBlzL/MpFdOepDg+cohI/zvw8DEVM8cXY/OZ8tKUXWpew1HpUglwnAI3ivm0L2k9laUIB9siW0g04ZWiH9Lg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
   "@react-stately/utils@3.11.0":
     resolution:
@@ -6846,227 +6267,10 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
 
-  "@react-stately/virtualizer@4.4.5":
-    resolution:
-      {
-        integrity: sha512-MP33zys3nRYTk/+3BPchxlil9GrwbMksc3XuvNACeZqYEA/oEidsHffgPL+LY0iitKCmQE6pg49MI5HvBuOd2w==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-      react-dom: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/actionbar@3.1.20":
-    resolution:
-      {
-        integrity: sha512-K3fajms4FmeVnUAXuJ7iwhtS2Lh8hHFZCqCrvHdHqzRyIsx7vMRvITXyhHnIEuIXDCHb2k7cSzFJzn9kvJLosw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/actiongroup@3.4.22":
-    resolution:
-      {
-        integrity: sha512-J3MIpK3a+AXmyUTd2+bHn3J2XcZV1oJpZxFxmWonitiIvbyEZbiZHeMrBPxHST60BxVGzQK/J+mROZNjxIRWpg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/breadcrumbs@3.7.18":
-    resolution:
-      {
-        integrity: sha512-zwltqx2XSELBRQeuCraxrdfT4fpIOVu6eQXsZ4RhWlsT7DLhzj3pUGkxdPDAMfYaVdyNBqc+nhiAnCwz6tUJ8A==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/button@3.15.0":
-    resolution:
-      {
-        integrity: sha512-X/K2/Oeuq7Hi8nMIzx4/YlZuvWFiSOHZt27p4HmThCnNO/9IDFPmvPrpkYjWN5eN9Nuk+P5vZUb4A7QJgYpvGA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/calendar@3.8.2":
-    resolution:
-      {
-        integrity: sha512-QbPFhvBQfrsz3x1Nnatr5SL+8XtbxvP4obESFuDrKmsqaaAv+jG5vwLiPTKp6Z3L+MWkCvKavBPuW+byhq+69A==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/checkbox@3.10.3":
-    resolution:
-      {
-        integrity: sha512-Xw4jHG7uK352Wc18XXzdzmtr3Xjg8d2tPoBGNgsw39f92EY2UpoDAPHxYR0BaDe04lGfAn6YwVivI4OGVbjXIg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/combobox@3.13.11":
-    resolution:
-      {
-        integrity: sha512-5/tdmTAvqPpiWzEeaV7uLLSbSTkkoQ1mVz6NfKMPuw4ZBkY3lPc9JDkkQjY/JrquZao+KY4Dx8ZIoS0NqkrFrw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/datepicker@3.13.4":
-    resolution:
-      {
-        integrity: sha512-B5sAPoYZfluDBpgVK3ADlHbXBKRkFCQFO18Bs091IvRRwqzfoO/uf+/9UpXMw+BEF4pciLf0/kdiVQTvI3MzlA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/dialog@3.5.23":
-    resolution:
-      {
-        integrity: sha512-3tMzweYuaDOaufF5tZPMgXSA0pPFJNgdg89YRITh0wMXMG0pm+tAKVQJL1TSLLhOiLCEL08V8M/AK67dBdr2IA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/grid@3.3.7":
-    resolution:
-      {
-        integrity: sha512-riET3xeKPTcRWQy6hYCMxdbdL3yubPY5Ow66b2GA2rEqoYvmDBniYXAM2Oh+q9s+YgnAP7qJK++ym8NljvHiLA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/link@3.6.6":
-    resolution:
-      {
-        integrity: sha512-M6WXxUJFmiF6GNu7xUH0uHj0jsorFBN6npkfSCNM4puStC8NbUT2+ZPySQyZXCoHMQ89g6qZ6vCc8QduVkTE7Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/listbox@3.7.5":
-    resolution:
-      {
-        integrity: sha512-Cn+yNip+YZBaGzu+z5xPNgmfSupnLl+li7uG5hRc+EArkk8/G42myRXz6M8wPrLM1bFAq3r85tAbyoXVmKG5Jw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/menu@3.10.6":
-    resolution:
-      {
-        integrity: sha512-OJTznQ4xE/VddBJU+HO4x5tceSOdyQhiHA1bREE1aHl+PcgHOUZLdMjXp1zFaGF16HhItHJaxpifJ4hzf4hWQA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/meter@3.4.14":
-    resolution:
-      {
-        integrity: sha512-rNw0Do2AM3zLGZ0pSWweViuddg1uW99PWzE6RQXE8nsTHTeiwDZt9SYGdObEnjd+nJ3YzemqekG0Kqt93iNBcA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/numberfield@3.8.17":
-    resolution:
-      {
-        integrity: sha512-Q9n24OaSMXrebMowbtowmHLNclknN3XkcBIaYMwA2BIGIl+fZFnI8MERM0pG87W+wki6FepDExsDW9YxQF4pnw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/overlays@3.9.3":
-    resolution:
-      {
-        integrity: sha512-LzetThNNk8T26pQRbs1I7+isuFhdFYREy7wJCsZmbB0FnZgCukGTfOtThZWv+ry11veyVJiX68jfl4SV6ACTWA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/progress@3.5.17":
-    resolution:
-      {
-        integrity: sha512-JtiGlek6QS04bFrRj1WfChjPNr7+3/+pd6yZayXGUkQUPHt1Z/cFnv3QZ/tSQTdUt1XXmjnCak9ZH9JQBqe64Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/radio@3.9.3":
-    resolution:
-      {
-        integrity: sha512-w2BrMGIiZxYXPCnnB2NQyifwE/rRFMIW87MyawrKO9zPSbnDkqLIHAAtqmlNk2zkz1ZEWjk9opNsuztjP7D4sA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/searchfield@3.6.7":
-    resolution:
-      {
-        integrity: sha512-POo3spZcYD14aqo0f4eNbymJ8w9EKrlu0pOOjYYWI2P0GUSRmib9cBA9xZFhvRGHuNlHo3ePjeFitYQI7L3g1g==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/select@3.12.1":
-    resolution:
-      {
-        integrity: sha512-PtIUymvQNIIzgr+piJtK/8gbH7akWtbswIbfoADPSxtZEd1/vfUIO0s8c750s3XYNlmx/4DrhugQsLYwgC35yg==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/shared@3.33.0":
-    resolution:
-      {
-        integrity: sha512-xuUpP6MyuPmJtzNOqF5pzFUIHH2YogyOQfUQHag54PRmWB7AbjuGWBUv0l1UDmz6+AbzAYGmDVAzcRDOu2PFpw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
   "@react-types/shared@3.36.0":
     resolution:
       {
         integrity: sha512-DkP/H0C2YjjS7gZWKNqOmU8a16qHPjQNdzMwmTq9SzplM6Iw0kVMTZ0OIoe6FOgGqa+FwMsE2QbPjh/n3g/jXQ==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/switch@3.5.16":
-    resolution:
-      {
-        integrity: sha512-6fynclkyg0wGHo3f1bwk4Z+gZZEg0Z63iP5TFhgHWdZ8W+Uq6F3u7V4IgQpuJ2NleL1c2jy2/CKdS9v06ac2Og==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/table@3.13.5":
-    resolution:
-      {
-        integrity: sha512-4/CixlNmXSuJuX2IKuUlgNd/dEgNh3WvfE/bdwuI1t5JBdShP9tHIzSkgZbrzE2xX46NeA2xq4vXNO5kBv+QDA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/tabs@3.3.21":
-    resolution:
-      {
-        integrity: sha512-Dq9bKI62rHoI4LGGcBGlZ5s0aSwB0G4Y8o0r7hQZvf1eZWc9fmqdAdTTaGG/RUyhMIGRYWl5RRUBUuC5RmaO6w==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/textfield@3.12.7":
-    resolution:
-      {
-        integrity: sha512-ddiacsS6sLFtAn2/fym7lR8nbdsLgPfelNDcsDqHiu6XUHh5TCNe8ItXHFaIiyfnKTH8uJqZrSli4wfAYNfMsw==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
-
-  "@react-types/tooltip@3.5.1":
-    resolution:
-      {
-        integrity: sha512-h6xOAWbWUJKs9CzcCyzSPATLHq7W5dS866HkXLrtCrRDShLuzQnojZnctD2tKtNt17990hjnOhl36GUBuO5kyw==,
       }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0-rc.1 || ^18.0.0 || ^19.0.0-rc.1
@@ -13730,12 +12934,6 @@ packages:
       }
     engines: { node: ">=12" }
 
-  intl-messageformat@10.7.16:
-    resolution:
-      {
-        integrity: sha512-UmdmHUmp5CIKKjSoE10la5yfU+AYJAaiYLsodbjL4lji83JNvgOQUjGaGhGrpFCb0Uh7sl7qfP1IyILa8Z40ug==,
-      }
-
   intl-messageformat@11.2.8:
     resolution:
       {
@@ -19828,8 +19026,8 @@ snapshots:
 
   "@babel/helper-member-expression-to-functions@7.27.1":
     dependencies:
-      "@babel/traverse": 7.28.4
-      "@babel/types": 7.28.4
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -19867,7 +19065,7 @@ snapshots:
 
   "@babel/helper-optimise-call-expression@7.27.1":
     dependencies:
-      "@babel/types": 7.28.4
+      "@babel/types": 7.29.7
 
   "@babel/helper-plugin-utils@7.27.1": {}
 
@@ -19911,8 +19109,8 @@ snapshots:
   "@babel/helper-wrap-function@7.28.3":
     dependencies:
       "@babel/template": 7.27.2
-      "@babel/traverse": 7.28.4
-      "@babel/types": 7.28.4
+      "@babel/traverse": 7.29.7
+      "@babel/types": 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -20895,7 +20093,7 @@ snapshots:
 
   "@emotion/babel-plugin@11.13.5":
     dependencies:
-      "@babel/helper-module-imports": 7.27.1
+      "@babel/helper-module-imports": 7.29.7
       "@babel/runtime": 7.28.4
       "@emotion/hash": 0.9.2
       "@emotion/memoize": 0.9.0
@@ -20945,7 +20143,7 @@ snapshots:
       "@emotion/memoize": 0.9.0
       "@emotion/unitless": 0.10.0
       "@emotion/utils": 1.4.2
-      csstype: 3.1.3
+      csstype: 3.2.3
 
   "@emotion/sheet@1.4.0": {}
 
@@ -21132,33 +20330,11 @@ snapshots:
 
   "@floating-ui/utils@0.2.11": {}
 
-  "@formatjs/ecma402-abstract@2.3.4":
-    dependencies:
-      "@formatjs/fast-memoize": 2.2.7
-      "@formatjs/intl-localematcher": 0.6.1
-      decimal.js: 10.6.0
-      tslib: 2.8.1
-
-  "@formatjs/fast-memoize@2.2.7":
-    dependencies:
-      tslib: 2.8.1
-
   "@formatjs/fast-memoize@3.1.6": {}
-
-  "@formatjs/icu-messageformat-parser@2.11.2":
-    dependencies:
-      "@formatjs/ecma402-abstract": 2.3.4
-      "@formatjs/icu-skeleton-parser": 1.8.14
-      tslib: 2.8.1
 
   "@formatjs/icu-messageformat-parser@3.5.11":
     dependencies:
       "@formatjs/icu-skeleton-parser": 2.1.10
-
-  "@formatjs/icu-skeleton-parser@1.8.14":
-    dependencies:
-      "@formatjs/ecma402-abstract": 2.3.4
-      tslib: 2.8.1
 
   "@formatjs/icu-skeleton-parser@2.1.10": {}
 
@@ -21548,28 +20724,11 @@ snapshots:
     optionalDependencies:
       "@types/node": 24.13.3
 
-  "@internationalized/date@3.11.0":
-    dependencies:
-      "@swc/helpers": 0.5.17
-
   "@internationalized/date@3.12.2":
     dependencies:
       "@swc/helpers": 0.5.17
 
-  "@internationalized/message@3.1.8":
-    dependencies:
-      "@swc/helpers": 0.5.17
-      intl-messageformat: 10.7.16
-
-  "@internationalized/number@3.6.5":
-    dependencies:
-      "@swc/helpers": 0.5.17
-
   "@internationalized/number@3.6.7":
-    dependencies:
-      "@swc/helpers": 0.5.17
-
-  "@internationalized/string@3.2.7":
     dependencies:
       "@swc/helpers": 0.5.17
 
@@ -21617,93 +20776,15 @@ snapshots:
 
   "@juggle/resize-observer@3.4.0": {}
 
-  "@keystar/ui@0.7.21(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
       "@emotion/css": 11.13.5
       "@floating-ui/react": 0.24.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@internationalized/date": 3.11.0
-      "@internationalized/string": 3.2.7
-      "@react-aria/actiongroup": 3.7.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/breadcrumbs": 3.5.31(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/button": 3.14.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/calendar": 3.9.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/checkbox": 3.16.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/combobox": 3.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/datepicker": 3.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/dialog": 3.5.33(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/dnd": 3.11.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/gridlist": 3.14.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.25.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/label": 3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/link": 3.8.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/listbox": 3.15.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/live-announcer": 3.4.4
-      "@react-aria/menu": 3.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/meter": 3.4.29(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/numberfield": 3.12.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/overlays": 3.31.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/progress": 3.4.29(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/radio": 3.12.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/searchfield": 3.8.11(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/select": 3.17.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/selection": 3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/separator": 3.4.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/ssr": 3.9.10(react@19.2.6)
-      "@react-aria/switch": 3.7.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/table": 3.17.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/tabs": 3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/tag": 3.8.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/textfield": 3.18.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/toast": 3.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/tooltip": 3.9.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/virtualizer": 4.1.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/visually-hidden": 3.8.30(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/calendar": 3.9.2(react@19.2.6)
-      "@react-stately/checkbox": 3.7.4(react@19.2.6)
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/combobox": 3.12.2(react@19.2.6)
-      "@react-stately/data": 3.15.1(react@19.2.6)
-      "@react-stately/datepicker": 3.16.0(react@19.2.6)
-      "@react-stately/dnd": 3.7.3(react@19.2.6)
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-stately/layout": 4.5.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/list": 3.13.3(react@19.2.6)
-      "@react-stately/menu": 3.9.10(react@19.2.6)
-      "@react-stately/numberfield": 3.10.4(react@19.2.6)
-      "@react-stately/overlays": 3.6.22(react@19.2.6)
-      "@react-stately/radio": 3.11.4(react@19.2.6)
-      "@react-stately/searchfield": 3.5.18(react@19.2.6)
-      "@react-stately/select": 3.9.1(react@19.2.6)
-      "@react-stately/selection": 3.20.8(react@19.2.6)
-      "@react-stately/table": 3.15.3(react@19.2.6)
-      "@react-stately/tabs": 3.8.8(react@19.2.6)
-      "@react-stately/toast": 3.1.0(react@19.2.6)
-      "@react-stately/toggle": 3.9.4(react@19.2.6)
-      "@react-stately/tooltip": 3.5.10(react@19.2.6)
-      "@react-stately/tree": 3.9.5(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-stately/virtualizer": 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/actionbar": 3.1.20(react@19.2.6)
-      "@react-types/actiongroup": 3.4.22(react@19.2.6)
-      "@react-types/breadcrumbs": 3.7.18(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/calendar": 3.8.2(react@19.2.6)
-      "@react-types/combobox": 3.13.11(react@19.2.6)
-      "@react-types/datepicker": 3.13.4(react@19.2.6)
-      "@react-types/grid": 3.3.7(react@19.2.6)
-      "@react-types/menu": 3.10.6(react@19.2.6)
-      "@react-types/numberfield": 3.8.17(react@19.2.6)
-      "@react-types/overlays": 3.9.3(react@19.2.6)
-      "@react-types/radio": 3.9.3(react@19.2.6)
-      "@react-types/select": 3.12.1(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@react-types/switch": 3.5.16(react@19.2.6)
-      "@react-types/table": 3.13.5(react@19.2.6)
-      "@react-types/tabs": 3.3.21(react@19.2.6)
+      "@internationalized/date": 3.12.2
+      "@internationalized/number": 3.6.7
+      "@internationalized/string": 3.2.9
+      "@react-types/shared": 3.36.0(react@19.2.6)
       "@types/react": 19.1.12
       emery: 1.4.4
       facepaint: 1.2.1
@@ -21711,31 +20792,22 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
-  "@keystatic/core@0.5.50(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@keystatic/core@0.6.0(@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
       "@braintree/sanitize-url": 6.0.4
       "@emotion/weak-memoize": 0.3.1
       "@floating-ui/react": 0.24.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@internationalized/string": 3.2.7
-      "@keystar/ui": 0.7.21(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@internationalized/date": 3.12.2
+      "@internationalized/number": 3.6.7
+      "@internationalized/string": 3.2.9
       "@markdoc/markdoc": 0.4.0(@types/react@19.1.12)(react@19.2.6)
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.25.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/label": 3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/overlays": 3.31.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/selection": 3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/visually-hidden": 3.8.30(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/list": 3.13.3(react@19.2.6)
-      "@react-stately/overlays": 3.6.22(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
+      "@react-types/shared": 3.36.0(react@19.2.6)
       "@sindresorhus/slugify": 1.1.2
       "@toeverything/y-indexeddb": 0.10.0-canary.9(yjs@13.6.29)
       "@ts-gql/tag": 0.7.3(graphql@16.12.0)
@@ -21788,14 +20860,17 @@ snapshots:
       y-prosemirror: 1.3.7(prosemirror-model@1.25.4)(prosemirror-state@1.4.4)(prosemirror-view@1.41.6)(y-protocols@1.0.7(yjs@13.6.29))(yjs@13.6.29)
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
+    optionalDependencies:
+      "@keystar/ui": 0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
+      react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-stately: 3.48.0(react@19.2.6)
     transitivePeerDependencies:
-      - next
       - supports-color
 
-  "@keystatic/next@5.0.4(@keystatic/core@0.5.50(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@keystatic/next@5.0.4(@keystatic/core@0.6.0(@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
-      "@keystatic/core": 0.5.50(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@keystatic/core": 0.6.0(@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
       "@types/react": 19.1.12
       chokidar: 3.6.0
       next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
@@ -23208,207 +22283,13 @@ snapshots:
 
   "@radix-ui/rect@1.1.1": {}
 
-  "@react-aria/actiongroup@3.7.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/list": 3.13.3(react@19.2.6)
-      "@react-types/actiongroup": 3.4.22(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/breadcrumbs@3.5.31(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/link": 3.8.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/breadcrumbs": 3.7.18(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/button@3.14.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/toolbar": 3.0.0-beta.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/toggle": 3.9.4(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/calendar@3.9.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@internationalized/date": 3.11.0
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/live-announcer": 3.4.4
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/calendar": 3.9.2(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/calendar": 3.8.2(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/checkbox@3.16.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/form": 3.1.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/label": 3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/toggle": 3.12.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/checkbox": 3.7.4(react@19.2.6)
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-stately/toggle": 3.9.4(react@19.2.6)
-      "@react-types/checkbox": 3.10.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/combobox@3.14.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/listbox": 3.15.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/live-announcer": 3.4.4
-      "@react-aria/menu": 3.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/overlays": 3.31.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/selection": 3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/textfield": 3.18.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/combobox": 3.12.2(react@19.2.6)
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/combobox": 3.13.11(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/datepicker@3.16.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@internationalized/date": 3.11.0
-      "@internationalized/number": 3.6.5
-      "@internationalized/string": 3.2.7
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/form": 3.1.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/label": 3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/spinbutton": 3.7.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/datepicker": 3.16.0(react@19.2.6)
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/calendar": 3.8.2(react@19.2.6)
-      "@react-types/datepicker": 3.13.4(react@19.2.6)
-      "@react-types/dialog": 3.5.23(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/dialog@3.5.33(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/overlays": 3.31.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/dialog": 3.5.23(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/dnd@3.11.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@internationalized/string": 3.2.7
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/live-announcer": 3.4.4
-      "@react-aria/overlays": 3.31.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/dnd": 3.7.3(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
   "@react-aria/focus@3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
+      "@react-types/shared": 3.36.0(react@19.2.6)
       "@swc/helpers": 0.5.17
       clsx: 2.1.1
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/form@3.1.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/grid@3.14.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/live-announcer": 3.4.4
-      "@react-aria/selection": 3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/grid": 3.11.8(react@19.2.6)
-      "@react-stately/selection": 3.20.8(react@19.2.6)
-      "@react-types/checkbox": 3.10.3(react@19.2.6)
-      "@react-types/grid": 3.3.7(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/gridlist@3.14.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/grid": 3.14.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/selection": 3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/list": 3.13.3(react@19.2.6)
-      "@react-stately/tree": 3.9.5(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/i18n@3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@internationalized/date": 3.11.0
-      "@internationalized/message": 3.1.8
-      "@internationalized/number": 3.6.5
-      "@internationalized/string": 3.2.7
-      "@react-aria/ssr": 3.9.10(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -23417,7 +22298,7 @@ snapshots:
       "@react-aria/ssr": 3.9.10(react@19.2.6)
       "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@react-stately/flags": 3.1.2
-      "@react-types/shared": 3.33.0(react@19.2.6)
+      "@react-types/shared": 3.36.0(react@19.2.6)
       "@swc/helpers": 0.5.17
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
@@ -23430,718 +22311,33 @@ snapshots:
       react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom: 19.2.6(react@19.2.6)
 
-  "@react-aria/label@3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/landmark@3.0.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      use-sync-external-store: 1.6.0(react@19.2.6)
-
-  "@react-aria/link@3.8.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/link": 3.6.6(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/listbox@3.15.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/label": 3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/selection": 3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/list": 3.13.3(react@19.2.6)
-      "@react-types/listbox": 3.7.5(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/live-announcer@3.4.4":
-    dependencies:
-      "@swc/helpers": 0.5.17
-
-  "@react-aria/menu@3.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/overlays": 3.31.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/selection": 3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/menu": 3.9.10(react@19.2.6)
-      "@react-stately/selection": 3.20.8(react@19.2.6)
-      "@react-stately/tree": 3.9.5(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/menu": 3.10.6(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/meter@3.4.29(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/progress": 3.4.29(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/meter": 3.4.14(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/numberfield@3.12.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/spinbutton": 3.7.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/textfield": 3.18.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-stately/numberfield": 3.10.4(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/numberfield": 3.8.17(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/overlays@3.31.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/ssr": 3.9.10(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/visually-hidden": 3.8.30(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/overlays": 3.6.22(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/overlays": 3.9.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/progress@3.4.29(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/label": 3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/progress": 3.5.17(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/radio@3.12.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/form": 3.1.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/label": 3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/radio": 3.11.4(react@19.2.6)
-      "@react-types/radio": 3.9.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/searchfield@3.8.11(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/textfield": 3.18.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/searchfield": 3.5.18(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/searchfield": 3.6.7(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/select@3.17.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/form": 3.1.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/label": 3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/listbox": 3.15.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/menu": 3.20.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/selection": 3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/visually-hidden": 3.8.30(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/select": 3.9.1(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/select": 3.12.1(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/selection@3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/selection": 3.20.8(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/separator@3.4.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/spinbutton@3.7.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/live-announcer": 3.4.4
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
   "@react-aria/ssr@3.9.10(react@19.2.6)":
     dependencies:
       "@swc/helpers": 0.5.17
       react: 19.2.6
-
-  "@react-aria/switch@3.7.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/toggle": 3.12.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/toggle": 3.9.4(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@react-types/switch": 3.5.16(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/table@3.17.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/grid": 3.14.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/live-announcer": 3.4.4
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/visually-hidden": 3.8.30(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/flags": 3.1.2
-      "@react-stately/table": 3.15.3(react@19.2.6)
-      "@react-types/checkbox": 3.10.3(react@19.2.6)
-      "@react-types/grid": 3.3.7(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@react-types/table": 3.13.5(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/tabs@3.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/selection": 3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/tabs": 3.8.8(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@react-types/tabs": 3.3.21(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/tag@3.8.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/gridlist": 3.14.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/label": 3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/selection": 3.27.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/list": 3.13.3(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/textfield@3.18.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/form": 3.1.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/label": 3.7.24(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@react-types/textfield": 3.12.7(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/toast@3.0.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.25.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/landmark": 3.0.9(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/toast": 3.1.0(react@19.2.6)
-      "@react-types/button": 3.15.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/toggle@3.12.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/toggle": 3.9.4(react@19.2.6)
-      "@react-types/checkbox": 3.10.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/toolbar@3.0.0-beta.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/focus": 3.21.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/tooltip@3.9.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/tooltip": 3.5.10(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@react-types/tooltip": 3.5.1(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
 
   "@react-aria/utils@3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@react-aria/ssr": 3.9.10(react@19.2.6)
       "@react-stately/flags": 3.1.2
       "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
+      "@react-types/shared": 3.36.0(react@19.2.6)
       "@swc/helpers": 0.5.17
       clsx: 2.1.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  "@react-aria/virtualizer@4.1.12(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/i18n": 3.12.15(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-stately/virtualizer": 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-aria/visually-hidden@3.8.30(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-aria/interactions": 3.28.1(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-aria/utils": 3.33.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-stately/calendar@3.9.2(react@19.2.6)":
-    dependencies:
-      "@internationalized/date": 3.11.0
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/calendar": 3.8.2(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/checkbox@3.7.4(react@19.2.6)":
-    dependencies:
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/checkbox": 3.10.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/collections@3.12.9(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/combobox@3.12.2(react@19.2.6)":
-    dependencies:
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-stately/list": 3.13.3(react@19.2.6)
-      "@react-stately/overlays": 3.6.22(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/combobox": 3.13.11(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/data@3.15.1(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/datepicker@3.16.0(react@19.2.6)":
-    dependencies:
-      "@internationalized/date": 3.11.0
-      "@internationalized/number": 3.6.5
-      "@internationalized/string": 3.2.7
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-stately/overlays": 3.6.22(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/datepicker": 3.13.4(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/dnd@3.7.3(react@19.2.6)":
-    dependencies:
-      "@react-stately/selection": 3.20.8(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
   "@react-stately/flags@3.1.2":
     dependencies:
       "@swc/helpers": 0.5.17
-
-  "@react-stately/form@3.2.3(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/grid@3.11.8(react@19.2.6)":
-    dependencies:
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/selection": 3.20.8(react@19.2.6)
-      "@react-types/grid": 3.3.7(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/layout@4.5.3(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/table": 3.15.3(react@19.2.6)
-      "@react-stately/virtualizer": 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      "@react-types/grid": 3.3.7(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@react-types/table": 3.13.5(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-stately/list@3.13.3(react@19.2.6)":
-    dependencies:
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/selection": 3.20.8(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/menu@3.9.10(react@19.2.6)":
-    dependencies:
-      "@react-stately/overlays": 3.6.22(react@19.2.6)
-      "@react-types/menu": 3.10.6(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/numberfield@3.10.4(react@19.2.6)":
-    dependencies:
-      "@internationalized/number": 3.6.5
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/numberfield": 3.8.17(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/overlays@3.6.22(react@19.2.6)":
-    dependencies:
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/overlays": 3.9.3(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/radio@3.11.4(react@19.2.6)":
-    dependencies:
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/radio": 3.9.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/searchfield@3.5.18(react@19.2.6)":
-    dependencies:
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/searchfield": 3.6.7(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/select@3.9.1(react@19.2.6)":
-    dependencies:
-      "@react-stately/form": 3.2.3(react@19.2.6)
-      "@react-stately/list": 3.13.3(react@19.2.6)
-      "@react-stately/overlays": 3.6.22(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/select": 3.12.1(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/selection@3.20.8(react@19.2.6)":
-    dependencies:
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/table@3.15.3(react@19.2.6)":
-    dependencies:
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/flags": 3.1.2
-      "@react-stately/grid": 3.11.8(react@19.2.6)
-      "@react-stately/selection": 3.20.8(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/grid": 3.3.7(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@react-types/table": 3.13.5(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/tabs@3.8.8(react@19.2.6)":
-    dependencies:
-      "@react-stately/list": 3.13.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@react-types/tabs": 3.3.21(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/toast@3.1.0(react@19.2.6)":
-    dependencies:
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      use-sync-external-store: 1.6.0(react@19.2.6)
-
-  "@react-stately/toggle@3.9.4(react@19.2.6)":
-    dependencies:
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/checkbox": 3.10.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/tooltip@3.5.10(react@19.2.6)":
-    dependencies:
-      "@react-stately/overlays": 3.6.22(react@19.2.6)
-      "@react-types/tooltip": 3.5.1(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-
-  "@react-stately/tree@3.9.5(react@19.2.6)":
-    dependencies:
-      "@react-stately/collections": 3.12.9(react@19.2.6)
-      "@react-stately/selection": 3.20.8(react@19.2.6)
-      "@react-stately/utils": 3.11.0(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
 
   "@react-stately/utils@3.11.0(react@19.2.6)":
     dependencies:
       "@swc/helpers": 0.5.17
       react: 19.2.6
 
-  "@react-stately/virtualizer@4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@swc/helpers": 0.5.17
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  "@react-types/actionbar@3.1.20(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/actiongroup@3.4.22(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/breadcrumbs@3.7.18(react@19.2.6)":
-    dependencies:
-      "@react-types/link": 3.6.6(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/button@3.15.0(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/calendar@3.8.2(react@19.2.6)":
-    dependencies:
-      "@internationalized/date": 3.11.0
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/checkbox@3.10.3(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/combobox@3.13.11(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/datepicker@3.13.4(react@19.2.6)":
-    dependencies:
-      "@internationalized/date": 3.11.0
-      "@react-types/calendar": 3.8.2(react@19.2.6)
-      "@react-types/overlays": 3.9.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/dialog@3.5.23(react@19.2.6)":
-    dependencies:
-      "@react-types/overlays": 3.9.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/grid@3.3.7(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/link@3.6.6(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/listbox@3.7.5(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/menu@3.10.6(react@19.2.6)":
-    dependencies:
-      "@react-types/overlays": 3.9.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/meter@3.4.14(react@19.2.6)":
-    dependencies:
-      "@react-types/progress": 3.5.17(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/numberfield@3.8.17(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/overlays@3.9.3(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/progress@3.5.17(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/radio@3.9.3(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/searchfield@3.6.7(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      "@react-types/textfield": 3.12.7(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/select@3.12.1(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/shared@3.33.0(react@19.2.6)":
-    dependencies:
-      react: 19.2.6
-
   "@react-types/shared@3.36.0(react@19.2.6)":
     dependencies:
-      react: 19.2.6
-
-  "@react-types/switch@3.5.16(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/table@3.13.5(react@19.2.6)":
-    dependencies:
-      "@react-types/grid": 3.3.7(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/tabs@3.3.21(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/textfield@3.12.7(react@19.2.6)":
-    dependencies:
-      "@react-types/shared": 3.33.0(react@19.2.6)
-      react: 19.2.6
-
-  "@react-types/tooltip@3.5.1(react@19.2.6)":
-    dependencies:
-      "@react-types/overlays": 3.9.3(react@19.2.6)
-      "@react-types/shared": 3.33.0(react@19.2.6)
       react: 19.2.6
 
   "@resvg/resvg-wasm@2.4.0": {}
@@ -26534,9 +24730,9 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
-  acorn-import-attributes@1.9.5(acorn@8.15.0):
+  acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
 
   acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
@@ -28775,8 +26971,8 @@ snapshots:
 
   import-in-the-middle@1.14.2:
     dependencies:
-      acorn: 8.15.0
-      acorn-import-attributes: 1.9.5(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
       cjs-module-lexer: 1.4.3
       module-details-from-path: 1.0.4
 
@@ -28801,13 +26997,6 @@ snapshots:
   internmap@1.0.1: {}
 
   internmap@2.0.3: {}
-
-  intl-messageformat@10.7.16:
-    dependencies:
-      "@formatjs/ecma402-abstract": 2.3.4
-      "@formatjs/fast-memoize": 2.2.7
-      "@formatjs/icu-messageformat-parser": 2.11.2
-      tslib: 2.8.1
 
   intl-messageformat@11.2.8:
     dependencies:
@@ -29731,8 +27920,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.2
       micromark-extension-mdx-md: 2.0.0
@@ -32388,7 +30577,7 @@ snapshots:
 
   unplugin@1.0.1:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       chokidar: 3.6.0
       webpack-sources: 3.3.3
       webpack-virtual-modules: 0.5.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,7 @@ overrides:
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   immutable@>=5.0.0-beta.1 <5.1.8: 5.1.9
   fast-uri@>=3.0.0 <3.1.4: 3.1.4
+  postcss@<=8.5.11: 8.5.15
   sharp@<0.35.0: 0.35.3
   seti-icons@0.0.4>svgo: 2.8.3
   thrift@0.23.0>uuid: 11.1.1
@@ -161,7 +162,7 @@ importers:
         specifier: ^16.4.7
         version: 16.6.1
       postcss:
-        specifier: ^8.4.49
+        specifier: 8.5.15
         version: 8.5.15
       sass:
         specifier: ^1.92.1
@@ -249,7 +250,7 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       postcss:
-        specifier: ^8.4.49
+        specifier: 8.5.15
         version: 8.5.15
       tailwindcss:
         specifier: ^4.2.4
@@ -466,7 +467,7 @@ importers:
         specifier: ^10.4.27
         version: 10.5.0(postcss@8.5.15)
       postcss:
-        specifier: ^8.4.49
+        specifier: 8.5.15
         version: 8.5.15
       postcss-preset-env:
         specifier: ^10.0.9
@@ -768,7 +769,7 @@ importers:
         specifier: ^10.4.27
         version: 10.5.0(postcss@8.5.15)
       postcss:
-        specifier: ^8.4.49
+        specifier: 8.5.15
         version: 8.5.15
       sass:
         specifier: ^1.92.1
@@ -1048,7 +1049,7 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       postcss:
-        specifier: ^8.4.49
+        specifier: 8.5.15
         version: 8.5.15
       postcss-preset-env:
         specifier: ^10.0.9
@@ -2728,7 +2729,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-cascade-layers@5.0.2":
     resolution:
@@ -2737,7 +2738,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-color-function-display-p3-linear@1.0.0":
     resolution:
@@ -2746,7 +2747,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-color-function@4.0.11":
     resolution:
@@ -2755,7 +2756,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-color-mix-function@3.0.11":
     resolution:
@@ -2764,7 +2765,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-color-mix-variadic-function-arguments@1.0.1":
     resolution:
@@ -2773,7 +2774,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-content-alt-text@2.0.7":
     resolution:
@@ -2782,7 +2783,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-exponential-functions@2.0.9":
     resolution:
@@ -2791,7 +2792,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-font-format-keywords@4.0.0":
     resolution:
@@ -2800,7 +2801,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-gamut-mapping@2.0.11":
     resolution:
@@ -2809,7 +2810,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-gradients-interpolation-method@5.0.11":
     resolution:
@@ -2818,7 +2819,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-hwb-function@4.0.11":
     resolution:
@@ -2827,7 +2828,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-ic-unit@4.0.3":
     resolution:
@@ -2836,7 +2837,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-initial@2.0.1":
     resolution:
@@ -2845,7 +2846,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-is-pseudo-class@5.0.3":
     resolution:
@@ -2854,7 +2855,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-light-dark-function@2.0.10":
     resolution:
@@ -2863,7 +2864,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-logical-float-and-clear@3.0.0":
     resolution:
@@ -2872,7 +2873,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-logical-overflow@2.0.0":
     resolution:
@@ -2881,7 +2882,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-logical-overscroll-behavior@2.0.0":
     resolution:
@@ -2890,7 +2891,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-logical-resize@3.0.0":
     resolution:
@@ -2899,7 +2900,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-logical-viewport-units@3.0.4":
     resolution:
@@ -2908,7 +2909,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-media-minmax@2.0.9":
     resolution:
@@ -2917,7 +2918,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5":
     resolution:
@@ -2926,7 +2927,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-nested-calc@4.0.0":
     resolution:
@@ -2935,7 +2936,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-normalize-display-values@4.0.0":
     resolution:
@@ -2944,7 +2945,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-oklab-function@4.0.11":
     resolution:
@@ -2953,7 +2954,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-progressive-custom-properties@4.2.0":
     resolution:
@@ -2962,7 +2963,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-random-function@2.0.1":
     resolution:
@@ -2971,7 +2972,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-relative-color-syntax@3.0.11":
     resolution:
@@ -2980,7 +2981,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-scope-pseudo-class@4.0.1":
     resolution:
@@ -2989,7 +2990,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-sign-functions@1.1.4":
     resolution:
@@ -2998,7 +2999,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-stepped-value-functions@4.0.9":
     resolution:
@@ -3007,7 +3008,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-text-decoration-shorthand@4.0.3":
     resolution:
@@ -3016,7 +3017,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-trigonometric-functions@4.0.9":
     resolution:
@@ -3025,7 +3026,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/postcss-unset-value@4.0.0":
     resolution:
@@ -3034,7 +3035,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@csstools/selector-resolve-nested@3.1.0":
     resolution:
@@ -3061,7 +3062,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   "@dabh/diagnostics@2.0.8":
     resolution:
@@ -9786,7 +9787,7 @@ packages:
     engines: { node: ^10 || ^12 || >=14 }
     hasBin: true
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.15
 
   available-typed-arrays@1.0.7:
     resolution:
@@ -10579,7 +10580,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   css-box-shadow@1.0.0-3:
     resolution:
@@ -10608,7 +10609,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   css-prefers-color-scheme@10.0.0:
     resolution:
@@ -10617,7 +10618,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   css-select@4.3.0:
     resolution:
@@ -15309,7 +15310,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-clamp@4.1.0:
     resolution:
@@ -15318,7 +15319,7 @@ packages:
       }
     engines: { node: ">=7.6.0" }
     peerDependencies:
-      postcss: ^8.4.6
+      postcss: 8.5.15
 
   postcss-color-functional-notation@7.0.11:
     resolution:
@@ -15327,7 +15328,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-color-hex-alpha@10.0.0:
     resolution:
@@ -15336,7 +15337,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-color-rebeccapurple@10.0.0:
     resolution:
@@ -15345,7 +15346,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-custom-media@11.0.6:
     resolution:
@@ -15354,7 +15355,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-custom-properties@14.0.6:
     resolution:
@@ -15363,7 +15364,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-custom-selectors@8.0.5:
     resolution:
@@ -15372,7 +15373,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-dir-pseudo-class@9.0.1:
     resolution:
@@ -15381,7 +15382,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-double-position-gradients@6.0.3:
     resolution:
@@ -15390,7 +15391,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-flexbugs-fixes@5.0.2:
     resolution:
@@ -15398,7 +15399,7 @@ packages:
         integrity: sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==,
       }
     peerDependencies:
-      postcss: ^8.1.4
+      postcss: 8.5.15
 
   postcss-focus-visible@10.0.1:
     resolution:
@@ -15407,7 +15408,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-focus-within@9.0.1:
     resolution:
@@ -15416,7 +15417,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-font-variant@5.0.0:
     resolution:
@@ -15424,7 +15425,7 @@ packages:
         integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==,
       }
     peerDependencies:
-      postcss: ^8.1.0
+      postcss: 8.5.15
 
   postcss-gap-properties@6.0.0:
     resolution:
@@ -15433,7 +15434,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-image-set-function@7.0.0:
     resolution:
@@ -15442,7 +15443,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-import@15.1.0:
     resolution:
@@ -15451,7 +15452,7 @@ packages:
       }
     engines: { node: ">=14.0.0" }
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: 8.5.15
 
   postcss-import@16.1.1:
     resolution:
@@ -15460,7 +15461,7 @@ packages:
       }
     engines: { node: ">=18.0.0" }
     peerDependencies:
-      postcss: ^8.0.0
+      postcss: 8.5.15
 
   postcss-js@4.0.1:
     resolution:
@@ -15469,7 +15470,7 @@ packages:
       }
     engines: { node: ^12 || ^14 || >= 16 }
     peerDependencies:
-      postcss: ^8.4.21
+      postcss: 8.5.15
 
   postcss-lab-function@7.0.11:
     resolution:
@@ -15478,7 +15479,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-load-config@6.0.1:
     resolution:
@@ -15488,7 +15489,7 @@ packages:
     engines: { node: ">= 18" }
     peerDependencies:
       jiti: ">=1.21.0"
-      postcss: ">=8.0.9"
+      postcss: 8.5.15
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -15508,7 +15509,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-nested@6.2.0:
     resolution:
@@ -15517,7 +15518,7 @@ packages:
       }
     engines: { node: ">=12.0" }
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: 8.5.15
 
   postcss-nesting@13.0.2:
     resolution:
@@ -15526,7 +15527,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-opacity-percentage@3.0.0:
     resolution:
@@ -15535,7 +15536,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-overflow-shorthand@6.0.0:
     resolution:
@@ -15544,7 +15545,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-page-break@3.0.4:
     resolution:
@@ -15552,7 +15553,7 @@ packages:
         integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==,
       }
     peerDependencies:
-      postcss: ^8
+      postcss: 8.5.15
 
   postcss-place@10.0.0:
     resolution:
@@ -15561,7 +15562,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-preset-env@10.3.1:
     resolution:
@@ -15570,7 +15571,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-pseudo-class-any-link@10.0.1:
     resolution:
@@ -15579,7 +15580,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-replace-overflow-wrap@4.0.0:
     resolution:
@@ -15587,7 +15588,7 @@ packages:
         integrity: sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==,
       }
     peerDependencies:
-      postcss: ^8.0.3
+      postcss: 8.5.15
 
   postcss-selector-not@8.0.1:
     resolution:
@@ -15596,7 +15597,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: ^8.4
+      postcss: 8.5.15
 
   postcss-selector-parser@6.0.10:
     resolution:
@@ -15624,13 +15625,6 @@ packages:
       {
         integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
       }
-
-  postcss@8.4.31:
-    resolution:
-      {
-        integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==,
-      }
-    engines: { node: ^10 || ^12 || >=14 }
 
   postcss@8.5.15:
     resolution:
@@ -17723,7 +17717,7 @@ packages:
     peerDependencies:
       "@microsoft/api-extractor": ^7.36.0
       "@swc/core": ^1
-      postcss: ^8.4.12
+      postcss: 8.5.15
       typescript: ">=4.5.0"
     peerDependenciesMeta:
       "@microsoft/api-extractor":
@@ -28221,7 +28215,7 @@ snapshots:
       "@next/env": 15.5.21
       "@swc/helpers": 0.5.15
       caniuse-lite: 1.0.30001806
-      postcss: 8.4.31
+      postcss: 8.5.15
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.6)
@@ -28882,12 +28876,6 @@ snapshots:
       util-deprecate: 1.0.2
 
   postcss-value-parser@4.2.0: {}
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.15:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,9 @@ overrides:
   "immutable@>=5.0.0-beta.1 <5.1.8": 5.1.9
   # Keep AJV's URI parser on the release patched for GHSA-v2hh-gcrm-f6hx.
   "fast-uri@>=3.0.0 <3.1.4": 3.1.4
+  # Keep transitive PostCSS consumers on a release patched for
+  # GHSA-6g55-p6wh-862q.
+  "postcss@<=8.5.11": 8.5.15
   # Next.js 15 still requests Sharp 0.34, so force its optional dependency onto
   # the current patched release containing the updated libvips binaries.
   "sharp@<0.35.0": 0.35.3


### PR DESCRIPTION
## Summary

- upgrade `@keystatic/core` to 0.6.0 and pin its required `@keystar/ui` 0.8.0 stack, restoring the inert New branch dialog
- enforce the `staging-` Keystatic branch prefix so only `main` and dedicated content branches are surfaced
- update writer docs to create each `staging-*` branch from `main` and merge it directly back to `main`
- document GitHub App permissions, callback, writer role, reauthorization, ownership, and version checks
- add browser regression coverage for branch filtering and the exact GitHub `createRef` mutation
- force vulnerable transitive PostCSS versions onto 8.5.15, clearing the repository's high-severity dependency-audit gate

## Triage

- the new browser test reproduced the failure on `@keystatic/core` 0.5.50: the New branch control rendered but did not open its dialog
- the same test passes on Keystatic 0.6.0 with Keystar UI 0.8.0, including `refs/heads/staging-editor-article-name` created from the `main` commit
- GitHub's `createRef` mutation also succeeds directly against this repository, so current repository rules do not block branch creation
- if an affected writer still receives a GitHub rejection, check their Write role and the App installation approval, suspension, and reauthorization state
- CI exposed GHSA-6g55-p6wh-862q in Next.js's transitive PostCSS path; the workspace security override now resolves every PostCSS consumer to patched 8.5.15

## Validation

- `pnpm --filter solana-com-media test:keystatic-branches`
- `pnpm --filter solana-com-media test` (97 passed)
- `pnpm --filter solana-com-media check-types`
- `pnpm --filter solana-com-media lint` (zero errors; existing content warnings only)
- `pnpm --filter solana-com-media build`
- `pnpm --filter solana-com-media peers check`
- `pnpm audit --prod --audit-level high` (passes; no high-severity findings)
