### PR TITLE
docs(litesvm): add Go language docs

### DIFF
--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/account-management.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/account-management.mdx
@@ -1,0 +1,223 @@
+---
+title: Account Management
+description: Methods for managing accounts, balances, and rent in Go
+---
+
+# Account Management
+
+Methods for funding, reading, and writing accounts.
+
+## Airdrop
+
+```go
+func (s *LiteSVM) Airdrop(pubkey solana.PublicKey, lamports uint64) error
+```
+
+Fund an account with lamports. Implemented as a real system-program transfer
+from the internal faucet, so the recipient must be able to hold the resulting
+balance.
+
+```go
+priv, err := solana.NewRandomPrivateKey()
+if err != nil {
+    t.Fatal(err)
+}
+payer := priv.PublicKey()
+
+// Airdrop 5 SOL
+if err := svm.Airdrop(payer, 5_000_000_000); err != nil {
+    t.Fatal(err)
+}
+```
+
+## Balance
+
+```go
+func (s *LiteSVM) Balance(pubkey solana.PublicKey) (uint64, bool, error)
+```
+
+Return the account's SOL balance. The second value is `false` when the account
+does not exist - distinct from "account exists with zero lamports".
+
+```go
+lamports, ok, err := svm.Balance(payer)
+if err != nil {
+    t.Fatal(err)
+}
+if !ok {
+    t.Log("account does not exist")
+} else {
+    t.Logf("balance: %d lamports (%.3f SOL)", lamports, float64(lamports)/1e9)
+}
+```
+
+## GetAccount
+
+```go
+func (s *LiteSVM) GetAccount(pubkey solana.PublicKey) *Account
+```
+
+Retrieve an opaque account handle, or `nil` if the account does not exist.
+Always `Close` the handle (or rely on the finalizer).
+
+```go
+acct := svm.GetAccount(payer)
+if acct == nil {
+    t.Fatal("account missing")
+}
+defer acct.Close()
+
+_ = acct.Lamports()    // uint64
+_ = acct.Owner()       // solana.PublicKey
+_ = acct.Executable()  // bool
+_ = acct.RentEpoch()   // uint64
+_ = acct.Data()        // []byte (copy)
+```
+
+### Account methods
+
+| Method         | Returns            | Description                        |
+| -------------- | ------------------ | ---------------------------------- |
+| `Lamports()`   | `uint64`           | SOL balance                        |
+| `Owner()`      | `solana.PublicKey` | Owning program                     |
+| `Executable()` | `bool`             | Whether the account is executable  |
+| `RentEpoch()`  | `uint64`           | Rent epoch                         |
+| `Data()`       | `[]byte`           | Copy of the account data           |
+| `Close()`      | -                  | Release the underlying Rust handle |
+
+## NewAccount
+
+```go
+func NewAccount(lamports uint64, data []byte, owner solana.PublicKey, executable bool, rentEpoch uint64) (*Account, error)
+```
+
+Construct an `Account` value to pass to `SetAccount`. The caller still owns the
+returned handle and must `Close` it.
+
+```go
+payload := []byte{1, 2, 3, 4}
+rent, err := svm.MinimumBalanceForRentExemption(len(payload))
+if err != nil {
+    t.Fatal(err)
+}
+
+acct, err := litesvm.NewAccount(rent, payload, ownerProgramID, false, 0)
+if err != nil {
+    t.Fatal(err)
+}
+defer acct.Close()
+```
+
+## SetAccount
+
+```go
+func (s *LiteSVM) SetAccount(pubkey solana.PublicKey, acct *Account) error
+```
+
+Store a copy of `acct` at `pubkey`. The SVM keeps its own copy; the caller still
+owns `acct` and must `Close` it.
+
+```go
+if err := svm.SetAccount(targetAddr, acct); err != nil {
+    t.Fatal(err)
+}
+```
+
+<Callout type="info">
+  `SetAccount` is significantly faster than executing transactions when you just
+  need to seed many accounts for a test. Make sure the lamports value is at
+  least the rent-exempt minimum for the data size.
+</Callout>
+
+## MinimumBalanceForRentExemption
+
+```go
+func (s *LiteSVM) MinimumBalanceForRentExemption(dataLen int) (uint64, error)
+```
+
+Compute the lamports required for an account of the given data length to be
+rent-exempt.
+
+```go
+for _, size := range []int{0, 100, 1024} {
+    min, err := svm.MinimumBalanceForRentExemption(size)
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("%4d bytes -> %d lamports", size, min)
+}
+```
+
+## Program Management
+
+### AddProgram
+
+```go
+func (s *LiteSVM) AddProgram(programID solana.PublicKey, bytes []byte) error
+```
+
+Load an SBF program from in-memory bytes.
+
+```go
+bytes, err := os.ReadFile("./target/deploy/my_program.so")
+if err != nil {
+    t.Fatal(err)
+}
+if err := svm.AddProgram(programID, bytes); err != nil {
+    t.Fatal(err)
+}
+```
+
+### AddProgramFromFile
+
+```go
+func (s *LiteSVM) AddProgramFromFile(programID solana.PublicKey, path string) error
+```
+
+Load an SBF program from a `.so` file path.
+
+```go
+if err := svm.AddProgramFromFile(programID, "./target/deploy/my_program.so"); err != nil {
+    t.Fatal(err)
+}
+```
+
+### AddProgramWithLoader
+
+```go
+func (s *LiteSVM) AddProgramWithLoader(programID solana.PublicKey, bytes []byte, loaderID solana.PublicKey) error
+```
+
+Load an SBF program under a specific loader. Useful when testing against a
+non-default BPF loader version.
+
+## Batch Account Setup
+
+For tests that need many seeded accounts, loop over `SetAccount`:
+
+```go
+const N = 10
+for i := 0; i < N; i++ {
+    pk := solana.NewWallet().PublicKey()
+    data := []byte{byte(i)}
+    rent, err := svm.MinimumBalanceForRentExemption(len(data))
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    acct, err := litesvm.NewAccount(rent, data, owner, false, 0)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if err := svm.SetAccount(pk, acct); err != nil {
+        acct.Close()
+        t.Fatal(err)
+    }
+    acct.Close()
+}
+```
+
+<Callout type="info">
+  Always `Close` the `*Account` returned by `NewAccount` once the SVM has stored
+  its copy via `SetAccount` - the SVM does not take ownership of the handle.
+</Callout>

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/account-management.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/account-management.mdx
@@ -3,8 +3,6 @@ title: Account Management
 description: Methods for managing accounts, balances, and rent in Go
 ---
 
-# Account Management
-
 Methods for funding, reading, and writing accounts.
 
 ## Airdrop

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/configuration.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/configuration.mdx
@@ -3,8 +3,6 @@ title: Configuration
 description: Setter methods for configuring LiteSVM in Go
 ---
 
