### PR TITLE
Default RPC data region to FRA

### DIFF
--- a/apps/web/src/__tests__/lib/rpc/server.test.ts
+++ b/apps/web/src/__tests__/lib/rpc/server.test.ts
@@ -19,14 +19,14 @@ import {
 } from "@/lib/rpc/server";
 
 describe("RPC latency query options", () => {
-  it("defaults to TSW in Los Angeles", () => {
+  it("defaults to TSW in Frankfurt", () => {
     const options = parseRpcLatencyQueryOptions(
       new URLSearchParams("method=getTransactionRecent"),
     );
 
     expect(options.infra).toBe("tsw");
     expect(options.method).toBe("getTransactionRecent");
-    expect(options.region).toBe("lax");
+    expect(options.region).toBe("fra");
     expect(options.timeframe).toBe("6h");
   });
 
@@ -165,11 +165,11 @@ describe("RPC latency query options", () => {
     ).toBe("pit");
     expect(
       parseRpcLatencyQueryOptions(new URLSearchParams("region=unknown")).region,
-    ).toBe("lax");
+    ).toBe("fra");
     expect(
       parseRpcLatencyQueryOptions(new URLSearchParams("infra=aws&region=lax"))
         .region,
-    ).toBe("iad");
+    ).toBe("fra");
   });
 });
 
@@ -305,7 +305,7 @@ describe("RPC latency cache identity", () => {
 describe("RPC Prometheus queries", () => {
   it("threads the default TSW colo into latency queries", () => {
     expect(buildRpcAvgLatencyQuery()).toContain('infra=~"tsw"');
-    expect(buildRpcAvgLatencyQuery()).toContain('region=~"lax1"');
+    expect(buildRpcAvgLatencyQuery()).toContain('region=~"fra2"');
     expect(buildRpcAvgLatencyQuery()).not.toContain("geo=");
   });
 

--- a/apps/web/src/app/[locale]/data/data-config.ts
+++ b/apps/web/src/app/[locale]/data/data-config.ts
@@ -94,7 +94,7 @@ export type RpcTimeframe = (typeof rpcTimeframeOptions)[number]["value"];
 export type ProviderName = string;
 
 export const defaultRpcInfra = "tsw" satisfies RpcLatencyInfra;
-export const defaultRpcRegion = "lax" satisfies RpcLatencyRegion;
+export const defaultRpcRegion = "fra" satisfies RpcLatencyRegion;
 export const defaultRpcMethod = "getLatestBlockhash" satisfies RpcLatencyMethod;
 export const defaultRpcTimeframe = "6h" satisfies RpcTimeframe;
 


### PR DESCRIPTION
## Summary

- change the RPC data dashboard default region from LAX to FRA
- update server-side fallback and Prometheus query expectations

## Testing

- `pnpm --filter solana-com test`
- `pnpm --filter solana-com check-types`
- targeted ESLint and Prettier checks