### PR TITLE
fix(web): route /changelog to the media app

### DIFF
--- a/apps/web/src/__tests__/routes/app-rewrites.test.ts
+++ b/apps/web/src/__tests__/routes/app-rewrites.test.ts
@@ -48,6 +48,10 @@ describe("Cross-app rewrites", () => {
       `${MEDIA_APP_URL}/:locale/changelog/:path*`,
     );
     expectBeforeFileRewrite(
+      "/:locale/changelog",
+      `${MEDIA_APP_URL}/:locale/changelog`,
+    );
+    expectBeforeFileRewrite(
       "/podcasts/:path*",
       `${MEDIA_APP_URL}/podcasts/:path*`,
     );

--- a/apps/web/src/__tests__/routes/middleware-routing.test.ts
+++ b/apps/web/src/__tests__/routes/middleware-routing.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { config, isProxiedPath } from "@@/src/middleware";
+
+describe("Cross-app middleware routing", () => {
+  it("bypasses the main app middleware for media-owned changelog routes", () => {
+    expect(isProxiedPath("/changelog")).toBe(true);
+    expect(isProxiedPath("/changelog/rss.xml")).toBe(true);
+  });
+
+  it("excludes the bare changelog route from the middleware matcher", () => {
+    const appRouteMatcher = new RegExp(`^${config.matcher[2]}$`);
+
+    expect(appRouteMatcher.test("/changelog")).toBe(false);
+    expect(appRouteMatcher.test("/changelog/rss.xml")).toBe(false);
+  });
+});

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -7,14 +7,8 @@ import { getPathnameWithoutLocale } from "@workspace/i18n/pathname";
 // and doesn't need preserveProxiedLocaleCookie since it's the source of truth
 const handleI18nRouting = createMiddleware(routing);
 
-export default async function middleware(req: NextRequest) {
-  const { pathname } = req.nextUrl;
-  const pathSegments = pathname.split("/").filter(Boolean);
-  const normalizedPathname = getPathnameWithoutLocale(pathname);
-
-  // Skip i18n for paths that are proxied to other Vercel apps via rewrites
-  // These paths are handled by their respective app's middleware
-  if (
+export function isProxiedPath(normalizedPathname: string) {
+  return (
     normalizedPathname.startsWith("/accelerate") ||
     normalizedPathname.startsWith("/breakpoint") ||
     normalizedPathname === "/developers" ||
@@ -26,6 +20,7 @@ export default async function middleware(req: NextRequest) {
     normalizedPathname.startsWith("/learn") ||
     (normalizedPathname.startsWith("/news") &&
       !normalizedPathname.startsWith("/newsletter")) ||
+    normalizedPathname.startsWith("/changelog") ||
     normalizedPathname.startsWith("/reports") ||
     normalizedPathname.startsWith("/podcasts") ||
     normalizedPathname === "/upgrade" ||
@@ -33,7 +28,17 @@ export default async function middleware(req: NextRequest) {
     normalizedPathname.startsWith("/media-assets") ||
     normalizedPathname.startsWith("/templates-assets") ||
     normalizedPathname.startsWith("/opengraph")
-  ) {
+  );
+}
+
+export default async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const pathSegments = pathname.split("/").filter(Boolean);
+  const normalizedPathname = getPathnameWithoutLocale(pathname);
+
+  // Skip i18n for paths that are proxied to other Vercel apps via rewrites
+  // These paths are handled by their respective app's middleware
+  if (isProxiedPath(normalizedPathname)) {
     return NextResponse.next();
   }
 
@@ -99,7 +104,7 @@ export const config = {
   matcher: [
     "/SKILL.md",
     "/skill.md",
-    "/((?!api|opengraph|_next|_vercel|accelerate|breakpoint|docs|learn|news(?!letter)|reports|podcasts|upgrade|upgrades|media-assets|templates-assets|.*\\..*).*)",
+    "/((?!api|opengraph|_next|_vercel|accelerate|breakpoint|changelog|docs|learn|news(?!letter)|reports|podcasts|upgrade|upgrades|media-assets|templates-assets|.*\\..*).*)",
   ],
   runtime: "nodejs",
 };


### PR DESCRIPTION
## Summary

- bypass the main web app locale middleware for `/changelog` and its subpaths
- exclude bare changelog URLs from the web middleware matcher so the existing cross-app rewrites can proxy them to `solana-com-media`
- cover bare, localized, and RSS changelog routing with regression tests

## Validation

- `pnpm --filter solana-com check-types`
- `pnpm --filter solana-com test` (23 files, 148 passed, 18 skipped)
- `pnpm --filter solana-com lint` (passes with 6 pre-existing warnings)