-# Configuration
-
 Each setter mirrors the corresponding builder method on the Rust `LiteSVM` type.
 Calls take effect immediately and return an `error`.
 

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/configuration.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/configuration.mdx
@@ -1,0 +1,264 @@
+---
+title: Configuration
+description: Setter methods for configuring LiteSVM in Go
+---
+
+# Configuration
+
+Each setter mirrors the corresponding builder method on the Rust `LiteSVM` type.
+Calls take effect immediately and return an `error`.
+
+## Typical Test Setup
+
+```go
+svm, err := litesvm.New()
+if err != nil {
+    t.Fatal(err)
+}
+defer svm.Close()
+
+// Each setter returns an error. The calls below are infallible in practice,
+// so the docs use _ = ... for brevity; check the error in production code.
+_ = svm.SetSigverify(false)        // skip signature verification (faster)
+_ = svm.SetBlockhashCheck(false)   // skip blockhash validation (simpler)
+_ = svm.SetSysvars()               // reset Clock, Rent, etc. to defaults
+_ = svm.SetBuiltins()              // reload built-in programs
+_ = svm.SetTransactionHistory(100) // keep the last 100 transactions
+```
+
+## Signature and Blockhash
+
+### SetSigverify
+
+```go
+func (s *LiteSVM) SetSigverify(enabled bool) error
+```
+
+Toggle transaction signature verification.
+
+```go
+if err := svm.SetSigverify(false); err != nil { // accept unsigned / badly-signed txs
+    t.Fatal(err)
+}
+if err := svm.SetSigverify(true); err != nil {  // restore production-like behavior
+    t.Fatal(err)
+}
+```
+
+<Callout type="info">
+  Disabling signature verification makes tests faster but less realistic.
+</Callout>
+
+### Sigverify
+
+```go
+func (s *LiteSVM) Sigverify() (bool, error)
+```
+
+Read the current setting.
+
+### SetBlockhashCheck
+
+```go
+func (s *LiteSVM) SetBlockhashCheck(enabled bool) error
+```
+
+Toggle the recent-blockhash check on submitted transactions.
+
+```go
+if err := svm.SetBlockhashCheck(false); err != nil { // accept any blockhash
+    t.Fatal(err)
+}
+```
+
+## Programs and Sysvars
+
+### SetSysvars
+
+```go
+func (s *LiteSVM) SetSysvars() error
+```
+
+Re-initialize the built-in sysvars (Clock, Rent, EpochSchedule, ...) to their
+defaults.
+
+### SetBuiltins
+
+```go
+func (s *LiteSVM) SetBuiltins() error
+```
+
+Load the default set of built-in programs.
+
+### SetDefaultPrograms
+
+```go
+func (s *LiteSVM) SetDefaultPrograms() error
+```
+
+Load the standard SPL programs (System Program, SPL Token, Memo, ...).
+
+### SetPrecompiles
+
+```go
+func (s *LiteSVM) SetPrecompiles() error
+```
+
+Enable the ed25519 / secp256k1 precompiled programs.
+
+### WithNativeMints
+
+```go
+func (s *LiteSVM) WithNativeMints() error
+```
+
+Seed the SPL Token / Token-2022 native-mint accounts (wrapped SOL). No-op if the
+matching program is not loaded; call `SetDefaultPrograms` first if you want
+both.
+
+## Resource Limits
+
+### SetLamports
+
+```go
+func (s *LiteSVM) SetLamports(lamports uint64) error
+```
+
+Set the default lamports balance of the internal airdrop-pool account.
+
+```go
+if err := svm.SetLamports(1 << 40); err != nil { // ~1.1 trillion lamports (~1,100 SOL)
+    t.Fatal(err)
+}
+```
+
+### SetLogBytesLimit
+
+```go
+func (s *LiteSVM) SetLogBytesLimit(limit int) error
+```
+
+Bound the total log bytes captured per transaction. Pass a negative value to
+remove the limit.
+
+```go
+if err := svm.SetLogBytesLimit(10_000); err != nil { // 10 KB cap
+    t.Fatal(err)
+}
+if err := svm.SetLogBytesLimit(-1); err != nil {     // unlimited
+    t.Fatal(err)
+}
+```
+
+### SetTransactionHistory
+
+```go
+func (s *LiteSVM) SetTransactionHistory(capacity int) error
+```
+
+Set the capacity of the in-memory transaction history. Pass `0` to disable dedup
+and allow replaying identical transactions.
+
+```go
+if err := svm.SetTransactionHistory(100); err != nil { // cap at 100 entries
+    t.Fatal(err)
+}
+if err := svm.SetTransactionHistory(0); err != nil {   // disable dedup entirely
+    t.Fatal(err)
+}
+```
+
+## Compute Budget
+
+```go
+type ComputeBudget struct {
+    // See litesvm-go/litesvm.go for the full field list.
+    // usize fields are normalized to uint64; HeapSize stays uint32.
+    ComputeUnitLimit uint64
+    HeapSize         uint32
+    // ...
+}
+```
+
+### ComputeBudget
+
+```go
+func (s *LiteSVM) ComputeBudget() (ComputeBudget, bool, error)
+```
+
+Read the current compute budget. The second return value reports whether a
+budget was explicitly set; if `false`, the struct contains the default values
+that will be used.
+
+```go
+budget, set, err := svm.ComputeBudget()
+if err != nil {
+    t.Fatal(err)
+}
+if !set {
+    budget.ComputeUnitLimit = 1_400_000
+}
+if err := svm.SetComputeBudget(budget); err != nil {
+    t.Fatal(err)
+}
+```
+
+### SetComputeBudget
+
+```go
+func (s *LiteSVM) SetComputeBudget(b ComputeBudget) error
+```
+
+Install a compute budget for subsequent transactions.
+
+## Feature Sets
+
+`FeatureSet` is an opaque handle - construct it, mutate it with `Activate` /
+`Deactivate`, then install it with `SetFeatureSet`. Close handles you create.
+
+```go
+// Start with all features off, then activate what you care about.
+fs, err := litesvm.NewFeatureSet()
+if err != nil {
+    t.Fatal(err)
+}
+defer fs.Close()
+if err := fs.Activate(featureID, 0); err != nil {
+    t.Fatal(err)
+}
+
+// Or start from "everything enabled" and flip specific features off.
+fs2, err := litesvm.NewFeatureSetAllEnabled()
+if err != nil {
+    t.Fatal(err)
+}
+defer fs2.Close()
+if err := fs2.Deactivate(featureID); err != nil {
+    t.Fatal(err)
+}
+
+if err := svm.SetFeatureSet(fs); err != nil {
+    t.Fatal(err)
+}
+```
+
+| Method                                                   | Description                       |
+| -------------------------------------------------------- | --------------------------------- |
+| `litesvm.NewFeatureSet() (*FeatureSet, error)`           | Empty set (all features inactive) |
+| `litesvm.NewFeatureSetAllEnabled() (*FeatureSet, error)` | All features active               |
+| `fs.Activate(featureID, slot) error`                     | Mark feature active at slot       |
+| `fs.Deactivate(featureID) error`                         | Mark feature inactive             |
+| `fs.IsActive(featureID) bool`                            | Active check                      |
+| `fs.ActivatedSlot(featureID) (uint64, bool)`             | Slot a feature was activated at   |
+| `fs.ActiveCount() int`                                   | Active feature count              |
+| `fs.InactiveCount() int`                                 | Inactive feature count            |
+| `fs.ActiveFeatures() []solana.PublicKey`                 | List active feature IDs           |
+| `fs.InactiveFeatures() []solana.PublicKey`               | List inactive feature IDs         |
+| `fs.Close()`                                             | Release the handle                |
+| `svm.SetFeatureSet(*FeatureSet) error`                   | Install on the SVM                |
+
+<Callout type="info">
+  Use feature gating to test how programs behave under a specific Solana version
+  - activate the features that shipped with the release you target, then
+  deactivate any that arrived later.
+</Callout>

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/index.mdx
@@ -3,8 +3,6 @@ title: API Reference
 description: Complete Go API reference for LiteSVM
 ---
 
-# Go API Reference
-
 Complete API documentation for `litesvm-go`. Method names mirror the Rust
 `LiteSVM` builder where possible; getter / setter pairs use the same Go
 convention (`Clock` / `SetClock`, `Rent` / `SetRent`, ...).

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/index.mdx
@@ -15,22 +15,22 @@ convention (`Clock` / `SetClock`, `Rent` / `SetRent`, ...).
   <Card
     title="Account Management"
     description="Airdrop, Balance, GetAccount, SetAccount, NewAccount, programs"
-    href="/docs/go/api-reference/account-management"
+    href="/docs/tools/litesvm/go/api-reference/account-management"
   />
   <Card
     title="Transactions"
     description="Send / simulate legacy + versioned transactions, TxOutcome"
-    href="/docs/go/api-reference/transactions"
+    href="/docs/tools/litesvm/go/api-reference/transactions"
   />
   <Card
     title="Configuration"
     description="Toggles for sigverify, blockhash check, history, log limits, default programs"
-    href="/docs/go/api-reference/configuration"
+    href="/docs/tools/litesvm/go/api-reference/configuration"
   />
   <Card
     title="Time & Sysvars"
     description="WarpToSlot, Clock, Rent, EpochSchedule, EpochRewards, SlotHashes, SlotHistory, StakeHistory"
