### PR TITLE
content(/upgrades): Agave 4.2 Summary + Rent

### DIFF
--- a/apps/media/CLAUDE.md
+++ b/apps/media/CLAUDE.md
@@ -161,6 +161,13 @@ Podcast episodes link to Simplecast:
 - `SIMPLECAST_API_KEY` - API access
 - `SIMPLECAST_PODCAST_ID` - Podcast identifier
 
+### Upgrade Articles
+
+Articles in `content/upgrades/` follow a specific voice, structure, and
+Keystatic frontmatter shape. See
+[`content/upgrades/AGENTS.md`](./content/upgrades/AGENTS.md) before drafting or
+editing one.
+
 ## Key Dependencies (App-Specific)
 
 - `@keystatic/core`, `@keystatic/next` - CMS framework

--- a/apps/media/content/upgrades/AGENTS.md
+++ b/apps/media/content/upgrades/AGENTS.md
@@ -1,0 +1,116 @@
+# Upgrades Article Guide
+
+Read this before drafting or editing any file in `content/upgrades/`. It covers
+voice, required structure, Keystatic frontmatter, and sourcing expectations for
+`/upgrades` articles.
+
+## Voice & Tone
+
+- Technical but accessible — assume a reader who understands Solana basics but
+  not the specific mechanism being described.
+- Impact-focused: explain WHY a change matters, not just WHAT changed.
+- Use specific metrics and timelines instead of vague claims (`150ms finality`,
+  `Q3 2026` — not "much faster" or "soon").
+- Use "This means..." style statements to translate a technical fact into a
+  concrete consequence for validators, developers, or users.
+- Use analogies for complex mechanisms (e.g. XDP as "a shortcut that bypasses
+  normal network processing").
+- Active voice. No marketing hype or unsupported superlatives.
+
+## Required Structure
+
+Every new article follows this 6-part skeleton, in order:
+
+1. H1 title
+2. Byline line: `<Timeframe> • Solana Foundation` (e.g.
+   `Q3 2026 • Solana Foundation`)
+3. Intro paragraph — what the upgrade is and why it matters
+4. Key-facts table (2 columns; common rows: Status, Breaking Change?, Indexing
+   Changes Required?, Action Required?)
+5. `## Technical Details` with `###` subsections, one per sub-topic
+6. `## About This Upgrade` closing section, ending with the fixed line:
+   `**Learn more:** [Solana Upgrades](/upgrades)`
+
+Reference examples: `alpenglow.mdx` and `reduced-slot-times.mdx`.
+
+**Do not use `xdp.mdx` as a reference.** It predates the Keystatic migration
+described in
+`docs/superpowers/specs/2026-05-31-xdp-keystatic-migration-design.md` and does
+not follow this structure.
+
+## MDX Skeleton
+
+Start every new article from this template:
+
+```mdx
+---
+title: <Article Title>
+description: >-
+  <1-3 sentence SEO/meta description summarizing the upgrade and its impact.>
+subtitle: <Short subtitle shown in the hero section>
+publishedAt: <YYYY-MM-DDT00:00:00.000Z>
+status: draft
+author: solana-foundation
+badges:
+  - text: <e.g. "Under Development">
+    color: yellow # green | yellow | red | purple
+    variant: badge # badge | text
+metrics:
+  - value: <e.g. "150ms">
+    label: <e.g. "Target finality">
+categories:
+  - category: upgrades
+tags:
+  - tag: announcements
+---
+
+# <Article Title>
+
+<Timeframe> • Solana Foundation
+
+<Intro paragraph: what this upgrade is and why it matters.>
+
+|                            |     |
+| -------------------------- | --- |
+| Status                     |     |
+| Breaking Change?           |     |
+| Indexing Changes Required? |     |
+
+## Technical Details
+
+### <Subsection Title>
+
+<Content>
+
+## About This Upgrade
+
+<Closing context: why this matters for the network long-term.>
+
+**Learn more:** [Solana Upgrades](/upgrades)
+```
+
+## Keystatic Frontmatter Reference
+
+Fields defined in `apps/media/keystatic.config.tsx`, `upgrades` collection:
+
+| Field         | Type                              | Notes                                                   |
+| ------------- | --------------------------------- | ------------------------------------------------------- |
+| `title`       | slug/text                         | Required, becomes the URL slug                          |
+| `status`      | select                            | `draft` \| `published`, defaults to `draft`             |
+| `description` | text                              | SEO meta description                                    |
+| `subtitle`    | text                              | Shown below title in hero                               |
+| `badges`      | array of `{text, color, variant}` | `color`: green/yellow/red/purple; `variant`: badge/text |
+| `metrics`     | array of `{value, label}`         | Key stat cards                                          |
+| `heroImage`   | image                             | Optional, used as `og:image`                            |
+| `author`      | relationship                      | Author entry                                            |
+| `publishedAt` | datetime                          | Required                                                |
+| `categories`  | array → categories                | Typically just `upgrades`                               |
+| `tags`        | array → tags                      | Typically `announcements`                               |
+| `body`        | MDX                               | The article content itself                              |
+
+## Accuracy
+
+Double-check SIMD numbers, metrics, and activation timelines before publishing.
+Link to a primary source (SIMD proposal, Anza/Firedancer release notes) when a
+natural place for one exists in the text. This is a reminder, not a hard
+per-claim citation requirement.

--- a/apps/media/content/upgrades/AGENTS.md
+++ b/apps/media/content/upgrades/AGENTS.md
@@ -25,8 +25,8 @@ Every new article follows this 6-part skeleton, in order:
 2. Byline line: `<Timeframe> • Solana Foundation` (e.g.
    `Q3 2026 • Solana Foundation`)
 3. Intro paragraph — what the upgrade is and why it matters
-4. Key-facts table (2 columns; common rows: Status, Breaking Change?, Indexing
-   Changes Required?, Action Required?)
+4. Key-facts table (2 columns; common rows: Expected Mainnet Activation Date,
+   Devnet Activation, Breaking Change?, Indexing Changes Required?)
 5. `## Technical Details` with `###` subsections, one per sub-topic
 6. `## About This Upgrade` closing section, ending with the fixed line:
    `**Learn more:** [Solana Upgrades](/upgrades)`
@@ -70,11 +70,12 @@ tags:
 
 <Intro paragraph: what this upgrade is and why it matters.>
 
-|                            |     |
-| -------------------------- | --- |
-| Status                     |     |
-| Breaking Change?           |     |
-| Indexing Changes Required? |     |
+|                                  |     |
+| -------------------------------- | --- |
+| Expected Mainnet Activation Date |     |
+| Devnet Activation                |     |
+| Breaking Change?                 |     |
+| Indexing Changes Required?       |     |
 
 ## Technical Details
 

--- a/apps/media/content/upgrades/agave-4-2-release-overview.mdx
+++ b/apps/media/content/upgrades/agave-4-2-release-overview.mdx
@@ -6,7 +6,7 @@ description: >-
   feature-complete ahead of its expected activation in Agave 4.3.
 subtitle: Cheaper rent, larger transactions, and faster slots — with Alpenglow on deck
 publishedAt: 2026-07-24T00:00:00.000Z
-status: draft
+status: published
 author: solana-foundation
 badges:
   - text: Under Development

--- a/apps/media/content/upgrades/agave-4-2-release-overview.mdx
+++ b/apps/media/content/upgrades/agave-4-2-release-overview.mdx
@@ -42,12 +42,12 @@ to test Alpenglow in a community test cluster. Alpenglow will not be activated
 on mainnet in Agave 4.2, but it will be thoroughly tested for an expected Agave
 4.3 release.
 
-|                             |                                                               |
-| --------------------------- | ------------------------------------------------------------- |
-| Expected Mainnet Release    | August 2026                                                   |
-| Mainnet Feature Activations | Begin August 17, 2026                                         |
-| Devnet Release              | July 2026                                                     |
-| Breaking Change?            | Yes: reduced slot times, indexers need transaction v1 support |
+|                             |                       |
+| --------------------------- | --------------------- |
+| Expected Mainnet Release    | August 2026           |
+| Mainnet Feature Activations | Begin August 17, 2026 |
+| Devnet Release              | July 2026             |
+| Breaking Change?            | No                    |
 
 ## Technical Details
 

--- a/apps/media/content/upgrades/agave-4-2-release-overview.mdx
+++ b/apps/media/content/upgrades/agave-4-2-release-overview.mdx
@@ -1,0 +1,122 @@
+---
+title: Agave 4.2 Release Overview
+description: >-
+  Agave 4.2 brings a 90% rent reduction, 4096-byte transactions, and 200ms
+  slot times to Solana mainnet in August 2026, and ships Alpenglow
+  feature-complete ahead of its expected activation in Agave 4.3.
+subtitle: Cheaper rent, larger transactions, and faster slots — with Alpenglow on deck
+publishedAt: 2026-07-24T00:00:00.000Z
+status: draft
+author: solana-foundation
+badges:
+  - text: Under Development
+    color: yellow
+    variant: badge
+metrics:
+  - value: 90%
+    label: Rent reduction, phased over 5 steps
+  - value: "4096"
+    label: Bytes per transaction, up from 1232
+  - value: 200ms
+    label: Slot times, down from 400ms
+  - value: 150ms
+    label: Alpenglow target finality, activating in 4.3
+categories:
+  - category: upgrades
+tags:
+  - tag: announcements
+---
+
+# Agave 4.2 Release Overview
+
+August 2026 • Solana Foundation
+
+Agave 4.2 is the next release of Anza's Solana validator client, recommended
+for mainnet adoption in August 2026 with feature activations expected to start
+the week of August 17, per the
+[v4.2 release schedule](https://github.com/anza-xyz/agave/wiki/v4.2-Release-Schedule).
+The release carries three feature-gated upgrades: a 90% rent reduction,
+larger transaction sizes, and reduced slot times. The release also includes the
+necessary code to run Alpenglow, allowing core developers and validators
+to test Alpenglow in a community test cluster. Alpenglow will not be activated
+on mainnet in Agave 4.2, but it will be thoroughly tested for an expected Agave
+4.3 release.
+
+|                             |                                                               |
+| --------------------------- | ------------------------------------------------------------- |
+| Expected Mainnet Release    | August 2026                                                   |
+| Mainnet Feature Activations | Begin August 17, 2026                                         |
+| Devnet Release              | July 2026                                                     |
+| Breaking Change?            | Yes: reduced slot times, indexers need transaction v1 support |
+
+## Technical Details
+
+### Reduced Rent
+
+[SIMD-0437](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0437-incremental-rent-reduction.md)
+cuts `lamports_per_byte`, the constant behind Solana's fully refundable
+storage bond, from 6,960 to 696 — a 90% reduction. The cut rolls out across
+five independent feature gates so core developers can monitor state growth at
+each step, with a fallback gate that can restore the current value if needed.
+
+This means creating on-chain state gets dramatically cheaper: the rent
+deposit for a standard SPL token account falls from about $0.159 to $0.0159,
+making it practical for businesses to cover rent on behalf of their users at
+scale.
+
+Read the full article: [Reduced Rent](/upgrades/reduced-rent)
+
+### Larger Transaction Sizes
+
+[SIMD-0296](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0296-larger-transactions.md)
+raises the maximum transaction size from 1232 bytes to 4096 bytes, delivered
+through the new transaction v1 format. Existing `v0` and `legacy` transactions
+continue to work unchanged; applications opt in by adopting `v1`.
+
+This means workloads that never fit inside a single transaction, such as ZK
+proofs, large multisigs, and on-chain signature schemes like BLS, can now land
+as one atomic transaction instead of being stitched together with lookup tables or
+bundles. Indexers that decode raw transaction bytes will need to recognize
+the new transaction `v1` layout.
+
+Read the full article: [Larger Transaction Sizes](/upgrades/larger-transaction-sizes)
+
+### Reduced Slot Times
+
+[SIMD-0525](https://github.com/solana-foundation/solana-improvement-documents/pull/525)
+halves Solana's slot time from 400ms to 200ms, rolled out in four 50ms
+decrements gated by successive feature activations. The network will not
+advance to the next decrement if block skip rates are too high.
+
+This means users see confirmations twice as fast, market makers can quote
+tighter spreads, and each leader's monopoly over block building narrows —
+improving both latency and censorship resistance.
+
+Read the full article: [Reduced Slot Times](/upgrades/reduced-slot-times)
+
+### Alpenglow: Feature Complete, Activating in 4.3
+
+Agave 4.2 contains the code changes for Alpenglow, Solana's cutting-edge new
+consensus protocol, but core engineers will be doing more testing and hardening
+of the code base. Alpenglow will not be activated in 4.2: activation is
+expected in Agave 4.3, the following release, targeted for October 2026.
+
+Alpenglow replaces TowerBFT with the Votor voting algorithm, targeting
+roughly 150ms finality compared with today's 12.8-second TowerBFT finality.
+It eliminates vote transactions entirely. With Alpenglow, validators will
+exchange votes directly. Votor will tolerate 20% of stake being offline plus
+20% of stake being adversarial. This means validators running 4.2 already
+carry the complete Alpenglow code, setting the network up for the consensus
+migration in the next release.
+
+Read the full article: [Alpenglow](/upgrades/alpenglow)
+
+## About This Upgrade
+
+Agave 4.2 delivers major improvements across three axes: cheaper on-chain
+state through the rent reduction, more capable transactions through the
+4096-byte v1 format, and lower latency through 200ms slot times. Just as
+importantly, with Alpenglow feature-complete, the 4.2 release sets the stage
+for the largest protocol change in Solana's history, coming in Agave 4.3.
+
+**Learn more:** [Solana Upgrades](/upgrades)

--- a/apps/media/content/upgrades/reduced-rent.mdx
+++ b/apps/media/content/upgrades/reduced-rent.mdx
@@ -1,0 +1,119 @@
+---
+title: Reduced Rent
+description: >-
+  SIMD-0437 cuts Solana's rent constant from 6,960 to 696 lamports per byte, a
+  90% reduction, rolled out through five feature-gated steps with a fallback
+  to protect against unexpected state growth.
+subtitle: Cutting the cost of on-chain storage by 90%
+publishedAt: 2026-07-15T00:00:00.000Z
+status: draft
+author: solana-foundation
+badges:
+  - text: Under Development
+    color: yellow
+    variant: badge
+metrics:
+  - value: 90%
+    label: Rent reduction, phased over 5 steps
+  - value: 696
+    label: Target lamports per byte, down from 6,960
+categories:
+  - category: upgrades
+tags:
+  - tag: announcements
+---
+
+# Reduced Rent
+
+Phased Rollout • Solana Foundation
+
+"Rent" is a misleading name. It isn't a fee — it's a fully refundable bond
+that pays for the storage an account occupies on every validator. Solana
+requires accounts to hold a minimum balance sized to their data, and when
+that account is closed, the lamports are returned in full to whoever closes
+it. [SIMD-0437](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0437-incremental-rent-reduction.md)
+reduces the constant behind that bond, `lamports_per_byte`, from 6,960 down to
+696 — a 90% cut — rolled out in five separate feature-gated steps rather than
+a single change.
+
+|                                  |                          |
+| -------------------------------- | ------------------------ |
+| Expected Mainnet Activation Date | TBD — one step at a time |
+| Devnet Activation                | TBD                      |
+| Breaking Change?                 | No                       |
+| Indexing Changes Required?       | No                       |
+
+## Technical Details
+
+### What Rent Actually Pays For
+
+Every Solana account must hold enough lamports to be "rent exempt," meaning
+it never gets charged rent for as long as it stays above that threshold. This
+minimum balance isn't spent — it's held against the account and returned when
+the account is closed. In practice, this means a program or user pays a
+refundable bond up front to reserve space in the validator set's state, and
+gets that bond back the moment the state is freed.
+
+### The Lamports-Per-Byte Constant
+
+The minimum balance for an account is calculated as:
+
+```
+min_balance = (128 + data_size) * lamports_per_byte
+```
+
+The `128` is a fixed account storage overhead, and `data_size` is the size of
+the account in bytes. `lamports_per_byte` is currently 6,960, a constant set
+years ago and never adjusted since. Because it was fixed in lamports rather
+than tied to any actual validator storage cost, its real-world cost has moved
+independently of what storage actually costs to provide — bond sizes have
+stayed flat in lamports while SOL's price has moved, so the cost in USD terms
+to reserve the same byte of state has not tracked resource costs at all.
+
+### Five-Step Phased Rollout
+
+Rather than cut `lamports_per_byte` to 696 in one move, SIMD-0437 splits the
+reduction across five independent feature gates. Each step activates
+separately, and the network only proceeds to the next step once a risk
+analysis grounded in empirical data from the current step shows it's safe to
+continue.
+
+|                                                                                                                                    |             |                     |
+| ---------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------- |
+| [`4a6f7o7iTcA8hRDCrPLkSatnt5Ykxiu36wo5p1Tt12wC`](https://explorer.solana.com/address/4a6f7o7iTcA8hRDCrPLkSatnt5Ykxiu36wo5p1Tt12wC) | SIMD-0437-1 | 6,960 → 6,333 (9%)  |
+| [`61BtM7BkDEE8Yq5fskEVAQT9mYA8qCejJWoLe5apqg81`](https://explorer.solana.com/address/61BtM7BkDEE8Yq5fskEVAQT9mYA8qCejJWoLe5apqg81) | SIMD-0437-2 | 6,960 → 5,080 (27%) |
+| [`Ftxb3ZKq7aNqgxDBbP7EonvR2RszZk9ctjdsTX38kQaz`](https://explorer.solana.com/address/Ftxb3ZKq7aNqgxDBbP7EonvR2RszZk9ctjdsTX38kQaz) | SIMD-0437-3 | 6,960 → 2,575 (63%) |
+| [`GsUBNYNDPdMLHPD37TToHzrzcNcjpC9w5n1EcJk5iTaM`](https://explorer.solana.com/address/GsUBNYNDPdMLHPD37TToHzrzcNcjpC9w5n1EcJk5iTaM) | SIMD-0437-4 | 6,960 → 1,322 (81%) |
+| [`mZdnRh9T2EbDNvqKjkCR3bvo5c816tJaojtE9Xs7iuY`](https://explorer.solana.com/address/mZdnRh9T2EbDNvqKjkCR3bvo5c816tJaojtE9Xs7iuY)   | SIMD-0437-5 | 6,960 → 696 (90%)   |
+
+All five feature gates are currently inactive. Each one is independent, so
+the network can stop advancing at any step if the data doesn't support moving
+forward.
+
+### Fallback Safeguard
+
+A sixth feature gate exists specifically to reverse course: if a step causes
+unexpected state growth or other issues, this fallback resets
+`lamports_per_byte` back to 6,960, the current value, without disrupting
+existing accounts. This is paired with
+[SIMD-0392](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0392-rent-increase-adaptations.md),
+which allows rent to be raised again later if empirical state growth turns
+out to be a problem. This means the network isn't committing to 696
+lamports per byte unconditionally — it's committing to testing each step and
+keeping a way back if the data says otherwise.
+
+## About This Upgrade
+
+Cheaper rent means it costs less SOL to create token accounts, PDAs, and any
+other on-chain state, since the minimum balance is fully refundable but still
+has to be deposited up front. That's a real cost for developers and users doing
+onboarding, minting, or account creation at scale, and it has made Solana's
+storage bond disproportionately expensive relative to what other chains
+charge for similar space.
+
+This upgrade doesn't change what rent exemption means or how the bond
+mechanism works — it only recalibrates the constant behind it, one carefully
+monitored step at a time, with a fallback in place if state growth ends up
+outpacing expectations.
+
+**Learn more:** [Solana Upgrades](/upgrades)

--- a/apps/media/content/upgrades/reduced-rent.mdx
+++ b/apps/media/content/upgrades/reduced-rent.mdx
@@ -38,7 +38,7 @@ a single change.
 
 |                                  |                              |
 | -------------------------------- | ---------------------------- |
-| Expected Mainnet Activation Date | Agave 4.2 - Sept 2026        |
+| Expected Mainnet Activation Date | Agave 4.2 - August 2026      |
 | Devnet Activation                | August 2026                  |
 | Breaking Change?                 | No                           |
 | Indexing Changes Required?       | No, state growth is possible |

--- a/apps/media/content/upgrades/reduced-rent.mdx
+++ b/apps/media/content/upgrades/reduced-rent.mdx
@@ -5,8 +5,8 @@ description: >-
   90% reduction, rolled out through five feature-gated steps with a fallback
   to protect against unexpected state growth.
 subtitle: Cutting the cost of on-chain storage by 90%
-publishedAt: 2026-07-15T00:00:00.000Z
-status: draft
+publishedAt: 2026-07-24T00:00:00.000Z
+status: published
 author: solana-foundation
 badges:
   - text: Under Development

--- a/apps/media/content/upgrades/reduced-rent.mdx
+++ b/apps/media/content/upgrades/reduced-rent.mdx
@@ -27,7 +27,7 @@ tags:
 
 Phased Rollout • Solana Foundation
 
-"Rent" is a misleading name. It isn't a fee — it's a fully refundable bond
+"Rent" is a misleading name. It isn't a fee. Rent is a fully refundable bond
 that pays for the storage an account occupies on every validator. Solana
 requires accounts to hold a minimum balance sized to their data, and when
 that account is closed, the lamports are returned in full to whoever closes
@@ -36,23 +36,22 @@ reduces the constant behind that bond, `lamports_per_byte`, from 6,960 down to
 696 — a 90% cut — rolled out in five separate feature-gated steps rather than
 a single change.
 
-|                                  |                          |
-| -------------------------------- | ------------------------ |
-| Expected Mainnet Activation Date | TBD — one step at a time |
-| Devnet Activation                | TBD                      |
-| Breaking Change?                 | No                       |
-| Indexing Changes Required?       | No                       |
+|                                  |                              |
+| -------------------------------- | ---------------------------- |
+| Expected Mainnet Activation Date | Agave 4.2 - Sept 2026        |
+| Devnet Activation                | August 2026                  |
+| Breaking Change?                 | No                           |
+| Indexing Changes Required?       | No, state growth is possible |
 
 ## Technical Details
 
 ### What Rent Actually Pays For
 
-Every Solana account must hold enough lamports to be "rent exempt," meaning
-it never gets charged rent for as long as it stays above that threshold. This
-minimum balance isn't spent — it's held against the account and returned when
-the account is closed. In practice, this means a program or user pays a
-refundable bond up front to reserve space in the validator set's state, and
-gets that bond back the moment the state is freed.
+Every Solana account must hold enough lamports to cover the cost of storing the
+on-chain state for the account. This minimum balance is held against the
+account and returned when the account is closed. The intent is for a user to
+"rent" the storage space on chain. When the account is closed, validators no
+longer have to store that state, so the amount is refunded.
 
 ### The Lamports-Per-Byte Constant
 
@@ -66,17 +65,29 @@ The `128` is a fixed account storage overhead, and `data_size` is the size of
 the account in bytes. `lamports_per_byte` is currently 6,960, a constant set
 years ago and never adjusted since. Because it was fixed in lamports rather
 than tied to any actual validator storage cost, its real-world cost has moved
-independently of what storage actually costs to provide — bond sizes have
-stayed flat in lamports while SOL's price has moved, so the cost in USD terms
-to reserve the same byte of state has not tracked resource costs at all.
+independently of what storage actually costs to provide. Additionally, there has
+been concern that cheaper storage costs for accounts would lead to a large
+demand spike in on-chain storage space.
+
+### Rent Case Study
+
+Assuming a payments business wants to create one million token accounts for
+their users, the current on-chain cost of rent would be one million accounts times
+$0.159 for an SPL token account rent deposit. So a business would pay
+$159,000 at the time of this writing. However, once all five rent-reduction
+feature gates are active on mainnet and assuming similar economics, the cost of
+an SPL token account's rent would be $0.0159, resulting in a total cost of
+$15,900. A reduction of this size could make it practical for many more
+businesses to cover rent on behalf of their users, making onboarding easier.
 
 ### Five-Step Phased Rollout
 
-Rather than cut `lamports_per_byte` to 696 in one move, SIMD-0437 splits the
+To address concerns about a rapid spike in on-chain state, core developers
+chose to roll out rent reduction in a five-step phased approach. Rather than cut
+`lamports_per_byte` to 696 in one move, SIMD-0437 splits the
 reduction across five independent feature gates. Each step activates
-separately, and the network only proceeds to the next step once a risk
-analysis grounded in empirical data from the current step shows it's safe to
-continue.
+separately. Core developers will determine if they can proceed with the next
+feature activation or if they need to gather more data on state demand.
 
 |                                                                                                                                    |             |                     |
 | ---------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------- |
@@ -98,22 +109,27 @@ unexpected state growth or other issues, this fallback resets
 existing accounts. This is paired with
 [SIMD-0392](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0392-rent-increase-adaptations.md),
 which allows rent to be raised again later if empirical state growth turns
-out to be a problem. This means the network isn't committing to 696
-lamports per byte unconditionally — it's committing to testing each step and
-keeping a way back if the data says otherwise.
+out to be a problem.
+
+Umberto, a data researcher at the Solana Foundation, has done an in-depth
+analysis of the potential state growth issue when rent is reduced by 90%. His
+research suggests that the 90% reduction will not cause systemic risk to the
+cluster. The payoff for users is substantial: the rent deposit for a standard SPL
+token account falls from about $0.159 to $0.0159, a tenfold drop that makes
+account creation dramatically cheaper. Lowering rent by 90% puts
+Solana's onboarding costs in range of payment-specialized chains. Read more
+here: [Rent Reduction on Solana: A Data-Backed Analysis](https://solana.com/news/rent-reduction-deep-dive).
 
 ## About This Upgrade
 
-Cheaper rent means it costs less SOL to create token accounts, PDAs, and any
-other on-chain state, since the minimum balance is fully refundable but still
-has to be deposited up front. That's a real cost for developers and users doing
-onboarding, minting, or account creation at scale, and it has made Solana's
-storage bond disproportionately expensive relative to what other chains
-charge for similar space.
+Solana will decrease rent by 90%. Cheaper rent means it costs less SOL to create
+token accounts, PDAs, and any other on-chain state. The rent amount is fully
+refundable but still has to be deposited up front. That's a real cost reduction
+for developers and users doing onboarding, minting, or account creation at
+scale.
 
 This upgrade doesn't change what rent exemption means or how the bond
-mechanism works — it only recalibrates the constant behind it, one carefully
-monitored step at a time, with a fallback in place if state growth ends up
-outpacing expectations.
+mechanism works. The change only recalibrates the cost of rent, resulting in a
+90% reduction in costs for end users and businesses.
 
 **Learn more:** [Solana Upgrades](/upgrades)


### PR DESCRIPTION
### Problem

External teams want to know what's in Agave 4.2.

### Summary of Changes
Adds an agave 4.2 summary that links to related /upgrades pages. It also adds a rent page for /upgrades.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
