### PR TITLE
chore: patch transitive dependency vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,9 @@ overrides:
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   immutable@>=5.0.0-beta.1 <5.1.8: 5.1.9
   fast-uri@>=3.0.0 <3.1.4: 3.1.4
-  postcss@<=8.5.11: 8.5.15
+  postcss@<=8.5.17: 8.5.18
+  glob@9.3.5>minimatch: 9.0.7
+  brace-expansion@>=5.0.0 <5.0.8: 5.0.8
   sharp@<0.35.0: 0.35.3
   seti-icons@0.0.4>svgo: 2.8.3
   thrift@0.23.0>uuid: 11.1.1
@@ -66,16 +68,16 @@ importers:
     dependencies:
       "@mdx-js/loader":
         specifier: ^3.1.1
-        version: 3.1.1(webpack@5.101.3(postcss@8.5.15))
+        version: 3.1.1(webpack@5.101.3(postcss@8.5.18))
       "@mdx-js/react":
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.1.12)(react@19.2.6)
       "@next/mdx":
         specifier: ^15.2.9
-        version: 15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(postcss@8.5.15)))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))
+        version: 15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(postcss@8.5.18)))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.18))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -157,13 +159,13 @@ importers:
         version: link:../../packages/config-typescript
       autoprefixer:
         specifier: ^10.4.27
-        version: 10.5.0(postcss@8.5.15)
+        version: 10.5.0(postcss@8.5.18)
       dotenv:
         specifier: ^16.4.7
         version: 16.6.1
       postcss:
-        specifier: 8.5.15
-        version: 8.5.15
+        specifier: 8.5.18
+        version: 8.5.18
       sass:
         specifier: ^1.92.1
         version: 1.92.1
@@ -181,7 +183,7 @@ importers:
     dependencies:
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -250,8 +252,8 @@ importers:
         specifier: ^26.1.0
         version: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       postcss:
-        specifier: 8.5.15
-        version: 8.5.15
+        specifier: 8.5.18
+        version: 8.5.18
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -308,7 +310,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -380,7 +382,7 @@ importers:
         version: 5.1.0
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
-        version: 5.0.2(postcss@8.5.15)
+        version: 5.0.2(postcss@8.5.18)
       posthog-js:
         specifier: ^1.232.7
         version: 1.261.8
@@ -465,13 +467,13 @@ importers:
         version: link:../../packages/config-typescript
       autoprefixer:
         specifier: ^10.4.27
-        version: 10.5.0(postcss@8.5.15)
+        version: 10.5.0(postcss@8.5.18)
       postcss:
-        specifier: 8.5.15
-        version: 8.5.15
+        specifier: 8.5.18
+        version: 8.5.18
       postcss-preset-env:
         specifier: ^10.0.9
