### PR TITLE
Remove ZYJLiu as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,24 +8,24 @@
 # global owners for those paths.
 
 # Global owners — everything not matched by a more specific rule below.
-*                               @h4rkl @ZYJLiu @jacobcreech
+*                               @h4rkl @jacobcreech
 
 # --- Security-sensitive paths (Critical/Standard-tier changes) -------------
 
 # CI/CD, automation, and repo policy. Changes here alter the security gates
 # themselves, so they always need maintainer sign-off.
-/.github/                       @h4rkl @ZYJLiu
-/.github/workflows/             @h4rkl @ZYJLiu
-/.github/CODEOWNERS             @h4rkl @ZYJLiu
+/.github/                       @h4rkl
+/.github/workflows/             @h4rkl
+/.github/CODEOWNERS             @h4rkl
 
 # Secrets scanning and disclosure policy.
-/.gitleaks.toml                 @h4rkl @ZYJLiu
-/SECURITY.md                    @h4rkl @ZYJLiu
+/.gitleaks.toml                 @h4rkl
+/SECURITY.md                    @h4rkl
 
 # Secrets rollout / Vercel deployment tooling.
-/scripts/secrets-rollout/       @h4rkl @ZYJLiu
+/scripts/secrets-rollout/       @h4rkl
 
 # Dependency surface — lockfile and workspace audit config (ignore lists).
-/pnpm-lock.yaml                 @h4rkl @ZYJLiu
-/pnpm-workspace.yaml            @h4rkl @ZYJLiu
-/package.json                   @h4rkl @ZYJLiu
+/pnpm-lock.yaml                 @h4rkl
+/pnpm-workspace.yaml            @h4rkl
+/package.json                   @h4rkl

--- a/apps/web/builder/section-page/en/wallets.json
+++ b/apps/web/builder/section-page/en/wallets.json
@@ -1821,7 +1821,7 @@
                 "variant": "standard",
                 "eyebrow": "",
                 "headline": "Developer Resources",
-                "body": "Ready to run your own Solana wallet? Here are a few example implementations to help you get started."
+                "body": "Ready to run your own Solana wallet? Here is an example implementation to help you get started."
               }
             },
             "responsiveStyles": {
@@ -1843,13 +1843,7 @@
               "localizedTextInputs": [
                 "cards.0.eyebrow",
                 "cards.0.heading",
-                "cards.0.callToAction.label",
-                "cards.1.eyebrow",
-                "cards.1.heading",
-                "cards.1.callToAction.label",
-                "cards.2.eyebrow",
-                "cards.2.heading",
-                "cards.2.callToAction.label"
+                "cards.0.callToAction.label"
               ]
             },
             "component": {
@@ -1859,31 +1853,11 @@
                   {
                     "callToAction": {
                       "label": "Learn More",
-                      "url": "https://github.com/ZYJLiu/axum-solana-transfer"
-                    },
-                    "eyebrow": "",
-                    "heading": "Hello World Wallet Guide",
-                    "body": "An introduction to creating a Solana wallet frontend using Typescript and CLI.",
-                    "type": "standard"
-                  },
-                  {
-                    "callToAction": {
-                      "label": "Learn More",
                       "url": "https://github.com/kilogold/solana-rust-client/tree/kelvin"
                     },
                     "eyebrow": "",
                     "heading": "Confidential Transfers Guide",
                     "body": "A guide to enabling private onchain transactions through your Solana wallet.",
-                    "type": "standard"
-                  },
-                  {
-                    "callToAction": {
-                      "label": "Learn More",
-                      "url": "https://github.com/ZYJLiu/axum-solana-transfer"
-                    },
-                    "eyebrow": "",
-                    "heading": "Programmable Wallets Example",
-                    "body": "A reference for creating a basic programmable wallet that uses web services for token transfers.",
                     "type": "standard"
                   }
                 ],


### PR DESCRIPTION
### Problem

ZYJLiu is no longer at Solana, but the account is still configured as a global and security-sensitive code owner. The wallets page also links to a repository under that personal GitHub account.

### Summary of Changes

- Remove `@ZYJLiu` from every CODEOWNERS rule.
- Remove the two wallet developer-resource cards that link to `ZYJLiu/axum-solana-transfer`.
- Update the remaining card metadata and section copy for the single remaining resource.

This is security-relevant because it changes the CODEOWNERS coverage for security-sensitive paths. `@h4rkl` remains the owner for those paths, and `@jacobcreech` remains a global owner.

---

### Change classification (SDLC §2)

- [x] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] No user or external-service input handling changed.
- [x] No dependencies were added or updated; dependency audit inputs are unchanged.
- [x] No production error-handling paths changed.
- [x] A second reviewer has been requested for this Critical change.

New dependencies: none.

Threat-model note: CODEOWNERS is the affected trust boundary. Removing an inactive owner prevents reviews from being routed to a former maintainer, while reducing security-sensitive path ownership from two listed accounts to one. The remaining owner is `@h4rkl`; `@jacobcreech` has been requested as the second reviewer.

### Validation

- `pnpm --filter solana-com lint` (passes with 6 pre-existing warnings)
- `pnpm --filter solana-com test` (23 files passed; 148 tests passed, 18 skipped)
- Parsed `apps/web/builder/section-page/en/wallets.json` with `JSON.parse`
- `git diff --check`
- Confirmed there are no remaining case-insensitive `ZYJLiu` references in the working tree
