### PR TITLE
Add WealthVille Skill to community skills

### DIFF
--- a/apps/web/src/data/skills/communitySkills.ts
+++ b/apps/web/src/data/skills/communitySkills.ts
@@ -163,6 +163,14 @@ export const COMMUNITY_SKILLS: CommunitySkill[] = [
     url: "https://github.com/pnp-protocol/solana-skill/tree/54d164c1f1182a0674c9e57b24a82cf18e60e500",
     category: DEFI,
   },
+  {
+    slug: "wealthville-skill",
+    title: "WealthVille Skill",
+    description:
+      "Read-only skill for scoring Solana and EVM liquidity pools with Enter/Hold/Exit verdicts and a public miss-inclusive track record.",
+    url: "https://github.com/amitesh-m/wealthville-integrations/tree/89bc186f2bcd9f2fd2ddf20afd75f358cc1eff38/skills/wealthville",
+    category: DEFI,
+  },
 
   // ── AI Coding Skills – Infrastructure ───────────────────────────────
   {


### PR DESCRIPTION
Adds one entry to `apps/web/src/data/skills/communitySkills.ts` under `DEFI`.

## Required submission metadata

| Field | Value |
| --- | --- |
| Repository | https://github.com/amitesh-m/wealthville-integrations |
| Tag | `v0.3.0` (annotated, created before this PR was opened) |
| Commit SHA | `89bc186f2bcd9f2fd2ddf20afd75f358cc1eff38` |
| Skill path | `skills/wealthville/SKILL.md` |
| Maintainer | @amitesh-m |
| Security contact | amitesh.m@gmail.com |
| License | MIT |

The submitted URL is pinned to the **commit SHA**, matching every existing entry in this file, rather than to the tag name — a SHA cannot be repointed even if a tag were later moved. The tag `v0.3.0` resolves to that same commit, so it satisfies the "published from a tagged release" rule while giving reviewers the stronger immutability guarantee.

Both resolve today:
- https://github.com/amitesh-m/wealthville-integrations/tree/89bc186f2bcd9f2fd2ddf20afd75f358cc1eff38/skills/wealthville
- https://github.com/amitesh-m/wealthville-integrations/tree/v0.3.0/skills/wealthville

## What the skill can execute, install, or configure

**Nothing.** It is documentation for seven public read-only `GET` endpoints.

- No transactions are built, signed, simulated or sent.
- No install step, no `npx ...@latest`, no `curl | sh`, no `git clone`, no package lifecycle scripts. The examples are plain `curl` calls the reviewer can run.
- No mainnet/devnet distinction applies — nothing touches a wallet or an RPC.

## Required secrets

**None.** The API takes no authentication, so the skill has nothing to ask a user for.

An optional free partner key exists purely to raise the rate limit from 60 to 600 requests/minute. It is sent as `x-api-key`, grants no additional data, and the skill states this. It is not required for any documented call.

**Confirmed: the skill never requests a seed phrase or a raw private key.** The only occurrence of that phrase in the file is the sentence stating that it does not.

## What it does

Scores liquidity pools before an LP decision — a 0-100 score plus an ENTER/HOLD/EXIT/REDUCE/AVOID verdict with per-protocol calibrated confidence. Covers ~68,800 Solana pools (Meteora DLMM, Orca Whirlpool, Raydium AMM/CLMM/CPMM) and 575 EVM pools. The closest existing entries are the CoinGecko and Birdeye data skills; the Meteora, Orca and Raydium skills cover *how to LP*, and this covers *whether the pool is worth LPing into*.

Every endpoint cited in the skill returns 200 as of this PR.

## Things a reviewer should weigh against it

Being upfront rather than have you find these:

- The repo is **personally owned, not org-owned**, and your checklist prefers org repos.
- It is **young and has no stars**. It has real history and three published npm packages behind it (`@wealthville/mcp-server` is in the official MCP registry, `@wealthville/plugin-wealthville` is in the ElizaOS registry), but it is not an established repository and I won't pretend otherwise.
- The scoring model behind it has **no third-party audit**.

The skill itself carries these limits in its own text, including that the REDUCE verdict class currently has a 0.00 hit rate on n=16 — published rather than hidden, because a skill that overstates its accuracy is worse than no skill. Happy to move it to `INFRASTRUCTURE` alongside the other data-API skills if you'd prefer that placement.