-        version: 10.3.1(postcss@8.5.15)
+        version: 10.3.1(postcss@8.5.18)
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19(tsx@4.22.4)(yaml@2.8.1)
@@ -504,7 +506,7 @@ importers:
         version: 1.2.4(@types/react@19.1.12)(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -652,19 +654,19 @@ importers:
         version: link:../../packages/config-typescript
       autoprefixer:
         specifier: ^10.4.27
-        version: 10.5.0(postcss@8.5.15)
+        version: 10.5.0(postcss@8.5.18)
       eslint-plugin-mdx:
         specifier: ^3.7.0
         version: 3.7.0(eslint@9.39.4(jiti@2.6.1))
       postcss:
-        specifier: ^8.5.15
-        version: 8.5.15
+        specifier: 8.5.18
+        version: 8.5.18
       postcss-import:
         specifier: ^16.1.1
-        version: 16.1.1(postcss@8.5.15)
+        version: 16.1.1(postcss@8.5.18)
       postcss-nesting:
         specifier: ^13.0.2
-        version: 13.0.2(postcss@8.5.15)
+        version: 13.0.2(postcss@8.5.18)
       sharp:
         specifier: ^0.35.0
         version: 0.35.3(@types/node@24.13.3)
@@ -767,10 +769,10 @@ importers:
         version: link:../../packages/config-typescript
       autoprefixer:
         specifier: ^10.4.27
-        version: 10.5.0(postcss@8.5.15)
+        version: 10.5.0(postcss@8.5.18)
       postcss:
-        specifier: 8.5.15
-        version: 8.5.15
+        specifier: 8.5.18
+        version: 8.5.18
       sass:
         specifier: ^1.92.1
         version: 1.92.1
@@ -827,7 +829,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -932,7 +934,7 @@ importers:
         version: 5.1.0
       postcss-flexbugs-fixes:
         specifier: ^5.0.2
-        version: 5.0.2(postcss@8.5.15)
+        version: 5.0.2(postcss@8.5.18)
       posthog-js:
         specifier: ^1.232.7
         version: 1.261.8
@@ -1044,22 +1046,22 @@ importers:
         version: link:../../packages/config-typescript
       autoprefixer:
         specifier: ^10.4.27
-        version: 10.5.0(postcss@8.5.15)
+        version: 10.5.0(postcss@8.5.18)
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       postcss:
-        specifier: 8.5.15
-        version: 8.5.15
+        specifier: 8.5.18
+        version: 8.5.18
       postcss-preset-env:
         specifier: ^10.0.9
-        version: 10.3.1(postcss@8.5.15)
+        version: 10.3.1(postcss@8.5.18)
       tailwindcss:
         specifier: ^3.4.19
         version: 3.4.19(tsx@4.22.4)(yaml@2.8.1)
       ts-loader:
         specifier: ^9.5.7
-        version: 9.6.0(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
+        version: 9.6.0(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.17))(@types/node@24.13.3)(typescript@5.8.3)
@@ -1222,7 +1224,7 @@ importers:
         version: link:../config-typescript
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(@swc/core@1.15.41(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.8.3)(yaml@2.8.1)
+        version: 8.5.1(@swc/core@1.15.41(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.18)(tsx@4.22.4)(typescript@5.8.3)(yaml@2.8.1)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -2729,7 +2731,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-cascade-layers@5.0.2":
     resolution:
@@ -2738,7 +2740,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-color-function-display-p3-linear@1.0.0":
     resolution:
@@ -2747,7 +2749,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-color-function@4.0.11":
     resolution:
@@ -2756,7 +2758,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-color-mix-function@3.0.11":
     resolution:
@@ -2765,7 +2767,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-color-mix-variadic-function-arguments@1.0.1":
     resolution:
@@ -2774,7 +2776,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-content-alt-text@2.0.7":
     resolution:
@@ -2783,7 +2785,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-exponential-functions@2.0.9":
     resolution:
@@ -2792,7 +2794,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-font-format-keywords@4.0.0":
     resolution:
@@ -2801,7 +2803,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-gamut-mapping@2.0.11":
     resolution:
@@ -2810,7 +2812,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-gradients-interpolation-method@5.0.11":
     resolution:
@@ -2819,7 +2821,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-hwb-function@4.0.11":
     resolution:
@@ -2828,7 +2830,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-ic-unit@4.0.3":
     resolution:
@@ -2837,7 +2839,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-initial@2.0.1":
     resolution:
@@ -2846,7 +2848,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-is-pseudo-class@5.0.3":
     resolution:
@@ -2855,7 +2857,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-light-dark-function@2.0.10":
     resolution:
@@ -2864,7 +2866,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-logical-float-and-clear@3.0.0":
     resolution:
@@ -2873,7 +2875,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-logical-overflow@2.0.0":
     resolution:
@@ -2882,7 +2884,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-logical-overscroll-behavior@2.0.0":
     resolution:
@@ -2891,7 +2893,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-logical-resize@3.0.0":
     resolution:
@@ -2900,7 +2902,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-logical-viewport-units@3.0.4":
     resolution:
@@ -2909,7 +2911,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-media-minmax@2.0.9":
     resolution:
@@ -2918,7 +2920,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5":
     resolution:
@@ -2927,7 +2929,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-nested-calc@4.0.0":
     resolution:
@@ -2936,7 +2938,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-normalize-display-values@4.0.0":
     resolution:
@@ -2945,7 +2947,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-oklab-function@4.0.11":
     resolution:
@@ -2954,7 +2956,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-progressive-custom-properties@4.2.0":
     resolution:
@@ -2963,7 +2965,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-random-function@2.0.1":
     resolution:
@@ -2972,7 +2974,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-relative-color-syntax@3.0.11":
     resolution:
@@ -2981,7 +2983,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-scope-pseudo-class@4.0.1":
     resolution:
@@ -2990,7 +2992,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-sign-functions@1.1.4":
     resolution:
@@ -2999,7 +3001,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-stepped-value-functions@4.0.9":
     resolution:
@@ -3008,7 +3010,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-text-decoration-shorthand@4.0.3":
     resolution:
@@ -3017,7 +3019,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-trigonometric-functions@4.0.9":
     resolution:
@@ -3026,7 +3028,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/postcss-unset-value@4.0.0":
     resolution:
@@ -3035,7 +3037,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/selector-resolve-nested@3.1.0":
     resolution:
@@ -3062,7 +3064,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@dabh/diagnostics@2.0.8":
     resolution:
@@ -9787,7 +9789,7 @@ packages:
     engines: { node: ^10 || ^12 || >=14 }
     hasBin: true
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   available-typed-arrays@1.0.7:
     resolution:
@@ -9948,18 +9950,12 @@ packages:
         integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==,
       }
 
-  brace-expansion@2.1.2:
+  brace-expansion@5.0.8:
     resolution:
       {
-        integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==,
+        integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==,
       }
-
-  brace-expansion@5.0.7:
-    resolution:
-      {
-        integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==,
-      }
-    engines: { node: 18 || 20 || >=22 }
+    engines: { node: 20 || >=22 }
 
   braces@3.0.3:
     resolution:
@@ -10580,7 +10576,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   css-box-shadow@1.0.0-3:
     resolution:
@@ -10609,7 +10605,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   css-prefers-color-scheme@10.0.0:
     resolution:
@@ -10618,7 +10614,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   css-select@4.3.0:
     resolution:
@@ -14422,13 +14418,6 @@ packages:
         integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==,
       }
 
-  minimatch@8.0.6:
-    resolution:
-      {
-        integrity: sha512-JVNTX5Qc03lB0PuFDuUcVTbi8u5kKchLXDYEnLJrOosZW8cqamFiyItG/7cn0QEt7XmeFHSLJRYg4KujJKuqlw==,
-      }
-    engines: { node: ">=16 || 14 >=14.17" }
-
   minimatch@9.0.7:
     resolution:
       {
@@ -14557,14 +14546,6 @@ packages:
       {
         integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
       }
-
-  nanoid@3.3.11:
-    resolution:
-      {
-        integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==,
-      }
-    engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
-    hasBin: true
 
   nanoid@3.3.12:
     resolution:
@@ -15310,7 +15291,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-clamp@4.1.0:
     resolution:
@@ -15319,7 +15300,7 @@ packages:
       }
     engines: { node: ">=7.6.0" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-color-functional-notation@7.0.11:
     resolution:
@@ -15328,7 +15309,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-color-hex-alpha@10.0.0:
     resolution:
@@ -15337,7 +15318,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-color-rebeccapurple@10.0.0:
     resolution:
@@ -15346,7 +15327,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-custom-media@11.0.6:
     resolution:
@@ -15355,7 +15336,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-custom-properties@14.0.6:
     resolution:
@@ -15364,7 +15345,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-custom-selectors@8.0.5:
     resolution:
@@ -15373,7 +15354,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-dir-pseudo-class@9.0.1:
     resolution:
@@ -15382,7 +15363,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-double-position-gradients@6.0.3:
     resolution:
@@ -15391,7 +15372,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-flexbugs-fixes@5.0.2:
     resolution:
@@ -15399,7 +15380,7 @@ packages:
         integrity: sha512-18f9voByak7bTktR2QgDveglpn9DTbBWPUzSOe9g0N4WR/2eSt6Vrcbf0hmspvMI6YWGywz6B9f7jzpFNJJgnQ==,
       }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-focus-visible@10.0.1:
     resolution:
@@ -15408,7 +15389,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-focus-within@9.0.1:
     resolution:
@@ -15417,7 +15398,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-font-variant@5.0.0:
     resolution:
@@ -15425,7 +15406,7 @@ packages:
         integrity: sha512-1fmkBaCALD72CK2a9i468mA/+tr9/1cBxRRMXOUaZqO43oWPR5imcyPjXwuv7PXbCid4ndlP5zWhidQVVa3hmA==,
       }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-gap-properties@6.0.0:
     resolution:
