### PR TITLE
content(media) Update p-token -> now live on mainnet

### DIFF
--- a/apps/media/content/upgrades/p-token.mdx
+++ b/apps/media/content/upgrades/p-token.mdx
@@ -9,12 +9,9 @@ publishedAt: 2026-04-01T00:00:00.000Z
 status: published
 author: solana-foundation
 badges:
-  - text: Devnet Live
+  - text: "Mainnet Live"
     color: green
     variant: badge
-  - text: "Target Mainnet: May 2026"
-    color: green
-    variant: text
 metrics:
   - value: 95-98%
     label: Reduction in Compute Units
@@ -28,68 +25,63 @@ tags:
 
 # Optimized Token Program
 
-**April 1, 2026** • Solana Foundation
-
-A major upcoming upgrade to Solana is the optimized token program, also known as
-P-token. This upgrade as outlined in
-[SIMD-0266](https://github.com/solana-foundation/solana-improvement-documents/pull/266)
+A major upgrade to Solana, now live on mainnet, is the optimized token program,
+also known as p-token. This upgrade, as outlined in
+[SIMD-0266](https://github.com/solana-foundation/solana-improvement-documents/pull/266),
 dramatically improves the efficiency of all token usage on the network, leading
 to a ~10% reduction in total block space usage and opening up the potential to
 support more complex transactions on the network.
 
 The current token program's instruction set is fully backwards compatible with
-p-token, meaning current existing applications and wallets will continue to work
-as expected.
+p-token, meaning existing applications and wallets will continue to work as
+expected.
 
-|                                  |           |
-| -------------------------------- | --------- |
-| Expected Mainnet Activation Date | May 2026  |
-| Devnet Activation                | Completed |
-| Breaking Change?                 | No        |
-| Indexing Changes Required?       | Yes       |
+|                            |           |
+| -------------------------- | --------- |
+| Mainnet Activation         | Completed |
+| Devnet Activation          | Completed |
+| Breaking Change?           | No        |
+| Indexing Changes Required? | Yes       |
 
 ## Technical Details
 
 ### Additional Instructions
 
-SPL-Token's instruction set is fully backwards compatible with p-token, meaning
-current existing applications and wallets will continue to work as expected.
-
 There are three new instructions added in p-token:
 
 | Instruction                | Description                                                                                                       |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `withdraw_excess_lamports` | Allow recovering "bricked" SOL from mint (e.g., USDC mint as ~323 SOL in excess) and multisig accounts.           |
+| `withdraw_excess_lamports` | Allow recovering "bricked" SOL from mint (e.g., USDC mint has ~323 SOL in excess) and multisig accounts.          |
 | `batch`                    | Enable efficient CPI interaction with the Token program by batching multiple transfers into a single instruction. |
 | `unwrap_lamports`          | Allow transferring out lamports from native SOL token accounts directly to any destination account.               |
 
 ### Indexing Updates
 
 The new `batch`, `withdraw_excess_lamports`, and `unwrap_lamports` instructions
-add additional indexing requirements for normal token transfers. To support
-these new instructions, you have to update your indexing pipeline to parse the
-new instruction data.
+introduce additional indexing requirements for normal token transfers. To
+support these new instructions, you have to update your indexing pipeline to
+parse the new instruction data.
 
 The new IDL for parsing the data is
-[available in the solan-program repository](https://github.com/solana-program/token/blob/main/program/idl.json).
+[available in the solana-program repository](https://github.com/solana-program/token/blob/main/program/idl.json).
 If you're using an indexer like
-[Carbon](https://github.com/sevenlabs-hq/carbon), you will be able to update
-your indexer with the new IDL. If you use the Solana SDKs for indexing, you will
-either need to update your SDK to use `@solana-program/token@0.13` or
+[Carbon](https://github.com/sevenlabs-hq/carbon), you can update your indexer
+with the new IDL. If you use the Solana SDKs for indexing, you will need to
+update your SDK to either `@solana-program/token@0.13` or
 `spl-token-client@0.19.0`.
 
 ### Token Compute Cost Comparison (P-Token vs. SPL Token)
 
 The main impact is freeing up block CUs, allowing more transactions to be packed
-in a block; application developers benefit since interacting with the Token
-program will consume significantly less CUs.
+in a block; application developers benefit since interacting with the token
+program will consume significantly fewer CUs.
 
-Below is a sample of the CUs efficiency gained by `p-token` compared to the
+Below is a sample of the CU efficiency gained by p-Token compared to the
 current SPL Token program, including the percentage of CUs used in relation to
 the current SPL Token consumption — the lower the percentage, the better the
-gains in CUs consumption.
+gains in CU consumption.
 
-| **Instruction**            | **spl token** | **p-token** | **% of spl-token** |
+| **Instruction**            | **SPL Token** | **P-Token** | **% of SPL Token** |
 | -------------------------- | ------------- | ----------- | ------------------ |
 | `Approve`                  | 2904          | 124         | 4.2%               |
 | `ApproveChecked`           | 4458          | 164         | 3.6%               |
@@ -120,7 +112,7 @@ gains in CUs consumption.
 
 P-Token represents one of the most significant efficiency improvements in
 Solana's history. By optimizing the network's most frequently used program,
-P-Token frees up substantial resources for other applications while reducing
+p-token frees up substantial resources for other applications while reducing
 costs for users.
 
 This upgrade demonstrates Solana's commitment to continuous improvement and sets


### PR DESCRIPTION
### Problem
P-token /upgrades page is outdated. P-token is now live on mainnet.

### Summary of Changes

Updates the page to be accurate.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
