### PR TITLE
fix(breakpoint): apply Brave coupon to variant CTAs

### DIFF
--- a/apps/breakpoint/src/content/variants.ts
+++ b/apps/breakpoint/src/content/variants.ts
@@ -10,13 +10,12 @@
  * `src/lib/use-variant.ts`.
  */
 
-import {
-  DEVELOPER_APPLICATION_HREF,
-  GENERAL_ADMISSION_HREF,
-} from "@/content/links";
+import { DEVELOPER_APPLICATION_HREF } from "@/content/links";
 
 export const VARIANT_PARAM = "v";
 export const VARIANT_FALLBACK_PARAM = "utm_content";
+const BRAVE_GENERAL_ADMISSION_HREF =
+  "https://luma.com/breakpoint2026?coupon=BRAVE20";
 
 export type VariantStat = {
   value: string;
@@ -72,7 +71,7 @@ const tech: VariantConfig = {
   slug: "tech",
   heroHeadline: "The best tech event\nyou’ll ever experience",
   heroCtaLabel: "Buy Tickets Today",
-  heroCtaHref: GENERAL_ADMISSION_HREF,
+  heroCtaHref: BRAVE_GENERAL_ADMISSION_HREF,
   positioningStatement: "The Everything Chain",
   narrativeParagraphs: [
     "Breakpoint is where the people building the next wave of tech and finance come to meet each other. Whatever you’re working on, the person who can help you take it further will be in this room. Founders looking for a technical co-founder, engineers hunting for their next team, investors writing the checks that turn prototypes into companies, the operators and partners who help you actually ship. Three days, one place, and the shortest path between you and the people who matter for what comes next.",
@@ -96,7 +95,7 @@ const finance: VariantConfig = {
   slug: "finance",
   heroHeadline: "Where Global Finance\nComes Onchain",
   heroCtaLabel: "Join us in London",
-  heroCtaHref: GENERAL_ADMISSION_HREF,
+  heroCtaHref: BRAVE_GENERAL_ADMISSION_HREF,
   positioningStatement:
     "Breakpoint is Solana’s flagship yearly event, gathering the leaders, builders, and institutions shaping the future of global capital markets. For the first time, Breakpoint is coming to London, the birthplace of modern finance.",
   narrativeParagraphs: [

--- a/apps/breakpoint/src/tests/variants.test.tsx
+++ b/apps/breakpoint/src/tests/variants.test.tsx
@@ -5,10 +5,7 @@ import {
   resolveVariantFromParams,
   VARIANTS,
 } from "@/content/variants";
-import {
-  DEVELOPER_APPLICATION_HREF,
-  GENERAL_ADMISSION_HREF,
-} from "@/content/links";
+import { DEVELOPER_APPLICATION_HREF } from "@/content/links";
 import { useVariant } from "@/lib/use-variant";
 
 describe("resolveVariant", () => {
@@ -78,8 +75,12 @@ describe("resolveVariantFromParams", () => {
 describe("variant configs", () => {
   it("routes each hero CTA to the ticket flow it advertises", () => {
     expect(VARIANTS.developers?.heroCtaHref).toBe(DEVELOPER_APPLICATION_HREF);
-    expect(VARIANTS.tech?.heroCtaHref).toBe(GENERAL_ADMISSION_HREF);
-    expect(VARIANTS.finance?.heroCtaHref).toBe(GENERAL_ADMISSION_HREF);
+    expect(VARIANTS.tech?.heroCtaHref).toBe(
+      "https://luma.com/breakpoint2026?coupon=BRAVE20",
+    );
+    expect(VARIANTS.finance?.heroCtaHref).toBe(
+      "https://luma.com/breakpoint2026?coupon=BRAVE20",
+    );
   });
 
   it("shows the BRAVE20 offers as ticket straplines", () => {


### PR DESCRIPTION
### Problem

The Breakpoint Tech and Finance variants advertise the Brave BRAVE20 discount, but their CTA links open the standard Luma registration URL without applying the coupon.

### Summary of Changes

- point the Tech and Finance variant CTAs to `https://luma.com/breakpoint2026?coupon=BRAVE20`
- keep the Developers variant on its dedicated developer application flow
- update variant configuration tests to guard the campaign coupon links

No security-relevant behavior or dependencies changed.

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials added.
- [x] No user-input or HTML-rendering behavior changed.
- [x] No dependencies changed.
- [x] No new error paths introduced.
- [ ] Critical-change threat model and second reviewer — not applicable.

New dependencies: none.

Threat-model note: n/a.

### Validation

- `pnpm --filter solana-com-breakpoint test` (24 tests passed)
- `pnpm --filter solana-com-breakpoint check-types`
- `pnpm --filter solana-com-breakpoint lint`
- `git diff --check`