@@ -15434,7 +15415,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-image-set-function@7.0.0:
     resolution:
@@ -15443,7 +15424,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-import@15.1.0:
     resolution:
@@ -15452,7 +15433,7 @@ packages:
       }
     engines: { node: ">=14.0.0" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-import@16.1.1:
     resolution:
@@ -15461,7 +15442,7 @@ packages:
       }
     engines: { node: ">=18.0.0" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-js@4.0.1:
     resolution:
@@ -15470,7 +15451,7 @@ packages:
       }
     engines: { node: ^12 || ^14 || >= 16 }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-lab-function@7.0.11:
     resolution:
@@ -15479,7 +15460,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-load-config@6.0.1:
     resolution:
@@ -15489,7 +15470,7 @@ packages:
     engines: { node: ">= 18" }
     peerDependencies:
       jiti: ">=1.21.0"
-      postcss: 8.5.15
+      postcss: 8.5.18
       tsx: ^4.8.1
       yaml: ^2.4.2
     peerDependenciesMeta:
@@ -15509,7 +15490,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-nested@6.2.0:
     resolution:
@@ -15518,7 +15499,7 @@ packages:
       }
     engines: { node: ">=12.0" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-nesting@13.0.2:
     resolution:
@@ -15527,7 +15508,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-opacity-percentage@3.0.0:
     resolution:
@@ -15536,7 +15517,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-overflow-shorthand@6.0.0:
     resolution:
@@ -15545,7 +15526,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-page-break@3.0.4:
     resolution:
@@ -15553,7 +15534,7 @@ packages:
         integrity: sha512-1JGu8oCjVXLa9q9rFTo4MbeeA5FMe00/9C7lN4va606Rdb+HkxXtXsmEDrIraQ11fGz/WvKWa8gMuCKkrXpTsQ==,
       }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-place@10.0.0:
     resolution:
@@ -15562,7 +15543,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-preset-env@10.3.1:
     resolution:
@@ -15571,7 +15552,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-pseudo-class-any-link@10.0.1:
     resolution:
@@ -15580,7 +15561,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-replace-overflow-wrap@4.0.0:
     resolution:
@@ -15588,7 +15569,7 @@ packages:
         integrity: sha512-KmF7SBPphT4gPPcKZc7aDkweHiKEEO8cla/GjcBK+ckKxiZslIu3C4GCRW3DNfL0o7yW7kMQu9xlZ1kXRXLXtw==,
       }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-selector-not@8.0.1:
     resolution:
@@ -15597,7 +15578,7 @@ packages:
       }
     engines: { node: ">=18" }
     peerDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   postcss-selector-parser@6.0.10:
     resolution:
@@ -15626,10 +15607,10 @@ packages:
         integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==,
       }
 
-  postcss@8.5.15:
+  postcss@8.5.18:
     resolution:
       {
-        integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==,
+        integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -17717,7 +17698,7 @@ packages:
     peerDependencies:
       "@microsoft/api-extractor": ^7.36.0
       "@swc/core": ^1
-      postcss: 8.5.15
+      postcss: 8.5.18
       typescript: ">=4.5.0"
     peerDependenciesMeta:
       "@microsoft/api-extractor":
@@ -18830,7 +18811,7 @@ snapshots:
   "@ai-sdk/provider-utils@2.2.8(zod@4.4.3)":
     dependencies:
       "@ai-sdk/provider": 1.1.3
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       secure-json-parse: 2.7.0
       zod: 4.4.3
 
@@ -19764,242 +19745,242 @@ snapshots:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
 
-  "@csstools/postcss-alpha-function@1.0.0(postcss@8.5.15)":
+  "@csstools/postcss-alpha-function@1.0.0(postcss@8.5.18)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.15)":
+  "@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.18)":
     dependencies:
       "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.0)
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
-  "@csstools/postcss-color-function-display-p3-linear@1.0.0(postcss@8.5.15)":
+  "@csstools/postcss-color-function-display-p3-linear@1.0.0(postcss@8.5.18)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-color-function@4.0.11(postcss@8.5.15)":
+  "@csstools/postcss-color-function@4.0.11(postcss@8.5.18)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-color-mix-function@3.0.11(postcss@8.5.15)":
+  "@csstools/postcss-color-mix-function@3.0.11(postcss@8.5.18)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-color-mix-variadic-function-arguments@1.0.1(postcss@8.5.15)":
+  "@csstools/postcss-color-mix-variadic-function-arguments@1.0.1(postcss@8.5.18)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-content-alt-text@2.0.7(postcss@8.5.15)":
+  "@csstools/postcss-content-alt-text@2.0.7(postcss@8.5.18)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-exponential-functions@2.0.9(postcss@8.5.15)":
+  "@csstools/postcss-exponential-functions@2.0.9(postcss@8.5.18)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.15)":
+  "@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.18)":
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-gamut-mapping@2.0.11(postcss@8.5.15)":
+  "@csstools/postcss-gamut-mapping@2.0.11(postcss@8.5.18)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-gradients-interpolation-method@5.0.11(postcss@8.5.15)":
+  "@csstools/postcss-gradients-interpolation-method@5.0.11(postcss@8.5.18)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-hwb-function@4.0.11(postcss@8.5.15)":
+  "@csstools/postcss-hwb-function@4.0.11(postcss@8.5.18)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-ic-unit@4.0.3(postcss@8.5.15)":
+  "@csstools/postcss-ic-unit@4.0.3(postcss@8.5.18)":
     dependencies:
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-initial@2.0.1(postcss@8.5.15)":
+  "@csstools/postcss-initial@2.0.1(postcss@8.5.18)":
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.15)":
+  "@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.18)":
     dependencies:
       "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.0)
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
-  "@csstools/postcss-light-dark-function@2.0.10(postcss@8.5.15)":
+  "@csstools/postcss-light-dark-function@2.0.10(postcss@8.5.18)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.15)":
+  "@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.18)":
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.15)":
+  "@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.18)":
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.15)":
+  "@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.18)":
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-logical-resize@3.0.0(postcss@8.5.15)":
+  "@csstools/postcss-logical-resize@3.0.0(postcss@8.5.18)":
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-logical-viewport-units@3.0.4(postcss@8.5.15)":
+  "@csstools/postcss-logical-viewport-units@3.0.4(postcss@8.5.18)":
     dependencies:
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-media-minmax@2.0.9(postcss@8.5.15)":
+  "@csstools/postcss-media-minmax@2.0.9(postcss@8.5.18)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
       "@csstools/media-query-list-parser": 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5(postcss@8.5.15)":
