### PR TITLE
test(docs): prevent Finance MDX registry regressions

### DIFF
--- a/apps/docs/__tests__/finance-mdx.test.tsx
+++ b/apps/docs/__tests__/finance-mdx.test.tsx
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+import { compileMDX } from "@fumadocs/mdx-remote";
+import { renderToReadableStream } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { mdxComponents } from "../src/app/mdx-components";
+
+describe("Finance docs MDX", () => {
+  it("renders with the shared MDX component registry", async () => {
+    const source = await readFile(
+      new URL("../content/docs/en/finance/index.mdx", import.meta.url),
+      "utf8",
+    );
+    const { body: FinanceContent } = await compileMDX({ source });
+
+    const stream = await renderToReadableStream(
+      <FinanceContent components={mdxComponents} />,
+    );
+    await stream.allReady;
+    const markup = await new Response(stream).text();
+
+    expect(markup).toContain("Assets power payments and onchain markets");
+    expect(markup).toContain("/assets/docs/diagrams/finance-overview.svg");
+    expect(markup).toContain(
+      "/assets/docs/diagrams/finance-overview-light.svg",
+    );
+  });
+});

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -81,7 +81,8 @@
     "postcss-preset-env": "^10.0.9",
     "tailwindcss": "^3.4.19",
     "ts-node": "^10.9.2",
-    "typescript": "5.8.3"
+    "typescript": "5.8.3",
+    "vitest": "catalog:"
   },
   "scripts": {
     "build": "NODE_OPTIONS='--max-old-space-size=4096' next build",
@@ -93,6 +94,7 @@
     "lint": "pnpm check:frontmatter && pnpm exec eslint . && pnpm -w exec prettier --ignore-path .prettierignore --check apps/docs",
     "lint:fix": "pnpm exec eslint --fix . && pnpm -w exec prettier --ignore-path .prettierignore --write apps/docs",
     "check-types": "tsc --noEmit",
+    "test": "vitest run",
     "postinstall": "fumadocs-mdx",
     "add:radix": "npx @radix-ui/scripts",
     "clean": "node ../../scripts/clean.mjs ."

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,0 +1,43 @@
+import path from "node:path";
+import { createRequire } from "node:module";
+import { defineConfig } from "vitest/config";
+
+const require = createRequire(import.meta.url);
+
+export default defineConfig({
+  esbuild: {
+    jsx: "automatic",
+  },
+  css: {
+    postcss: {
+      plugins: [],
+    },
+  },
+  resolve: {
+    alias: [
+      {
+        find: "@",
+        replacement: path.resolve(__dirname, "./src"),
+      },
+      {
+        find: "@@",
+        replacement: path.resolve(__dirname, "./"),
+      },
+      {
+        find: "next/image",
+        replacement: require.resolve("next/image"),
+      },
+      {
+        find: "next/navigation",
+        replacement: require.resolve("next/navigation"),
+      },
+    ],
+  },
+  ssr: {
+    noExternal: ["fumadocs-ui", "next-intl"],
+  },
+  test: {
+    environment: "node",
+    include: ["__tests__/**/*.test.{ts,tsx}"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -483,6 +483,9 @@ importers:
       typescript:
         specifier: 5.8.3
         version: 5.8.3
+      vitest:
+        specifier: "catalog:"
+        version: 4.1.8(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(jsdom@26.1.0(bufferutil@4.1.0))(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1))
 
   apps/media:
     dependencies:


### PR DESCRIPTION
### Problem

The Finance docs landing page referenced the custom DocsDiagram MDX component before it was registered, causing request-time rendering failures in release 6bb805bc771de1fa0ee19df52ec7217e15fdb347. The registration hotfix landed in #1771, but async MDX rendering had no regression coverage for this production path.

Sentry issue: [JAVASCRIPT-NEXTJS-2BW](https://solana-fndn.sentry.io/issues/JAVASCRIPT-NEXTJS-2BW)

### Summary of Changes

- Add a docs-app Vitest configuration and test command.
- Compile and server-render the real English Finance landing-page MDX with the shared component registry.
- Assert that both dark and light Finance diagram assets render, catching a missing DocsDiagram registration before deployment.

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] No new user or external-service input is introduced.
- [ ] New or updated dependencies are justified below, and pnpm audit passes with no High/Critical advisories. The workspace has three pre-existing High advisories; this change introduces no new package version.
- [x] The production rendering failure is explicitly exercised by the regression test.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependency: Vitest is added to the docs app from the existing workspace catalog so the regression test participates in Turborepo test runs.

Threat-model note: n/a.

### Testing

- pnpm --filter solana-docs test
- pnpm --filter solana-docs check-types
- pnpm --filter solana-docs lint
- pnpm --filter solana-docs build