### PR TITLE
Add repo-local page localization skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,17 @@
+# Repository skills
+
+This directory contains repo-scoped skills for repeatable agent workflows in the
+Solana.com monorepo. Skills capture project-specific procedures and guardrails
+that do not belong in runtime application code.
+
+Each skill lives in its own directory and has a `SKILL.md` file with its trigger
+description and operating instructions. A skill may also include:
+
+- `agents/` for skill-list metadata
+- `references/` for detailed repository or domain guidance
+- `scripts/` for deterministic workflow helpers
+- `assets/` for files copied into generated output
+
+Invoke a skill by name, for example `$localize-page`. Keep skills concise,
+validate them with the standard skill validator, and update them when repository
+conventions change.

--- a/skills/README.md
+++ b/skills/README.md
@@ -12,13 +12,11 @@ description and operating instructions. A skill may also include:
 - `references/` for detailed repository or domain guidance
 - `scripts/` for deterministic workflow helpers
 - `assets/` for files copied into generated output
-- `agents/` for optional product-specific adapter metadata
 
-The `SKILL.md` workflow must not depend on files under `agents/`. Compatible
-agents can discover or register this directory using their normal skill
-mechanism. Other agents can use the same workflow by reading the relevant
-`SKILL.md` and its linked resources directly. Product-specific invocation
-syntax, such as `$localize-page`, is optional.
+Compatible agents can discover or register this directory using their normal
+skill mechanism. Other agents can use the same workflow by reading the relevant
+`SKILL.md` and its linked resources directly. Product-specific invocation syntax
+is optional.
 
 Keep skills concise, validate them against the open specification, and update
 them when repository conventions change.

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,17 +1,24 @@
 # Repository skills
 
-This directory contains repo-scoped skills for repeatable agent workflows in the
-Solana.com monorepo. Skills capture project-specific procedures and guardrails
-that do not belong in runtime application code.
+This directory contains repo-scoped, agent-agnostic skills for repeatable
+workflows in the Solana.com monorepo. Skills capture project-specific procedures
+and guardrails that do not belong in runtime application code.
 