+  "@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5(postcss@8.5.18)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
       "@csstools/media-query-list-parser": 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-nested-calc@4.0.0(postcss@8.5.15)":
+  "@csstools/postcss-nested-calc@4.0.0(postcss@8.5.18)":
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-normalize-display-values@4.0.0(postcss@8.5.15)":
+  "@csstools/postcss-normalize-display-values@4.0.0(postcss@8.5.18)":
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-oklab-function@4.0.11(postcss@8.5.15)":
+  "@csstools/postcss-oklab-function@4.0.11(postcss@8.5.18)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-progressive-custom-properties@4.2.0(postcss@8.5.15)":
+  "@csstools/postcss-progressive-custom-properties@4.2.0(postcss@8.5.18)":
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-random-function@2.0.1(postcss@8.5.15)":
+  "@csstools/postcss-random-function@2.0.1(postcss@8.5.18)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-relative-color-syntax@3.0.11(postcss@8.5.15)":
+  "@csstools/postcss-relative-color-syntax@3.0.11(postcss@8.5.18)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  "@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.15)":
+  "@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.18)":
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
-  "@csstools/postcss-sign-functions@1.1.4(postcss@8.5.15)":
+  "@csstools/postcss-sign-functions@1.1.4(postcss@8.5.18)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-stepped-value-functions@4.0.9(postcss@8.5.15)":
+  "@csstools/postcss-stepped-value-functions@4.0.9(postcss@8.5.18)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-text-decoration-shorthand@4.0.3(postcss@8.5.15)":
+  "@csstools/postcss-text-decoration-shorthand@4.0.3(postcss@8.5.18)":
     dependencies:
       "@csstools/color-helpers": 5.1.0
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-trigonometric-functions@4.0.9(postcss@8.5.15)":
+  "@csstools/postcss-trigonometric-functions@4.0.9(postcss@8.5.18)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  "@csstools/postcss-unset-value@4.0.0(postcss@8.5.15)":
+  "@csstools/postcss-unset-value@4.0.0(postcss@8.5.18)":
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.0)":
     dependencies:
@@ -20009,9 +19990,9 @@ snapshots:
     dependencies:
       postcss-selector-parser: 7.1.0
 
-  "@csstools/utilities@2.0.0(postcss@8.5.15)":
+  "@csstools/utilities@2.0.0(postcss@8.5.18)":
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   "@dabh/diagnostics@2.0.8":
     dependencies:
@@ -20878,12 +20859,12 @@ snapshots:
       "@types/react": 19.1.12
       react: 19.2.6
 
-  "@mdx-js/loader@3.1.1(webpack@5.101.3(postcss@8.5.15))":
+  "@mdx-js/loader@3.1.1(webpack@5.101.3(postcss@8.5.18))":
     dependencies:
       "@mdx-js/mdx": 3.1.1
       source-map: 0.7.6
     optionalDependencies:
-      webpack: 5.101.3(postcss@8.5.15)
+      webpack: 5.101.3(postcss@8.5.18)
     transitivePeerDependencies:
       - supports-color
 
@@ -20950,11 +20931,11 @@ snapshots:
     dependencies:
       fast-glob: 3.3.1
 
-  "@next/mdx@15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(postcss@8.5.15)))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))":
+  "@next/mdx@15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(postcss@8.5.18)))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))":
     dependencies:
       source-map: 0.7.6
     optionalDependencies:
-      "@mdx-js/loader": 3.1.1(webpack@5.101.3(postcss@8.5.15))
+      "@mdx-js/loader": 3.1.1(webpack@5.101.3(postcss@8.5.18))
       "@mdx-js/react": 3.1.1(@types/react@19.1.12)(react@19.2.6)
 
   "@next/swc-darwin-arm64@15.5.21":
@@ -22521,7 +22502,7 @@ snapshots:
 
   "@sentry/core@10.11.0": {}
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.15))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.18))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -22533,7 +22514,7 @@ snapshots:
       "@sentry/opentelemetry": 10.11.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)
       "@sentry/react": 10.11.0(react@19.2.6)
       "@sentry/vercel-edge": 10.11.0
-      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(postcss@8.5.15))
+      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(postcss@8.5.18))
       chalk: 3.0.0
       next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
@@ -22548,7 +22529,7 @@ snapshots:
       - supports-color
       - webpack
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -22560,7 +22541,7 @@ snapshots:
       "@sentry/opentelemetry": 10.11.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)
       "@sentry/react": 10.11.0(react@19.2.6)
       "@sentry/vercel-edge": 10.11.0
-      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
+      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))
       chalk: 3.0.0
       next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
@@ -22575,7 +22556,7 @@ snapshots:
       - supports-color
       - webpack
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -22587,7 +22568,7 @@ snapshots:
       "@sentry/opentelemetry": 10.11.0(@opentelemetry/api@1.9.0)(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/semantic-conventions@1.37.0)
       "@sentry/react": 10.11.0(react@19.2.6)
       "@sentry/vercel-edge": 10.11.0
-      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
+      "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
       chalk: 3.0.0
       next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
@@ -22677,32 +22658,32 @@ snapshots:
       "@opentelemetry/resources": 2.1.0(@opentelemetry/api@1.9.0)
       "@sentry/core": 10.11.0
 
-  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))":
+  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))":
     dependencies:
       "@sentry/bundler-plugin-core": 4.3.0
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))":
+  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))":
     dependencies:
       "@sentry/bundler-plugin-core": 4.3.0
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.101.3(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.101.3(lightningcss@1.32.0)(postcss@8.5.18)
     transitivePeerDependencies:
       - encoding
       - supports-color
 
-  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3(postcss@8.5.15))":
+  "@sentry/webpack-plugin@4.3.0(webpack@5.101.3(postcss@8.5.18))":
     dependencies:
       "@sentry/bundler-plugin-core": 4.3.0
       unplugin: 1.0.1
       uuid: 9.0.1