-    href="/docs/go/api-reference/time-and-sysvars"
+    href="/docs/tools/litesvm/go/api-reference/time-and-sysvars"
   />
 </Cards>
 

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/index.mdx
@@ -1,0 +1,131 @@
+---
+title: API Reference
+description: Complete Go API reference for LiteSVM
+---
+
+# Go API Reference
+
+Complete API documentation for `litesvm-go`. Method names mirror the Rust
+`LiteSVM` builder where possible; getter / setter pairs use the same Go
+convention (`Clock` / `SetClock`, `Rent` / `SetRent`, ...).
+
+## API Sections
+
+<Cards>
+  <Card
+    title="Account Management"
+    description="Airdrop, Balance, GetAccount, SetAccount, NewAccount, programs"
+    href="/docs/go/api-reference/account-management"
+  />
+  <Card
+    title="Transactions"
+    description="Send / simulate legacy + versioned transactions, TxOutcome"
+    href="/docs/go/api-reference/transactions"
+  />
+  <Card
+    title="Configuration"
+    description="Toggles for sigverify, blockhash check, history, log limits, default programs"
+    href="/docs/go/api-reference/configuration"
+  />
+  <Card
+    title="Time & Sysvars"
+    description="WarpToSlot, Clock, Rent, EpochSchedule, EpochRewards, SlotHashes, SlotHistory, StakeHistory"
+    href="/docs/go/api-reference/time-and-sysvars"
+  />
+</Cards>
+
+## Quick Reference
+
+### Handle Setup
+
+```go
+import (
+    litesvm "github.com/LiteSVM/litesvm-go"
+    solana "github.com/gagliardetto/solana-go"
+)
+
+svm, err := litesvm.New()
+if err != nil {
+    // handle error
+}
+defer svm.Close()
+```
+
+### Account Management
+
+| Method                                                                       | Description                                          |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `Airdrop(pubkey, lamports) error`                                            | Fund an account                                      |
+| `Balance(pubkey) (uint64, bool, error)`                                      | SOL balance; bool reports whether the account exists |
+| `GetAccount(pubkey) *Account`                                                | Retrieve an account handle (nil if missing)          |
+| `SetAccount(pubkey, *Account) error`                                         | Store account state directly                         |
+| `MinimumBalanceForRentExemption(dataLen int) (uint64, error)`                | Compute rent-exempt minimum                          |
+| `NewAccount(lamports, data, owner, executable, rentEpoch) (*Account, error)` | Build an Account handle for SetAccount               |
+
+### Program Management
+
+| Method                                                   | Description                             |
+| -------------------------------------------------------- | --------------------------------------- |
+| `AddProgram(programID, bytes) error`                     | Load program from bytes                 |
+| `AddProgramFromFile(programID, path) error`              | Load program from `.so` file            |
+| `AddProgramWithLoader(programID, bytes, loaderID) error` | Load under a specific loader (advanced) |
+
+### Transactions
+
+| Method                                                                        | Description                                                                     |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `SendLegacyTransaction(txBytes) (*TxOutcome, error)`                          | Execute a legacy transaction                                                    |
+| `SendVersionedTransaction(txBytes) (*TxOutcome, error)`                       | Execute a v0+ transaction                                                       |
+| `SimulateLegacyTransaction(txBytes) (*TxOutcome, error)`                      | Simulate without state changes                                                  |
+| `SimulateVersionedTransaction(txBytes) (*TxOutcome, error)`                   | Simulate v0+ without state changes                                              |
+| `LatestBlockhash() (solana.Hash, error)`                                      | Current blockhash                                                               |
+| `ExpireBlockhash() error`                                                     | Advance to a new blockhash                                                      |
+| `GetTransaction(signature) *TxOutcome`                                        | Look up transaction in history (nil if absent)                                  |
+| `litesvm.BuildTransferTx(payerSeed, to, lamports, blockhash) ([]byte, error)` | Test helper that builds a signed legacy transfer without pulling in `solana-go` |
+
+### Configuration
+
+| Method                                         | Description                                             |
+| ---------------------------------------------- | ------------------------------------------------------- |
+| `SetSigverify(bool) error`                     | Enable / disable signature verification                 |
+| `Sigverify() (bool, error)`                    | Read the current setting                                |
+| `SetBlockhashCheck(bool) error`                | Enable / disable blockhash validation                   |
+| `SetTransactionHistory(int) error`             | Capacity of in-memory tx history (0 disables)           |
+| `SetLogBytesLimit(int) error`                  | Per-tx log byte cap (negative = unlimited)              |
+| `SetLamports(uint64) error`                    | Default lamports for new airdrop-pool accounts          |
+| `SetSysvars() error`                           | Reset sysvars to defaults                               |
+| `SetBuiltins() error`                          | Reload built-in programs                                |
+| `SetDefaultPrograms() error`                   | Reload SPL Token, Memo, etc.                            |
+| `SetPrecompiles() error`                       | Enable ed25519 / secp256k1 precompiles                  |
+| `WithNativeMints() error`                      | Seed wrapped-SOL mint                                   |
+| `SetFeatureSet(*FeatureSet) error`             | Install a feature gate set                              |
+| `SetComputeBudget(ComputeBudget) error`        | Apply a compute budget                                  |
+| `ComputeBudget() (ComputeBudget, bool, error)` | Read the current budget (bool reports "explicitly set") |
+
+### Time and Sysvars
+
+| Method                                       | Description                          |
+| -------------------------------------------- | ------------------------------------ |
+| `WarpToSlot(slot uint64) error`              | Jump to a specific slot              |
+| `Clock() (Clock, error)`                     | Read the Clock sysvar                |
+| `SetClock(Clock) error`                      | Overwrite the Clock sysvar           |
+| `Rent() (Rent, error)`                       | Read the Rent sysvar                 |
+| `SetRent(Rent) error`                        | Overwrite the Rent sysvar            |
+| `EpochSchedule() (EpochSchedule, error)`     | Read the EpochSchedule sysvar        |
+| `SetEpochSchedule(EpochSchedule) error`      | Overwrite the EpochSchedule sysvar   |
+| `EpochRewards() (EpochRewards, error)`       | Read the EpochRewards sysvar         |
+| `SetEpochRewards(EpochRewards) error`        | Overwrite the EpochRewards sysvar    |
+| `LastRestartSlot() (uint64, error)`          | Read last-restart-slot               |
+| `SetLastRestartSlot(uint64) error`           | Set last-restart-slot                |
+| `SlotHashes() ([]SlotHash, error)`           | Read the SlotHashes sysvar           |
+| `SetSlotHashes([]SlotHash) error`            | Overwrite the SlotHashes sysvar      |
+| `SlotHistory() (*SlotHistory, error)`        | Read the SlotHistory sysvar (handle) |
+| `SetSlotHistory(*SlotHistory) error`         | Overwrite the SlotHistory sysvar     |
+| `StakeHistory() ([]StakeHistoryItem, error)` | Read the StakeHistory sysvar         |
+| `SetStakeHistory([]StakeHistoryItem) error`  | Overwrite the StakeHistory sysvar    |
+
+### Utilities
+
+| Method                     | Description                                                    |
+| -------------------------- | -------------------------------------------------------------- |
+| `litesvm.Version() string` | Version string reported by the underlying Rust `litesvm` crate |

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "API Reference",
+  "pages": [
+    "index",
+    "account-management",
+    "transactions",
+    "configuration",
+    "time-and-sysvars"
+  ]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/time-and-sysvars.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/time-and-sysvars.mdx
@@ -1,0 +1,304 @@
+---
+title: Time & Sysvars
+description: Clock manipulation and sysvar access in Go
+---
+
+# Time and Sysvars
+
+Methods for manipulating time and accessing system variables. Every sysvar
+getter has a matching setter; the structs are plain Go mirrors of the Solana
+source.
+
+## Clock Manipulation
+
+### WarpToSlot
+
+```go
+func (s *LiteSVM) WarpToSlot(slot uint64) error
+```
+
+Advance the internal clock to a specific slot.
+
+```go
+before, err := svm.Clock()
+if err != nil {
+    t.Fatal(err)
+}
+t.Logf("current slot: %d", before.Slot)
+
+if err := svm.WarpToSlot(10_000_000); err != nil {
+    t.Fatal(err)
+}
+
+after, err := svm.Clock()
+if err != nil {
+    t.Fatal(err)
+}
+t.Logf("new slot:     %d", after.Slot)
+```
+
+### Clock
+
+```go
+type Clock struct {
+    Slot                uint64
+    EpochStartTimestamp int64
+    Epoch               uint64
+    LeaderScheduleEpoch uint64
+    UnixTimestamp       int64
+}
+
+func (s *LiteSVM) Clock() (Clock, error)
+```
+
+Read the Clock sysvar.
+
+```go
+c, err := svm.Clock()
+if err != nil {
+    t.Fatal(err)
+}
+t.Logf("slot=%d epoch=%d unix=%d", c.Slot, c.Epoch, c.UnixTimestamp)
+```
+
+### SetClock
+
+```go
+func (s *LiteSVM) SetClock(c Clock) error
+```
+
+Overwrite the Clock sysvar. Read it, mutate fields, write it back when you need
+control over `Epoch` or `UnixTimestamp` (which `WarpToSlot` does not update).
+
+```go
+c, err := svm.Clock()
+if err != nil {
+    t.Fatal(err)
+}
+c.Slot = 1_000
+c.Epoch = 10
+c.UnixTimestamp = 1_735_689_600
+if err := svm.SetClock(c); err != nil {
+    t.Fatal(err)
+}
+```
+
+<Callout type="info">
+  `WarpToSlot` only updates `Slot`. Use `SetClock` when your program reads
+  `Epoch` or `UnixTimestamp` from the Clock sysvar.
+</Callout>
+
+## Rent
+
+### Rent / SetRent
+
+```go
+type Rent struct {
+    LamportsPerByteYear uint64
+    ExemptionThreshold  float64
+    BurnPercent         uint8
+}
+
+func (s *LiteSVM) Rent() (Rent, error)
+func (s *LiteSVM) SetRent(r Rent) error
+```
+
+```go
+r, err := svm.Rent()
+if err != nil {
+    t.Fatal(err)
+}
+t.Logf("lamports/byte-year: %d", r.LamportsPerByteYear)
+t.Logf("exemption threshold: %.2f", r.ExemptionThreshold)
+t.Logf("burn percent: %d", r.BurnPercent)
+```
+
+### MinimumBalanceForRentExemption
+
+```go
+func (s *LiteSVM) MinimumBalanceForRentExemption(dataLen int) (uint64, error)
+```
+
+```go
+for _, size := range []int{0, 100, 1024} {
+    min, err := svm.MinimumBalanceForRentExemption(size)
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("%4d bytes -> %d lamports", size, min)
+}
+```
+
+## Epoch Schedule
+
+```go
+type EpochSchedule struct {
+    SlotsPerEpoch            uint64
+    LeaderScheduleSlotOffset uint64
+    Warmup                   bool
+    FirstNormalEpoch         uint64
+    FirstNormalSlot          uint64
+}
+
+func (s *LiteSVM) EpochSchedule() (EpochSchedule, error)
+func (s *LiteSVM) SetEpochSchedule(e EpochSchedule) error
+```
+
+```go
+es, err := svm.EpochSchedule()
+if err != nil {
+    t.Fatal(err)
+}
+t.Logf("slots per epoch: %d", es.SlotsPerEpoch)
+t.Logf("first normal epoch: %d", es.FirstNormalEpoch)
+t.Logf("first normal slot:  %d", es.FirstNormalSlot)
+```
+
+## Epoch Rewards
+
+```go
+type EpochRewards struct {
+    DistributionStartingBlockHeight uint64
+    NumPartitions                   uint64
+    ParentBlockhash                 solana.Hash
+    TotalPointsLo                   uint64 // low 64 bits of the u128 total_points
+    TotalPointsHi                   uint64 // high 64 bits
+    TotalRewards                    uint64
+    DistributedRewards              uint64
+    Active                          bool
+}
+
+func (s *LiteSVM) EpochRewards() (EpochRewards, error)
+func (s *LiteSVM) SetEpochRewards(e EpochRewards) error
+```
+
+`total_points` is a `u128` on the Solana side; `litesvm-go` surfaces both halves
+explicitly so Go callers do not need a u128 library. For values that fit in 64
+bits, `TotalPointsHi` is `0` and `TotalPointsLo` is the value.
+
+## Slot Information
+
+### LastRestartSlot / SetLastRestartSlot
+
+```go
+func (s *LiteSVM) LastRestartSlot() (uint64, error)
+func (s *LiteSVM) SetLastRestartSlot(slot uint64) error
+```
+
+```go
+last, err := svm.LastRestartSlot()
+if err != nil {
+    t.Fatal(err)
+}
+if err := svm.SetLastRestartSlot(last + 1); err != nil {
+    t.Fatal(err)
+}
+```
+
+### SlotHashes / SetSlotHashes
+
+```go
+type SlotHash struct {
+    Slot uint64
+    Hash solana.Hash
+}
+
+func (s *LiteSVM) SlotHashes() ([]SlotHash, error)
+func (s *LiteSVM) SetSlotHashes(items []SlotHash) error
+```
+
+### SlotHistory
+
+`SlotHistory` is a ~128 KB bitvec; `litesvm-go` exposes it as a handle rather
+than a slice.
+
+```go
+sh, err := litesvm.NewSlotHistory()
+if err != nil {
+    t.Fatal(err)
+}
+defer sh.Close()
+
+sh.Add(42)
+
+switch sh.Check(42) {
+case litesvm.SlotHistoryFound:
+    // ...
+case litesvm.SlotHistoryNotFound:
+    // ...
+case litesvm.SlotHistoryTooOld:
+    // ...
+case litesvm.SlotHistoryFuture:
+    // ...
+}
+
+if err := svm.SetSlotHistory(sh); err != nil {
+    t.Fatal(err)
+}
+```
+
+| Method                                           | Description                                |
+| ------------------------------------------------ | ------------------------------------------ |
+| `litesvm.NewSlotHistory() (*SlotHistory, error)` | Empty handle                               |
+| `sh.Add(slot uint64)`                            | Record a slot                              |
+| `sh.Check(slot uint64) SlotHistoryCheck`         | `Future` / `TooOld` / `Found` / `NotFound` |
+| `sh.Oldest() uint64`                             | Oldest slot tracked                        |
+| `sh.Newest() uint64`                             | Newest slot tracked                        |
+| `sh.NextSlot() uint64`                           | Next slot to record                        |
+| `sh.SetNextSlot(slot uint64) error`              | Override the next-slot marker              |
+| `sh.Close()`                                     | Release the handle                         |
+| `svm.SlotHistory() (*SlotHistory, error)`        | Read into a fresh handle                   |
+| `svm.SetSlotHistory(*SlotHistory) error`         | Install on the SVM                         |
+
+## Stake History
+
+```go
+type StakeHistoryItem struct {
+    Epoch        uint64
+    Effective    uint64
+    Activating   uint64
+    Deactivating uint64
+}
+
+func (s *LiteSVM) StakeHistory() ([]StakeHistoryItem, error)
+func (s *LiteSVM) SetStakeHistory(items []StakeHistoryItem) error
+```
+
+## Testing Time-Dependent Logic
+
+Use `WarpToSlot` for plain slot-based advancement, `SetClock` for full control:
+
+```go
+func TestTimeLockedVault(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    const unlockSlot = uint64(10_000)
+
+    // Setup: create the time-locked account ...
+
+    // Test 1: Try to withdraw before unlock (should fail)
+    before, err := svm.Clock()
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("current slot: %d", before.Slot)
+    // ... attempt withdrawal, expect failure ...
+
+    // Warp time forward past unlock slot
+    if err := svm.WarpToSlot(unlockSlot + 1); err != nil {
+        t.Fatal(err)
+    }
+
+    // Test 2: Try to withdraw after unlock (should succeed)
+    after, err := svm.Clock()
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("new slot: %d", after.Slot)
+    // ... attempt withdrawal, expect success ...
+}
+```

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/time-and-sysvars.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/time-and-sysvars.mdx
@@ -3,8 +3,6 @@ title: Time & Sysvars
 description: Clock manipulation and sysvar access in Go
 ---
 
