### PR TITLE
docs(frontend): update wallet hooks for kit-plugin-wallet 0.14

### DIFF
--- a/apps/docs/content/docs/en/frontend/client.mdx
+++ b/apps/docs/content/docs/en/frontend/client.mdx
@@ -141,12 +141,6 @@ const client = createClient()
   .use(tokenProgram()); // adds client.token
 ```
 
-<Callout type="warn" title="Peer dependency ranges">
-  Some `@solana-program/*` releases still declare a `@solana/kit ^6.x` peer
-  while Kit is at 7.x. They work with Kit 7 — override the peer range in your
-  package manager if it complains.
-</Callout>
-
 ## Signing without a browser wallet
 
 Running headless in an API route, worker, or script? Sign with a backend

--- a/apps/docs/content/docs/en/frontend/nextjs-solana.mdx
+++ b/apps/docs/content/docs/en/frontend/nextjs-solana.mdx
@@ -51,10 +51,8 @@ The default `create-next-app` output needs two small changes for this tutorial:
 $ npm install @solana/kit @solana/kit-plugin-rpc @solana/kit-plugin-wallet @solana/react @solana-program/system
 ```
 
-This tutorial targets Kit 7+, the `@solana/kit-plugin-*` packages at 0.13+, and
-`@solana/react` 7+. If your package manager surfaces peer warnings from a
-`@solana-program/*` package declaring an older Kit peer range, override it — the
-packages work with Kit 7.
+This tutorial targets Kit 7+, the `@solana/kit-plugin-*` packages at 0.13+
+(0.14+ for `@solana/kit-plugin-wallet`), and `@solana/react` 7+.
 
 <ScrollyCoding>
 
@@ -137,7 +135,8 @@ access the client and wallet hooks.
 Dropdown to connect/disconnect Wallet Standard wallets. `useWallets` returns the
 wallets discovered in the browser; `useConnect` / `useDisconnect` return an
 `ActionResult` — this component uses its `dispatch`, `isRunning`, and `error`
-fields.
+fields. Every wallet hook takes the client as its first argument, so pull it
+from `useClient<AppClient>()` first.
 
 ```tsx !! title="app/components/wallet-connect-button.tsx"
 "use client";
@@ -150,17 +149,20 @@ import {
   useWallets,
   useWalletStatus
 } from "@solana/kit-plugin-wallet/react";
+import { useClient } from "@solana/react";
+import type { AppClient } from "../providers";
 
 function truncate(address: string) {
   return `${address.slice(0, 4)}…${address.slice(-4)}`;
 }
 
 export function WalletConnectButton() {
-  const status = useWalletStatus();
-  const wallets = useWallets();
-  const connected = useConnectedWallet();
-  const connect = useConnect();
-  const disconnect = useDisconnect();
+  const client = useClient<AppClient>();
+  const status = useWalletStatus(client);
+  const wallets = useWallets(client);
+  const connected = useConnectedWallet(client);
+  const connect = useConnect(client);
+  const disconnect = useDisconnect(client);
   const [open, setOpen] = useState(false);
 
   const address = connected ? String(connected.account.address) : null;
@@ -281,7 +283,7 @@ function parseLamports(input: string) {
 
 export function SolTransferCard() {
   const client = useClient<AppClient>();
-  const connected = useConnectedWallet();
+  const connected = useConnectedWallet(client);
   const [destination, setDestination] = useState("");
   const [amount, setAmount] = useState("0.001");
   const [signature, setSignature] = useState<string | null>(null);

--- a/apps/docs/content/docs/en/frontend/react-hooks.mdx
+++ b/apps/docs/content/docs/en/frontend/react-hooks.mdx
@@ -41,7 +41,9 @@ add a plugin that resolves asynchronously, and pass that `AppClient` to every
 
 ## Wrap your tree once
 
-`ClientProvider` publishes the client. Every hook below reads from it.
+`ClientProvider` publishes the client. The data hooks (`useRequest`,
+`useSubscription`, `useTrackedData`) read it via `useClient`. The wallet hooks
+below need the same client passed in explicitly as their first argument.
 
 ```tsx title="providers.tsx"
 "use client";
@@ -56,17 +58,20 @@ export function Providers({ children }: { children: React.ReactNode }) {
 
 ## Wallet hooks
 
-The wallet hooks read the client's `wallet` capability, so they only work inside
-a `ClientProvider` whose client installed a wallet plugin.
+The wallet hooks need a client with a wallet plugin installed (e.g.
+`walletSigner`). Get it from `useClient<AppClient>()` and pass it as each hook's
+first argument — this keeps the app fully typed end-to-end instead of relying on
+context lookups.
 
-- `useWallets()` — Wallet Standard wallets discovered for the client's chain.
-- `useWalletStatus()` —
+- `useWallets(client)` — Wallet Standard wallets discovered for the client's
+  chain.
+- `useWalletStatus(client)` —
   `"pending" | "disconnected" | "connecting" | "connected" | "disconnecting" | "reconnecting"`.
-- `useConnectedWallet()` — `{ account, signer, wallet }` or `null`. `signer` is
-  `null` for read-only wallets.
-- `useConnect()` / `useDisconnect()` — return an `ActionResult` whose `dispatch`
-  (and `dispatchAsync`) runs the action and whose `isRunning`, `status`, `data`,
-  `error`, and `reset` track its result.
+- `useConnectedWallet(client)` — `{ account, signer, wallet }` or `null`.
+  `signer` is `null` for read-only wallets.
+- `useConnect(client)` / `useDisconnect(client)` — return an `ActionResult`
+  whose `dispatch` (and `dispatchAsync`) runs the action and whose `isRunning`,
+  `status`, `data`, `error`, and `reset` track its result.
 
 ```tsx
 "use client";
@@ -78,13 +83,16 @@ import {
   useWallets,
   useWalletStatus
 } from "@solana/kit-plugin-wallet/react";
+import { useClient } from "@solana/react";
+import type { AppClient } from "./client";
 
 function WalletPanel() {
-  const status = useWalletStatus();
-  const wallets = useWallets();
-  const connected = useConnectedWallet();
-  const connect = useConnect();
-  const disconnect = useDisconnect();
+  const client = useClient<AppClient>();
+  const status = useWalletStatus(client);
+  const wallets = useWallets(client);
+  const connected = useConnectedWallet(client);
+  const connect = useConnect(client);
+  const disconnect = useDisconnect(client);
 
   if (status === "pending") return null; // wait out auto-reconnect
 
@@ -129,7 +137,7 @@ import type { AppClient } from "./client";
 
 function SendSol({ destination }: { destination: string }) {
   const client = useClient<AppClient>();
-  const connected = useConnectedWallet();
+  const connected = useConnectedWallet(client);
 
   async function handleSend() {
     if (!connected?.signer) return;
@@ -200,8 +208,8 @@ subpaths wrap the same hooks for [SWR](https://swr.vercel.app) and
 
 ## Common patterns for Solana devs
 
-- **One provider**: `ClientProvider` is the only provider you need; wallet hooks
-  read it via the client's `wallet` capability.
+- **One provider**: `ClientProvider` is the only provider you need; get the
+  client with `useClient<AppClient>()` and pass it into the wallet hooks.
 - **Server components aware**: Only mark leaf components that call hooks with
   `"use client"`; server reads can use a plain Kit RPC client without a wallet.
 - **Testing**: Publish a mocked client through `ClientProvider` to simulate
@@ -209,8 +217,8 @@ subpaths wrap the same hooks for [SWR](https://swr.vercel.app) and
 
 <Callout type="warn" title="Two hook families, same names">
   `useSignIn` and `useSignMessage` exist in both `@solana/react` (they take a
-  `UiWalletAccount` argument) and `@solana/kit-plugin-wallet/react`
-  (client-based, no account argument, return an `ActionResult`). Use the
+  `UiWalletAccount` argument) and `@solana/kit-plugin-wallet/react` (take the
+  `client` instead, return an `ActionResult`). Use the
   `@solana/kit-plugin-wallet/react` versions with the client pattern above; the
   older `@solana/react` wallet hooks are being superseded.
 </Callout>


### PR DESCRIPTION
## Summary
- `@solana/kit-plugin-wallet` 0.14 makes every React hook (`useWallets`, `useConnect`, `useConnectedWallet`, `useWalletStatus`, `useIsWalletReady`, `useDisconnect`, `useSignIn`, `useSignMessage`, `useSelectAccount`) and `WalletReadyGate` take the wallet-enabled client as an explicit argument/prop instead of reading it from `ClientProvider` context. Updated the code examples in `client.mdx`, `react-hooks.mdx`, and `nextjs-solana.mdx` to match.
- Removed the now-stale peer-dependency warning about `@solana-program/*` packages declaring an older `@solana/kit ^6.x` range — confirmed against npm that token/system/token-2022/compute-budget/memo all now declare `^7.0.0`.

Closes DEV-779

## Test plan
- [x] `pnpm lint --filter solana-docs`
- [x] `pnpm --filter solana-docs check-types`
- [x] Verified updated hook signatures against the published `@solana/kit-plugin-wallet@0.14.0` type declarations