-      webpack: 5.101.3(postcss@8.5.15)
+      webpack: 5.101.3(postcss@8.5.18)
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -23843,7 +23824,7 @@ snapshots:
       "@alloc/quick-lru": 5.2.0
       "@tailwindcss/node": 4.2.4
       "@tailwindcss/oxide": 4.2.4
-      postcss: 8.5.15
+      postcss: 8.5.18
       tailwindcss: 4.2.4
 
   "@tailwindcss/typography@0.5.19(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1))":
@@ -24934,13 +24915,13 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  autoprefixer@10.5.0(postcss@8.5.15):
+  autoprefixer@10.5.0(postcss@8.5.18):
     dependencies:
       browserslist: 4.28.6
       caniuse-lite: 1.0.30001793
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
   available-typed-arrays@1.0.7:
@@ -25030,11 +25011,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
-    dependencies:
-      balanced-match: 1.0.2
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -25380,9 +25357,9 @@ snapshots:
 
   css-background-parser@0.1.0: {}
 
-  css-blank-pseudo@7.0.1(postcss@8.5.15):
+  css-blank-pseudo@7.0.1(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
   css-box-shadow@1.0.0-3: {}
@@ -25391,16 +25368,16 @@ snapshots:
 
   css-gradient-parser@0.0.16: {}
 
-  css-has-pseudo@7.0.3(postcss@8.5.15):
+  css-has-pseudo@7.0.3(postcss@8.5.18):
     dependencies:
       "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.0)
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
       postcss-value-parser: 4.2.0
 
-  css-prefers-color-scheme@10.0.0(postcss@8.5.15):
+  css-prefers-color-scheme@10.0.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   css-select@4.3.0:
     dependencies:
@@ -26620,7 +26597,7 @@ snapshots:
   glob@9.3.5:
     dependencies:
       fs.realpath: 1.0.0
-      minimatch: 8.0.6
+      minimatch: 9.0.7
       minipass: 4.2.8
       path-scurry: 1.11.1
 
@@ -28078,19 +28055,15 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.16
 
-  minimatch@8.0.6:
-    dependencies:
-      brace-expansion: 2.1.2
-
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minipass-collect@2.0.1:
     dependencies:
@@ -28151,8 +28124,6 @@ snapshots:
       any-promise: 1.3.0
       object-assign: 4.1.1
       thenify-all: 1.6.0
-
-  nanoid@3.3.11: {}
 
   nanoid@3.3.12: {}
 
@@ -28215,7 +28186,7 @@ snapshots:
       "@next/env": 15.5.21
       "@swc/helpers": 0.5.15
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.15
+      postcss: 8.5.18
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.6)
@@ -28599,265 +28570,265 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-attribute-case-insensitive@7.0.1(postcss@8.5.15):
+  postcss-attribute-case-insensitive@7.0.1(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
-  postcss-clamp@4.1.0(postcss@8.5.15):
+  postcss-clamp@4.1.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  postcss-color-functional-notation@7.0.11(postcss@8.5.15):
+  postcss-color-functional-notation@7.0.11(postcss@8.5.18):
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  postcss-color-hex-alpha@10.0.0(postcss@8.5.15):
+  postcss-color-hex-alpha@10.0.0(postcss@8.5.18):
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  postcss-color-rebeccapurple@10.0.0(postcss@8.5.15):
+  postcss-color-rebeccapurple@10.0.0(postcss@8.5.18):
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  postcss-custom-media@11.0.6(postcss@8.5.15):
+  postcss-custom-media@11.0.6(postcss@8.5.18):
     dependencies:
       "@csstools/cascade-layer-name-parser": 2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
       "@csstools/media-query-list-parser": 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  postcss-custom-properties@14.0.6(postcss@8.5.15):
+  postcss-custom-properties@14.0.6(postcss@8.5.18):
     dependencies:
       "@csstools/cascade-layer-name-parser": 2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  postcss-custom-selectors@8.0.5(postcss@8.5.15):
+  postcss-custom-selectors@8.0.5(postcss@8.5.18):
     dependencies:
       "@csstools/cascade-layer-name-parser": 2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
-  postcss-dir-pseudo-class@9.0.1(postcss@8.5.15):
+  postcss-dir-pseudo-class@9.0.1(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
-  postcss-double-position-gradients@6.0.3(postcss@8.5.15):
+  postcss-double-position-gradients@6.0.3(postcss@8.5.18):
     dependencies:
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  postcss-flexbugs-fixes@5.0.2(postcss@8.5.15):
+  postcss-flexbugs-fixes@5.0.2(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  postcss-focus-visible@10.0.1(postcss@8.5.15):
+  postcss-focus-visible@10.0.1(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
-  postcss-focus-within@9.0.1(postcss@8.5.15):
+  postcss-focus-within@9.0.1(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
-  postcss-font-variant@5.0.0(postcss@8.5.15):
+  postcss-font-variant@5.0.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  postcss-gap-properties@6.0.0(postcss@8.5.15):
+  postcss-gap-properties@6.0.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  postcss-image-set-function@7.0.0(postcss@8.5.15):
+  postcss-image-set-function@7.0.0(postcss@8.5.18):
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  postcss-import@15.1.0(postcss@8.5.15):
+  postcss-import@15.1.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
-      postcss-value-parser: 4.2.0
-      read-cache: 1.0.0
-      resolve: 1.22.10
-
-  postcss-import@16.1.1(postcss@8.5.15):
-    dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.10
 
-  postcss-js@4.0.1(postcss@8.5.15):
+  postcss-import@16.1.1(postcss@8.5.18):
+    dependencies:
+      postcss: 8.5.18
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.10
+
+  postcss-js@4.0.1(postcss@8.5.18):
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  postcss-lab-function@7.0.11(postcss@8.5.15):
+  postcss-lab-function@7.0.11(postcss@8.5.18):
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/utilities": 2.0.0(postcss@8.5.15)
-      postcss: 8.5.15
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/utilities": 2.0.0(postcss@8.5.18)
+      postcss: 8.5.18
 
-  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.8.1):
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.18)(tsx@4.22.4)(yaml@2.8.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 1.21.7
-      postcss: 8.5.15
+      postcss: 8.5.18
       tsx: 4.22.4
       yaml: 2.8.1
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.8.1):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.18)(tsx@4.22.4)(yaml@2.8.1):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
-      postcss: 8.5.15
+      postcss: 8.5.18
       tsx: 4.22.4
       yaml: 2.8.1
 
-  postcss-logical@8.1.0(postcss@8.5.15):
+  postcss-logical@8.1.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  postcss-nested@6.2.0(postcss@8.5.15):
+  postcss-nested@6.2.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 6.1.2
 
-  postcss-nesting@13.0.2(postcss@8.5.15):
+  postcss-nesting@13.0.2(postcss@8.5.18):
     dependencies:
       "@csstools/selector-resolve-nested": 3.1.0(postcss-selector-parser@7.1.0)
       "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.0)
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
-  postcss-opacity-percentage@3.0.0(postcss@8.5.15):
+  postcss-opacity-percentage@3.0.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  postcss-overflow-shorthand@6.0.0(postcss@8.5.15):
+  postcss-overflow-shorthand@6.0.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  postcss-page-break@3.0.4(postcss@8.5.15):
+  postcss-page-break@3.0.4(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  postcss-place@10.0.0(postcss@8.5.15):
+  postcss-place@10.0.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-value-parser: 4.2.0
 
-  postcss-preset-env@10.3.1(postcss@8.5.15):
+  postcss-preset-env@10.3.1(postcss@8.5.18):
     dependencies:
-      "@csstools/postcss-alpha-function": 1.0.0(postcss@8.5.15)
-      "@csstools/postcss-cascade-layers": 5.0.2(postcss@8.5.15)
-      "@csstools/postcss-color-function": 4.0.11(postcss@8.5.15)
-      "@csstools/postcss-color-function-display-p3-linear": 1.0.0(postcss@8.5.15)
-      "@csstools/postcss-color-mix-function": 3.0.11(postcss@8.5.15)
-      "@csstools/postcss-color-mix-variadic-function-arguments": 1.0.1(postcss@8.5.15)
-      "@csstools/postcss-content-alt-text": 2.0.7(postcss@8.5.15)
-      "@csstools/postcss-exponential-functions": 2.0.9(postcss@8.5.15)
-      "@csstools/postcss-font-format-keywords": 4.0.0(postcss@8.5.15)
-      "@csstools/postcss-gamut-mapping": 2.0.11(postcss@8.5.15)
-      "@csstools/postcss-gradients-interpolation-method": 5.0.11(postcss@8.5.15)
-      "@csstools/postcss-hwb-function": 4.0.11(postcss@8.5.15)
-      "@csstools/postcss-ic-unit": 4.0.3(postcss@8.5.15)
-      "@csstools/postcss-initial": 2.0.1(postcss@8.5.15)
-      "@csstools/postcss-is-pseudo-class": 5.0.3(postcss@8.5.15)
-      "@csstools/postcss-light-dark-function": 2.0.10(postcss@8.5.15)
-      "@csstools/postcss-logical-float-and-clear": 3.0.0(postcss@8.5.15)
-      "@csstools/postcss-logical-overflow": 2.0.0(postcss@8.5.15)
-      "@csstools/postcss-logical-overscroll-behavior": 2.0.0(postcss@8.5.15)
-      "@csstools/postcss-logical-resize": 3.0.0(postcss@8.5.15)
-      "@csstools/postcss-logical-viewport-units": 3.0.4(postcss@8.5.15)
-      "@csstools/postcss-media-minmax": 2.0.9(postcss@8.5.15)
-      "@csstools/postcss-media-queries-aspect-ratio-number-values": 3.0.5(postcss@8.5.15)
-      "@csstools/postcss-nested-calc": 4.0.0(postcss@8.5.15)
-      "@csstools/postcss-normalize-display-values": 4.0.0(postcss@8.5.15)
-      "@csstools/postcss-oklab-function": 4.0.11(postcss@8.5.15)
-      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.15)
-      "@csstools/postcss-random-function": 2.0.1(postcss@8.5.15)
-      "@csstools/postcss-relative-color-syntax": 3.0.11(postcss@8.5.15)
-      "@csstools/postcss-scope-pseudo-class": 4.0.1(postcss@8.5.15)
-      "@csstools/postcss-sign-functions": 1.1.4(postcss@8.5.15)
-      "@csstools/postcss-stepped-value-functions": 4.0.9(postcss@8.5.15)
-      "@csstools/postcss-text-decoration-shorthand": 4.0.3(postcss@8.5.15)
-      "@csstools/postcss-trigonometric-functions": 4.0.9(postcss@8.5.15)
-      "@csstools/postcss-unset-value": 4.0.0(postcss@8.5.15)
-      autoprefixer: 10.5.0(postcss@8.5.15)
+      "@csstools/postcss-alpha-function": 1.0.0(postcss@8.5.18)
+      "@csstools/postcss-cascade-layers": 5.0.2(postcss@8.5.18)
+      "@csstools/postcss-color-function": 4.0.11(postcss@8.5.18)
+      "@csstools/postcss-color-function-display-p3-linear": 1.0.0(postcss@8.5.18)
+      "@csstools/postcss-color-mix-function": 3.0.11(postcss@8.5.18)
+      "@csstools/postcss-color-mix-variadic-function-arguments": 1.0.1(postcss@8.5.18)
+      "@csstools/postcss-content-alt-text": 2.0.7(postcss@8.5.18)
+      "@csstools/postcss-exponential-functions": 2.0.9(postcss@8.5.18)
+      "@csstools/postcss-font-format-keywords": 4.0.0(postcss@8.5.18)
+      "@csstools/postcss-gamut-mapping": 2.0.11(postcss@8.5.18)
+      "@csstools/postcss-gradients-interpolation-method": 5.0.11(postcss@8.5.18)
+      "@csstools/postcss-hwb-function": 4.0.11(postcss@8.5.18)
+      "@csstools/postcss-ic-unit": 4.0.3(postcss@8.5.18)
+      "@csstools/postcss-initial": 2.0.1(postcss@8.5.18)
+      "@csstools/postcss-is-pseudo-class": 5.0.3(postcss@8.5.18)
+      "@csstools/postcss-light-dark-function": 2.0.10(postcss@8.5.18)
+      "@csstools/postcss-logical-float-and-clear": 3.0.0(postcss@8.5.18)
+      "@csstools/postcss-logical-overflow": 2.0.0(postcss@8.5.18)
+      "@csstools/postcss-logical-overscroll-behavior": 2.0.0(postcss@8.5.18)
+      "@csstools/postcss-logical-resize": 3.0.0(postcss@8.5.18)
+      "@csstools/postcss-logical-viewport-units": 3.0.4(postcss@8.5.18)
+      "@csstools/postcss-media-minmax": 2.0.9(postcss@8.5.18)
+      "@csstools/postcss-media-queries-aspect-ratio-number-values": 3.0.5(postcss@8.5.18)
+      "@csstools/postcss-nested-calc": 4.0.0(postcss@8.5.18)
+      "@csstools/postcss-normalize-display-values": 4.0.0(postcss@8.5.18)
+      "@csstools/postcss-oklab-function": 4.0.11(postcss@8.5.18)
+      "@csstools/postcss-progressive-custom-properties": 4.2.0(postcss@8.5.18)
+      "@csstools/postcss-random-function": 2.0.1(postcss@8.5.18)
+      "@csstools/postcss-relative-color-syntax": 3.0.11(postcss@8.5.18)
+      "@csstools/postcss-scope-pseudo-class": 4.0.1(postcss@8.5.18)
+      "@csstools/postcss-sign-functions": 1.1.4(postcss@8.5.18)
+      "@csstools/postcss-stepped-value-functions": 4.0.9(postcss@8.5.18)
+      "@csstools/postcss-text-decoration-shorthand": 4.0.3(postcss@8.5.18)
+      "@csstools/postcss-trigonometric-functions": 4.0.9(postcss@8.5.18)
+      "@csstools/postcss-unset-value": 4.0.0(postcss@8.5.18)
+      autoprefixer: 10.5.0(postcss@8.5.18)
       browserslist: 4.25.4
-      css-blank-pseudo: 7.0.1(postcss@8.5.15)
-      css-has-pseudo: 7.0.3(postcss@8.5.15)
-      css-prefers-color-scheme: 10.0.0(postcss@8.5.15)
+      css-blank-pseudo: 7.0.1(postcss@8.5.18)
+      css-has-pseudo: 7.0.3(postcss@8.5.18)
+      css-prefers-color-scheme: 10.0.0(postcss@8.5.18)
       cssdb: 8.4.0
-      postcss: 8.5.15
-      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.15)
-      postcss-clamp: 4.1.0(postcss@8.5.15)
-      postcss-color-functional-notation: 7.0.11(postcss@8.5.15)
-      postcss-color-hex-alpha: 10.0.0(postcss@8.5.15)
-      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.15)
-      postcss-custom-media: 11.0.6(postcss@8.5.15)
-      postcss-custom-properties: 14.0.6(postcss@8.5.15)
-      postcss-custom-selectors: 8.0.5(postcss@8.5.15)
-      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.15)
-      postcss-double-position-gradients: 6.0.3(postcss@8.5.15)
-      postcss-focus-visible: 10.0.1(postcss@8.5.15)
-      postcss-focus-within: 9.0.1(postcss@8.5.15)
-      postcss-font-variant: 5.0.0(postcss@8.5.15)
-      postcss-gap-properties: 6.0.0(postcss@8.5.15)
-      postcss-image-set-function: 7.0.0(postcss@8.5.15)
-      postcss-lab-function: 7.0.11(postcss@8.5.15)
-      postcss-logical: 8.1.0(postcss@8.5.15)
-      postcss-nesting: 13.0.2(postcss@8.5.15)
-      postcss-opacity-percentage: 3.0.0(postcss@8.5.15)
-      postcss-overflow-shorthand: 6.0.0(postcss@8.5.15)
-      postcss-page-break: 3.0.4(postcss@8.5.15)
-      postcss-place: 10.0.0(postcss@8.5.15)
-      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.15)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.15)
-      postcss-selector-not: 8.0.1(postcss@8.5.15)
+      postcss: 8.5.18
+      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.18)
+      postcss-clamp: 4.1.0(postcss@8.5.18)
+      postcss-color-functional-notation: 7.0.11(postcss@8.5.18)
+      postcss-color-hex-alpha: 10.0.0(postcss@8.5.18)
+      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.18)
+      postcss-custom-media: 11.0.6(postcss@8.5.18)
+      postcss-custom-properties: 14.0.6(postcss@8.5.18)
+      postcss-custom-selectors: 8.0.5(postcss@8.5.18)
+      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.18)
+      postcss-double-position-gradients: 6.0.3(postcss@8.5.18)
+      postcss-focus-visible: 10.0.1(postcss@8.5.18)
+      postcss-focus-within: 9.0.1(postcss@8.5.18)
+      postcss-font-variant: 5.0.0(postcss@8.5.18)
+      postcss-gap-properties: 6.0.0(postcss@8.5.18)
+      postcss-image-set-function: 7.0.0(postcss@8.5.18)
+      postcss-lab-function: 7.0.11(postcss@8.5.18)
+      postcss-logical: 8.1.0(postcss@8.5.18)
+      postcss-nesting: 13.0.2(postcss@8.5.18)
+      postcss-opacity-percentage: 3.0.0(postcss@8.5.18)
+      postcss-overflow-shorthand: 6.0.0(postcss@8.5.18)
+      postcss-page-break: 3.0.4(postcss@8.5.18)
+      postcss-place: 10.0.0(postcss@8.5.18)
+      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.18)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.18)
+      postcss-selector-not: 8.0.1(postcss@8.5.18)
 