-# Time and Sysvars
-
 Methods for manipulating time and accessing system variables. Every sysvar
 getter has a matching setter; the structs are plain Go mirrors of the Solana
 source.

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/transactions.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/transactions.mdx
@@ -1,0 +1,259 @@
+---
+title: Transactions
+description: Execute and simulate transactions with LiteSVM in Go
+---
+
+# Transactions
+
+Methods for sending, simulating, and managing transactions. Both legacy and v0+
+versioned transactions are supported.
+
+`litesvm-go` accepts bincode-encoded transaction bytes produced by
+`(*solana.Transaction).MarshalBinary` from
+[`gagliardetto/solana-go`](https://github.com/gagliardetto/solana-go).
+
+## SendLegacyTransaction
+
+```go
+func (s *LiteSVM) SendLegacyTransaction(txBytes []byte) (*TxOutcome, error)
+```
+
+Submit a bincode-encoded legacy `Transaction`. On success the transaction
+commits to the in-memory ledger.
+
+```go
+out, err := svm.SendLegacyTransaction(txBytes)
+if err != nil {
+    t.Fatal(err)
+}
+defer out.Close()
+
+if !out.IsOk() {
+    t.Fatalf("tx failed: %s\nlogs: %v", out.Error(), out.Logs())
+}
+
+t.Logf("signature: %s", out.Signature())
+t.Logf("compute:   %d CU", out.ComputeUnits())
+t.Logf("fee:       %d lamports", out.Fee())
+```
+
+<Callout type="warn">
+  The returned error is non-nil only when the bytes could not be decoded or an
+  internal failure occurred. A transaction that *executes and fails* still
+  returns a non-nil `*TxOutcome`; always check `IsOk()` before consuming
+  success-only state.
+</Callout>
+
+## SendVersionedTransaction
+
+```go
+func (s *LiteSVM) SendVersionedTransaction(txBytes []byte) (*TxOutcome, error)
+```
+
+Same shape as `SendLegacyTransaction`, but for v0+ messages. `solana-go`'s
+`MarshalBinary` produces the right bytes for either case.
+
+## SimulateLegacyTransaction / SimulateVersionedTransaction
+
+```go
+func (s *LiteSVM) SimulateLegacyTransaction(txBytes []byte) (*TxOutcome, error)
+func (s *LiteSVM) SimulateVersionedTransaction(txBytes []byte) (*TxOutcome, error)
+```
+
+Execute the transaction without committing state. The same `*TxOutcome` shape is
+returned, plus `PostAccounts()` is populated on success with the would-be
+post-execution account state.
+
+```go
+sim, err := svm.SimulateLegacyTransaction(txBytes)
+if err != nil {
+    t.Fatal(err)
+}
+defer sim.Close()
+
+if !sim.IsOk() {
+    t.Fatalf("sim failed: %s", sim.Error())
+}
+
+t.Logf("would use %d compute units", sim.ComputeUnits())
+t.Logf("logs: %v", sim.Logs())
+
+posts, err := sim.PostAccounts()
+if err != nil {
+    t.Fatal(err)
+}
+for _, p := range posts {
+    t.Logf("%s: %d lamports", p.Address, p.Account.Lamports())
+    p.Account.Close()
+}
+```
+
+<Callout type="info">
+  Simulation does not change state. Use it to size compute budgets or assert on
+  logs without polluting your ledger.
+</Callout>
+
+## TxOutcome
+
+Every send / simulate call returns a `*TxOutcome` carrying the same metadata
+regardless of success or failure. Always `Close` it.
+
+| Method                | Returns                            | Description                                               |
+| --------------------- | ---------------------------------- | --------------------------------------------------------- |
+| `IsOk()`              | `bool`                             | Transaction succeeded                                     |
+| `Error()`             | `string`                           | Failure description (empty on success)                    |
+| `Signature()`         | `solana.Signature`                 | Transaction signature                                     |
+| `ComputeUnits()`      | `uint64`                           | Compute units consumed                                    |
+| `Fee()`               | `uint64`                           | Fee charged                                               |
+| `Logs()`              | `[]string`                         | Program logs                                              |
+| `ReturnData()`        | `(solana.PublicKey, []byte, bool)` | Return data set via `set_return_data`; `ok=false` if none |
+| `InnerInstructions()` | `[][]InnerInstruction`             | CPIs grouped by top-level instruction                     |
+| `PostAccounts()`      | `([]PostAccount, error)`           | Post-execution state - simulate only                      |
+| `Close()`             | -                                  | Release the underlying Rust handle                        |
+
+### InnerInstruction
+
+```go
+type CompiledInstruction struct {
+    ProgramIDIndex uint8
+    Accounts       []byte // indices into the transaction's account table
+    Data           []byte
+}
+
+type InnerInstruction struct {
+    Instruction CompiledInstruction
+    StackHeight uint8 // 1 for top-level, higher for deeper CPIs
+}
+```
+
+`InnerInstructions()` returns a slice indexed by the top-level instruction that
+triggered each batch of CPIs.
+
+### PostAccount
+
+```go
+type PostAccount struct {
+    Address solana.PublicKey
+    Account *Account // close this when done
+}
+```
+
+Populated only for successful simulations.
+
+## Blockhash Management
+
+### LatestBlockhash
+
+```go
+func (s *LiteSVM) LatestBlockhash() (solana.Hash, error)
+```
+
+Read the current blockhash. Pass it into `solana.NewTransaction(...)` when
+building transactions.
+
+```go
+blockhash, err := svm.LatestBlockhash()
+if err != nil {
+    t.Fatal(err)
+}
+
+tx, _ := solana.NewTransaction(
+    []solana.Instruction{ix},
+    blockhash,
+    solana.TransactionPayer(payer),
+)
+```
+
+### ExpireBlockhash
+
+```go
+func (s *LiteSVM) ExpireBlockhash() error
+```
+
+Advance past the current blockhash so the next `LatestBlockhash` returns a new
+value. Useful for testing blockhash-expiry edge cases.
+
+```go
+bh1, err := svm.LatestBlockhash()
+if err != nil {
+    t.Fatal(err)
+}
+if err := svm.ExpireBlockhash(); err != nil {
+    t.Fatal(err)
+}
+bh2, err := svm.LatestBlockhash()
+if err != nil {
+    t.Fatal(err)
+}
+// bh1 != bh2
+_, _ = bh1, bh2
+```
+
+## Transaction History
+
+Transaction history is on by default. Adjust the capacity (or disable dedup)
+with `SetTransactionHistory`:
+
+```go
+// Cap history at 100 entries.
+if err := svm.SetTransactionHistory(100); err != nil {
+    t.Fatal(err)
+}
+
+// Disable dedup entirely (allows replaying identical transactions).
+if err := svm.SetTransactionHistory(0); err != nil {
+    t.Fatal(err)
+}
+```
+
+Look up a prior transaction by signature:
+
+```go
+prior := svm.GetTransaction(sig) // nil if unknown
+if prior != nil {
+    defer prior.Close()
+    t.Logf("found: %s, fee=%d", prior.Signature(), prior.Fee())
+}
+```
+
+## BuildTransferTx (test helper)
+
+```go
+func BuildTransferTx(
+    payerSeed [32]byte,
+    to solana.PublicKey,
+    lamports uint64,
+    blockhash solana.Hash,
+) ([]byte, error)
+```
+
+Produces a bincode-encoded, signed legacy `Transaction` transferring `lamports`
+from the keypair derived from `payerSeed` to `to`, using `blockhash`. The
+returned bytes are ready to hand to `SendLegacyTransaction`.
+
+```go
+var seed [32]byte
+copy(seed[:], somePayerSeedBytes)
+
+bh, err := svm.LatestBlockhash()
+if err != nil {
+    t.Fatal(err)
+}
+txBytes, err := litesvm.BuildTransferTx(seed, recipient, 1_000_000_000, bh)
+if err != nil {
+    t.Fatal(err)
+}
+
+out, err := svm.SendLegacyTransaction(txBytes)
+if err != nil {
+    t.Fatal(err)
+}
+defer out.Close()
+```
+
+<Callout type="info">
+  This exists to bootstrap tests and for callers who want to avoid pulling in
+  `solana-go`. Once you are building real transactions, prefer the `solana-go`
+  path shown above - it scales to multi-instruction transactions, v0 messages,
+  and arbitrary programs.
+</Callout>

--- a/apps/docs/content/docs/en/tools/litesvm/go/api-reference/transactions.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/api-reference/transactions.mdx
@@ -3,8 +3,6 @@ title: Transactions
 description: Execute and simulate transactions with LiteSVM in Go
 ---
 
-# Transactions
-
 Methods for sending, simulating, and managing transactions. Both legacy and v0+
 versioned transactions are supported.
 

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/account-setup.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/account-setup.mdx
@@ -3,8 +3,6 @@ title: Account Setup
 description: Set up test accounts and state with litesvm-go
 ---
 
-# Account Setup Example
-
 Demonstrates seeding account state directly with `SetAccount`, without executing
 transactions. This is significantly faster than airdropping + funding through
 the runtime when you need many accounts ready for a test.

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/account-setup.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/account-setup.mdx
@@ -1,0 +1,183 @@
+---
+title: Account Setup
+description: Set up test accounts and state with litesvm-go
+---
+
+# Account Setup Example
+
+Demonstrates seeding account state directly with `SetAccount`, without executing
+transactions. This is significantly faster than airdropping + funding through
+the runtime when you need many accounts ready for a test.
+
+## Basic Account Setup
+
+```go
+package mytest
+
+import (
+    "testing"
+
+    litesvm "github.com/LiteSVM/litesvm-go"
+    solana "github.com/gagliardetto/solana-go"
+)
+
+func TestBasicAccountSetup(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    // Calculate minimum balance for rent exemption.
+    accountData := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
+    minBalance, err := svm.MinimumBalanceForRentExemption(len(accountData))
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("minimum balance for %d bytes: %d lamports", len(accountData), minBalance)
+
+    // Owner program (system program in this trivial example).
+    owner := solana.SystemProgramID
+    testAddr := solana.NewWallet().PublicKey()
+
+    // Build the account handle, then store it.
+    acct, err := litesvm.NewAccount(minBalance, accountData, owner, false, 0)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer acct.Close()
+
+    if err := svm.SetAccount(testAddr, acct); err != nil {
+        t.Fatal(err)
+    }
+    t.Log("account state set successfully")
+
+    // Retrieve the account back.
+    retrieved := svm.GetAccount(testAddr)
+    if retrieved == nil {
+        t.Fatal("expected account to exist")
+    }
+    defer retrieved.Close()
+
+    t.Logf("  address:    %s", testAddr)
+    t.Logf("  lamports:   %d", retrieved.Lamports())
+    t.Logf("  owner:      %s", retrieved.Owner())
+    t.Logf("  executable: %v", retrieved.Executable())
+    t.Logf("  data:       %v", retrieved.Data())
+
+    // Or just read the balance.
+    bal, _, err := svm.Balance(testAddr)
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("balance: %d lamports", bal)
+}
+```
+
+## Setting Up Multiple Accounts
+
+```go
+func TestMultipleAccounts(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    owner := solana.SystemProgramID
+
+    // Set up 5 accounts with different data payloads.
+    addrs := make([]solana.PublicKey, 5)
+    for i := range addrs {
+        addrs[i] = solana.NewWallet().PublicKey()
+
+        data := []byte{byte(i), byte(i + 1), byte(i + 2)}
+        rent, err := svm.MinimumBalanceForRentExemption(len(data))
+        if err != nil {
+            t.Fatal(err)
+        }
+
+        acct, err := litesvm.NewAccount(rent, data, owner, false, 0)
+        if err != nil {
+            t.Fatal(err)
+        }
+        if err := svm.SetAccount(addrs[i], acct); err != nil {
+            acct.Close()
+            t.Fatal(err)
+        }
+        acct.Close()
+
+        t.Logf("account %d: %s", i, addrs[i])
+    }
+
+    // Verify each account.
+    for i, addr := range addrs {
+        a := svm.GetAccount(addr)
+        if a == nil {
+            t.Fatalf("account %d missing", i)
+        }
+        t.Logf("  account %d: %d lamports, data[0]=%d", i, a.Lamports(), a.Data()[0])
+        a.Close()
+    }
+}
+```
+
+## Program Data Account Setup
+
+Set up a program-owned data account by serializing your struct layout into the
+account `data`. This snippet additionally imports `encoding/binary`:
+
+```go
+import "encoding/binary"
+
+func TestProgramDataAccount(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    programID := solana.NewWallet().PublicKey()
+    dataAddr := solana.NewWallet().PublicKey()
+
+    // Example layout: [u8 discriminator, u64 counter, 32-byte owner pubkey]
+    data := make([]byte, 1+8+32)
+    data[0] = 0x01                                      // discriminator
+    binary.LittleEndian.PutUint64(data[1:9], 100)       // counter
+    // copy(data[9:], ownerPubkey[:])                   // owner
+
+    rent, err := svm.MinimumBalanceForRentExemption(len(data))
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    acct, err := litesvm.NewAccount(rent, data, programID, false, 0)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer acct.Close()
+
+    if err := svm.SetAccount(dataAddr, acct); err != nil {
+        t.Fatal(err)
+    }
+
+    t.Logf("program data account set up: %s", dataAddr)
+}
+```
+
+<Callout type="info">
+  `SetAccount` is faster than executing transactions for bulk account setup, and
+  keeps your test code focused on the behavior being tested rather than the
+  plumbing to construct state.
+</Callout>
+
+## Key Points
+
+1. **Direct state** - `SetAccount` writes account state without going through
+   the runtime.
+2. **Rent exemption** - use `MinimumBalanceForRentExemption` to compute lamports
+   before constructing the account.
+3. **Ownership** - `NewAccount` returns a handle you still own. The SVM keeps
+   its own copy after `SetAccount`; close yours when done.
+4. **Verification** - use `GetAccount` to read back into a handle, or `Balance`
+   for a lamports-only check.

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/index.mdx
@@ -1,0 +1,53 @@
+---
+title: Examples
+description: Complete Go examples for LiteSVM
+---
+
+# Go Examples
+
+Complete, runnable examples demonstrating `litesvm-go`. Each example is a
+self-contained Go test you can drop into a package and run with `go test`.
+
+<Cards>
+  <Card
+    title="SOL Transfer"
+    description="Build and send a system-program transfer"
+    href="/docs/go/examples/sol-transfer"
+  />
+  <Card
+    title="Account Setup"
+    description="Seed test accounts and program data state"
+    href="/docs/go/examples/account-setup"
+  />
+  <Card
+    title="Program Testing"
+    description="Load and exercise custom SBF programs"
+    href="/docs/go/examples/program-testing"
+  />
+  <Card
+    title="Time-Based Testing"
+    description="Test time-dependent logic with WarpToSlot / SetClock"
+    href="/docs/go/examples/time-based"
+  />
+</Cards>
+
+## Running Examples
+
+```bash
+# 1) Initialize a Go module (skip if you already have a go.mod)
+go mod init mytest
+
+# 2) Add the dependencies to your Go project
+go get github.com/LiteSVM/litesvm-go
+go get github.com/gagliardetto/solana-go
+
+# 3) Drop an example into a _test.go file and run
+go test ./...
+```
+
+On Alpine / musl, add `-tags musl` to your `go test` invocation so the right
+vendored archive is linked.
+
+For a standalone command-line example (no test runner), see
+[`examples/transfer/main.go`](https://github.com/LiteSVM/litesvm-go/blob/main/examples/transfer/main.go)
+in the `litesvm-go` repo.

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/index.mdx
@@ -3,8 +3,6 @@ title: Examples
 description: Complete Go examples for LiteSVM
 ---
 
-# Go Examples
-
 Complete, runnable examples demonstrating `litesvm-go`. Each example is a
 self-contained Go test you can drop into a package and run with `go test`.
 

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/index.mdx
@@ -12,22 +12,22 @@ self-contained Go test you can drop into a package and run with `go test`.
   <Card
     title="SOL Transfer"
     description="Build and send a system-program transfer"
-    href="/docs/go/examples/sol-transfer"
+    href="/docs/tools/litesvm/go/examples/sol-transfer"
   />
   <Card
     title="Account Setup"
     description="Seed test accounts and program data state"
-    href="/docs/go/examples/account-setup"
+    href="/docs/tools/litesvm/go/examples/account-setup"
   />
   <Card
     title="Program Testing"
     description="Load and exercise custom SBF programs"
-    href="/docs/go/examples/program-testing"
+    href="/docs/tools/litesvm/go/examples/program-testing"
   />
   <Card
     title="Time-Based Testing"
     description="Test time-dependent logic with WarpToSlot / SetClock"
-    href="/docs/go/examples/time-based"
+    href="/docs/tools/litesvm/go/examples/time-based"
   />
 </Cards>
 

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/meta.json
@@ -1,0 +1,10 @@
+{
+  "title": "Examples",
+  "pages": [
+    "index",
+    "sol-transfer",
+    "account-setup",
+    "program-testing",
+    "time-based"
+  ]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/program-testing.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/program-testing.mdx
@@ -3,8 +3,6 @@ title: Program Testing
 description: Load and test custom Solana programs with litesvm-go
 ---
 
-# Program Testing Example
-
 Testing a custom Solana program from Go means loading its compiled `.so` file
 into the SVM, setting up the accounts it expects, and sending instructions
 against it. `litesvm-go` handles all of this in-process - no validator needed.

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/program-testing.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/program-testing.mdx
@@ -1,0 +1,225 @@
+---
+title: Program Testing
+description: Load and test custom Solana programs with litesvm-go
+---
+
+# Program Testing Example
+
+Testing a custom Solana program from Go means loading its compiled `.so` file
+into the SVM, setting up the accounts it expects, and sending instructions
+against it. `litesvm-go` handles all of this in-process - no validator needed.
+
+## Loading a Program
+
+```go
+package mytest
+
+import (
+    "os"
+    "testing"
+
+    litesvm "github.com/LiteSVM/litesvm-go"
+    solana "github.com/gagliardetto/solana-go"
+)
+
+func TestLoadProgram(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    // Configure for program testing. Setters are infallible in practice;
+    // discarding the return keeps the example readable.
+    _ = svm.SetSigverify(false)
+    _ = svm.SetBlockhashCheck(false)
+    _ = svm.SetSysvars()
+    _ = svm.SetBuiltins()
+
+    // Load program from .so file.
+    programID := solana.NewWallet().PublicKey()
+    soPath := "./target/deploy/my_program.so"
+
+    if _, err := os.Stat(soPath); err != nil {
+        t.Skipf("program file not found: %s (build with: cargo build-sbf)", soPath)
+    }
+
+    if err := svm.AddProgramFromFile(programID, soPath); err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("program loaded: %s", programID)
+
+    // Verify the program account.
+    acct := svm.GetAccount(programID)
+    if acct == nil {
+        t.Fatal("program account missing after load")
+    }
+    defer acct.Close()
+
+    t.Logf("  executable: %v", acct.Executable())
+    t.Logf("  data size:  %d bytes", len(acct.Data()))
+}
+```
+
+## Complete Program Test Setup
+
+```go
+package mytest
+
+import (
+    "os"
+    "testing"
+
+    litesvm "github.com/LiteSVM/litesvm-go"
+    solana "github.com/gagliardetto/solana-go"
+)
+
+func TestProgramEndToEnd(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    // Wide-open config: faster tests, less plumbing. Setters are infallible
+    // in practice; discarding the return keeps the example readable.
+    _ = svm.SetSigverify(false)
+    _ = svm.SetBlockhashCheck(false)
+    _ = svm.SetSysvars()
+    _ = svm.SetBuiltins()
+    _ = svm.SetPrecompiles()
+    _ = svm.SetTransactionHistory(100)
+
+    // Load the program.
+    programID := solana.NewWallet().PublicKey()
+    soPath := "./target/deploy/my_program.so"
+    if _, err := os.Stat(soPath); err != nil {
+        t.Skipf("missing %s", soPath)
+    }
+    if err := svm.AddProgramFromFile(programID, soPath); err != nil {
+        t.Fatal(err)
+    }
+
+    // Seed any data accounts the program expects.
+    dataAddr := solana.NewWallet().PublicKey()
+    dataPayload := make([]byte, 100)
+
+    rent, err := svm.MinimumBalanceForRentExemption(len(dataPayload))
+    if err != nil {
+        t.Fatal(err)
+    }
+    acct, err := litesvm.NewAccount(rent, dataPayload, programID, false, 0)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer acct.Close()
+
+    if err := svm.SetAccount(dataAddr, acct); err != nil {
+        t.Fatal(err)
+    }
+
+    // Fund a payer that will sign the test instruction.
+    priv, err := solana.NewRandomPrivateKey()
+    if err != nil {
+        t.Fatal(err)
+    }
+    payer := priv.PublicKey()
+    if err := svm.Airdrop(payer, 1_000_000_000); err != nil {
+        t.Fatal(err)
+    }
+
+    // Build an instruction against the program.
+    bh, err := svm.LatestBlockhash()
+    if err != nil {
+        t.Fatal(err)
+    }
+    ix := &solana.GenericInstruction{
+        ProgID: programID,
+        AccountValues: solana.AccountMetaSlice{
+            {PublicKey: dataAddr, IsWritable: true, IsSigner: false},
+            {PublicKey: payer, IsWritable: true, IsSigner: true},
+        },
+        DataBytes: []byte{0x01 /* discriminator + args */},
+    }
+
+    tx, err := solana.NewTransaction(
+        []solana.Instruction{ix},
+        bh,
+        solana.TransactionPayer(payer),
+    )
+    if err != nil {
+        t.Fatal(err)
+    }
+    if _, err := tx.Sign(func(k solana.PublicKey) *solana.PrivateKey {
+        if k.Equals(payer) {
+            return &priv
+        }
+        return nil
+    }); err != nil {
+        t.Fatal(err)
+    }
+    txBytes, err := tx.MarshalBinary()
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    // Execute and inspect.
+    out, err := svm.SendLegacyTransaction(txBytes)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer out.Close()
+
+    if !out.IsOk() {
+        t.Fatalf("program failed: %s\nlogs: %v", out.Error(), out.Logs())
+    }
+
+    t.Logf("logs: %v", out.Logs())
+    t.Logf("compute: %d CU", out.ComputeUnits())
+
+    // Verify state changes by reading the data account back.
+    updated := svm.GetAccount(dataAddr)
+    if updated == nil {
+        t.Fatal("data account missing after execution")
+    }
+    defer updated.Close()
+    // Decode `updated.Data()` and assert as needed.
+}
+```
+
+## Using Default Programs
+
+For tests that need standard programs (SPL Token, Memo, ...):
+
+```go
+svm, err := litesvm.New()
+if err != nil {
+    t.Fatal(err)
+}
+defer svm.Close()
+
+if err := svm.SetDefaultPrograms(); err != nil { // SPL Token, Memo, etc.
+    t.Fatal(err)
+}
+if err := svm.WithNativeMints(); err != nil {    // wrapped-SOL mint
+    t.Fatal(err)
+}
+```
+
+<Callout type="info">
+  Build your Solana program with `cargo build-sbf` to generate the `.so` file.
+</Callout>
+
+The pattern is always the same:
+
+1. **Configuration** - enable sysvars, builtins, precompiles as needed.
+2. **Program loading** - `AddProgramFromFile` (or `AddProgram` for in-memory
+   bytes).
+3. **Account setup** - pre-populate data accounts with `SetAccount`.
+4. **Sending** - build the instruction with `solana-go`, marshal, submit via
+   `SendLegacyTransaction`.
+5. **Verification** - read accounts back with `GetAccount` and assert on logs,
+   compute units, and post-state.
+
+Once you have this skeleton working, scale up by adding more instructions, more
+accounts, and a helper for the boilerplate.

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/sol-transfer.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/sol-transfer.mdx
@@ -3,8 +3,6 @@ title: SOL Transfer
 description: Build and send a SOL transfer transaction with litesvm-go
 ---
 
-# SOL Transfer Example
-
 The most basic Solana transaction: move SOL from one account to another. This is
 a good first test to verify your `litesvm-go` setup works before testing more
 complex program logic.

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/sol-transfer.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/sol-transfer.mdx
@@ -1,0 +1,124 @@
+---
+title: SOL Transfer
+description: Build and send a SOL transfer transaction with litesvm-go
+---
+
+# SOL Transfer Example
+
+The most basic Solana transaction: move SOL from one account to another. This is
+a good first test to verify your `litesvm-go` setup works before testing more
+complex program logic.
+
+## Full Example
+
+```go
+package mytest
+
+import (
+    "testing"
+
+    litesvm "github.com/LiteSVM/litesvm-go"
+    solana "github.com/gagliardetto/solana-go"
+    "github.com/gagliardetto/solana-go/programs/system"
+)
+
+func TestSolTransfer(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    // Generate payer + recipient.
+    priv, err := solana.NewRandomPrivateKey()
+    if err != nil {
+        t.Fatal(err)
+    }
+    payer := priv.PublicKey()
+    recipient := solana.NewWallet().PublicKey()
+
+    // Airdrop SOL to the payer.
+    if err := svm.Airdrop(payer, 10_000_000_000); err != nil {
+        t.Fatal(err)
+    }
+
+    // Check initial balance.
+    senderInitial, _, err := svm.Balance(payer)
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("sender initial: %.3f SOL", float64(senderInitial)/1e9)
+
+    // Build, sign, and encode the transfer.
+    blockhash, err := svm.LatestBlockhash()
+    if err != nil {
+        t.Fatal(err)
+    }
+    ix := system.NewTransferInstruction(1_000_000_000, payer, recipient).Build()
+    tx, err := solana.NewTransaction(
+        []solana.Instruction{ix},
+        blockhash,
+        solana.TransactionPayer(payer),
+    )
+    if err != nil {
+        t.Fatal(err)
+    }
+    if _, err := tx.Sign(func(k solana.PublicKey) *solana.PrivateKey {
+        if k.Equals(payer) {
+            return &priv
+        }
+        return nil
+    }); err != nil {
+        t.Fatal(err)
+    }
+    txBytes, err := tx.MarshalBinary()
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    // Execute the transfer.
+    out, err := svm.SendLegacyTransaction(txBytes)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer out.Close()
+
+    if !out.IsOk() {
+        t.Fatalf("tx failed: %s\nlogs: %v", out.Error(), out.Logs())
+    }
+
+    // Check final balances.
+    senderFinal, _, err := svm.Balance(payer)
+    if err != nil {
+        t.Fatal(err)
+    }
+    recipientFinal, _, err := svm.Balance(recipient)
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("sender final:    %.6f SOL", float64(senderFinal)/1e9)
+    t.Logf("recipient final: %.3f SOL", float64(recipientFinal)/1e9)
+    t.Logf("compute units:   %d", out.ComputeUnits())
+    t.Logf("fee:             %d lamports", out.Fee())
+}
+```
+
+## Expected Output
+
+```
+sender initial: 10.000 SOL
+sender final:    8.999995 SOL
+recipient final: 1.000 SOL
+compute units:   150
+fee:             5000 lamports
+```
+
+<Callout type="info">
+  The sender's final balance is slightly less than 9 SOL due to transaction fees
+  (5,000 lamports per signature).
+</Callout>
+
+This covers the simplest transaction type. For testing with custom programs, see
+[Program Testing](/docs/tools/litesvm/go/examples/program-testing). For
+time-dependent logic, see
+[Time-Based Testing](/docs/tools/litesvm/go/examples/time-based).

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/time-based.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/time-based.mdx
@@ -3,8 +3,6 @@ title: Time-Based Testing
 description: Test time-dependent logic with litesvm-go clock manipulation
 ---
 
-# Time-Based Testing Example
-
 Demonstrates using `WarpToSlot` and `SetClock` to test time-dependent program
 logic.
 

--- a/apps/docs/content/docs/en/tools/litesvm/go/examples/time-based.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/examples/time-based.mdx
@@ -1,0 +1,259 @@
+---
+title: Time-Based Testing
+description: Test time-dependent logic with litesvm-go clock manipulation
+---
+
+# Time-Based Testing Example
+
+Demonstrates using `WarpToSlot` and `SetClock` to test time-dependent program
+logic.
+
+## Basic Clock Manipulation
+
+```go
+package mytest
+
+import (
+    "testing"
+
+    litesvm "github.com/LiteSVM/litesvm-go"
+)
+
+func TestClockWarp(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    // Read the initial clock.
+    initial, err := svm.Clock()
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("initial state:")
+    t.Logf("  slot:           %d", initial.Slot)
+    t.Logf("  epoch:          %d", initial.Epoch)
+    t.Logf("  unix timestamp: %d", initial.UnixTimestamp)
+
+    // Warp to slot 1_000.
+    if err := svm.WarpToSlot(1_000); err != nil {
+        t.Fatal(err)
+    }
+
+    after, err := svm.Clock()
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("after warpToSlot(1000):")
+    t.Logf("  slot:  %d", after.Slot)
+    t.Logf("  epoch: %d", after.Epoch)
+
+    // Warp further.
+    if err := svm.WarpToSlot(100_000); err != nil {
+        t.Fatal(err)
+    }
+
+    after2, err := svm.Clock()
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("after warpToSlot(100000):")
+    t.Logf("  slot:  %d", after2.Slot)
+    t.Logf("  epoch: %d", after2.Epoch)
+}
+```
+
+## Testing Time-Locked Logic
+
+```go
+package mytest
+
+import (
+    "encoding/binary"
+    "testing"
+
+    litesvm "github.com/LiteSVM/litesvm-go"
+    solana "github.com/gagliardetto/solana-go"
+)
+
+func TestTimeLockedVault(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    // Setters are infallible in practice; discarding the return keeps the
+    // example readable.
+    _ = svm.SetSigverify(false)
+    _ = svm.SetBlockhashCheck(false)
+    _ = svm.SetSysvars()
+
+    // Fund a payer.
+    priv, err := solana.NewRandomPrivateKey()
+    if err != nil {
+        t.Fatal(err)
+    }
+    payer := priv.PublicKey()
+    if err := svm.Airdrop(payer, 10_000_000_000); err != nil {
+        t.Fatal(err)
+    }
+
+    // Set up a time-locked vault account.
+    // Layout: [u8 discriminator, u64 unlock_slot, u64 amount]
+    const unlockSlot = uint64(10_000)
+    const lockedAmount = uint64(5_000_000_000)
+
+    vaultData := make([]byte, 1+8+8)
+    vaultData[0] = 0x01
+    binary.LittleEndian.PutUint64(vaultData[1:9], unlockSlot)
+    binary.LittleEndian.PutUint64(vaultData[9:17], lockedAmount)
+
+    programID := solana.NewWallet().PublicKey()
+    vaultAddr := solana.NewWallet().PublicKey()
+    minBalance, err := svm.MinimumBalanceForRentExemption(len(vaultData))
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    acct, err := litesvm.NewAccount(minBalance+lockedAmount, vaultData, programID, false, 0)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer acct.Close()
+
+    if err := svm.SetAccount(vaultAddr, acct); err != nil {
+        t.Fatal(err)
+    }
+
+    t.Logf("vault created: unlock slot=%d, locked=%.3f SOL",
+        unlockSlot, float64(lockedAmount)/1e9)
+
+    // --- Test 1: Before unlock ---
+    cBefore, err := svm.Clock()
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("current slot: %d", cBefore.Slot)
+    // In a real test you would build a withdraw instruction here and assert
+    // it fails because the current slot < unlock_slot.
+    t.Log("withdrawal attempt: EXPECTED TO FAIL (too early)")
+
+    // --- Test 2: After unlock ---
+    if err := svm.WarpToSlot(unlockSlot + 100); err != nil {
+        t.Fatal(err)
+    }
+
+    cAfter, err := svm.Clock()
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("current slot: %d", cAfter.Slot)
+    // Build and submit the withdraw instruction; assert it succeeds.
+    t.Log("withdrawal attempt: EXPECTED TO SUCCEED (after unlock)")
+
+    // Verify vault state.
+    updated := svm.GetAccount(vaultAddr)
+    if updated == nil {
+        t.Fatal("vault missing")
+    }
+    defer updated.Close()
+    t.Logf("vault balance: %d lamports", updated.Lamports())
+
+    _ = payer // payer would be referenced when building the withdraw ix
+}
+```
+
+## Reading the Epoch Schedule
+
+```go
+func TestReadEpochSchedule(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    es, err := svm.EpochSchedule()
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("slots per epoch:    %d", es.SlotsPerEpoch)
+    t.Logf("first normal epoch: %d", es.FirstNormalEpoch)
+    t.Logf("first normal slot:  %d", es.FirstNormalSlot)
+}
+```
+
+<Callout type="warn">
+  `WarpToSlot` advances the clock's `Slot` field but does **not** automatically
+  update `Epoch` or `UnixTimestamp`. Use `SetClock` for full control over clock
+  fields.
+</Callout>
+
+## Manual Clock Manipulation
+
+When your program reads `Epoch` or `UnixTimestamp` from the Clock sysvar, set
+those fields directly with `SetClock`:
+
+```go
+func TestSetClock(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    c, err := svm.Clock()
+    if err != nil {
+        t.Fatal(err)
+    }
+    c.Slot = 50_000
+    c.Epoch = 5
+    c.UnixTimestamp = 1_700_000_000
+    if err := svm.SetClock(c); err != nil {
+        t.Fatal(err)
+    }
+
+    after, err := svm.Clock()
+    if err != nil {
+        t.Fatal(err)
+    }
+    t.Logf("slot:  %d", after.Slot)           // 50000
+    t.Logf("epoch: %d", after.Epoch)          // 5
+    t.Logf("unix:  %d", after.UnixTimestamp)  // 1700000000
+}
+```
+
+This mirrors the Rust `set_sysvar(&clock)` pattern. Use `WarpToSlot` for simple
+slot advancement, `SetClock` when you need epoch or timestamp control.
+
+## Use Cases
+
+Time manipulation is useful for testing:
+
+| Scenario                | Approach                             |
+| ----------------------- | ------------------------------------ |
+| Token vesting           | Warp past vesting cliff / milestones |
+| Auction endings         | Warp past auction end slot           |
+| Staking rewards         | Use `SetClock` to set epoch          |
+| Time-locked withdrawals | Warp past unlock slot                |
+| Rate limiting           | Warp between allowed intervals       |
+| Expiring orders         | Warp past order expiration           |
+
+<Callout type="info">
+  `WarpToSlot` only changes the slot. The unix timestamp may not update
+  proportionally - use `SetClock` if your program reads `UnixTimestamp`.
+</Callout>
+
+## Key Points
+
+1. **Default sysvars are on** - `litesvm.New()` returns a handle with sysvars
+   initialized; call `SetSysvars()` to reset to defaults if you have mutated
+   them.
+2. **Warp forward** - `WarpToSlot(slot)` advances the slot field only.
+3. **Full control** - `SetClock(Clock{...})` lets you set `Epoch`,
+   `UnixTimestamp`, and the other fields.
+4. **Read** - `svm.Clock()` reads the current values.
+5. **Test pattern** - test before and after the time boundary; expect failure on
+   one side and success on the other.

--- a/apps/docs/content/docs/en/tools/litesvm/go/getting-started.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/getting-started.mdx
@@ -1,0 +1,314 @@
+---
+title: Getting Started
+description:
+  Use LiteSVM from Go with litesvm-go for fast, in-process Solana testing
+---
+
+# LiteSVM for Go
+
+Solana test suites that spin up `solana-test-validator` take seconds per test -
+you are waiting on process startup, RPC connections, and network round-trips.
+LiteSVM runs the same tests in milliseconds. No external process, no network,
+everything in-memory inside your test runner.
+
+`litesvm-go` is the official Go binding. Core types (`PublicKey`, `Hash`,
+`Signature`) come straight from
+[`gagliardetto/solana-go`](https://github.com/gagliardetto/solana-go), so values
+flow naturally between `litesvm-go` and the rest of the Go Solana ecosystem.
+
+<Callout type="info">
+  **Requirements:** Go 1.24+. No Rust toolchain needed - prebuilt static
+  archives are vendored in the module and selected automatically by `GOOS` /
+  `GOARCH`. Supported platforms: macOS (amd64, arm64), Linux (amd64, arm64;
+  glibc or musl), Windows (amd64).
+</Callout>
+
+A fresh `LiteSVM` handle exposes airdrops, transactions (legacy + v0),
+simulation, account read/write, sysvars, compute budget, feature gates, time
+travel, custom programs, and transaction history - all backed by the same Rust
+core that powers the Rust and TypeScript SDKs.
+
+## Quick Start
+
+<Steps>
+
+<Step>
+### Install the module
+
+`go get` resolves dependencies into a Go module, so initialize one first if you
+do not already have a `go.mod`:
+
+```bash
+go mod init mytest
+```
+
+Then add the module:
+
+```bash
+go get github.com/LiteSVM/litesvm-go
+```
+
+Also pull in `solana-go` for keypair, instruction, and transaction building:
+
+```bash
+go get github.com/gagliardetto/solana-go
+```
+
+<Callout type="warn">
+  **Alpine / musl users:** add `-tags musl` to your `go build` / `go test`
+  invocation so the right vendored archive is linked.
+</Callout>
+
+</Step>
+
+<Step>
+### Create your SVM
+
+```go
+package mytest
+
+import (
+    "testing"
+
+    litesvm "github.com/LiteSVM/litesvm-go"
+    solana "github.com/gagliardetto/solana-go"
+)
+
+func TestSetup(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    // Fund a payer
+    priv, err := solana.NewRandomPrivateKey()
+    if err != nil {
+        t.Fatal(err)
+    }
+    payer := priv.PublicKey()
+
+    if err := svm.Airdrop(payer, 5_000_000_000); err != nil {
+        t.Fatal(err)
+    }
+
+    // Check the balance
+    lamports, ok, err := svm.Balance(payer)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if !ok {
+        t.Fatal("payer account missing")
+    }
+    t.Logf("balance: %d lamports", lamports)
+}
+```
+
+<Callout type="info">
+  `litesvm.New()` returns a `*LiteSVM` and an `error`. Every entry point in
+  `litesvm-go` follows the same `(value, error)` shape; panics on the Rust side
+  are caught and converted to errors. Always `defer svm.Close()` so the
+  underlying Rust handle is released - or rely on the finalizer, though explicit
+  `Close` is preferred for predictable cleanup.
+</Callout>
+
+</Step>
+
+</Steps>
+
+## Understanding the Handle
+
+After `litesvm.New()`, the returned `*LiteSVM` exposes these capability groups:
+
+| Group                | Methods                                                                                                                            |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| Accounts             | `Airdrop`, `Balance`, `GetAccount`, `SetAccount`, `MinimumBalanceForRentExemption`                                                 |
+| Transactions         | `SendLegacyTransaction`, `SendVersionedTransaction`, `SimulateLegacyTransaction`, `SimulateVersionedTransaction`, `GetTransaction` |
+| Blockhash            | `LatestBlockhash`, `ExpireBlockhash`                                                                                               |
+| Programs             | `AddProgram`, `AddProgramFromFile`, `AddProgramWithLoader`                                                                         |
+| Time and sysvars     | `WarpToSlot`, `Clock`, `SetClock`, `Rent`, `SetRent`, `EpochSchedule`, `SetEpochSchedule`, `EpochRewards`, ...                     |
+| Configuration        | `SetSigverify`, `SetBlockhashCheck`, `SetTransactionHistory`, `SetLogBytesLimit`, `SetSysvars`, `SetBuiltins`, ...                 |
+| Compute and features | `ComputeBudget`, `SetComputeBudget`, `SetFeatureSet`                                                                               |
+
+A fresh `LiteSVM` ships with the core Solana programs (System Program, SPL
+Token, etc.) preloaded, so simple transfers work out of the box.
+
+## Sending Transactions
+
+Build instructions with `solana-go`, marshal the transaction, and submit the
+bytes. `litesvm-go` accepts the bincode-encoded bytes produced by
+`(*solana.Transaction).MarshalBinary`:
+
+```go
+package mytest
+
+import (
+    "testing"
+
+    litesvm "github.com/LiteSVM/litesvm-go"
+    solana "github.com/gagliardetto/solana-go"
+    "github.com/gagliardetto/solana-go/programs/system"
+)
+
+func TestTransfer(t *testing.T) {
+    svm, err := litesvm.New()
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer svm.Close()
+
+    priv, err := solana.NewRandomPrivateKey()
+    if err != nil {
+        t.Fatal(err)
+    }
+    payer := priv.PublicKey()
+    recipient := solana.NewWallet().PublicKey()
+
+    if err := svm.Airdrop(payer, 2_000_000_000); err != nil {
+        t.Fatal(err)
+    }
+
+    blockhash, err := svm.LatestBlockhash()
+    if err != nil {
+        t.Fatal(err)
+    }
+    ix := system.NewTransferInstruction(1_000_000_000, payer, recipient).Build()
+    tx, err := solana.NewTransaction(
+        []solana.Instruction{ix},
+        blockhash,
+        solana.TransactionPayer(payer),
+    )
+    if err != nil {
+        t.Fatal(err)
+    }
+    if _, err := tx.Sign(func(k solana.PublicKey) *solana.PrivateKey {
+        if k.Equals(payer) {
+            return &priv
+        }
+        return nil
+    }); err != nil {
+        t.Fatal(err)
+    }
+    txBytes, err := tx.MarshalBinary()
+    if err != nil {
+        t.Fatal(err)
+    }
+
+    out, err := svm.SendLegacyTransaction(txBytes)
+    if err != nil {
+        t.Fatal(err)
+    }
+    defer out.Close()
+
+    if !out.IsOk() {
+        t.Fatalf("tx failed: %s\nlogs: %v", out.Error(), out.Logs())
+    }
+
+    lamports, _, err := svm.Balance(recipient)
+    if err != nil {
+        t.Fatal(err)
+    }
+    if lamports != 1_000_000_000 {
+        t.Fatalf("recipient balance = %d, want 1_000_000_000", lamports)
+    }
+}
+```
+
+<Callout type="info">
+  `SendLegacyTransaction` and `SendVersionedTransaction` both return a
+  `*TxOutcome` whether the transaction succeeded or failed. Call `IsOk()` before
+  reading success-only fields, and always `defer out.Close()` to release the
+  Rust handle.
+</Callout>
+
+## Working with TxOutcome
+
+Every send / simulate entry point returns a `*TxOutcome`. The same handle
+carries metadata for success and failure:
+
+```go
+out, err := svm.SendLegacyTransaction(txBytes)
+if err != nil {
+    t.Fatal(err)
+}
+defer out.Close()
+
+if !out.IsOk() {
+    t.Fatalf("error: %s", out.Error())
+}
+
+_ = out.Signature()    // solana.Signature
+_ = out.ComputeUnits() // uint64
+_ = out.Fee()          // uint64
+_ = out.Logs()         // []string
+_ = out.InnerInstructions()
+
+// Programs that call set_return_data expose it here.
+if pid, data, ok := out.ReturnData(); ok {
+    _ = pid
+    _ = data
+}
+```
+
+For `SimulateLegacyTransaction` / `SimulateVersionedTransaction`, the same
+`*TxOutcome` additionally exposes `PostAccounts()` - the would-be post-execution
+account state:
+
+```go
+sim, err := svm.SimulateLegacyTransaction(txBytes)
+if err != nil {
+    t.Fatal(err)
+}
+defer sim.Close()
+
+posts, err := sim.PostAccounts()
+if err != nil {
+    t.Fatal(err)
+}
+for _, p := range posts {
+    _ = p.Address
+    _ = p.Account.Lamports()
+    p.Account.Close()
+}
+```
+
+## Configuration
+
+`litesvm-go` exposes the same builder switches as the Rust crate, surfaced as
+`Set*` methods:
+
+```go
+// Each setter returns an error. In tests where the values are known good,
+// the calls are infallible and assigning to _ keeps the example readable;
+// in production code, check the error or wrap with require.NoError(t, ...).
+_ = svm.SetSigverify(false)        // accept unsigned / badly-signed txs
+_ = svm.SetBlockhashCheck(false)   // skip recent-blockhash enforcement
+_ = svm.SetTransactionHistory(0)   // 0 disables dedup; any N caps history
+_ = svm.SetLogBytesLimit(-1)       // negative = unlimited
+_ = svm.SetLamports(1 << 40)       // default lamports for new accounts
+_ = svm.SetSysvars()               // reset sysvars to defaults
+_ = svm.SetBuiltins()              // reload built-in programs
+_ = svm.SetDefaultPrograms()       // reload SPL Token, Memo, etc.
+_ = svm.SetPrecompiles()           // enable ed25519 / secp256k1 precompiles
+_ = svm.WithNativeMints()          // seed wrapped-SOL mint
+```
+
+## Notes
+
+**Thread safety.** A `*LiteSVM` handle is not safe for concurrent use from
+multiple goroutines (the underlying Rust type is not `Sync`, and most methods
+mutate internal state). Confine a handle to a single goroutine, or guard it with
+a `sync.Mutex`.
+
+**Panic behavior.** Vendored release archives are built with `immediate-abort`:
+any panic inside Rust aborts the host process directly, without unwinding. This
+is a deliberate trade for smaller archives. If you ever hit one in practice,
+please open an issue with a reproducer.
+
+## What's Next
+
+This covers the core handle - creating accounts, sending instructions, and
+reading state. For a full method-by-method reference see the
+[API docs](/docs/tools/litesvm/go/api-reference). For runnable examples (SOL
+transfer, account setup, program testing, time-based logic) see
+[Examples](/docs/tools/litesvm/go/examples).

--- a/apps/docs/content/docs/en/tools/litesvm/go/getting-started.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/go/getting-started.mdx
@@ -4,8 +4,6 @@ description:
   Use LiteSVM from Go with litesvm-go for fast, in-process Solana testing
 ---
 
-# LiteSVM for Go
-
 Solana test suites that spin up `solana-test-validator` take seconds per test -
 you are waiting on process startup, RPC connections, and network round-trips.
 LiteSVM runs the same tests in milliseconds. No external process, no network,

--- a/apps/docs/content/docs/en/tools/litesvm/go/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/go/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "Go",
+  "pages": ["getting-started", "api-reference", "examples"]
+}

--- a/apps/docs/content/docs/en/tools/litesvm/meta.json
+++ b/apps/docs/content/docs/en/tools/litesvm/meta.json
@@ -13,6 +13,10 @@
     "typescript/tokens",
     "typescript/api-reference",
     "typescript/examples",
+    "---Go---",
+    "go/getting-started",
+    "go/api-reference",
+    "go/examples",
     "--- ---",
     "[GitHub](https://github.com/LiteSVM/litesvm)"
   ]

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/account-management.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/account-management.mdx
@@ -3,8 +3,6 @@ title: Account Management
 description: Methods for managing accounts, balances, and rent in TypeScript
 ---
 
-# Account Management
-
 Methods for managing accounts, balances, and setting account state.
 
 ## airdrop

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/configuration.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/configuration.mdx
@@ -3,8 +3,6 @@ title: Configuration
 description: Builder methods for configuring LiteSVM in TypeScript
 ---
 
-# Configuration
-
 LiteSVM uses a builder pattern for configuration. All methods return `LiteSVM`
 for chaining.
 

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/index.mdx
@@ -3,8 +3,6 @@ title: API Reference
 description: Complete TypeScript API reference for LiteSVM
 ---
 
-# TypeScript API Reference
-
 Complete API documentation for using LiteSVM with `@solana/kit` and its plugin
 ecosystem.
 

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/time-and-sysvars.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/time-and-sysvars.mdx
@@ -3,8 +3,6 @@ title: Time & Sysvars
 description: Clock manipulation and sysvar access in TypeScript
 ---
 
-# Time & Sysvars
-
 Methods for manipulating time and accessing system variables.
 
 <Callout type="warn">

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/transactions.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/api-reference/transactions.mdx
@@ -3,8 +3,6 @@ title: Transactions
 description: Execute and simulate transactions with LiteSVM in TypeScript
 ---
 
-# Transactions
-
 Methods for sending, simulating, and managing transactions.
 
 ## sendTransaction

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/account-setup.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/account-setup.mdx
@@ -3,8 +3,6 @@ title: Account Setup
 description: Set up test accounts and state with LiteSVM
 ---
 
-# Account Setup Example
-
 Demonstrates setting up test account state directly without transactions.
 
 ## Basic Account Setup

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/index.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/index.mdx
@@ -3,8 +3,6 @@ title: Examples
 description: Complete TypeScript examples for LiteSVM
 ---
 
-# TypeScript Examples
-
 Complete, runnable examples demonstrating LiteSVM usage with `@solana/kit`.
 
 <Cards>

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/program-testing.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/program-testing.mdx
@@ -3,8 +3,6 @@ title: Program Testing
 description: Load and test custom Solana programs with LiteSVM
 ---
 
-# Program Testing Example
-
 Testing a custom Solana program means loading its compiled `.so` file into the
 SVM, setting up the accounts it expects, and sending instructions against it.
 LiteSVM handles all of this in-process — no validator needed. We recommend

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/sol-transfer.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/sol-transfer.mdx
@@ -3,8 +3,6 @@ title: SOL Transfer
 description: Build and send a SOL transfer transaction with LiteSVM
 ---
 
-# SOL Transfer Example
-
 The most basic Solana transaction: move SOL from one account to another. This is
 a good first test to verify your LiteSVM setup works before testing more complex
 program logic.

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/examples/time-based.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/examples/time-based.mdx
@@ -3,8 +3,6 @@ title: Time-Based Testing
 description: Test time-dependent logic with LiteSVM clock manipulation
 ---
 
-# Time-Based Testing Example
-
 Demonstrates using `warpToSlot` to test time-dependent program logic.
 
 ## Basic Clock Manipulation

--- a/apps/docs/content/docs/en/tools/litesvm/typescript/getting-started.mdx
+++ b/apps/docs/content/docs/en/tools/litesvm/typescript/getting-started.mdx
@@ -3,8 +3,6 @@ title: Getting Started
 description: Use LiteSVM with @solana/kit for fast, in-process Solana testing
 ---
 
-# LiteSVM for TypeScript
-
 Solana test suites that spin up `solana-test-validator` take seconds per test —
 you're waiting on process startup, RPC connections, and network round-trips.
 LiteSVM runs the same tests in milliseconds. No external process, no network,


### PR DESCRIPTION
## Problem

The LiteSVM tool docs cover Rust and TypeScript, but the `litesvm-go` binding had no docs on solana.com — the Go section was recently added (ref: https://github.com/solana-foundation/litesvm-docs/pull/9)

## Summary of changes

Ports the Go docs from `litesvm-docs` into `apps/docs/content/docs/en/tools/litesvm/go/`:

- `getting-started.mdx`
- `api-reference/` — index, account-management, transactions, configuration, time-and-sysvars
- `examples/` — index, sol-transfer, account-setup, program-testing, time-based

Adds a `---Go---` section to the LiteSVM nav (`litesvm/meta.json`).

Migration transforms applied to match existing tool-docs conventions (same as the prior TypeScript port):

- Stripped per-file `fumadocs-ui` component imports (globally registered)
- Normalized `<Callout type="warning">` → `"warn"`
- Rewrote internal links `/docs/go/…` → `/docs/tools/litesvm/go/…`
- Prettier reflow

## Verification

- `fumadocs-mdx` regenerates clean
- `prettier --check` passes
- All 11 new Go pages return HTTP 200 on the local docs server

English-only under `/en/`; other locales are generated by the translation pipeline.

Closes DEV-775