-Each skill lives in its own directory and has a `SKILL.md` file with its trigger
+The portable interface follows the
+[Agent Skills specification](https://agentskills.io/specification). Each skill
+lives in its own directory and has a `SKILL.md` file with its trigger
 description and operating instructions. A skill may also include:
 
-- `agents/` for skill-list metadata
 - `references/` for detailed repository or domain guidance
 - `scripts/` for deterministic workflow helpers
 - `assets/` for files copied into generated output
+- `agents/` for optional product-specific adapter metadata
 
-Invoke a skill by name, for example `$localize-page`. Keep skills concise,
-validate them with the standard skill validator, and update them when repository
-conventions change.
+The `SKILL.md` workflow must not depend on files under `agents/`. Compatible
+agents can discover or register this directory using their normal skill
+mechanism. Other agents can use the same workflow by reading the relevant
+`SKILL.md` and its linked resources directly. Product-specific invocation
+syntax, such as `$localize-page`, is optional.
+
+Keep skills concise, validate them against the open specification, and update
+them when repository conventions change.

--- a/skills/localize-page/SKILL.md
+++ b/skills/localize-page/SKILL.md
@@ -34,7 +34,9 @@ Start from the repository root.
    content.
 4. Check the worktree status and preserve unrelated user changes.
 5. If the user supplied a public URL rather than a file, resolve it with the
-   route map in the root `AGENTS.md` and the app's rewrites.
+   root `AGENTS.md` route map and the canonical cross-app routing sources
+   `apps/web/rewrites-redirects.ts` and `apps/web/apps-urls.ts`, then inspect
+   the owning app's rewrites when needed.
 
 Do not change providers, locale middleware, shared package contracts, asset
 prefixes, or rewrites for a page-only task unless the existing route cannot

--- a/skills/localize-page/SKILL.md
+++ b/skills/localize-page/SKILL.md
@@ -100,20 +100,51 @@ configured Lingo engine's glossary and instructions handle them.
 - Reuse an inherited key only when its meaning and context truly match. Do not
   duplicate a web namespace into a child app catalog.
 
-### 5. Wire the page without widening client boundaries
+### 5. Use the shared drop-ins and classify every link
 
-Prefer the shared exports for new code:
+Prefer `@workspace/i18n/*` over direct `next-intl`, `next/link`, or
+`next/navigation` imports when the package exposes the required API. Use the
+core page-level drop-ins:
 
-- server components and metadata: `getTranslations` from
-  `@workspace/i18n/server`
-- client components: `useTranslations`, `useLocale`, or the provider from
-  `@workspace/i18n/client`
-- locale-aware internal navigation: `Link`, `redirect`, `usePathname`, or
-  `useRouter` from `@workspace/i18n/routing`
+- `@workspace/i18n/server` for `getTranslations`
+- `@workspace/i18n/client` for `useTranslations`, `useLocale`, `useMessages`,
+  and `NextIntlClientProvider`
+- `@workspace/i18n/routing` for locale-aware `Link`, `redirect`, `usePathname`,
+  `useRouter`, `getAlternates`, and static-param helpers
+- `@workspace/i18n/messages` for full merged catalogs, locale resolution, and
+  English fallback outside ordinary component translation
+- `@workspace/i18n/config` and `@workspace/i18n/pathname` for canonical locale
+  data and locale-prefix parsing
 
-Use a direct `next-intl` import only for an API the shared package does not
-export or when a narrow adjacent convention makes changing it safer. Avoid
-unrelated import churn.
+When app-level i18n wiring is genuinely missing or in scope, reuse
+`createAppRequestConfig` or `loadAppRequestMessages` from
+`@workspace/i18n/request`, `createNextIntlPlugin` from `@workspace/i18n/plugin`,
+and the shared middleware primitives from `@workspace/i18n/middleware`. Do not
+copy their merging, fallback, cookie, proxy-origin, or locale-detection behavior
+into an app. Read the full drop-in matrix in the reference before changing app
+setup.
+
+Use a direct framework import only for an API the shared package does not export
+or when a narrow adjacent convention makes changing it safer. Avoid unrelated
+import churn.
+
+Classify each link before choosing a component:
+
+1. For a route owned by the current deployed app, use `Link` from
+   `@workspace/i18n/routing`; it applies the configured locale prefix.
+2. For a known sibling-app route, use a normal same-domain `<a href="/...">` so
+   navigation performs a full page load through the public rewrite. Do not use a
+   Vercel deployment URL or manually add a locale prefix.
+3. For shared or reusable UI whose target may be same-app or cross-app, use
+   `Link` from `@solana-com/ui-chrome/link`; it delegates to the i18n link or a
+   normal anchor using `NEXT_PUBLIC_APP_NAME` and the shared route map.
+4. Use normal anchors for external URLs, protocol-relative URLs, `mailto:`,
+   `tel:`, downloads, and hash-only navigation unless an established local
+   component requires otherwise.
+
+Use `apps/web/rewrites-redirects.ts` and `packages/ui-chrome/src/url-config.ts`
+as the canonical ownership sources. Treat `apps/web/apps-urls.ts` as proxy
+destination configuration, never as a source of public hrefs.
 
 Keep server pages as server components. Translate there with `getTranslations`,
 or translate inside an existing client child with `useTranslations`; do not add
@@ -143,14 +174,18 @@ official pages linked in the reference before editing.
 ### 7. Validate proportionally
 
 1. Re-scan the affected JSX/TSX for remaining hard-coded user-facing copy.
-2. Parse every edited JSON source catalog.
-3. Run `pnpm i18n:verify-source-locales`.
-4. Run `pnpm i18n:audit` when JSON namespaces changed and inspect its report.
-5. Run the owning workspace's formatter/lint and type check from its
+2. Review new direct imports from `next-intl`, `next/link`, and
+   `next/navigation`; replace them with shared drop-ins when applicable.
+3. Verify each affected href uses same-app, cross-app, or external navigation
+   intentionally.
+4. Parse every edited JSON source catalog.
+5. Run `pnpm i18n:verify-source-locales`.
+6. Run `pnpm i18n:audit` when JSON namespaces changed and inspect its report.
+7. Run the owning workspace's formatter/lint and type check from its
    `package.json` or `AGENTS.md`; run focused tests when present.
-6. For docs content, run the docs frontmatter guard and regenerate Fumadocs
+8. For docs content, run the docs frontmatter guard and regenerate Fumadocs
    sources when the app guidance requires it.
-7. If the user explicitly requested generated translations, use the repo's
+9. If the user explicitly requested generated translations, use the repo's
    scoped `pnpm i18n:app <app>` or `pnpm i18n:docs` command and review all
    generated target and lockfile changes.
 

--- a/skills/localize-page/SKILL.md
+++ b/skills/localize-page/SKILL.md
@@ -15,6 +15,13 @@ Make the requested page locale-ready while preserving its design, behavior, data
 flow, and app ownership. Produce the implementation, not only a list of strings,
 unless the user explicitly asks for an audit.
 
+Use this as a runtime-neutral Agent Skills procedure. Do not depend on a
+particular agent product, proprietary tool name, or invocation syntax. Use the
+host agent's equivalent file-reading, search, editing, shell, and web
+capabilities. If the host does not discover skills automatically, load this
+`SKILL.md` and its linked reference directly. Product-specific files under
+`agents/` are optional adapters and are not required to follow this workflow.
+
 Read [references/repo-i18n-patterns.md](references/repo-i18n-patterns.md) before
 editing. Treat the checked-out repository as the final authority when it has
 evolved beyond the reference.

--- a/skills/localize-page/SKILL.md
+++ b/skills/localize-page/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: localize-page
+description:
+  Convert or refactor Solana.com monorepo pages and their directly owned
+  components to the repository's shared i18n system. Use when asked to
+  internationalize, localize, remove hard-coded user-facing copy from, add
+  translations to, or audit a page or route in apps/web, apps/docs, apps/media,
+  apps/templates, apps/accelerate, or apps/breakpoint, including localized
+  metadata, route links, JSON catalogs, docs MDX, and Lingo.dev source setup.
+---
+
+# Localize Page
+
+Make the requested page locale-ready while preserving its design, behavior, data
+flow, and app ownership. Produce the implementation, not only a list of strings,
+unless the user explicitly asks for an audit.
+
+Read [references/repo-i18n-patterns.md](references/repo-i18n-patterns.md) before
+editing. Treat the checked-out repository as the final authority when it has
+evolved beyond the reference.
+
+## Follow the workflow
+
+### 1. Resolve the owning surface
+
+Start from the repository root.
+
+1. Read the root `AGENTS.md`, the owning app's `AGENTS.md`, its `package.json`,
+   and `next.config.ts`.
+2. Inspect the target route, its directly owned components, the app's i18n
+   request file and locale layout, and one nearby localized route.
+3. Inspect `packages/i18n/src/config.ts`, `packages/i18n/src/messages.ts`,
+   `.lingo/config.json`, and the relevant English source catalog or docs
+   content.
+4. Check the worktree status and preserve unrelated user changes.
+5. If the user supplied a public URL rather than a file, resolve it with the
+   route map in the root `AGENTS.md` and the app's rewrites.
+
+Do not change providers, locale middleware, shared package contracts, asset
+prefixes, or rewrites for a page-only task unless the existing route cannot
+otherwise use the shared setup.
+
+### 2. Choose the source of truth
+
+Use the narrowest source already owned by the app:
+
+| Target        | English source                                                             |
+| ------------- | -------------------------------------------------------------------------- |
+| Web UI        | `packages/i18n/messages/web/en/common.json`                                |
+| Docs React UI | Web catalog inherited by the docs app                                      |
+| Docs prose    | The matching English MDX or `meta.json` covered by `.lingo/config.json`    |
+| Media UI      | Media catalog; reuse inherited web keys only when semantically shared      |
+| Templates UI  | Templates catalog; reuse inherited web keys only when semantically shared  |
+| Accelerate UI | Accelerate catalog; reuse inherited web keys only when semantically shared |
+| Breakpoint UI | `packages/i18n/messages/breakpoint/en/breakpoint.json`                     |
+
+Do not create a docs JSON catalog: `docs` intentionally inherits `web`.
+Breakpoint has runtime i18n but is not currently an automated Lingo source. Keep
+that limitation visible in the handoff rather than silently expanding
+translation scope.
+
+### 3. Inventory all user-facing copy
+
+Cover the route and its directly owned components. Extract:
+
+- headings, paragraphs, labels, buttons, links, captions, badges, and tooltips
+- form labels, placeholders, validation, loading, empty, success, and error text
+- meaningful image alt text, `aria-label` text, screen-reader text, and titles
+- page metadata, social image alt text, structured data, and breadcrumb names
+- client-side notices, modal copy, filter names, and generated count labels
+
+Keep decorative empty alt text, URLs, IDs, code tokens, analytics values,
+machine-readable constants, and external data out of catalogs. Do not translate
+brand or technical terms by hard-coding target-language values; let the
+configured Lingo engine's glossary and instructions handle them.
+
+### 4. Design stable messages
+
+- Add English source keys only. Never hand-translate every target catalog during
+  ordinary page work.
+- Create one semantic route-level namespace when a suitable namespace does not
+  exist. Follow nearby casing and nesting.
+- Name keys by purpose, not by copying the English sentence.
+- Nest related `metadata`, `actions`, `form`, `errors`, `aria`, and content
+  groups.
+- Use ICU variables such as `{count}` and `{name}` instead of concatenating
+  translated fragments.
+- Use `t.rich` when markup or links belong inside a sentence. Do not split a
+  grammatical sentence across JSX nodes or keys.
+- Keep arrays and identifiers in typed code when they control behavior; map
+  stable IDs to translated leaf keys at render time.
+- Reuse an inherited key only when its meaning and context truly match. Do not
+  duplicate a web namespace into a child app catalog.
+
+### 5. Wire the page without widening client boundaries
+
+Prefer the shared exports for new code:
+
+- server components and metadata: `getTranslations` from
+  `@workspace/i18n/server`
+- client components: `useTranslations`, `useLocale`, or the provider from
+  `@workspace/i18n/client`
+- locale-aware internal navigation: `Link`, `redirect`, `usePathname`, or
+  `useRouter` from `@workspace/i18n/routing`
+
+Use a direct `next-intl` import only for an API the shared package does not
+export or when a narrow adjacent convention makes changing it safer. Avoid
+unrelated import churn.
+
+Keep server pages as server components. Translate there with `getTranslations`,
+or translate inside an existing client child with `useTranslations`; do not add
+`"use client"` to an entire page merely to access messages.
+
+For `generateMetadata`, await `params`, pass `locale` explicitly to
+`getTranslations`, and preserve the owning app's canonical/alternate helper.
+Localize structured data wherever its human-readable fields mirror page copy.
+
+### 6. Handle docs and Lingo correctly
+
+For docs prose already represented by MDX, edit the English MDX instead of
+moving it into a JSON catalog. Preserve frontmatter and component structure.
+Only the frontmatter fields and component props listed in `.lingo/config.json`
+are translated automatically. Never put backticks in docs frontmatter.
+
+Treat `.lingo/config.json` as the repository's source/target scope and engine
+authority. Treat `.lingo/lock.json` as generated state; never edit it manually.
+Do not run Lingo, use `--force`, change engine settings, or mutate target locale
+files unless the user explicitly requests translation output or configuration
+changes. Routine source work is picked up by the main-branch localization
+workflow.
+
+If Lingo configuration or platform behavior must change, consult the current
+official pages linked in the reference before editing.
+
+### 7. Validate proportionally
+
+1. Re-scan the affected JSX/TSX for remaining hard-coded user-facing copy.
+2. Parse every edited JSON source catalog.
+3. Run `pnpm i18n:verify-source-locales`.
+4. Run `pnpm i18n:audit` when JSON namespaces changed and inspect its report.
+5. Run the owning workspace's formatter/lint and type check from its
+   `package.json` or `AGENTS.md`; run focused tests when present.
+6. For docs content, run the docs frontmatter guard and regenerate Fumadocs
+   sources when the app guidance requires it.
+7. If the user explicitly requested generated translations, use the repo's
+   scoped `pnpm i18n:app <app>` or `pnpm i18n:docs` command and review all
+   generated target and lockfile changes.
+
+Do not claim complete localization when a CMS record, fetched API value, or
+Lingo-excluded content source remains English. State those boundaries.
+
+## Report the result
+
+Summarize the route and owned components localized, the source namespace or MDX
+files changed, metadata and navigation handling, validations run, and any
+content outside the automated Lingo scope. Mention that target locales will be
+generated by the existing workflow when Lingo was not run.

--- a/skills/localize-page/SKILL.md
+++ b/skills/localize-page/SKILL.md
@@ -19,8 +19,7 @@ Use this as a runtime-neutral Agent Skills procedure. Do not depend on a
 particular agent product, proprietary tool name, or invocation syntax. Use the
 host agent's equivalent file-reading, search, editing, shell, and web
 capabilities. If the host does not discover skills automatically, load this
-`SKILL.md` and its linked reference directly. Product-specific files under
-`agents/` are optional adapters and are not required to follow this workflow.
+`SKILL.md` and its linked reference directly.
 
 Read [references/repo-i18n-patterns.md](references/repo-i18n-patterns.md) before
 editing. Treat the checked-out repository as the final authority when it has

--- a/skills/localize-page/agents/openai.yaml
+++ b/skills/localize-page/agents/openai.yaml
@@ -1,0 +1,6 @@
+interface:
+  display_name: "Localize Page"
+  short_description: "Apply Solana.com page i18n conventions"
+  default_prompt:
+    "Use $localize-page to internationalize this Solana.com page using the
+    owning app’s shared catalog and routing patterns."

--- a/skills/localize-page/agents/openai.yaml
+++ b/skills/localize-page/agents/openai.yaml
@@ -1,6 +1,0 @@
-interface:
-  display_name: "Localize Page"
-  short_description: "Apply Solana.com page i18n conventions"
-  default_prompt:
-    "Use $localize-page to internationalize this Solana.com page using the
-    owning app’s shared catalog and routing patterns."

--- a/skills/localize-page/references/repo-i18n-patterns.md
+++ b/skills/localize-page/references/repo-i18n-patterns.md
@@ -3,6 +3,19 @@
 Use this reference for repository-specific decisions. Verify paths against the
 checkout before editing because the monorepo continues to evolve.
 
+## Contents
+
+- [Architecture](#architecture)
+- [App and source matrix](#app-and-source-matrix)
+- [Core `@workspace/i18n` drop-ins](#core-workspacei18n-drop-ins)
+- [Server and client component patterns](#server-component-pattern)
+- [Links and navigation](#links-and-navigation)
+- [Metadata and structured data](#metadata-and-structured-data)
+- [Message construction](#message-construction)
+- [Docs content rules](#docs-content-rules)
+- [Lingo.dev integration](#lingodev-integration)
+- [Validation](#validation)
+
 ## Architecture
 
 - `packages/i18n/src/config.ts` owns supported locales and the English default.
@@ -48,6 +61,68 @@ learn/developer UI, currently come from the web catalog. Do not add
 The templates app currently renders with English as its layout locale even
 though translated target catalogs exist. Localize source copy consistently, but
 do not redesign templates routing during a page-only task.
+
+## Core `@workspace/i18n` drop-ins
+
+The package exposes each source module through `@workspace/i18n/<module>`.
+Prefer these shared contracts over reimplementing `next-intl` setup or importing
+framework navigation directly.
+
+| Module       | Public API to prefer                                                                                                              | Use it for                                                                   |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `client`     | `NextIntlClientProvider`, `useLocale`, `useMessages`, `useTranslations`                                                           | Client components and locale providers                                       |
+| `server`     | `getRequestConfig`, `getTranslations`                                                                                             | Server components, metadata, and request configuration internals             |
+| `routing`    | `routing`, `Link`, `redirect`, `usePathname`, `useRouter`, `getAlternates`, `withLocales`, `slugWithLocales`, `pathsWithLocales`  | Locale-aware same-app navigation, canonical alternates, and static params    |
+| `request`    | `createAppRequestConfig`, `loadAppRequestMessages`                                                                                | Standard app request files and typed full-message loading                    |
+| `messages`   | `resolveLocale`, `deepMergeMessages`, `loadAppMessages`, `loadMergedMessages`, `getEnglishFallbackMessages`, `getMessageFallback` | Layouts, route handlers, social images, and app catalog inheritance/fallback |
+| `config`     | `locales`, `languages`, `defaultLocale`, `namespaces`, `staticLocales`                                                            | Canonical locale data and language labels                                    |
+| `pathname`   | `getLocaleFromPathname`, `getPathnameWithoutLocale`                                                                               | Parsing raw URL strings and middleware paths                                 |
+| `plugin`     | `createNextIntlPlugin`                                                                                                            | Wiring an app request file into `next.config.ts`                             |
+| `middleware` | `createMiddleware`, `routing`, `routingWithoutDetection`, `SHARED_LOCALE_COOKIE`, cookie, pathname, and proxy-origin helpers      | Locale routing across the multi-app deployment                               |
+| `use-router` | compatibility `useRouter` and locale-free `usePathname`                                                                           | Existing shared code that must span Pages Router and App Router              |
+
+`@workspace/i18n/alternates` and `@workspace/i18n/load-messages` are lower-level
+entry points. Prefer `getAlternates` from `routing` and the app-aware
+`request`/`messages` loaders unless the existing code genuinely needs those
+primitives.
+
+Use `@workspace/i18n/use-router` only for the existing mixed-router
+compatibility case. New App Router components should normally use
+`useRouter`/`usePathname` from `@workspace/i18n/routing`.
+
+If the shared package does not export a needed API, such as `useFormatter`,
+importing that API directly from `next-intl` is valid. Keep the exception
+narrow; do not bypass the shared routing, message-loading, or request contracts.
+
+Use `loadMergedMessages` instead of importing locale JSON directly when code
+needs a complete catalog. It applies app inheritance and English fallback.
+Ordinary components should still use `getTranslations` or `useTranslations`
+rather than loading entire catalogs.
+
+For standard request setup, prefer:
+
+```ts
+import { createAppRequestConfig } from "@workspace/i18n/request";
+
+export default createAppRequestConfig("breakpoint");
+```
+
+Use a custom request callback only when the owning app has a verified
+requirement not covered by the shared factory.
+
+For app configuration, prefer:
+
+```ts
+import { createNextIntlPlugin } from "@workspace/i18n/plugin";
+
+const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
+```
+
+For the main web app, use middleware `routing` with locale detection. For
+separately deployed apps reached through web rewrites, use
+`routingWithoutDetection` and preserve proxied locale-cookie behavior by
+following the adjacent middleware pattern. Do not change this distinction in a
+page-only task.
 
 ## Server component pattern
 
@@ -99,19 +174,82 @@ If a server component already owns the copy and a client child is presentation
 only, passing translated string props is also valid. Match the narrower local
 pattern.
 
-## Internal navigation
+## Links and navigation
 
-Use the shared locale-aware navigation for internal Solana.com routes:
+### Same-app routes
+
+Use the shared locale-aware link for routes owned by the current deployed app:
 
 ```tsx
 import { Link } from "@workspace/i18n/routing";
 
-<Link href="/developers">{t("actions.developers")}</Link>;
+<Link href="/data">{t("actions.exploreData")}</Link>;
 ```
 
-Keep ordinary anchors for hash links, downloads, `mailto:`, and truly external
-URLs. When navigation crosses separately deployed apps, also inspect
-`packages/ui-chrome/src/url-config.ts` and the owning app's `next.config.ts`.
+The configured `Link` adds or changes the locale prefix according to
+`localePrefix: "as-needed"`. Its `usePathname` returns a pathname without the
+locale prefix, and its `useRouter` provides locale-aware client navigation. Do
+not manually build `/${locale}/...` hrefs.
+
+### Sibling-app routes
+
+Routes can share the public `solana.com` origin while being owned by different
+Next.js deployments. A client-side Next navigation to a sibling route asks the
+wrong app router to resolve it. Use a full document navigation:
+
+```tsx
+<a href="/docs">{t("actions.readDocs")}</a>
+```
+
+Keep the href relative to the public origin. Do not link to the deployment hosts
+from `apps/web/apps-urls.ts`. Do not manually prefix the locale: the shared
+`SOLANA_LOCALE` cookie and destination middleware restore the preferred locale
+on the full request.
+
+Determine ownership from:
+
+1. `apps/web/rewrites-redirects.ts`
+2. `packages/ui-chrome/src/url-config.ts`
+3. the target app's `next.config.ts`
+
+The ordering matters for overlapping paths such as `/developers/templates`
+versus broader docs-owned `/developers` routes.
+
+### Reusable links
+
+When a shared component accepts arbitrary internal or external targets, use the
+cross-app-aware chrome link:
+
+```tsx
+import { Link } from "@solana-com/ui-chrome/link";
+
+<Link href={href}>{label}</Link>;
+```
+
+It calls `shouldUseNextLink` from `@solana-com/ui-chrome/url-config`. On the web
+app, routes owned by sibling apps become anchors; on a non-web app, only routes
+owned by that app use client navigation. Non-web apps declare ownership with
+`NEXT_PUBLIC_APP_NAME` in `next.config.ts`.
+
+The chrome link is a client component. Do not turn a server-rendered page into a
+client component solely to use it. When a server component has a known target,
+render the same-app i18n `Link` or cross-app anchor directly.
+
+If an app-owned component cannot use the chrome link but still accepts variable
+targets, call `shouldUseNextLink` and render either `@workspace/i18n/routing`'s
+`Link` or an anchor. Do not use `next/link` for the localized branch.
+
+### External and special links
+
+Use normal anchors for:
+
+- `https://`, `http://`, and protocol-relative URLs
+- `mailto:` and `tel:`
+- downloads
+- hash-only navigation when no established local component requires otherwise
+
+Preserve appropriate `target`, `rel`, download, and accessibility behavior.
+Translate the visible label and accessible name, not the href.
 
 ## Metadata and structured data
 

--- a/skills/localize-page/references/repo-i18n-patterns.md
+++ b/skills/localize-page/references/repo-i18n-patterns.md
@@ -1,0 +1,277 @@
+# Solana.com page i18n patterns
+
+Use this reference for repository-specific decisions. Verify paths against the
+checkout before editing because the monorepo continues to evolve.
+
+## Architecture
+
+- `packages/i18n/src/config.ts` owns supported locales and the English default.
+- `packages/i18n/src/messages.ts` owns app catalog loaders, English fallback,
+  deep merging, and app inheritance.
+- App request files connect `next-intl` to the appropriate `AppId`.
+- Locale layouts load merged messages and provide `NextIntlClientProvider`.
+- `@workspace/i18n/server`, `client`, and `routing` expose the preferred shared
+  APIs for new code.
+- `localePrefix: "as-needed"` means English has no URL prefix while other
+  locales do.
+- Most apps statically generate English and serve other locales dynamically.
+- Child app catalogs inherit the web catalog. A child catalog should contain
+  only app-specific messages.
+
+The current inheritance graph in `packages/i18n/src/messages.ts` is:
+
+```text
+web
+├── docs
+├── accelerate
+├── media
+├── breakpoint
+└── templates
+```
+
+## App and source matrix
+
+| App          | Workspace               | UI source                                                  | Automated Lingo scope                  | Scoped command             |
+| ------------ | ----------------------- | ---------------------------------------------------------- | -------------------------------------- | -------------------------- |
+| Web          | `solana-com`            | `packages/i18n/messages/web/en/common.json`                | Web English JSON                       | `pnpm i18n:app web`        |
+| Docs UI      | `solana-docs`           | Inherited web English JSON                                 | Run as web UI, not docs content        | `pnpm i18n:app web`        |
+| Docs content | `solana-docs`           | English MDX and `meta.json` listed in `.lingo/config.json` | Configured docs and learn patterns     | `pnpm i18n:docs`           |
+| Media        | `solana-com-media`      | `packages/i18n/messages/media/en/common.json`              | Media English JSON                     | `pnpm i18n:app media`      |
+| Templates    | `solana-templates`      | `packages/i18n/messages/templates/en/common.json`          | Templates English JSON                 | `pnpm i18n:app templates`  |
+| Accelerate   | `solana-com-accelerate` | `packages/i18n/messages/accelerate/en/common.json`         | Accelerate English JSON                | `pnpm i18n:app accelerate` |
+| Breakpoint   | `solana-com-breakpoint` | `packages/i18n/messages/breakpoint/en/breakpoint.json`     | Not configured; the command is a no-op | `pnpm i18n:app breakpoint` |
+
+The docs app has no local JSON loader. Its React UI namespaces, including shared
+learn/developer UI, currently come from the web catalog. Do not add
+`messages/docs` without an explicit architecture change.
+
+The templates app currently renders with English as its layout locale even
+though translated target catalogs exist. Localize source copy consistently, but
+do not redesign templates routing during a page-only task.
+
+## Server component pattern
+
+Pass the route locale explicitly when available, especially for metadata and
+static rendering:
+
+```tsx
+import { getTranslations } from "@workspace/i18n/server";
+
+type Props = {
+  params: Promise<{ locale: string }>;
+};
+
+export default async function Page({ params }: Props) {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "routeName" });
+
+  return <h1>{t("hero.title")}</h1>;
+}
+```
+
+Passing a namespace to `getTranslations` is supported, but the object form makes
+locale ownership explicit and is preferable when `params.locale` is already
+present.
+
+## Client component pattern
+
+Do not turn the route into a client component just to translate a client-owned
+section:
+
+```tsx
+"use client";
+
+import { useTranslations } from "@workspace/i18n/client";
+
+export function SearchForm() {
+  const t = useTranslations("routeName.form");
+
+  return (
+    <label>
+      {t("label")}
+      <input placeholder={t("placeholder")} />
+    </label>
+  );
+}
+```
+
+If a server component already owns the copy and a client child is presentation
+only, passing translated string props is also valid. Match the narrower local
+pattern.
+
+## Internal navigation
+
+Use the shared locale-aware navigation for internal Solana.com routes:
+
+```tsx
+import { Link } from "@workspace/i18n/routing";
+
+<Link href="/developers">{t("actions.developers")}</Link>;
+```
+
+Keep ordinary anchors for hash links, downloads, `mailto:`, and truly external
+URLs. When navigation crosses separately deployed apps, also inspect
+`packages/ui-chrome/src/url-config.ts` and the owning app's `next.config.ts`.
+
+## Metadata and structured data
+
+Localize metadata from the same route namespace and keep each app's URL helper:
+
+```tsx
+import type { Metadata } from "next";
+import { getAlternates } from "@workspace/i18n/routing";
+import { getTranslations } from "@workspace/i18n/server";
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({
+    locale,
+    namespace: "routeName.metadata",
+  });
+
+  return {
+    title: t("title"),
+    description: t("description"),
+    alternates: getAlternates("/route-name", locale),
+  };
+}
+```
+
+Web and docs commonly use `getAlternates`. Accelerate and Breakpoint have
+microsite-aware metadata helpers that preserve their public route prefix; use
+those helpers instead of substituting the generic one. Media also has its own
+metadata and content model. Preserve the adjacent app pattern.
+
+Human-readable JSON-LD fields should use localized strings and the route locale.
+Keep schema URLs, identifiers, dates, and numeric values machine-readable.
+
+## Message construction
+
+Prefer a semantic namespace:
+
+```json
+{
+  "routeName": {
+    "metadata": {
+      "title": "Page title",
+      "description": "Page description"
+    },
+    "hero": {
+      "title": "Build with Solana",
+      "description": "Tools for {audience}"
+    },
+    "actions": {
+      "getStarted": "Get started"
+    },
+    "aria": {
+      "openMenu": "Open navigation menu"
+    }
+  }
+}
+```
+
+Use interpolation:
+
+```tsx
+t("results", { count: results.length });
+```
+
+Use rich messages when tags must stay inside a grammatical unit:
+
+```json
+{
+  "terms": "Read the <link>terms of service</link>."
+}
+```
+
+```tsx
+t.rich("terms", {
+  link: (chunks) => <Link href="/tos">{chunks}</Link>,
+});
+```
+
+Do not build sentences with multiple translated fragments. Word order,
+pluralization, punctuation, and markup placement differ across locales.
+
+## Docs content rules
+
+The current `.lingo/config.json` translates:
+
+- `apps/docs/content/docs/en/**/*.mdx`, excluding RPC content
+- `apps/docs/content/learn/en/*.mdx`
+- `apps/docs/content/docs/en/**/meta.json`, excluding RPC metadata
+
+The config lists the frontmatter fields and MDX component props Lingo may
+translate. Content outside those patterns is not automatically localized. Check
+the configuration before promising coverage for cookbook, guides, nested learn
+files, RPC docs, or newly introduced content trees.
+
+Keep code samples, imports, component names, URLs, and technical identifiers
+stable. Preserve frontmatter syntax, and do not use backticks in frontmatter;
+`scripts/i18n/verify-docs-frontmatter.mjs` enforces this.
+
+## Lingo.dev integration
+
+The repository uses the current `@lingo.dev/cli` with:
+
+- `.lingo/config.json` for organization, engine, locales, and source patterns
+- `.lingo/lock.json` for tracked localization state
+- `scripts/i18n/run.mjs` for repo-scoped commands
+- `.github/workflows/i18n.yml` to run incremental localization after changes
+  reach `main` and open an i18n pull request
+
+Normal `lingo push` runs are incremental. The repo uses `--wait` explicitly so
+the command returns after translated files have been written. Do not use
+`--force` for routine source changes: it retranslates and overwrites all target
+keys in scope.
+
+Every CLI request is routed through the engine in `.lingo/config.json`. Engine
+brand voice, instructions, and glossary rules apply automatically. Keep product
+terminology policy in the engine rather than duplicating per-language rules in
+page code.
+
+Before changing Lingo configuration or behavior, consult the current official
+documentation:
+
+- [Localization platform](https://lingo.dev/en/docs/platform)
+- [Localization engines](https://lingo.dev/en/docs/platform/engines)
+- [Instructions](https://lingo.dev/en/docs/platform/instructions)
+- [Glossaries](https://lingo.dev/en/docs/platform/glossaries)
+- [Current CLI overview](https://lingo.dev/en/docs/cli)
+- [Continuous localization](https://lingo.dev/en/docs/workflows)
+
+Never commit API keys. Local commands authenticate through `LINGO_API_KEY` or a
+Lingo login session.
+
+## Validation
+
+Start with source-only checks:
+
+```bash
+node -e 'JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"))' \
+  packages/i18n/messages/<app>/en/common.json
+pnpm i18n:verify-source-locales
+pnpm i18n:audit
+```
+
+Use the owning workspace's actual scripts. Common targeted checks are:
+
+```bash
+pnpm --filter solana-com lint
+pnpm --filter solana-com test
+pnpm --filter solana-docs lint
+pnpm --filter solana-docs postinstall
+pnpm --filter solana-com-media lint
+pnpm --filter solana-com-media typecheck
+pnpm --filter solana-com-media test
+pnpm --filter solana-templates lint
+pnpm --filter solana-templates check-types
+pnpm --filter solana-com-accelerate lint
+pnpm --filter solana-com-accelerate check-types
+pnpm --filter solana-com-breakpoint lint
+pnpm --filter solana-com-breakpoint check-types
+pnpm --filter solana-com-breakpoint test
+```
+
+Run only commands that exist in the current workspace. Prefer focused tests and
+targeted checks before root-wide Turborepo tasks.


### PR DESCRIPTION
## Summary

- add an agent-agnostic localize-page skill using the open Agent Skills format
- document app catalog ownership, docs MDX handling, and the current Lingo.dev workflow
- map the core @workspace/i18n page and app-setup drop-ins, including request, plugin, message-loading, routing, and middleware helpers
- document same-app locale-aware links, sibling-app full reloads, reusable chrome links, and external-link handling using the canonical route ownership sources
- support portable direct-file usage without product-specific adapter files
- add a README explaining the purpose and structure of the repository skills directory

## Validation

- official skills-ref validator
- skill-creator quick_validate.py
- Prettier check for all added Markdown
- node scripts/i18n/verify-source-locales.mjs
- git diff --check