### PR TITLE
feat(breakpoint): update Brave campaign variants

### DIFF
--- a/apps/breakpoint/src/components/sections/HeroSection.tsx
+++ b/apps/breakpoint/src/components/sections/HeroSection.tsx
@@ -9,7 +9,6 @@ import ImageTreatment from "@/components/ImageTreatment";
 import TextScramble from "@/components/TextScramble";
 import WordReveal from "@/components/WordReveal";
 import { publicAssetPath } from "@/config";
-import { GENERAL_ADMISSION_HREF } from "@/content/links";
 import { useVariant } from "@/lib/use-variant";
 
 export default function HeroSection() {
@@ -123,7 +122,7 @@ export default function HeroSection() {
                 label={variant.heroCtaLabel}
                 variant="primary"
                 arrow
-                href={GENERAL_ADMISSION_HREF}
+                href={variant.heroCtaHref}
               />
             ) : (
               <Button

--- a/apps/breakpoint/src/components/sections/TicketsSection.tsx
+++ b/apps/breakpoint/src/components/sections/TicketsSection.tsx
@@ -191,6 +191,11 @@ export default function TicketsSection() {
           <h2 className="type-h3 mx-auto max-w-[24ch] text-white">
             {variant?.ticketsHeadline ?? t("tickets.headline")}
           </h2>
+          {variant?.ticketsStrapline && (
+            <p className="type-p-large mx-auto max-w-[48ch] text-white">
+              {variant.ticketsStrapline}
+            </p>
+          )}
         </div>
 
         <div className="grid grid-cols-1 gap-xs md:grid-cols-bp-desktop md:gap-s">

--- a/apps/breakpoint/src/content/variants.ts
+++ b/apps/breakpoint/src/content/variants.ts
@@ -1,12 +1,13 @@
 /**
  * Audience variants for the Breakpoint home page.
  *
- * Paid campaigns land on `/breakpoint?v=<slug>` and the page swaps its
- * messaging layer (hero, narrative, stats, tickets closing line) to match the
- * ad the visitor clicked. A missing or unknown `v` renders the default page,
- * so a bad link can never 404 or show a broken variant. The swap happens
- * client-side after hydration so the page stays fully static — see
- * `useVariant` in `src/lib/use-variant.ts`.
+ * Paid campaigns land on `/breakpoint` with either a `v` variant or an exact
+ * `utm_content` fallback, and the page swaps its messaging layer (hero,
+ * narrative, stats, tickets closing line) to match the ad the visitor clicked.
+ * A missing or unknown variant renders the default page, so a bad link can
+ * never 404 or show broken variant copy. The swap happens client-side after
+ * hydration so the page stays fully static — see `useVariant` in
+ * `src/lib/use-variant.ts`.
  */
 
 export const VARIANT_PARAM = "v";
@@ -30,19 +31,22 @@ export type VariantConfig = {
   stats: VariantStat[];
   /** Closing conversion line, rendered as the tickets section headline. */
   ticketsHeadline: string;
+  /** Optional supporting copy rendered directly below the tickets headline. */
+  ticketsStrapline?: string;
 };
 
-const developers: VariantConfig = {
+const builders: VariantConfig = {
   slug: "developers",
   heroHeadline: "Building at the\nSpeed of Solana",
-  heroCtaLabel: "Get tickets",
+  heroCtaLabel: "Buy Dev Tickets $250",
   positioningStatement:
     "Firedancer is live. Alpenglow is coming. Meet the engineers shipping the fastest chain in production — and build what comes next.",
   narrativeParagraphs: [
-    "At Breakpoint 2025 in Abu Dhabi, the headline was Firedancer — the promise of a faster, more resilient network that no longer ran on a single piece of software.",
-    "That promise has been kept. Firedancer, which demonstrated over 1 million transactions per second in controlled testing, reached Solana mainnet. The Alpenglow consensus upgrade is bringing finality down from roughly 12.8 seconds toward about 150 milliseconds — close to a 100x improvement.",
-    "These upgrades unlock use cases that weren't possible before: latency-sensitive apps, high-frequency DeFi, payments, real-time games. And the progress is measurable — Solana processed more than 10 billion transactions in the first quarter of 2026 alone.",
-    "At Breakpoint 2026 in London, hear directly from the engineers and founders building all of it — core protocol, infra, payment rails, and the next wave of onchain apps.",
+    "Everything is happening on Solana, and this November, the builders driving that innovation are heading to London for Breakpoint.",
+    "Whether you’re working on an app, protocol, agent, market, or something entirely new, the people you need to meet will be in this room.",
+    "Breakpoint is more than an event, it’s the convergence of the people and technologies creating new possibilities for our future, and this year we’ll have the most robust technical agenda ever. Hacker Houses and Scale or Die kick will set the tone, and even more awaits once the main event kicks off.",
+    "Join us November 15-17 to swap notes, find your next collaborator, and see why Google, Mastercard and Paypal are building here.",
+    "Dev tickets are available now at a special subsidized rate.",
   ],
   stats: [
     { value: "1M", suffix: "+", label: "TPS demonstrated by Firedancer" },
@@ -54,48 +58,43 @@ const developers: VariantConfig = {
     { value: "10B", suffix: "+", label: "Transactions processed in Q1 2026" },
   ],
   ticketsHeadline:
-    "Claim your ticket and help write the next chapter of what's possible onchain.",
+    "Dev tickets are available now at a special subsidized rate.",
 };
 
-const ai: VariantConfig = {
-  slug: "ai",
-  heroHeadline: "Home Base for the\nAgentic Economy",
-  heroCtaLabel: "Get tickets",
-  positioningStatement:
-    "AI agents already make millions of payments on Solana. Meet the people building the infrastructure of the agentic internet.",
+const tech: VariantConfig = {
+  slug: "tech",
+  heroHeadline: "The best tech event\nyou’ll ever experience",
+  heroCtaLabel: "Buy Tickets Today",
+  positioningStatement: "The Everything Chain",
   narrativeParagraphs: [
-    "Autonomous AI agents transact in fractions of a cent — paying for an API call, a data query, a few seconds of compute. Those economics simply don't work on higher-fee chains, which is why Solana has quietly become home base for the agentic economy.",
-    "The network has already processed 15 million payments initiated by agents, and roughly 65% of agentic payments settling through the x402 standard now run on Solana. x402 is an open payment standard stewarded by the Linux Foundation, with backing from Google, Stripe, Visa, and Mastercard. Through gateways like Pay.sh, an agent can fund a wallet in about a minute and pay per request for Google Cloud services like Gemini and Vertex AI alongside 50-plus other APIs — no accounts, no subscriptions.",
-    "At Breakpoint 2026 in London, the people building this stack will be on stage and in the halls — agent frameworks, payment rails, and the companies wiring AI to money. Hear what they shipped, what's next, and where the opportunities are.",
+    "Breakpoint is where the people building the next wave of tech and finance come to meet each other. Whatever you’re working on, the person who can help you take it further will be in this room. Founders looking for a technical co-founder, engineers hunting for their next team, investors writing the checks that turn prototypes into companies, the operators and partners who help you actually ship. Three days, one place, and the shortest path between you and the people who matter for what comes next.",
+    "We’ve carefully designed Breakpoint so the conversations you want are the ones you fall into, whether that’s over coffee between talks, at a Hacker House late into the night, or across the table during VC speed-dating. You leave with more than notes. You leave with relationships, collaborators, and a few introductions that change your trajectory.",
+    "Solana has become the place where AI, fintech, and frontier tech converge, which means the people you’ll meet aren’t just from your corner of the industry. They’re from every corner of what’s coming next. It’s the rare event where the person beside you might be the key to unlocking the future you’ve always wanted to build.",
   ],
   stats: [
+    { value: "1M", suffix: "+", label: "TPS demonstrated by Firedancer" },
     {
-      value: "15M",
-      suffix: "",
-      label: "Payments initiated by AI agents on Solana",
+      value: "150",
+      suffix: "ms",
+      label: "Finality with Alpenglow — close to a 100x improvement",
     },
-    {
-      value: "65",
-      suffix: "%",
-      label: "Of x402 agentic payments settle on Solana",
-    },
-    { value: "50", suffix: "+", label: "APIs payable per-request via Pay.sh" },
+    { value: "10B", suffix: "+", label: "Transactions processed in Q1 2026" },
   ],
-  ticketsHeadline:
-    "Be in the room where AI meets money. Get your Breakpoint 2026 ticket.",
+  ticketsHeadline: "Breakpoint is coming to London on November 15–17.",
+  ticketsStrapline: "Buy your tickets today and use code BRAVE20 to save 20%.",
 };
 
 const finance: VariantConfig = {
   slug: "finance",
   heroHeadline: "Where Global Finance\nComes Onchain",
-  heroCtaLabel: "Get tickets",
+  heroCtaLabel: "Join us in London",
   positioningStatement:
-    "Equities, bonds, and billions in real-world assets now trade on Solana. Meet the institutions and builders making markets onchain.",
+    "Breakpoint is Solana’s flagship yearly event, gathering the leaders, builders, and institutions shaping the future of global capital markets. For the first time, Breakpoint is coming to London, the birthplace of modern finance.",
   narrativeParagraphs: [
-    "At Breakpoint 2025, the conversation about tokenized real-world assets revolved around their promise. The case was simple but powerful: Solana's speed and near-zero transaction costs make it a natural home for global finance.",
-    "Over the next year, that narrative moved from promise to reality. Equities, bonds, precious metals, and private-company stock were tokenized in record numbers — and found real liquidity onchain.",
-    "The value of real-world assets tokenized on Solana climbed past $2 billion in early 2026, up 43% in a single quarter. More wallets hold tokenized RWAs on Solana than on any other blockchain, and tokenized equities like Tesla and NVIDIA trade with instant settlement — Solana has captured roughly 97% of all onchain tokenized-equity spot volume.",
-    "At Breakpoint 2026 in London — a global capital of finance — hear directly from the institutions and founders driving this shift: the progress made, and where the story goes next.",
+    "The internet has rewritten the rules of nearly every industry. Finance, insulated by cheap leverage and financial engineering, has long been the exception. That era is over.",
+    "We’ve entered a new supercycle defined by physical capacity: the energy grids, semiconductors, and datacenters powering the AI revolution have created global demand for capitalization at an unprecedented rate.",
+    "Legacy markets can’t meet that demand, because the real obstacle was never financial, it was technological. Solana is rebuilding the rails of modern finance: an always-on, unified layer for the world’s capital, enabling the seamless issuance and trading of real assets.",
+    "Breakpoint will gather the sharpest minds in finance, technology, and policy in one room to shape the narratives and build the rails for this transformative moment for global capital. You will want to be in that room.",
   ],
   stats: [
     {
@@ -115,43 +114,14 @@ const finance: VariantConfig = {
       label: "Chain by wallets holding tokenized RWAs",
     },
   ],
-  ticketsHeadline:
-    "Buy your ticket and be in the room where the next chapter of onchain finance is written.",
-};
-
-const collectibles: VariantConfig = {
-  slug: "collectibles",
-  heroHeadline: "Every Asset,\nOnchain",
-  heroCtaLabel: "Get tickets",
-  positioningStatement:
-    "From Pokémon cards to dinosaur bones, collectors are trading real-world assets on Solana with instant liquidity and global reach.",
-  narrativeParagraphs: [
-    "From SpaceX stock to Pokémon cards, Solana has emerged as the best network to trade every asset. Global access, instant liquidity, and fast, near-free execution have enabled novel ways to invest, collect, and trade for millions of users.",
-    "The value of real-world assets tokenized on Solana climbed past $2 billion in early 2026, up 43% in a single quarter — and today, more wallets hold tokenized RWAs on Solana than on any other blockchain. Precious metals, luxury goods, sports and gaming collectibles, even dinosaur bones: if it can be collected, it's coming onchain.",
-    "At Breakpoint 2026, the companies and people powering this trend will be in the room. Hear how blockchain is transforming legacy assets — directly from the people driving the transformation.",
-  ],
-  stats: [
-    {
-      value: "$2B",
-      suffix: "+",
-      label: "In real-world assets tokenized on Solana",
-    },
-    { value: "43", suffix: "%", label: "RWA growth in a single quarter" },
-    {
-      value: "#1",
-      suffix: "",
-      label: "Chain by wallets holding tokenized RWAs",
-    },
-  ],
-  ticketsHeadline:
-    "Get your ticket and meet the people bringing every asset onchain.",
+  ticketsHeadline: "You will want to be in that room.",
+  ticketsStrapline: "Use code BRAVE20 to save 20%.",
 };
 
 export const VARIANTS: Record<string, VariantConfig> = {
-  developers,
-  ai,
+  tech,
   finance,
-  collectibles,
+  developers: builders,
 };
 
 export function resolveVariant(

--- a/apps/breakpoint/src/content/variants.ts
+++ b/apps/breakpoint/src/content/variants.ts
@@ -10,6 +10,11 @@
  * `src/lib/use-variant.ts`.
  */
 
+import {
+  DEVELOPER_APPLICATION_HREF,
+  GENERAL_ADMISSION_HREF,
+} from "@/content/links";
+
 export const VARIANT_PARAM = "v";
 export const VARIANT_FALLBACK_PARAM = "utm_content";
 
@@ -24,6 +29,7 @@ export type VariantConfig = {
   /** Hero headline; `\n` forces a line break like the default headline. */
   heroHeadline: string;
   heroCtaLabel: string;
+  heroCtaHref: string;
   /** Ad-continuity positioning statement, rendered as the narrative eyebrow. */
   positioningStatement: string;
   /** Narrative body paragraphs, revealed in order. */
@@ -39,6 +45,7 @@ const builders: VariantConfig = {
   slug: "developers",
   heroHeadline: "Building at the\nSpeed of Solana",
   heroCtaLabel: "Buy Dev Tickets $250",
+  heroCtaHref: DEVELOPER_APPLICATION_HREF,
   positioningStatement:
     "Firedancer is live. Alpenglow is coming. Meet the engineers shipping the fastest chain in production — and build what comes next.",
   narrativeParagraphs: [
@@ -65,6 +72,7 @@ const tech: VariantConfig = {
   slug: "tech",
   heroHeadline: "The best tech event\nyou’ll ever experience",
   heroCtaLabel: "Buy Tickets Today",
+  heroCtaHref: GENERAL_ADMISSION_HREF,
   positioningStatement: "The Everything Chain",
   narrativeParagraphs: [
     "Breakpoint is where the people building the next wave of tech and finance come to meet each other. Whatever you’re working on, the person who can help you take it further will be in this room. Founders looking for a technical co-founder, engineers hunting for their next team, investors writing the checks that turn prototypes into companies, the operators and partners who help you actually ship. Three days, one place, and the shortest path between you and the people who matter for what comes next.",
@@ -88,6 +96,7 @@ const finance: VariantConfig = {
   slug: "finance",
   heroHeadline: "Where Global Finance\nComes Onchain",
   heroCtaLabel: "Join us in London",
+  heroCtaHref: GENERAL_ADMISSION_HREF,
   positioningStatement:
     "Breakpoint is Solana’s flagship yearly event, gathering the leaders, builders, and institutions shaping the future of global capital markets. For the first time, Breakpoint is coming to London, the birthplace of modern finance.",
   narrativeParagraphs: [

--- a/apps/breakpoint/src/tests/variants.test.tsx
+++ b/apps/breakpoint/src/tests/variants.test.tsx
@@ -16,7 +16,7 @@ describe("resolveVariant", () => {
 
   it("is case-insensitive", () => {
     expect(resolveVariant("Developers")?.slug).toBe("developers");
-    expect(resolveVariant("AI")?.slug).toBe("ai");
+    expect(resolveVariant("TECH")?.slug).toBe("tech");
   });
 
   it("falls back to null for missing or unknown values", () => {
@@ -36,13 +36,27 @@ describe("resolveVariant", () => {
 
 describe("resolveVariantFromParams", () => {
   it("prefers ?v= over utm_content", () => {
-    const params = new URLSearchParams("v=ai&utm_content=finance");
-    expect(resolveVariantFromParams(params)?.slug).toBe("ai");
+    const params = new URLSearchParams("v=finance&utm_content=tech");
+    expect(resolveVariantFromParams(params)?.slug).toBe("finance");
   });
 
-  it("falls back to an exact-slug utm_content when v is absent", () => {
+  it("resolves the Tech campaign from its utm_content fallback", () => {
     const params = new URLSearchParams(
-      "utm_source=meta&utm_content=developers",
+      "utm_source=brave&utm_medium=ntt&utm_campaign=bp26&utm_content=tech",
+    );
+    expect(resolveVariantFromParams(params)?.slug).toBe("tech");
+  });
+
+  it("resolves the Finance campaign from its canonical variant", () => {
+    const params = new URLSearchParams(
+      "v=finance&utm_source=brave&utm_medium=ntt&utm_campaign=bp26&utm_content=finance",
+    );
+    expect(resolveVariantFromParams(params)?.slug).toBe("finance");
+  });
+
+  it("resolves the Builders campaign from its developers variant", () => {
+    const params = new URLSearchParams(
+      "v=developers&utm_source=brave&utm_medium=ntt&utm_campaign=bp26&utm_content=builders",
     );
     expect(resolveVariantFromParams(params)?.slug).toBe("developers");
   });
@@ -58,6 +72,16 @@ describe("resolveVariantFromParams", () => {
 });
 
 describe("variant configs", () => {
+  it("shows the BRAVE20 offers as ticket straplines", () => {
+    expect(VARIANTS.tech?.ticketsStrapline).toBe(
+      "Buy your tickets today and use code BRAVE20 to save 20%.",
+    );
+    expect(VARIANTS.finance?.ticketsStrapline).toBe(
+      "Use code BRAVE20 to save 20%.",
+    );
+    expect(VARIANTS.developers?.ticketsStrapline).toBeUndefined();
+  });
+
   it("carry complete copy for every swapped section", () => {
     for (const variant of Object.values(VARIANTS)) {
       expect(variant.heroHeadline).toBeTruthy();
@@ -65,7 +89,7 @@ describe("variant configs", () => {
       expect(variant.positioningStatement).toBeTruthy();
       expect(variant.ticketsHeadline).toBeTruthy();
       expect(variant.narrativeParagraphs.length).toBeGreaterThanOrEqual(3);
-      expect(variant.narrativeParagraphs.length).toBeLessThanOrEqual(4);
+      expect(variant.narrativeParagraphs.length).toBeLessThanOrEqual(5);
       expect(variant.stats.length).toBeGreaterThanOrEqual(3);
       expect(variant.stats.length).toBeLessThanOrEqual(4);
       for (const stat of variant.stats) {

--- a/apps/breakpoint/src/tests/variants.test.tsx
+++ b/apps/breakpoint/src/tests/variants.test.tsx
@@ -5,6 +5,10 @@ import {
   resolveVariantFromParams,
   VARIANTS,
 } from "@/content/variants";
+import {
+  DEVELOPER_APPLICATION_HREF,
+  GENERAL_ADMISSION_HREF,
+} from "@/content/links";
 import { useVariant } from "@/lib/use-variant";
 
 describe("resolveVariant", () => {
@@ -72,6 +76,12 @@ describe("resolveVariantFromParams", () => {
 });
 
 describe("variant configs", () => {
+  it("routes each hero CTA to the ticket flow it advertises", () => {
+    expect(VARIANTS.developers?.heroCtaHref).toBe(DEVELOPER_APPLICATION_HREF);
+    expect(VARIANTS.tech?.heroCtaHref).toBe(GENERAL_ADMISSION_HREF);
+    expect(VARIANTS.finance?.heroCtaHref).toBe(GENERAL_ADMISSION_HREF);
+  });
+
   it("shows the BRAVE20 offers as ticket straplines", () => {
     expect(VARIANTS.tech?.ticketsStrapline).toBe(
       "Buy your tickets today and use code BRAVE20 to save 20%.",
@@ -86,6 +96,7 @@ describe("variant configs", () => {
     for (const variant of Object.values(VARIANTS)) {
       expect(variant.heroHeadline).toBeTruthy();
       expect(variant.heroCtaLabel).toBeTruthy();
+      expect(variant.heroCtaHref).toBeTruthy();
       expect(variant.positioningStatement).toBeTruthy();
       expect(variant.ticketsHeadline).toBeTruthy();
       expect(variant.narrativeParagraphs.length).toBeGreaterThanOrEqual(3);


### PR DESCRIPTION
## Summary

- align Breakpoint campaign variants with the Tech, Finance, and Builders Brave URLs
- update the audience-specific hero, narrative, CTA, and ticket copy
- render optional ticket straplines for the BRAVE20 offers
- cover all three campaign query-string shapes in the variant tests

## Validation

- `pnpm --filter solana-com-breakpoint test`
- `pnpm --filter solana-com-breakpoint check-types`
- `pnpm --filter solana-com-breakpoint lint`