### PR TITLE
Update 100m cus after activation

### DIFF
--- a/apps/media/content/upgrades/100m-cu-blocks.mdx
+++ b/apps/media/content/upgrades/100m-cu-blocks.mdx
@@ -1,8 +1,8 @@
 ---
 title: 100M CU Blocks
 description: >-
-  Solana is raising its block limit from 60M to 100M compute units via
-  SIMD-0286, a 66% increase in block capacity, activating on mainnet July 29,
+  Solana has raised its block limit from 60M to 100M compute units via
+  SIMD-0286, a 66% increase in block capacity, live on mainnet since July 29,
   2026. The per-account write limit stays at 12M CUs, so the added capacity
   goes to more parallel transactions.
 subtitle: Raising Solana's block limit from 60M to 100M compute units
@@ -10,7 +10,7 @@ publishedAt: 2026-07-27T00:00:00.000Z
 status: published
 author: solana-foundation
 badges:
-  - text: "Mainnet: July 29, 2026"
+  - text: "Mainnet Live"
     color: green
     variant: badge
 metrics:
@@ -28,10 +28,10 @@ tags:
 
 July 2026 • Solana Foundation
 
-Solana is raising the maximum block size from 60M to 100M compute units (CUs),
-a 66% increase in block capacity. The feature is scheduled to activate on
-mainnet on July 29, 2026, and is already live on testnet and devnet. The
-upcoming change is defined in
+Solana has raised the maximum block size from 60M to 100M compute units (CUs),
+a 66% increase in block capacity. The feature activated on mainnet on July 29,
+2026, at the start of epoch 1009, following earlier activations on testnet and
+devnet. The change is defined in
 [SIMD-0286](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0286-raise-block-limits-to-100M.md),
 authored by Jito Labs. Compute units are how Solana measures the work a
 transaction performs, and the block limit caps how much work a leader can pack
@@ -40,42 +40,43 @@ block, which adds headroom for high-volume use cases like trading and payments
 without changing how applications are built.
 
 Current mainnet traffic is largely not constrained by block execution times,
-which is why the network can take a substantial step up in capacity and continue
-to maintain today's 400ms block times. (See
+which is why the network could take a substantial step up in capacity while
+continuing to maintain today's 400ms block times. (See
 [reduced slot times](/upgrades/reduced-slot-times) for another upcoming
 improvement to block times on Solana.)
 
-|                                  |                         |
-| -------------------------------- | ----------------------- |
-| Expected Mainnet Activation Date | July 29, 2026           |
-| Devnet Activation                | Active since epoch 1100 |
-| Breaking Change?                 | No                      |
-| Indexing Changes Required?       | No                      |
+|                            |                            |
+| -------------------------- | -------------------------- |
+| Mainnet Activation         | July 29, 2026 (epoch 1009) |
+| Devnet Activation          | Active since epoch 1100    |
+| Breaking Change?           | No                         |
+| Indexing Changes Required? | No                         |
 
 ## Technical Details
 
 ### What Changes and What Doesn't
 
-Solana enforces several block-level limits. SIMD-0286 raises exactly one of
+Solana enforces several block-level limits. SIMD-0286 raised exactly one of
 them:
 
-| Limit                              | Current | Proposed |
-| ---------------------------------- | ------- | -------- |
-| Max Block Compute Units            | 60M CUs | 100M CUs |
-| Max Writable Account Compute Units | 12M CUs | 12M CUs  |
-| Max Block Accounts Data Size Delta | 100MB   | 100MB    |
+| Limit                              | Previous | New      |
+| ---------------------------------- | -------- | -------- |
+| Max Block Compute Units            | 60M CUs  | 100M CUs |
+| Max Writable Account Compute Units | 12M CUs  | 12M CUs  |
+| Max Block Accounts Data Size Delta | 100MB    | 100MB    |
 
