### PR TITLE
docs(keychain): add Fordefi signer backend

### DIFF
--- a/apps/docs/content/docs/en/tools/keychain/choosing-a-backend.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/choosing-a-backend.mdx
@@ -34,7 +34,7 @@ flowchart TD
     Start{Signing for your own app,<br/>or provisioning wallets<br/>for end users?}
     Start -->|End users| Managed[Embedded / managed wallets<br/>Privy · Turnkey · CDP<br/>Crossmint · Openfort]
     Start -->|Your own app| Q2{Need multi-party approval,<br/>institutional custody,<br/>or regulatory controls?}
-    Q2 -->|Yes| MPC[MPC / institutional custody<br/>Fireblocks · Dfns · Para · Utila]
+    Q2 -->|Yes| MPC[MPC / institutional custody<br/>Fireblocks · Dfns · Para · Utila · Fordefi]
     Q2 -->|No| Q3{Hold the key yourself,<br/>or let a provider hold it?}
     Q3 -->|Provider holds it| Q4{Which cloud do you<br/>already run on?}
     Q4 -->|AWS| AWS[AWS KMS]
@@ -73,7 +73,8 @@ automation — continue below.
 If signatures must clear an approval policy, spending limit, or compliance
 workflow before they're produced — or you need a regulated custodian holding the
 keys — use an **MPC / institutional custody** backend: Fireblocks, Dfns, Para,
-or Utila. These split or custody the key and co-sign according to your policy.
+Utila, or Fordefi. These split or custody the key and co-sign according to your
+policy.
 
 If you only need a key that signs on request, continue below.
 
@@ -112,7 +113,7 @@ them.
   who can sign. Backends: **AWS KMS**, **GCP KMS**.
 - **MPC & institutional custody** — the key is split or custodied across a
   provider, which co-signs according to your policy (approvals, limits).
-  Backends: **Fireblocks**, **Dfns**, **Para**, **Utila**.
+  Backends: **Fireblocks**, **Dfns**, **Para**, **Utila**, **Fordefi**.
 - **Embedded & managed wallets** — a provider manages wallets on your behalf,
   often to onboard end users. Backends: **Privy**, **Turnkey**, **CDP**,
   **Crossmint**, **Openfort**.
@@ -129,6 +130,7 @@ them.
 | Dfns            | MPC wallet infrastructure    | Programmatic wallets with policy controls  | Ed25519 signing                                      |
 | Para            | MPC wallets                  | Apps that want MPC-backed wallets          | API key + wallet ID                                  |
 | Utila           | MPC custody + co-signer      | Existing Utila-managed Solana wallets      | `signMessage` unsupported; you broadcast the tx      |
+| Fordefi         | MPC / institutional custody  | Institutional custody with policy controls | Native mode auto-broadcasts; black box mode you send |
 | Privy           | Embedded wallets             | Consumer apps onboarding users to wallets  | App-managed embedded wallets                         |
 | Turnkey         | Non-custodial key management | Programmatic, policy-gated signing         | Non-custodial key management                         |
 | CDP             | Managed wallet (Coinbase)    | Apps on the Coinbase Developer Platform    | `signMessage` accepts UTF-8 payloads only            |

--- a/apps/docs/content/docs/en/tools/keychain/getting-started/rust.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/getting-started/rust.mdx
@@ -36,6 +36,7 @@ solana-keychain = { version = "1.2", features = ["all"] }
 | `openfort`   | Openfort embedded wallets       |
 | `para`       | Para MPC wallets                |
 | `utila`      | Utila MPC custody               |
+| `fordefi`    | Fordefi MPC custody             |
 | `all`        | Enable all backends             |
 
 ## Basic Usage
@@ -248,6 +249,41 @@ let signer = Signer::from_para(
     "wallet_id".to_string(), // Para wallet ID
     None,                    // Default API base URL
 ).await?;