-  postcss-pseudo-class-any-link@10.0.1(postcss@8.5.15):
+  postcss-pseudo-class-any-link@10.0.1(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
-  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.15):
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  postcss-selector-not@8.0.1(postcss@8.5.15):
+  postcss-selector-not@8.0.1(postcss@8.5.18):
     dependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
       postcss-selector-parser: 7.1.0
 
   postcss-selector-parser@6.0.10:
@@ -28877,7 +28848,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.15:
+  postcss@8.5.18:
     dependencies:
       nanoid: 3.3.12
       picocolors: 1.1.1
@@ -29600,7 +29571,7 @@ snapshots:
       is-plain-object: 5.0.0
       launder: 1.7.1
       parse-srcset: 1.0.2
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   sass@1.92.1:
     dependencies:
@@ -30152,11 +30123,11 @@ snapshots:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.1.1
-      postcss: 8.5.15
-      postcss-import: 15.1.0(postcss@8.5.15)
-      postcss-js: 4.0.1(postcss@8.5.15)
-      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.8.1)
-      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss: 8.5.18
+      postcss-import: 15.1.0(postcss@8.5.18)
+      postcss-js: 4.0.1(postcss@8.5.18)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.18)(tsx@4.22.4)(yaml@2.8.1)
+      postcss-nested: 6.2.0(postcss@8.5.18)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
       sucrase: 3.35.0
