### PR TITLE
Add Tx Senders tab to Solana Data

### DIFF
--- a/apps/web/src/__tests__/components/data/solana-data-dashboard.test.ts
+++ b/apps/web/src/__tests__/components/data/solana-data-dashboard.test.ts
@@ -10,6 +10,7 @@ import {
   getKpiValue,
   getMedian,
   getSelectedProviderList,
+  getSenderEconomicsItems,
   parseProviders,
   updateProvidersParam,
 } from "@/app/[locale]/data/solana-data-dashboard";
@@ -168,6 +169,66 @@ describe("available providers", () => {
       "DeFiLlama",
       "Dune",
     ]);
+  });
+});
+
+describe("transaction sender economics", () => {
+  const date = "2026-07-29T00:00:00.000Z";
+  const rows: MetricRow[] = [
+    {
+      date,
+      metricName: "Sender Total Transactions",
+      providerName: "jito",
+      unit: "Count",
+      value: 204_212,
+    },
+    {
+      date,
+      metricName: "Sender Total Tips",
+      providerName: "jito",
+      unit: "SOL",
+      value: 38.3,
+    },
+    {
+      date,
+      metricName: "Sender Total Fees",
+      providerName: "jito",
+      unit: "SOL",
+      value: 5.6,
+    },
+    {
+      date,
+      metricName: "Sender Median Tip",
+      providerName: "jito",
+      unit: "Lamports",
+      value: 4_000,
+    },
+    {
+      date,
+      metricName: "Sender Median Fee",
+      providerName: "jito",
+      unit: "Lamports",
+      value: 5_000,
+    },
+  ];
+
+  it("normalizes provider labels and returns complete economics rows", () => {
+    expect(
+      getSenderEconomicsItems(rows, new Set<ProviderName>(["Jito"])),
+    ).toEqual([
+      {
+        medianFeeLamports: 5_000,
+        medianTipLamports: 4_000,
+        provider: "Jito",
+        totalFeesSol: 5.6,
+        totalTipsSol: 38.3,
+        transactions: 204_212,
+      },
+    ]);
+  });
+
+  it("honors the provider selection", () => {
+    expect(getSenderEconomicsItems(rows, new Set<ProviderName>())).toEqual([]);
   });
 });
 

--- a/apps/web/src/__tests__/components/data/time-series-chart.test.ts
+++ b/apps/web/src/__tests__/components/data/time-series-chart.test.ts
@@ -4,6 +4,8 @@ import {
   compareTooltipValues,
   formatValue,
   getAxisValueFormatter,
+  getLogTickValues,
+  getLogValueDomain,
   getSeriesDashPatterns,
   getValueDomain,
   getYAxisTickValues,
@@ -149,5 +151,20 @@ describe("percent y-axis domain", () => {
     );
 
     expect(ticks).toEqual([99, 100]);
+  });
+});
+
+describe("log y-axis domain", () => {
+  it("uses enclosing powers of ten for positive values", () => {
+    expect(getLogValueDomain(makeSeries("a", [23, 9_850]).points)).toEqual([
+      10, 10_000,
+    ]);
+  });
+
+  it("ignores non-positive values and returns major power-of-ten ticks", () => {
+    const domain = getLogValueDomain(makeSeries("a", [-1, 0, 12]).points);
+
+    expect(domain).toEqual([10, 100]);
+    expect(getLogTickValues(domain)).toEqual([10, 100]);
   });
 });