+```
+
+### Fordefi
+
+For Fordefi MPC custody signing. API requests are authenticated with an ECDSA
+P-256 request signature parsed from `private_key_pem`; to keep that key in a
+KMS/HSM, implement `FordefiRequestSigner` and use
+`Signer::from_fordefi_with_signer`.
+
+Fordefi has two signing modes. Set `chain` for **native Solana mode**, where
+Fordefi may replace the blockhash or fees and broadcasts the transaction itself.
+Leave `chain` as `None` for **black box mode**, where Fordefi signs raw bytes
+and you broadcast the transaction yourself.
+
+```rust
+use solana_keychain::{
+    Signer, FordefiSignerConfig, SolanaChainUniqueId, FordefiSolanaFee, FordefiPriorityLevel,
+};
+
+let config = FordefiSignerConfig {
+    access_token: "api_token".to_string(),
+    vault_id: "vault_uuid".to_string(),
+    private_key_pem: std::fs::read_to_string("./secret/private.pem")?,
+    public_key: "base58_public_key".to_string(), // Solana vault address
+    chain: Some(SolanaChainUniqueId::SolanaDevnet), // None for black box mode
+    fee: Some(FordefiSolanaFee::Priority {
+        priority_level: FordefiPriorityLevel::Medium,
+    }),
+    api_base_url: None,       // Default: https://api.fordefi.com
+    poll_interval_ms: None,   // Default: 2000
+    max_poll_attempts: None,  // Default: 50
+    http_client_config: None, // Default HTTP timeouts
+};
+
+let signer = Signer::from_fordefi(config)?;
 ```
 
 ## Unified Signer Enum

--- a/apps/docs/content/docs/en/tools/keychain/getting-started/typescript.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/getting-started/typescript.mdx
@@ -26,6 +26,7 @@ pnpm add @solana/keychain-dfns        # Dfns
 pnpm add @solana/keychain-openfort    # Openfort
 pnpm add @solana/keychain-para        # Para
 pnpm add @solana/keychain-utila       # Utila
+pnpm add @solana/keychain-fordefi     # Fordefi
 
 # Kit client plugins (keychainSigner / keychainPayer / keychainIdentity)
 pnpm add @solana/keychain-kit-plugin
@@ -271,6 +272,53 @@ import { createParaSigner } from "@solana/keychain-para";
 const signer = await createParaSigner({
   apiKey: "api_key",
   walletId: "wallet_id"
+});
+```
+
+### Fordefi
+
+Fordefi has two signing modes, selected by whether you pass `chain`. API
+requests are authenticated with an ECDSA P-256 request signature — supply the
+signing key as `privateKeyPem`, or keep it in a KMS/HSM by passing a
+`requestSigner`.
+
+**Native Solana mode** (recommended for on-chain use): set `chain`, and Fordefi
+signs and broadcasts the transaction itself. Because Fordefi may replace the
+blockhash or fees before signing, the signer is a Kit `TransactionSendingSigner`
+— use it with `signAndSendTransactionMessageWithSigners`, not the partial-signer
+flow shown above.
+
+```typescript
+import { createFordefiSigner } from "@solana/keychain-fordefi";
+import { signAndSendTransactionMessageWithSigners } from "@solana/signers";
+import { readFileSync } from "node:fs";
+
+const signer = await createFordefiSigner({
+  accessToken: process.env.FORDEFI_ACCESS_TOKEN!,
+  vaultId: process.env.FORDEFI_VAULT_ID!,
+  publicKey: process.env.FORDEFI_PUBLIC_KEY!, // Solana vault address (base58)
+  privateKeyPem: readFileSync("./secret/private.pem", "utf8"),
+  chain: "solana_devnet", // or "solana_mainnet"
+  fee: { type: "custom", priority_fee: "1000" } // optional
+});
+
+const signature =
+  await signAndSendTransactionMessageWithSigners(transactionMessage);
+```
+
+**Black box mode**: omit `chain`. Fordefi signs raw bytes and does not
+broadcast; you assemble and submit the transaction yourself. Use this with a
+Fordefi black box vault.
+
+```typescript
+import { createFordefiSigner } from "@solana/keychain-fordefi";
+import { readFileSync } from "node:fs";
+
+const signer = await createFordefiSigner({
+  accessToken: process.env.FORDEFI_ACCESS_TOKEN!,
+  vaultId: process.env.FORDEFI_BB_VAULT_ID!,
+  publicKey: process.env.FORDEFI_BB_PUBLIC_KEY!,
+  privateKeyPem: readFileSync("./secret/private.pem", "utf8")
 });
 ```
 

--- a/apps/docs/content/docs/en/tools/keychain/index.mdx
+++ b/apps/docs/content/docs/en/tools/keychain/index.mdx
@@ -21,7 +21,7 @@ services in production — without rewriting your signing code.
 - **Languages**: Rust + TypeScript, at full parity
 - **Trait**: Unified `SolanaSigner` interface
 - **Backends**: Memory, Vault, AWS KMS, GCP KMS, Privy, Turnkey, Fireblocks,
-  CDP, Crossmint, Dfns, Openfort, Para, Utila
+  CDP, Crossmint, Dfns, Openfort, Para, Utila, Fordefi
 - **Compatibility**: `@solana/kit` and `@solana/signers` compatible (TypeScript)
   | `solana-sdk` and `solana-sdk-v3` compatible (Rust)
 
@@ -47,6 +47,7 @@ models and pick the right one.
 | Openfort        | Openfort backend wallets     | ✓    | ✓          |
 | Para            | Para MPC wallets             | ✓    | ✓          |
 | Utila           | Utila MPC custody            | ✓    | ✓          |
+| Fordefi         | Fordefi MPC custody          | ✓    | ✓          |
 
 ## Quick Start
 


### PR DESCRIPTION

## Problem

Keychain gained a **Fordefi** MPC custody signer ([solana-keychain#202](https://github.com/solana-foundation/solana-keychain/pull/202)), but the docs don't mention it.

## Summary of changes

Documents Fordefi across the keychain docs, matching the exact API from the source PR:

- **`getting-started/typescript.mdx`** — adds `@solana/keychain-fordefi` to the install list and a Fordefi config section covering both signing modes (`createFordefiSigner`).
- **`getting-started/rust.mdx`** — adds the `fordefi` feature flag and a `Signer::from_fordefi(FordefiSignerConfig { … })` config section.
- **`choosing-a-backend.mdx`** — adds Fordefi to the decision-flow diagram, the MPC/institutional custody model, and the backend comparison table.
- **`index.mdx`** — adds Fordefi to the backends list and supported-backends table.

### Fordefi's two signing modes (documented in both guides)

- **Native Solana mode** (`chain` set): Fordefi replaces the blockhash/fees and auto-broadcasts (`push_mode: 'auto'`). In TS this is a Kit `TransactionSendingSigner` — used via `signAndSendTransactionMessageWithSigners`, not the partial-signer flow.
- **Black box mode** (`chain` omitted): Fordefi signs raw bytes; the caller assembles and submits the transaction.

## Notes

- Only `/en/` MDX edited; other locales auto-sync.
- Refs DEV-792.