@@ -30168,38 +30139,38 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.0(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18)
     optionalDependencies:
       "@swc/core": 1.15.41(@swc/helpers@0.5.17)
       lightningcss: 1.32.0
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  terser-webpack-plugin@5.6.0(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.0(lightningcss@1.32.0)(postcss@8.5.18)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.101.3(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.101.3(lightningcss@1.32.0)(postcss@8.5.18)
     optionalDependencies:
       lightningcss: 1.32.0
-      postcss: 8.5.15
+      postcss: 8.5.18
 
-  terser-webpack-plugin@5.6.0(postcss@8.5.15)(webpack@5.101.3(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.0(postcss@8.5.18)(webpack@5.101.3(postcss@8.5.18)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.101.3(postcss@8.5.15)
+      webpack: 5.101.3(postcss@8.5.18)
     optionalDependencies:
-      postcss: 8.5.15
+      postcss: 8.5.18
 
   terser@5.48.0:
     dependencies:
@@ -30297,7 +30268,7 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  ts-loader@9.6.0(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)):
+  ts-loader@9.6.0(typescript@5.8.3)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18)):
     dependencies:
       chalk: 4.1.2
       enhanced-resolve: 5.22.0
@@ -30305,7 +30276,7 @@ snapshots:
       semver: 7.7.4
       source-map: 0.7.6
       typescript: 5.8.3
-      webpack: 5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18)
 
   ts-node@10.9.2(@swc/core@1.15.41(@swc/helpers@0.5.17))(@types/node@24.13.3)(typescript@5.8.3):
     dependencies:
@@ -30329,7 +30300,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(@swc/core@1.15.41(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.15)(tsx@4.22.4)(typescript@5.8.3)(yaml@2.8.1):
+  tsup@8.5.1(@swc/core@1.15.41(@swc/helpers@0.5.17))(jiti@2.6.1)(postcss@8.5.18)(tsx@4.22.4)(typescript@5.8.3)(yaml@2.8.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.28.1)
       cac: 6.7.14
@@ -30340,7 +30311,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.8.1)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.18)(tsx@4.22.4)(yaml@2.8.1)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -30350,7 +30321,7 @@ snapshots:
       tree-kill: 1.2.2
     optionalDependencies:
       "@swc/core": 1.15.41(@swc/helpers@0.5.17)