--- a/apps/web/src/__tests__/lib/rpc/sender-server.test.ts
+++ b/apps/web/src/__tests__/lib/rpc/sender-server.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getRpcSenderCacheKey,
+  getRpcSenderMetricRows,
+  parseRpcSenderQueryOptions,
+} from "@/lib/rpc/sender-server";
+
+describe("RPC Sender query options", () => {
+  it("uses the shared RPC timeframe parser and defaults", () => {
+    expect(parseRpcSenderQueryOptions(new URLSearchParams()).timeframe).toBe(
+      "6h",
+    );
+    expect(
+      parseRpcSenderQueryOptions(new URLSearchParams("timeframe=30m"))
+        .timeframe,
+    ).toBe("30m");
+    expect(
+      parseRpcSenderQueryOptions(new URLSearchParams("timeframe=unknown"))
+        .timeframe,
+    ).toBe("6h");
+  });
+
+  it("keeps each timeframe in a distinct cache entry", () => {
+    expect(getRpcSenderCacheKey({ timeframe: "30m" })).not.toBe(
+      getRpcSenderCacheKey({ timeframe: "1y" }),
+    );
+    expect(getRpcSenderCacheKey({ timeframe: "30m" })).toContain(
+      "|30m|1800|60",
+    );
+  });
+});
+
+describe("RPC Sender Grafana panels", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("maps the economics and time-series panels into dashboard rows", async () => {
+    const now = 1_800_000_000_000;
+    const fetchMock = vi.fn().mockImplementation(async (input: string) => {
+      const panelId = new URL(input).pathname.split("/").at(-2);
+
+      return new Response(
+        JSON.stringify(
+          panelId === "1"
+            ? panelResponse(
+                [
+                  "provider",
+                  "Transactions",
+                  "Total tips (SOL)",
+                  "Total fees (SOL)",
+                  "Median tip (lamports)",
+                  "Median fee (lamports)",
+                ],
+                [
+                  ["jito", "helius"],
+                  [204_212, 19_336],
+                  [38.3, 9.38],
+                  [5.6, 10.3],
+                  [4_000, 5_000],
+                  [5_000, 13_028],
+                ],
+              )
+            : panelResponse(
+                ["time", "provider", "txs"],
+                [
+                  [now - 60_000, now - 60_000, now],
+                  ["jito", "helius", "jito"],
+                  [7_000, 500, 7_100],
+                ],
+              ),
+        ),
+        { status: 200 },
+      );
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(now);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getRpcSenderMetricRows({ timeframe: "30m" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    for (const [, init] of fetchMock.mock.calls) {
+      const request = JSON.parse(String(init?.body));
+
+      expect(request).toEqual({
+        intervalMs: 60_000,
+        maxDataPoints: 30,
+        timeRange: {
+          from: String(now - 30 * 60 * 1000),
+          timezone: "browser",
+          to: String(now),
+        },
+      });
+    }
+
+    expect(result).toMatchObject({
+      generatedAt: new Date(now).toISOString(),
+      truncated: false,
+    });
+    expect(result.rows).toHaveLength(13);
+    expect(result.rows).toContainEqual({
+      date: new Date(now).toISOString(),
+      metricName: "Sender Total Tips",
+      providerName: "jito",
+      unit: "SOL",
+      value: 38.3,
+    });
+    expect(result.rows).toContainEqual({
+      date: new Date(now - 60_000).toISOString(),
+      metricName: "Sender Transactions",
+      providerName: "helius",
+      unit: "Count",
+      value: 500,
+    });
+  });
+
+  it("rejects a panel response when a required field disappears", async () => {
+    const fetchMock = vi.fn().mockImplementation(
+      async () =>
+        new Response(JSON.stringify(panelResponse(["provider"], [["jito"]])), {
+          status: 200,
+        }),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(getRpcSenderMetricRows({ timeframe: "30m" })).rejects.toThrow(
+      "missing-field:Transactions",
+    );
+  });
+});
+
+function panelResponse(fieldNames: string[], values: unknown[][]) {
+  return {
+    results: {
+      A: {
+        frames: [
+          {
+            data: { values },
+            schema: {
+              fields: fieldNames.map((name) => ({ name })),
+            },
+          },
+        ],
+        status: 200,
+      },
+    },
+  };
+}

--- a/apps/web/src/app/[locale]/data/data-config.ts
+++ b/apps/web/src/app/[locale]/data/data-config.ts
@@ -332,11 +332,13 @@ export type DashboardTab =
   | "overview"
   | "network"
   | "defi"
-  | "rpc";
+  | "rpc"
+  | "senders";
 export type Aggregation = "avg" | "sum";
 export type SeriesField = "provider" | "metric";
 export type TimeGranularity = "day" | "hour";
 export type ChartVisualization = "line" | "bar";
+export type ChartScale = "linear" | "log";
 
 export type MethodologyComment = {
   provider: ProviderName;
@@ -351,8 +353,10 @@ export type ChartDefinition = {
   metrics: readonly string[];
   aggregation: Aggregation;
   seriesField: SeriesField;
+  fullWidth?: boolean;
   lowerIsBetter?: boolean;
   methodology?: readonly MethodologyComment[];
+  scale?: ChartScale;
   timeGranularity?: TimeGranularity;
   visualization?: ChartVisualization;
 };
@@ -467,28 +471,42 @@ export type DataApiResponse = {
 };
 
 export const providerColors: Record<string, string> = {
+  "0Slot": "#22C55E",
   Allium: "#DFA3DA",
   Alchemy: "#2196F3",
+  Astralane: "#EAB308",
   Artemis: "#14F195",
+  BlockRazor: "#FACC15",
   Blockworks: "#E32EE9",
+  bloXroute: "#86EFAC",
   DeFiLlama: "#3B8CFF",
   Dune: "#F75F47",
   Helius: "#E84125",
+  Jito: "#A78BFA",
   QuickNode: "#6CFF75",
   RWA: "#A1B9E3",
   Stakewiz: "#f6b486",
+  Stellium: "#FB7185",
+  Temporal: "#FB923C",
   "Token Terminal": "#45A88E",
   Triton: "#A12CFF",
   "Validators App": "#38BDF8",
 };
 
 const providerAliases: Record<string, ProviderName> = {
+  "0slot": "0Slot",
   alchemy: "Alchemy",
+  astralane: "Astralane",
+  blockrazor: "BlockRazor",
+  bloxroute: "bloXroute",
   DefiLama: "DeFiLlama",
   DefiLlama: "DeFiLlama",
   helius: "Helius",
+  jito: "Jito",
   Quicknode: "QuickNode",
   quicknode: "QuickNode",
+  stellium: "Stellium",
+  temporal: "Temporal",
   triton: "Triton",
 };
 
@@ -979,7 +997,60 @@ export const chartDefinitions = [
       },
     ],
   },
+  {
+    id: "sender-transactions-over-time",
+    tab: "senders",
+    title: "Tipping transactions over time by provider",
+    valueLabel: "Count",
+    metrics: ["Sender Transactions"],
+    aggregation: "sum",
+    seriesField: "provider",
+    fullWidth: true,
+    scale: "log",
+    timeGranularity: "hour",
+  },
+  {
+    id: "sender-transactions",
+    tab: "senders",
+    title: "Tipping transactions by provider",
+    valueLabel: "Count",
+    metrics: ["Sender Total Transactions"],
+    aggregation: "sum",
+    seriesField: "provider",
+    timeGranularity: "hour",
+    visualization: "bar",
+  },
+  {
+    id: "sender-total-tips",
+    tab: "senders",
+    title: "Total tips by provider",
+    valueLabel: "SOL",
+    metrics: ["Sender Total Tips"],
+    aggregation: "sum",
+    seriesField: "provider",
+    timeGranularity: "hour",
+    visualization: "bar",
+  },
+  {
+    id: "sender-total-fees",
+    tab: "senders",
+    title: "Total fees by provider",
+    valueLabel: "SOL",
+    metrics: ["Sender Total Fees"],
+    aggregation: "sum",
+    seriesField: "provider",
+    timeGranularity: "hour",
+    visualization: "bar",
+  },
 ] as const satisfies readonly ChartDefinition[];
+
+export const senderEconomicsMetricNames = [
+  "Sender Total Transactions",
+  "Sender Total Tips",
+  "Sender Total Fees",
+  "Sender Median Tip",
+  "Sender Median Fee",
+] as const;
 
 export const metricNames = Array.from(
   new Set(chartDefinitions.flatMap((chart) => chart.metrics)),

--- a/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
+++ b/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
@@ -13,6 +13,7 @@ import {
   Loader2,
   Network,
   RadioTower,
+  Send,
   type LucideIcon,
 } from "lucide-react";
 import { useSearchParams } from "next/navigation";
@@ -64,6 +65,7 @@ import {
   rpcMethodOptions,
   rpcRegionOptions,
   rpcTimeframeOptions,
+  senderEconomicsMetricNames,
   type Aggregation,
   type ChartDefinition,
   type DashboardTab,
@@ -89,6 +91,7 @@ const tabOptions = [
   { labelKey: "tabs.stablecoins.label", value: "stablecoins" },
   { labelKey: "tabs.defi.label", value: "defi" },
   { labelKey: "tabs.rpc.label", value: "rpc" },
+  { labelKey: "tabs.senders.label", value: "senders" },
 ] as const satisfies readonly { labelKey: string; value: DashboardTab }[];
 
 const tabIcons: Record<DashboardTab, LucideIcon> = {
@@ -97,6 +100,7 @@ const tabIcons: Record<DashboardTab, LucideIcon> = {
   stablecoins: CircleDollarSign,
   defi: ArrowLeftRight,
   rpc: RadioTower,
+  senders: Send,
 };
 
 const tabIndicatorSpring = {
@@ -302,6 +306,8 @@ export function SolanaDataDashboard() {
     rpcTimeframe,
   } = useDashboardQueryParams();
   const isRpcTab = activeTab === "rpc";
+  const isSendersTab = activeTab === "senders";
+  const isLiveInfrastructureTab = isRpcTab || isSendersTab;
   const { data: rpcFilters } = useSWR<RpcLatencyFiltersResponse>(
     isRpcTab ? "/api/rpc/filters" : null,
     fetchRpcFilters,
@@ -335,11 +341,16 @@ export function SolanaDataDashboard() {
   const { data, error, isLoading, isValidating } = useSWR<DataApiResponse>(
     dataUrl,
     fetchDashboardData,
-    isRpcTab ? rpcDataSWRConfig : dataSWRConfig,
+    isLiveInfrastructureTab ? rpcDataSWRConfig : dataSWRConfig,
   );
   const rows = useMemo(
-    () => filterRowsForCharts(data?.rows ?? emptyRows, activeCharts),
-    [activeCharts, data?.rows],
+    () =>
+      filterRowsForCharts(
+        data?.rows ?? emptyRows,
+        activeCharts,
+        isSendersTab ? senderEconomicsMetricNames : [],
+      ),
+    [activeCharts, data?.rows, isSendersTab],
   );
   const availableProviders = useMemo(() => getAvailableProviders(rows), [rows]);
   const selectedProviders = useMemo(
@@ -388,12 +399,16 @@ export function SolanaDataDashboard() {
     () => getKpis(kpiCharts, rows, selectedProviders, kpiAggregation),
     [kpiAggregation, kpiCharts, rows, selectedProviders],
   );
-  const hasKpiGrid = !isRpcTab;
+  const hasKpiGrid = !isLiveInfrastructureTab;
   const isInitialLoading = (isLoading || isValidating) && rows.length === 0;
   const isRefreshing = isValidating && rows.length > 0;
   const footerMetaItems = [
     <span key="cadence">
-      {isRpcTab ? t("footer.rpcRefreshCadence") : t("footer.refreshCadence")}
+      {isRpcTab
+        ? t("footer.rpcRefreshCadence")
+        : isSendersTab
+          ? t("footer.senderRefreshCadence")
+          : t("footer.refreshCadence")}
     </span>,
     data?.generatedAt ? (
       <span key="refreshed">
@@ -411,10 +426,12 @@ export function SolanaDataDashboard() {
           region: getRpcRegionLabel(rpcRegion),
         })}
       </span>
-    ) : (
+    ) : isSendersTab ? null : (
       <span key="lag">{t("footer.lagNotice")}</span>
     ),
-    isRpcTab ? null : <span key="backfill">{t("footer.backfillCadence")}</span>,
+    isLiveInfrastructureTab ? null : (
+      <span key="backfill">{t("footer.backfillCadence")}</span>
+    ),
   ].filter((item): item is React.ReactElement => item !== null);
 
   return (
@@ -452,30 +469,29 @@ export function SolanaDataDashboard() {
             rpcTimeframe={rpcTimeframe}
             selectedProviders={selectedProviders}
             showProviderControls={showProviderControls}
-            showRangeControl={!isRpcTab}
-            showRpcControls={isRpcTab}
+            showRangeControl={!isLiveInfrastructureTab}
+            showRpcFilterControls={isRpcTab}
+            showTimeframeControl={isLiveInfrastructureTab}
             onUpdateQuery={updateQuery}
           />
         </nav>
 
-        {!isRpcTab ? (
-          <section
-            aria-label={t("summaryAriaLabel", {
-              tab: activeTabContent.label,
-            })}
-            className="mt-8 max-w-[720px]"
-          >
-            <h2 className="sr-only">{activeTabContent.label}</h2>
-            <p className="nd-body-m text-nd-mid-em-text">
-              {activeTabContent.description}
+        <section
+          aria-label={t("summaryAriaLabel", {
+            tab: activeTabContent.label,
+          })}
+          className="mt-8 max-w-[720px]"
+        >
+          <h2 className="sr-only">{activeTabContent.label}</h2>
+          <p className="nd-body-m text-nd-mid-em-text">
+            {activeTabContent.description}
+          </p>
+          {activeTabContent.clarification ? (
+            <p className="mt-3 nd-body-s text-nd-mid-em-text/80">
+              {activeTabContent.clarification}
             </p>
-            {activeTabContent.clarification ? (
-              <p className="mt-3 nd-body-s text-nd-mid-em-text/80">
-                {activeTabContent.clarification}
-              </p>
-            ) : null}
-          </section>
-        ) : null}
+          ) : null}
+        </section>
 
         <DataResourceCarousel />
 
@@ -491,10 +507,18 @@ export function SolanaDataDashboard() {
               />
             ) : null}
 
+            {isSendersTab ? (
+              <SenderEconomicsTable
+                isLoading={isInitialLoading}
+                rows={rows}
+                selectedProviders={selectedProviders}
+              />
+            ) : null}
+
             <ChartGrid
               activeCharts={activeCharts}
               activeTab={activeTab}
-              hasKpiGrid={hasKpiGrid}
+              isConnectedToPrevious={hasKpiGrid || isSendersTab}
               isLoading={isInitialLoading}
               isRefreshing={isRefreshing}
               rows={rows}
@@ -517,7 +541,7 @@ export function SolanaDataDashboard() {
                 aria-hidden="true"
                 className="h-1 w-1 rounded-full bg-nd-border-prominent"
               />
-              {isRpcTab
+              {isLiveInfrastructureTab
                 ? t("footer.lastTimeframe", { timeframe: rpcTimeframe })
                 : t("footer.lastDays", { days: rangeDays })}
             </span>
@@ -554,6 +578,17 @@ export function SolanaDataDashboard() {
                     <ExternalLink aria-hidden="true" className="h-3 w-3" />
                   </a>
                 </>
+              ) : isSendersTab ? (
+                <a
+                  className="inline-flex items-center gap-1.5 text-nd-high-em-text transition-colors hover:text-nd-primary"
+                  href={rpcSenderGrafanaUrl}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <Send aria-hidden="true" className="h-3.5 w-3.5" />
+                  {t("footer.senderSource")}
+                  <ExternalLink aria-hidden="true" className="h-3 w-3" />
+                </a>
               ) : (
                 <>
                   <a
@@ -615,7 +650,8 @@ function DashboardControls({
   selectedProviders,
   showProviderControls,
   showRangeControl,
-  showRpcControls,
+  showRpcFilterControls,
+  showTimeframeControl,
 }: {
   activeTab: DashboardTab;
   availableProviders: ProviderName[];
@@ -630,7 +666,8 @@ function DashboardControls({
   selectedProviders: Set<ProviderName>;
   showProviderControls: boolean;
   showRangeControl: boolean;
-  showRpcControls: boolean;
+  showRpcFilterControls: boolean;
+  showTimeframeControl: boolean;
 }) {
   const t = useTranslations("dataDashboard");
 
@@ -662,7 +699,7 @@ function DashboardControls({
             </div>
           </>
         ) : null}
-        {showRpcControls ? (
+        {showTimeframeControl ? (
           <>
             <Separator />
             <div className="flex flex-wrap items-center gap-2">
@@ -673,6 +710,13 @@ function DashboardControls({
                 value={rpcTimeframe}
                 onChange={(value) => onUpdateQuery({ timeframe: value })}
               />
+            </div>
+          </>
+        ) : null}
+        {showRpcFilterControls ? (
+          <>
+            <Separator />
+            <div className="flex flex-wrap items-center gap-2">
               <FilterSelect
                 ariaLabel={t("controls.rpcRegionAriaLabel")}
                 label={t("controls.rpcRegionLabel")}
@@ -753,6 +797,14 @@ function TabSwitcher({
   onChange: (_value: DashboardTab) => void;
 }) {
   const t = useTranslations("dataDashboard");
+  const activeTabRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    activeTabRef.current?.scrollIntoView({
+      block: "nearest",
+      inline: "center",
+    });
+  }, [activeTab]);
 
   return (
     <div
@@ -776,6 +828,7 @@ function TabSwitcher({
             )}
             key={option.value}
             onClick={() => onChange(option.value)}
+            ref={isActive ? activeTabRef : undefined}
             role="tab"
             type="button"
           >
@@ -895,19 +948,176 @@ function KpiGrid({
   );
 }
 
+type SenderEconomicsItem = {
+  medianFeeLamports: number;
+  medianTipLamports: number;
+  provider: ProviderName;
+  totalFeesSol: number;
+  totalTipsSol: number;
+  transactions: number;
+};
+
+function SenderEconomicsTable({
+  isLoading,
+  rows,
+  selectedProviders,
+}: {
+  isLoading: boolean;
+  rows: MetricRow[];
+  selectedProviders: Set<ProviderName>;
+}) {
+  const locale = useLocale();
+  const t = useTranslations("dataDashboard");
+  const items = useMemo(
+    () => getSenderEconomicsItems(rows, selectedProviders),
+    [rows, selectedProviders],
+  );
+  const columns = [
+    {
+      key: "transactions",
+      label: t("senderEconomics.transactions"),
+      unit: "count",
+    },
+    {
+      key: "totalTipsSol",
+      label: t("senderEconomics.totalTips"),
+      unit: "sol",
+    },
+    {
+      key: "totalFeesSol",
+      label: t("senderEconomics.totalFees"),
+      unit: "sol",
+    },
+    {
+      key: "medianTipLamports",
+      label: t("senderEconomics.medianTip"),
+      unit: "lamports",
+    },
+    {
+      key: "medianFeeLamports",
+      label: t("senderEconomics.medianFee"),
+      unit: "lamports",
+    },
+  ] as const;
+
+  return (
+    <section
+      aria-label={t("senderEconomics.ariaLabel")}
+      className="mt-10 border border-nd-border-light xl:mt-14"
+    >
+      <div className="flex items-center justify-between gap-4 border-b border-nd-border-light px-4 py-5 md:px-6 xl:px-8">
+        <h2 className="m-0 text-[20px] leading-[1.25] font-medium tracking-normal xl:text-[24px]">
+          {t("senderEconomics.title")}
+        </h2>
+        <span className="shrink-0 font-brand-mono text-[11px] leading-[1.42] font-bold uppercase text-nd-mid-em-text">
+          {t("senderEconomics.rangeTotal")}
+        </span>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full min-w-[880px] border-collapse">
+          <thead>
+            <tr className="font-brand-mono text-[11px] leading-[1.42] font-bold uppercase text-nd-mid-em-text">
+              <th
+                className="border-r border-nd-border-light px-4 py-3 text-left md:px-6 xl:px-8"
+                scope="col"
+              >
+                {t("senderEconomics.provider")}
+              </th>
+              {columns.map((column) => (
+                <th
+                  className="px-4 py-3 text-right md:px-6"
+                  key={column.key}
+                  scope="col"
+                >
+                  {column.label}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading
+              ? Array.from({ length: 6 }).map((_, index) => (
+                  <tr className="border-t border-nd-border-light" key={index}>
+                    {Array.from({ length: 6 }).map((__, columnIndex) => (
+                      <td
+                        className={cn(
+                          "px-4 py-4 md:px-6",
+                          columnIndex === 0
+                            ? "border-r border-nd-border-light xl:px-8"
+                            : "",
+                        )}
+                        key={columnIndex}
+                      >
+                        <span
+                          className={cn(
+                            "block h-3 animate-pulse bg-nd-border-light",
+                            columnIndex === 0 ? "w-24" : "ml-auto w-16",
+                          )}
+                        />
+                      </td>
+                    ))}
+                  </tr>
+                ))
+              : items.map((item) => (
+                  <tr
+                    className="border-t border-nd-border-light font-brand-mono text-[12px] leading-[1.42] font-bold text-nd-high-em-text"
+                    key={item.provider}
+                  >
+                    <th
+                      className="border-r border-nd-border-light px-4 py-4 text-left uppercase md:px-6 xl:px-8"
+                      scope="row"
+                    >
+                      <span className="inline-flex items-center gap-2">
+                        <span
+                          aria-hidden="true"
+                          className="h-2 w-2 shrink-0"
+                          style={{
+                            backgroundColor: getProviderColor(item.provider),
+                          }}
+                        />
+                        {item.provider}
+                      </span>
+                    </th>
+                    {columns.map((column) => (
+                      <td
+                        className="px-4 py-4 text-right tabular-nums md:px-6"
+                        key={column.key}
+                      >
+                        {formatSenderEconomicsValue(
+                          item[column.key],
+                          column.unit,
+                          locale,
+                        )}
+                      </td>
+                    ))}
+                  </tr>
+                ))}
+          </tbody>
+        </table>
+        {!isLoading && items.length === 0 ? (
+          <div className="border-t border-nd-border-light px-6 py-12 text-center font-brand-mono text-[12px] uppercase text-nd-mid-em-text">
+            {t("empty.noDataForSelection")}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
 function ChartGrid({
   activeCharts,
   activeTab,
   isLoading,
   isRefreshing,
-  hasKpiGrid,
+  isConnectedToPrevious,
   rows,
   selectedProviders,
   visibleCharts,
 }: {
   activeCharts: readonly ChartDefinition[];
   activeTab: DashboardTab;
-  hasKpiGrid: boolean;
+  isConnectedToPrevious: boolean;
   isLoading: boolean;
   isRefreshing: boolean;
   rows: MetricRow[];
@@ -915,6 +1125,7 @@ function ChartGrid({
   visibleCharts: readonly ChartDefinition[];
 }) {
   const t = useTranslations("dataDashboard");
+  const hasLeadingFullWidthChart = activeCharts[0]?.fullWidth === true;
 
   return (
     <TooltipProvider delayDuration={100}>
@@ -923,14 +1134,18 @@ function ChartGrid({
           tab: getTabContent(t, activeTab).label,
         })}
         className={cn(
-          "border-x border-b border-nd-border-light grid grid-cols-1 lg:grid-cols-2 divide-y divide-nd-border-light lg:divide-y-0",
-          hasKpiGrid ? "" : "mt-10 border-t xl:mt-14",
-          "[&>*]:border-nd-border-light lg:[&>*:nth-child(even)]:border-l lg:[&>*:nth-child(n+3)]:border-t",
+          "border-x border-b border-nd-border-light grid grid-cols-1 lg:grid-cols-2",
+          isConnectedToPrevious ? "" : "mt-10 border-t xl:mt-14",
         )}
       >
         {isLoading
           ? activeCharts.map((chart, index) => (
               <ChartSkeleton
+                className={getChartGridItemClassName(
+                  chart,
+                  index,
+                  hasLeadingFullWidthChart,
+                )}
                 index={index}
                 key={chart.id}
                 title={getChartTitle(t, chart)}
@@ -939,6 +1154,11 @@ function ChartGrid({
           : visibleCharts.map((chart, index) => (
               <ChartCard
                 chart={chart}
+                className={getChartGridItemClassName(
+                  chart,
+                  index,
+                  hasLeadingFullWidthChart,
+                )}
                 index={index}
                 isRefreshing={isRefreshing}
                 key={chart.id}
@@ -1279,12 +1499,14 @@ function DataResourceDecorGrid() {
 
 function ChartCard({
   chart,
+  className,
   index,
   isRefreshing,
   rows,
   selectedProviders,
 }: {
   chart: ChartDefinition;
+  className?: string;
   index: number;
   isRefreshing: boolean;
   rows: MetricRow[];
@@ -1299,9 +1521,18 @@ function ChartCard({
   const title = getChartTitle(t, chart);
   const caption = getChartCaption(t, chart);
   const methodologyNotes = getMethodologyNotes(chart, selectedProviders);
+  const resolvedChartHeight =
+    chart.visualization === "bar"
+      ? Math.max(chartHeight, series.length * 56)
+      : chartHeight;
 
   return (
-    <article className="relative p-3 md:p-6 xl:p-8 flex flex-col gap-4 md:gap-5">
+    <article
+      className={cn(
+        "relative p-3 md:p-6 xl:p-8 flex flex-col gap-4 md:gap-5",
+        className,
+      )}
+    >
       <div className="grid gap-1.5">
         <div className="flex items-start justify-between gap-4">
           <div className="flex min-w-0 items-center gap-2">
@@ -1323,18 +1554,19 @@ function ChartCard({
         ) : null}
       </div>
 
-      <ChartWatermarkFrame>
+      <ChartWatermarkFrame height={resolvedChartHeight}>
         {series.length > 0 ? (
           chart.visualization === "bar" ? (
             <ProviderBarChart
-              height={chartHeight}
+              height={resolvedChartHeight}
               lowerIsBetter={chart.lowerIsBetter}
               series={series}
               valueLabel={chart.valueLabel}
             />
           ) : (
             <TimeSeriesChart
-              height={chartHeight}
+              height={resolvedChartHeight}
+              scaleType={chart.scale}
               series={series}
               timeGranularity={chart.timeGranularity}
               valueLabel={chart.valueLabel}
@@ -1353,12 +1585,19 @@ function ChartCard({
   );
 }
 
-function ChartWatermarkFrame({ children }: { children: ReactNode }) {
+function ChartWatermarkFrame({
+  children,
+  height,
+}: {
+  children: ReactNode;
+  height: number;
+}) {
   return (
     <div className="relative">
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 bottom-0 z-0 flex h-[320px] items-center justify-center overflow-hidden"
+        className="pointer-events-none absolute inset-x-0 bottom-0 z-0 flex items-center justify-center overflow-hidden"
+        style={{ height }}
       >
         <img
           alt=""
@@ -1630,9 +1869,22 @@ function KpiSkeleton({ index }: { index: number }) {
   );
 }
 
-function ChartSkeleton({ index, title }: { index: number; title: string }) {
+function ChartSkeleton({
+  className,
+  index,
+  title,
+}: {
+  className?: string;
+  index: number;
+  title: string;
+}) {
   return (
-    <article className="p-3 md:p-6 xl:p-8 flex flex-col gap-4 md:gap-5">
+    <article
+      className={cn(
+        "p-3 md:p-6 xl:p-8 flex flex-col gap-4 md:gap-5",
+        className,
+      )}
+    >
       <div className="flex items-baseline justify-between gap-4">
         <div className="h-5 w-40 rounded-sm bg-nd-border-light animate-pulse">
           <span className="sr-only">{title}</span>
@@ -1642,6 +1894,25 @@ function ChartSkeleton({ index, title }: { index: number; title: string }) {
       <div className="h-[352px] animate-pulse bg-nd-border-light/40" />
       <ChartOrdinal index={index} />
     </article>
+  );
+}
+
+function getChartGridItemClassName(
+  chart: ChartDefinition,
+  index: number,
+  hasLeadingFullWidthChart: boolean,
+) {
+  const hasDesktopTopBorder = hasLeadingFullWidthChart ? index > 0 : index >= 2;
+  const hasDesktopLeftBorder = hasLeadingFullWidthChart
+    ? index > 0 && index % 2 === 0
+    : index % 2 === 1;
+
+  return cn(
+    "border-nd-border-light",
+    chart.fullWidth ? "lg:col-span-2" : "",
+    index > 0 ? "border-t" : "",
+    hasDesktopTopBorder ? "lg:border-t" : "lg:border-t-0",
+    hasDesktopLeftBorder ? "lg:border-l" : "",
   );
 }
 
@@ -1889,8 +2160,16 @@ function getDashboardDataUrl({
   rpcRegion: RpcLatencyRegion;
   rpcTimeframe: RpcTimeframe;
 }) {
-  if (activeTab !== "rpc") {
+  if (activeTab !== "rpc" && activeTab !== "senders") {
     return `/api/databricks/data?days=${rangeDays}`;
+  }
+
+  if (activeTab === "senders") {
+    const params = new URLSearchParams({
+      timeframe: rpcTimeframe,
+    });
+
+    return `/api/rpc/sender/data?${params.toString()}`;
   }
 
   const params = new URLSearchParams({
@@ -1980,10 +2259,90 @@ function getKpiCharts(
 function filterRowsForCharts(
   rows: readonly MetricRow[],
   charts: readonly ChartDefinition[],
+  additionalMetrics: readonly string[] = [],
 ) {
-  const metricSet = new Set(charts.flatMap((chart) => chart.metrics));
+  const metricSet = new Set([
+    ...charts.flatMap((chart) => chart.metrics),
+    ...additionalMetrics,
+  ]);
 
   return rows.filter((row) => isChartDataRow(row, metricSet));
+}
+
+export function getSenderEconomicsItems(
+  rows: readonly MetricRow[],
+  selectedProviders: ReadonlySet<ProviderName>,
+): SenderEconomicsItem[] {
+  const rowsByProvider = new Map<ProviderName, MetricRow[]>();
+
+  for (const row of rows) {
+    const providerName = getRowProviderName(row);
+
+    if (
+      !selectedProviders.has(providerName) ||
+      !senderEconomicsMetricNames.includes(
+        row.metricName as (typeof senderEconomicsMetricNames)[number],
+      )
+    ) {
+      continue;
+    }
+
+    const providerRows = rowsByProvider.get(providerName) ?? [];
+
+    providerRows.push(row);
+    rowsByProvider.set(providerName, providerRows);
+  }
+
+  return Array.from(rowsByProvider.entries())
+    .flatMap(([provider, providerRows]) => {
+      const transactions = getLatestMetricValue(
+        providerRows,
+        "Sender Total Transactions",
+      );
+      const totalTipsSol = getLatestMetricValue(
+        providerRows,
+        "Sender Total Tips",
+      );
+      const totalFeesSol = getLatestMetricValue(
+        providerRows,
+        "Sender Total Fees",
+      );
+      const medianTipLamports = getLatestMetricValue(
+        providerRows,
+        "Sender Median Tip",
+      );
+      const medianFeeLamports = getLatestMetricValue(
+        providerRows,
+        "Sender Median Fee",
+      );
+
+      return transactions !== undefined &&
+        totalTipsSol !== undefined &&
+        totalFeesSol !== undefined &&
+        medianTipLamports !== undefined &&
+        medianFeeLamports !== undefined
+        ? [
+            {
+              medianFeeLamports,
+              medianTipLamports,
+              provider,
+              totalFeesSol,
+              totalTipsSol,
+              transactions,
+            },
+          ]
+        : [];
+    })
+    .sort(
+      (a, b) =>
+        b.transactions - a.transactions || a.provider.localeCompare(b.provider),
+    );
+}
+
+function getLatestMetricValue(rows: MetricRow[], metricName: string) {
+  return rows
+    .filter((row) => row.metricName === metricName)
+    .sort((a, b) => b.date.localeCompare(a.date))[0]?.value;
 }
 
 function getKpis(
@@ -2320,7 +2679,8 @@ function parseTab(value: string | null): DashboardTab {
   return value === "network" ||
     value === "stablecoins" ||
     value === "defi" ||
-    value === "rpc"
+    value === "rpc" ||
+    value === "senders"
     ? value
     : "overview";
 }
@@ -2435,6 +2795,16 @@ function formatTimestamp(value: string, locale: string) {
     dateStyle: "medium",
     timeStyle: "short",
   }).format(new Date(value));
+}
+
+function formatSenderEconomicsValue(
+  value: number,
+  unit: "count" | "lamports" | "sol",
+  locale: string,
+) {
+  return new Intl.NumberFormat(locale, {
+    maximumFractionDigits: unit === "sol" ? 4 : 0,
+  }).format(value);
 }
 
 function getTabContent(t: DashboardTranslator, tab: DashboardTab) {

--- a/apps/web/src/app/[locale]/data/time-series-chart.tsx
+++ b/apps/web/src/app/[locale]/data/time-series-chart.tsx
@@ -5,7 +5,7 @@ import { localPoint } from "@visx/event";
 import { GridRows } from "@visx/grid";
 import { Group } from "@visx/group";
 import { ParentSize } from "@visx/responsive";
-import { scaleLinear, scaleTime } from "@visx/scale";
+import { scaleLinear, scaleLog, scaleTime } from "@visx/scale";
 import { LinePath } from "@visx/shape";
 import { TooltipWithBounds, useTooltip } from "@visx/tooltip";
 import { useMemo, useState } from "react";
@@ -13,7 +13,7 @@ import { useLocale, useTranslations } from "@workspace/i18n/client";
 
 import { cn } from "@/app/components/utils";
 
-import type { MetricRowDetail } from "./data-config";
+import type { ChartScale, MetricRowDetail } from "./data-config";
 
 export type SeriesPoint = {
   date: Date;
@@ -32,6 +32,7 @@ type TimeSeriesChartProps = {
   series: ChartSeries[];
   valueLabel: string;
   height?: number;
+  scaleType?: ChartScale;
   timeGranularity?: TimeGranularity;
 };
 
@@ -68,6 +69,7 @@ export function TimeSeriesChart({
   series,
   valueLabel,
   height = 320,
+  scaleType = "linear",
   timeGranularity = "day",
 }: TimeSeriesChartProps) {
   const locale = useLocale();
@@ -162,6 +164,7 @@ export function TimeSeriesChart({
                 height={measuredHeight}
                 highlightedSeriesId={highlightedSeriesId}
                 locale={locale}
+                scaleType={scaleType}
                 series={visibleSeries}
                 seriesDashPatterns={seriesDashPatterns}
                 timeGranularity={timeGranularity}
@@ -184,6 +187,7 @@ function ChartSvg({
   height,
   highlightedSeriesId,
   locale,
+  scaleType,
   series,
   seriesDashPatterns,
   timeGranularity,
@@ -193,6 +197,7 @@ function ChartSvg({
   height: number;
   highlightedSeriesId: string | null;
   locale: string;
+  scaleType: ChartScale;
   series: ChartSeries[];
   seriesDashPatterns: ReadonlyMap<string, string>;
   timeGranularity: TimeGranularity;
@@ -218,21 +223,33 @@ function ChartSvg({
     new Set(points.map((point) => point.date.getTime())),
   ).sort((a, b) => a - b);
   const xDomain = getDateDomain(points);
-  const yDomain = getValueDomain(points, valueLabel);
+  const yDomain =
+    scaleType === "log"
+      ? getLogValueDomain(points)
+      : getValueDomain(points, valueLabel);
   const xScale = scaleTime<number>({
     domain: xDomain,
     range: [0, innerWidth],
   });
-  const yScale = scaleLinear<number>({
-    domain: yDomain,
-    nice: true,
-    range: [innerHeight, 0],
-  });
-  const yTickValues = getYAxisTickValues(
-    yScale.ticks(yAxisTickCount),
-    yScale.domain(),
-    valueLabel,
-  );
+  const yScale =
+    scaleType === "log"
+      ? scaleLog<number>({
+          domain: yDomain,
+          range: [innerHeight, 0],
+        })
+      : scaleLinear<number>({
+          domain: yDomain,
+          nice: true,
+          range: [innerHeight, 0],
+        });
+  const yTickValues =
+    scaleType === "log"
+      ? getLogTickValues(yDomain)
+      : getYAxisTickValues(
+          yScale.ticks(yAxisTickCount),
+          yScale.domain(),
+          valueLabel,
+        );
   const formatYAxisValue = getAxisValueFormatter(valueLabel, locale);
 
   if (width < 10 || height < 10 || innerWidth <= 0 || innerHeight <= 0) {
@@ -290,7 +307,10 @@ function ChartSvg({
           {series.map((item) => (
             <LinePath
               data={item.points}
-              defined={(point) => Number.isFinite(point.value)}
+              defined={(point) =>
+                Number.isFinite(point.value) &&
+                (scaleType !== "log" || point.value > 0)
+              }
               key={item.id}
               stroke={item.color}
               strokeDasharray={seriesDashPatterns.get(item.id)}
@@ -565,6 +585,35 @@ export function getValueDomain(
     minValue >= 0 ? Math.max(0, minValue - padding) : minValue - padding,
     maxValue + padding,
   ];
+}
+
+export function getLogValueDomain(points: SeriesPoint[]): [number, number] {
+  const values = points
+    .map((point) => point.value)
+    .filter((value) => Number.isFinite(value) && value > 0);
+
+  if (values.length === 0) {
+    return [1, 10];
+  }
+
+  const minPower = Math.floor(Math.log10(Math.min(...values)));
+  let maxPower = Math.ceil(Math.log10(Math.max(...values)));
+
+  if (maxPower <= minPower) {
+    maxPower = minPower + 1;
+  }
+
+  return [10 ** minPower, 10 ** maxPower];
+}
+
+export function getLogTickValues([minValue, maxValue]: readonly number[]) {
+  const minPower = Math.ceil(Math.log10(minValue));
+  const maxPower = Math.floor(Math.log10(maxValue));
+
+  return Array.from(
+    { length: Math.max(maxPower - minPower + 1, 0) },
+    (_, index) => 10 ** (minPower + index),
+  );
 }
 
 function getPercentValueDomain(

--- a/apps/web/src/app/api/rpc/sender/data/route.ts
+++ b/apps/web/src/app/api/rpc/sender/data/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from "next/server";
+import { unstable_cache } from "next/cache";
+
+import type { DataApiResponse } from "@/app/[locale]/data/data-config";
+import {
+  getRpcSenderCacheKey,
+  getRpcSenderMetricRows,
+  parseRpcSenderQueryOptions,
+  type RpcSenderQueryOptions,
+} from "@/lib/rpc/sender-server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const RPC_SENDER_CACHE_REVALIDATE_SECONDS = 60;
+const EDGE_STALE_SECONDS = 5 * 60;
+const RPC_SENDER_CACHE_KEY_VERSION = "solana-data-rpc-sender-v1";
+const IS_PRODUCTION = process.env.NODE_ENV === "production";
+const NO_STORE_CACHE_CONTROL = "no-store, max-age=0";
+const DATA_UNAVAILABLE_ERROR =
+  "Solana transaction sender data is unavailable right now. Try again in a moment.";
+
+type ErrorResponse = {
+  detail?: string;
+  error: string;
+};
+
+type RpcSenderData = {
+  generatedAt: string;
+  rows: DataApiResponse["rows"];
+  truncated: boolean;
+};
+
+export async function GET(request: NextRequest) {
+  try {
+    const options = parseRpcSenderQueryOptions(request.nextUrl.searchParams);
+    const result = await getRpcSenderData(options);
+
+    return json<DataApiResponse>(
+      {
+        generatedAt: result.generatedAt,
+        rangeDays: 0,
+        rows: result.rows,
+        truncated: result.truncated,
+      },
+      200,
+      getSuccessCacheControl(),
+    );
+  } catch (error) {
+    console.error("Failed to load Solana transaction sender data", error);
+
+    return json<ErrorResponse>(
+      {
+        error: DATA_UNAVAILABLE_ERROR,
+        ...devOnly({
+          detail: error instanceof Error ? error.message : String(error),
+        }),
+      },
+      502,
+      NO_STORE_CACHE_CONTROL,
+    );
+  }
+}
+
+function getRpcSenderData(options: RpcSenderQueryOptions) {
+  return IS_PRODUCTION
+    ? getCachedRpcSenderData(options)
+    : fetchRpcSenderData(options);
+}
+
+function getCachedRpcSenderData(options: RpcSenderQueryOptions) {
+  const dataCacheKey = getRpcSenderCacheKey(options);
+  const cacheKeyParts = [RPC_SENDER_CACHE_KEY_VERSION, dataCacheKey];
+
+  return unstable_cache(
+    () => getInMemoryCachedRpcSenderData(options, cacheKeyParts.join("|")),
+    cacheKeyParts,
+    {
+      revalidate: RPC_SENDER_CACHE_REVALIDATE_SECONDS,
+      tags: ["solana-data-rpc-sender"],
+    },
+  )();
+}
+
+function fetchRpcSenderData(options: RpcSenderQueryOptions) {
+  return getRpcSenderMetricRows(options);
+}
+
+const rpcSenderDataRequests = new Map<string, Promise<RpcSenderData>>();
+
+function getInMemoryCachedRpcSenderData(
+  options: RpcSenderQueryOptions,
+  cacheKey: string,
+) {
+  const cachedRequest = rpcSenderDataRequests.get(cacheKey);
+
+  if (cachedRequest) {
+    return cachedRequest;
+  }
+
+  const request = fetchRpcSenderData(options);
+
+  request.then(
+    () => rpcSenderDataRequests.delete(cacheKey),
+    () => rpcSenderDataRequests.delete(cacheKey),
+  );
+
+  rpcSenderDataRequests.set(cacheKey, request);
+
+  return request;
+}
+
+function getSuccessCacheControl() {
+  if (!IS_PRODUCTION) {
+    return NO_STORE_CACHE_CONTROL;
+  }
+
+  return [
+    "public",
+    "max-age=0",
+    `s-maxage=${RPC_SENDER_CACHE_REVALIDATE_SECONDS}`,
+    `stale-while-revalidate=${EDGE_STALE_SECONDS}`,
+  ].join(", ");
+}
+
+function devOnly<T extends Record<string, unknown>>(value: T) {
+  return IS_PRODUCTION ? {} : value;
+}
+
+function json<T>(body: T, status: number, cacheControl: string) {
+  return NextResponse.json(body, {
+    status,
+    headers: {
+      "Cache-Control": cacheControl,
+    },
+  });
+}

--- a/apps/web/src/lib/rpc/sender-server.ts
+++ b/apps/web/src/lib/rpc/sender-server.ts
@@ -1,0 +1,341 @@
+import "server-only";
+
+import {
+  getRpcTimeframeOption,
+  parseRpcTimeframe,
+  type MetricRow,
+  type RpcTimeframe,
+} from "@/app/[locale]/data/data-config";
+
+const GRAFANA_PUBLIC_DASHBOARD_API_URL =
+  "https://rpclatency.grafana.net/api/public/dashboards/6f18bcfc9e0e4e0ea62d10e5e484c50d";
+const ECONOMICS_PANEL_ID = 1;
+const TRANSACTIONS_OVER_TIME_PANEL_ID = 2;
+const MS_PER_SECOND = 1000;
+
+export type RpcSenderQueryOptions = {
+  timeframe?: RpcTimeframe;
+};
+
+type GrafanaField = {
+  name?: string;
+};
+
+type GrafanaFrame = {
+  data?: {
+    values?: unknown[][];
+  };
+  schema?: {
+    fields?: GrafanaField[];
+  };
+};
+
+type GrafanaPanelResponse = {
+  results?: Record<
+    string,
+    {
+      error?: string;
+      frames?: GrafanaFrame[];
+      status?: number;
+    }
+  >;
+};
+
+type RpcSenderRowsResult = {
+  generatedAt: string;
+  rows: MetricRow[];
+  truncated: boolean;
+};
+
+type SenderEconomicsRow = {
+  medianFeeLamports: number;
+  medianTipLamports: number;
+  provider: string;
+  totalFeesSol: number;
+  totalTipsSol: number;
+  transactions: number;
+};
+
+type SenderTransactionSample = {
+  provider: string;
+  timestamp: number;
+  transactions: number;
+};
+
+export function parseRpcSenderQueryOptions(
+  params: URLSearchParams,
+): Required<RpcSenderQueryOptions> {
+  return {
+    timeframe: parseRpcTimeframe(params.get("timeframe")),
+  };
+}
+
+export function getRpcSenderCacheKey(options: RpcSenderQueryOptions = {}) {
+  const timeframe = getRpcTimeframeOption(options.timeframe);
+
+  return [
+    GRAFANA_PUBLIC_DASHBOARD_API_URL,
+    timeframe.value,
+    timeframe.durationSeconds,
+    timeframe.stepSeconds,
+  ].join("|");
+}
+
+export async function getRpcSenderMetricRows(
+  options: RpcSenderQueryOptions = {},
+): Promise<RpcSenderRowsResult> {
+  const timeframe = getRpcTimeframeOption(options.timeframe);
+  const end = Date.now();
+  const start = end - timeframe.durationSeconds * MS_PER_SECOND;
+  const request = {
+    intervalMs: timeframe.stepSeconds * MS_PER_SECOND,
+    maxDataPoints: Math.ceil(timeframe.durationSeconds / timeframe.stepSeconds),
+    timeRange: {
+      from: String(start),
+      timezone: "browser",
+      to: String(end),
+    },
+  };
+  const [economicsResponse, transactionsResponse] = await Promise.all([
+    queryPublicDashboardPanel(ECONOMICS_PANEL_ID, request),
+    queryPublicDashboardPanel(TRANSACTIONS_OVER_TIME_PANEL_ID, request),
+  ]);
+  const generatedAt = new Date(end).toISOString();
+
+  return {
+    generatedAt,
+    rows: [
+      ...toEconomicsMetricRows(
+        parseEconomicsRows(getFirstFrame(economicsResponse)),
+        generatedAt,
+      ),
+      ...toTransactionMetricRows(
+        parseTransactionSamples(getFirstFrame(transactionsResponse)),
+      ),
+    ],
+    truncated: false,
+  };
+}
+
+async function queryPublicDashboardPanel(
+  panelId: number,
+  request: {
+    intervalMs: number;
+    maxDataPoints: number;
+    timeRange: {
+      from: string;
+      timezone: string;
+      to: string;
+    };
+  },
+) {
+  const response = await fetch(
+    `${GRAFANA_PUBLIC_DASHBOARD_API_URL}/panels/${panelId}/query`,
+    {
+      body: JSON.stringify(request),
+      cache: "no-store",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    },
+  );
+  const payload = (await response
+    .json()
+    .catch(() => null)) as GrafanaPanelResponse | null;
+
+  if (!response.ok) {
+    throw new RpcSenderResponseError(
+      `Grafana Sender panel ${panelId}`,
+      `${response.status} ${response.statusText}`.trim(),
+    );
+  }
+
+  const result = payload?.results?.A;
+
+  if (
+    !result ||
+    (typeof result.status === "number" && result.status !== 200) ||
+    !Array.isArray(result.frames)
+  ) {
+    throw new RpcSenderResponseError(
+      `Grafana Sender panel ${panelId}`,
+      result?.error ?? "invalid-payload",
+    );
+  }
+
+  return payload;
+}
+
+function getFirstFrame(response: GrafanaPanelResponse) {
+  const frame = response.results?.A?.frames?.[0];
+
+  if (!frame) {
+    throw new RpcSenderResponseError(
+      "Grafana Sender response",
+      "missing-frame",
+    );
+  }
+
+  return frame;
+}
+
+function parseEconomicsRows(frame: GrafanaFrame): SenderEconomicsRow[] {
+  const providers = getFieldValues(frame, "provider");
+  const transactions = getFieldValues(frame, "Transactions");
+  const totalTips = getFieldValues(frame, "Total tips (SOL)");
+  const totalFees = getFieldValues(frame, "Total fees (SOL)");
+  const medianTips = getFieldValues(frame, "Median tip (lamports)");
+  const medianFees = getFieldValues(frame, "Median fee (lamports)");
+
+  return providers.flatMap((provider, index) => {
+    const row = {
+      medianFeeLamports: toFiniteNumber(medianFees[index]),
+      medianTipLamports: toFiniteNumber(medianTips[index]),
+      provider: toNonEmptyString(provider),
+      totalFeesSol: toFiniteNumber(totalFees[index]),
+      totalTipsSol: toFiniteNumber(totalTips[index]),
+      transactions: toFiniteNumber(transactions[index]),
+    };
+
+    return row.provider &&
+      row.transactions !== undefined &&
+      row.totalTipsSol !== undefined &&
+      row.totalFeesSol !== undefined &&
+      row.medianTipLamports !== undefined &&
+      row.medianFeeLamports !== undefined
+      ? [row as SenderEconomicsRow]
+      : [];
+  });
+}
+
+function parseTransactionSamples(
+  frame: GrafanaFrame,
+): SenderTransactionSample[] {
+  const timestamps = getFieldValues(frame, "time");
+  const providers = getFieldValues(frame, "provider");
+  const transactions = getFieldValues(frame, "txs");
+
+  return timestamps.flatMap((timestamp, index) => {
+    const sample = {
+      provider: toNonEmptyString(providers[index]),
+      timestamp: toFiniteNumber(timestamp),
+      transactions: toFiniteNumber(transactions[index]),
+    };
+
+    return sample.provider &&
+      sample.timestamp !== undefined &&
+      sample.transactions !== undefined
+      ? [sample as SenderTransactionSample]
+      : [];
+  });
+}
+
+function getFieldValues(frame: GrafanaFrame, fieldName: string) {
+  const fieldIndex = frame.schema?.fields?.findIndex(
+    (field) => field.name === fieldName,
+  );
+
+  if (
+    fieldIndex === undefined ||
+    fieldIndex < 0 ||
+    !Array.isArray(frame.data?.values?.[fieldIndex])
+  ) {
+    throw new RpcSenderResponseError(
+      "Grafana Sender response",
+      `missing-field:${fieldName}`,
+    );
+  }
+
+  return frame.data.values[fieldIndex];
+}
+
+function toEconomicsMetricRows(
+  rows: SenderEconomicsRow[],
+  generatedAt: string,
+): MetricRow[] {
+  return rows.flatMap((row) => [
+    toMetricRow(
+      generatedAt,
+      "Sender Total Transactions",
+      row.provider,
+      "Count",
+      row.transactions,
+    ),
+    toMetricRow(
+      generatedAt,
+      "Sender Total Tips",
+      row.provider,
+      "SOL",
+      row.totalTipsSol,
+    ),
+    toMetricRow(
+      generatedAt,
+      "Sender Total Fees",
+      row.provider,
+      "SOL",
+      row.totalFeesSol,
+    ),
+    toMetricRow(
+      generatedAt,
+      "Sender Median Tip",
+      row.provider,
+      "Lamports",
+      row.medianTipLamports,
+    ),
+    toMetricRow(
+      generatedAt,
+      "Sender Median Fee",
+      row.provider,
+      "Lamports",
+      row.medianFeeLamports,
+    ),
+  ]);
+}
+
+function toTransactionMetricRows(
+  samples: SenderTransactionSample[],
+): MetricRow[] {
+  return samples.map((sample) =>
+    toMetricRow(
+      new Date(sample.timestamp).toISOString(),
+      "Sender Transactions",
+      sample.provider,
+      "Count",
+      sample.transactions,
+    ),
+  );
+}
+
+function toMetricRow(
+  date: string,
+  metricName: string,
+  providerName: string,
+  unit: string,
+  value: number,
+): MetricRow {
+  return {
+    date,
+    metricName,
+    providerName,
+    unit,
+    value,
+  };
+}
+
+function toFiniteNumber(value: unknown) {
+  const number = typeof value === "number" ? value : Number(value);
+
+  return Number.isFinite(number) ? number : undefined;
+}
+
+function toNonEmptyString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export class RpcSenderResponseError extends Error {
+  constructor(context: string, reason: string) {
+    super(`${context} returned ${reason}`);
+    this.name = "RpcSenderResponseError";
+  }
+}

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -2,12 +2,12 @@
   "dataDashboard": {
     "metadata": {
       "title": "Solana Data",
-      "description": "Explore Solana network, stablecoin, DeFi, and RPC metrics."
+      "description": "Explore Solana network, stablecoin, DeFi, RPC, and transaction sender metrics."
     },
     "header": {
-      "eyebrow": "Twice-daily network data",
+      "eyebrow": "Live infrastructure and network data",
       "title": "Solana data",
-      "description": "Network, stablecoin, DeFi, and RPC metrics from leading providers."
+      "description": "Network, stablecoin, DeFi, RPC, and transaction sender metrics from leading providers."
     },
     "controls": {
       "ariaLabel": "Controls",
@@ -19,7 +19,7 @@
       "rpcInfraLabel": "Infra",
       "rpcRegionAriaLabel": "RPC region",
       "rpcRegionLabel": "Region",
-      "rpcTimeframeAriaLabel": "RPC time frame",
+      "rpcTimeframeAriaLabel": "Dashboard time frame",
       "rpcTimeframeLabel": "Time frame",
       "providersLabel": "Providers"
     },
@@ -46,6 +46,11 @@
       "rpc": {
         "label": "RPC",
         "description": "Latency metrics for Solana RPC providers."
+      },
+      "senders": {
+        "label": "Tx Senders",
+        "description": "Transaction volume, tips, and fee economics across Solana transaction-sending providers.",
+        "clarification": "Transactions represent activity with a positive tip during the selected time frame."
       }
     },
     "summaryAriaLabel": "{tab} summary",
@@ -86,8 +91,8 @@
           "cta": "View repo"
         },
         "senderMetrics": {
-          "title": "Sender Metrics",
-          "description": "View sender usage, tipping transactions, fees, and tips by provider.",
+          "title": "Tx Sender Metrics",
+          "description": "View transaction sender usage, tipping transactions, fees, and tips by provider.",
           "cta": "Open dashboard"
         },
         "allium": {
@@ -106,6 +111,17 @@
           "cta": "Open Lightspeed"
         }
       }
+    },
+    "senderEconomics": {
+      "ariaLabel": "Transaction sender provider economics",
+      "title": "Provider economics",
+      "rangeTotal": "Selected time frame",
+      "provider": "Provider",
+      "transactions": "Transactions",
+      "totalTips": "Total tips (SOL)",
+      "totalFees": "Total fees (SOL)",
+      "medianTip": "Median tip (lamports)",
+      "medianFee": "Median fee (lamports)"
     },
     "kpisAriaLabel": "Key metrics",
     "chartsAriaLabel": "{tab} charts",
@@ -134,10 +150,12 @@
       "lastTimeframe": "Last {timeframe}",
       "refreshCadence": "Refreshes twice daily after 10 AM and 10 PM ET",
       "rpcRefreshCadence": "RPC latency refreshes every minute",
+      "senderRefreshCadence": "Transaction sender metrics refresh every minute",
       "lastRefreshed": "Last refreshed",
       "lagNotice": "Lagging by 1 day to support all tools' refresh schedules.",
       "rpcFilter": "{method} in {region} on {infra}",
       "rpcSource": "Grafana Cloud Prometheus",
+      "senderSource": "Grafana sender dashboard",
       "ossRepo": "OSS repo",
       "addRpcProvider": "Add your RPC",
       "source": "Data aggregator",


### PR DESCRIPTION
## Summary

- add a native Tx Senders tab that mirrors the public Grafana economics table, tipping-volume time series, and provider rankings
- reuse the RPC timeframe/provider controls and live SWR refresh behavior while preserving RPC region, infrastructure, and method filters
- add the /api/rpc/sender/data server route with the same one-minute server/edge caching and in-flight deduplication pattern as RPC
- add logarithmic chart scaling for sender volume and keep the active RPC/Sender tab visible on mobile
- update dashboard copy and source links for the new first-class data view

## Validation

- pnpm --filter solana-com test (183 passed, 18 skipped)
- pnpm --filter solana-com check-types
- pnpm --filter solana-com lint (existing warnings only)
- pnpm --filter solana-com build
- live checks against 30m, 6h, and 1y Sender ranges
- production cache check: s-maxage=60, stale-while-revalidate=300
- desktop and mobile visual checks

## Stack

This PR is based on #1656 and contains only the Tx Senders follow-up.