-Only max block compute units, the total CUs a block can contain, increases.
+Only max block compute units, the total CUs a block can contain, increased.
 
 ### Demand for Block Capacity
 
-The 60M CU limit is being tested by real traffic. Since it was enabled on July
-22, 2025, 11.2% of blocks produced have had a CU usage of 56M CUs or more. That
+The 60M CU limit was tested by real traffic. Between its activation on July
+22, 2025 and the 100M increase, 11.2% of blocks produced had a CU usage of 56M
+CUs or more. That
 demand is not spread evenly: it arrives in spikes, typically during volatile
 market moments when traders most want to land their transactions.
 
-Roughly one block in nine has been close to full capacity over the
-past year. Raising the limit to 100M CUs, about a year after the 60M increase,
+Roughly one block in nine was close to full capacity over that
+year. Raising the limit to 100M CUs, about a year after the 60M increase,
 gives Solana the ability to handle those spikes in demand rather than forcing
 transactions to compete for nearly full blocks at exactly the moments
 blockspace matters most.
@@ -103,12 +104,12 @@ to 80M CUs was considered and rejected in favor of the full jump to 100M.
 
 ### Activation Schedule
 
-The change ships behind the feature gate
-`P1BCUMpAC7V2GRBRiJCNUgpMyWZhoqt3LKo712ePqsz`. It is already active on testnet
-(since testnet epoch 983) and devnet (since devnet epoch 1100), and sits second
-in the [pending mainnet activation queue](https://github.com/anza-xyz/agave/wiki/Feature-Gate-Tracker-Schedule#pending-mainnet-beta-activation).
-Mainnet feature gates activate one per epoch, and an epoch lasts roughly two
-days, which puts 100M CU blocks on mainnet on July 29, 2026.
+The change shipped behind the feature gate
+`P1BCUMpAC7V2GRBRiJCNUgpMyWZhoqt3LKo712ePqsz`. It activated first on testnet
+(epoch 983) and devnet (epoch 1100), then reached mainnet through the
+[feature gate activation queue](https://github.com/anza-xyz/agave/wiki/Feature-Gate-Tracker-Schedule),
+which activates one feature per epoch. The 100M CU gate went live at the start
+of mainnet epoch 1009 on July 29, 2026.
 
 ### Network Readiness
 
@@ -117,8 +118,8 @@ so block propagation had to speed up before the limit could rise safely. The
 key enabler is XDP, kernel-bypass networking for validators that is available
 in Agave 4.0.0+ and on by default in Firedancer. More than 70% of mainnet stake
 has enabled XDP. Additionally, XDP will be on by default in Agave 4.2. Core
-engineers have determined that activating the 100M CU feature gate now is safe
-given widespread XDP adoption across the network. See
+engineers determined that activating the 100M CU feature gate was safe given
+widespread XDP adoption across the network. See
 [XDP on Solana](/upgrades/xdp) for more information on XDP and how it relates
 to activating 100M CUs.
 
@@ -126,7 +127,7 @@ to activating 100M CUs.
 
 Bigger blocks take longer to execute. That can slow block replay for validators
 and lengthen catchup times for nodes that fall behind, which is why the limit
-only rises once propagation and execution performance have proven headroom.
+rose only after propagation and execution performance had proven headroom.
 Infrastructure beyond validators — RPC providers, indexers, and exchanges —
 should also verify their systems handle sustained 100M CU blocks, even though
 no data formats change.

--- a/apps/media/content/upgrades/100m-cu-blocks.mdx
+++ b/apps/media/content/upgrades/100m-cu-blocks.mdx
@@ -106,10 +106,8 @@ to 80M CUs was considered and rejected in favor of the full jump to 100M.
 
 The change shipped behind the feature gate
 `P1BCUMpAC7V2GRBRiJCNUgpMyWZhoqt3LKo712ePqsz`. It activated first on testnet
-(epoch 983) and devnet (epoch 1100), then reached mainnet through the
-[feature gate activation queue](https://github.com/anza-xyz/agave/wiki/Feature-Gate-Tracker-Schedule),
-which activates one feature per epoch. The 100M CU gate went live at the start
-of mainnet epoch 1009 on July 29, 2026.
+(epoch 983) and devnet (epoch 1100), then reached at the start
+of epoch 1009 on July 29, 2026.
 
 ### Network Readiness
 

--- a/apps/media/content/upgrades/xdp.mdx
+++ b/apps/media/content/upgrades/xdp.mdx
@@ -68,15 +68,17 @@ performance computing and are already adopting the new feature.
 
 ## Impact on Block Propagation
 
-Testing has shown that XDP is a key enabler for consistently producing 100M
-compute unit blocks. When enough top validators on the network adopt XDP, block
-propagation becomes very fast. The network will easily be able to handle larger
-block sizes.
+Testing showed that XDP is a key enabler for consistently producing 100M
+compute unit blocks. With enough top validators on the network running XDP,
+block propagation is fast enough for the network to easily handle larger block
+sizes.
 
-While XDP is not a protocol change and does not require a network upgrade,
-validator adoption is critical. The 100M CU feature cannot be
-activated until engineers see block propagation improvements in the network
-from widespread XDP adoption.
+While XDP is not a protocol change and did not require a network upgrade,
+validator adoption was critical. Activating the 100M CU feature waited until
+engineers saw block propagation improvements in the network from widespread
+XDP adoption. That milestone has been reached: more than 70% of mainnet stake
+runs XDP, and [100M CU blocks](/upgrades/100m-cu-blocks) went live on mainnet
+on July 29, 2026.
 
 ## Agave: How to Enable XDP
 
@@ -92,7 +94,7 @@ The guide covers:
 - Agave startup flags to enable XDP
 - How to verify XDP is active on your validator
 
-Future releases of Agave will turn XDP on by default.
+XDP will be on by default in Agave 4.2.
 
 ## Firedancer: Enabled by Default
 
@@ -105,25 +107,23 @@ If you are running Firedancer, no action is needed. XDP is already active.
 ## Why This Matters
 
 The Solana protocol is rapidly pushing the boundaries of bandwidth and
-performance. The current Solana block size limit is 60M CUs. At current block
-sizes, the block propagation layer of the protocol is not constrained. The
-Solana protocol is quickly moving to enable 100M CU blocks, a 66% increase in
-block capacity.
+performance. The Solana block size limit is now 100M CUs, a 66% increase over
+the previous 60M CU limit. At the previous block sizes, the block propagation
+layer of the protocol was not constrained.
 
-At 100M CUs, Turbine, the block propagation layer of the protocol, will become
-the network bottleneck. Larger blocks mean more data is being sent to thousands
-of machines every second. The bandwidth usage will require a large speed up in
-networking performance. XDP is the key improvement that will enable Solana to
-easily handle 100M CU blocks. Larger block capacity will enable real world use
-cases like trading and payments.
+At 100M CUs, Turbine, the block propagation layer of the protocol, would have
+become the network bottleneck without faster networking. Larger blocks mean
+more data is being sent to thousands of machines every second. XDP is the key
+improvement that enables Solana to easily handle 100M CU blocks. Larger block
+capacity enables real world use cases like trading and payments.
 
 ---
 
 ## Summary
 
-XDP is a linux kernel networking technology. Solana validator clients will
-leverage XDP to enable much higher performance networking and allow for a 66%
-increase in block capacity.
+XDP is a linux kernel networking technology. Solana validator clients leverage
+XDP to enable much higher performance networking, which allowed for a 66%
+increase in block capacity to 100M CU blocks.
 
 | Client       | XDP Status         | Action Required               |
 | ------------ | ------------------ | ----------------------------- |


### PR DESCRIPTION
### Problem

The 100M CU and XDP articles will be stale after 100M CUs are activated

### Summary of Changes

Update those pages to reflect 100M CU activation


### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