-      postcss: 8.5.15
+      postcss: 8.5.18
       typescript: 5.8.3
     transitivePeerDependencies:
       - jiti
@@ -30719,7 +30690,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.18
       rollup: 4.59.0
       tinyglobby: 0.2.15
     optionalDependencies:
@@ -30811,7 +30782,7 @@ snapshots:
 
   webpack-virtual-modules@0.5.0: {}
 
-  webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15):
+  webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18):
     dependencies:
       "@types/eslint-scope": 3.7.7
       "@types/estree": 1.0.9
@@ -30835,7 +30806,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.0(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:
@@ -30852,7 +30823,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15):
+  webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18):
     dependencies:
       "@types/eslint-scope": 3.7.7
       "@types/estree": 1.0.9
@@ -30876,7 +30847,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.0(lightningcss@1.32.0)(postcss@8.5.18)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:
@@ -30893,7 +30864,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.101.3(postcss@8.5.15):
+  webpack@5.101.3(postcss@8.5.18):
     dependencies:
       "@types/eslint-scope": 3.7.7
       "@types/estree": 1.0.9
@@ -30917,7 +30888,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.0(postcss@8.5.15)(webpack@5.101.3(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.0(postcss@8.5.18)(webpack@5.101.3(postcss@8.5.18))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,8 +21,15 @@ overrides:
   # Keep AJV's URI parser on the release patched for GHSA-v2hh-gcrm-f6hx.
   "fast-uri@>=3.0.0 <3.1.4": 3.1.4
   # Keep transitive PostCSS consumers on a release patched for
-  # GHSA-6g55-p6wh-862q.
-  "postcss@<=8.5.11": 8.5.15
+  # GHSA-6g55-p6wh-862q and GHSA-r28c-9q8g-f849.
+  "postcss@<=8.5.17": 8.5.18
+  # Sentry's glob 9 dependency resolves minimatch 8, whose brace-expansion 2
+  # fix is still inside the package-age quarantine window. Use the compatible
+  # minimatch 9 release already present in the workspace instead.
+  "glob@9.3.5>minimatch": 9.0.7
+  # Keep its transitive brace expansion on the release patched for
+  # GHSA-mh99-v99m-4gvg.
+  "brace-expansion@>=5.0.0 <5.0.8": 5.0.8
   # Next.js 15 still requests Sharp 0.34, so force its optional dependency onto
   # the current patched release containing the updated libvips binaries.
   "sharp@<0.35.0": 0.35.3


### PR DESCRIPTION
## Summary

- update the PostCSS override to 8.5.18 for GHSA-r28c-9q8g-f849
- move Sentry’s `glob@9` path to the compatible `minimatch@9.0.7` already used in the workspace
- pin that path to patched `brace-expansion@5.0.8` and refresh the lockfile

## Security context

This fixes the production dependency audit without changing direct application dependencies or bypassing the repository’s package-age quarantine. It is intentionally independent of the documentation stack that surfaced the repository-wide audit failure.