### PR TITLE
docs: sync localized Start Here pages

### DIFF
--- a/apps/docs/content/docs/ar/index.mdx
+++ b/apps/docs/content/docs/ar/index.mdx
@@ -1,42 +1,42 @@
 ---
-title: توثيق سولانا
-seoTitle: تعرف على كيفية عمل بلوكتشين سولانا
+title: ابدأ هنا
+seoTitle: ابدأ البناء على سولانا
 description:
-  سولانا هي بلوكتشين عالي الأداء مصمم للاعتماد الجماعي. تعرف على سبب كون سولانا
-  الخيار الأفضل للمطورين الذين يتطلعون إلى بناء تطبيقات بلوكتشين قابلة للتوسع.
+  اختر البدء السريع، أو اكتب التعليمات البرمجية باستخدام وكيل ذكاء اصطناعي، أو
+  تعرّف على كيفية عمل سولانا.
 ---
 
-## البدء
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="تتصل التطبيقات اليومية بسولانا، وهي شبكة مشتركة تعمل بفضل أجهزة كمبيوتر حول العالم"
+/>
 
-<Cards>
-  <Card title="البدء السريع" href="/docs/intro/quick-start" icon={<Rocket />}>
-    قم ببناء برنامجك الأول على سولانا مباشرة في المتصفح
-  </Card>
-  <Card
-    title="إعداد البيئة المحلية"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    تثبيت التبعيات اللازمة لتطوير سولانا
-  </Card>
-</Cards>
+## هل تريد البدء في البناء؟
 
-### ابنِ بشكل أسرع مع قوالب مطوري سولانا
-
-<Card title="استكشف قوالب المطورين" href="/developers/templates">
-  ابنِ بشكل أسرع مع قوالب جاهزة للإنتاج لتطبيقات dApps وبروتوكولات DeFi وأسواق
-  NFT والمزيد. ابدأ بأنماط أكواد مُختبرة ومُحسّنة لنظام سولانا البيئي.
+<Card
+  title="افتح البدء السريع"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  أنشئ وانشر مشروعك الأول على سولانا مباشرة في المتصفح.
 </Card>
 
-<Card title="الأدوات" href="/docs/tools">
-  استكشف الوثائق الخاصة بأدوات المطورين في سولانا.
+## هل تريد البرمجة باستخدام وكيل ذكاء اصطناعي؟
+
+<Card title="البرمجة باستخدام الوكلاء" href="/docs/intro/coding-with-agents">
+  قم بإعداد Solana MCP أو ثبّت مهارة سولانا الرسمية لوكيل البرمجة الخاص بك.
 </Card>
 
-## جرّب سولانا: العب 2048
+## هل تريد معرفة كيفية عمل سولانا؟
 
-العب 2048 على سولانا حيث كل حركة ترسل معاملة. انقر على "العب" للبدء بمحفظة شبكة
-التطوير الممولة واستخدم مفاتيح الأسهم للعب. إذا كنت على الهاتف المحمول، اسحب
-للتحكم بالمربعات.
+<Card title="تعلّم المفاهيم" href="/docs/core">
+  تعرّف على المكونات الأساسية التي تجعل سولانا تعمل.
+</Card>
+
+### جرّب سولانا: العب 2048
+
+العب 2048 على سولانا حيث ترسل كل حركة معاملة. انقر على "العب" للبدء بمحفظة
+Devnet ممولة، ثم استخدم مفاتيح الأسهم أو اسحب على الهاتف المحمول.
 
 <Accordions>
 <Accordion title="العب سولانا 2048">
@@ -60,86 +60,3 @@ description:
 
 تم تطويره بواسطة [Jonas](https://x.com/SolPlay_jonas)، من فريق DevRel في مؤسسة
 سولانا.
-
-## ابدأ التعلم
-
-تعرّف على المفاهيم الأساسية الخاصة بتطوير سولانا.
-
-<Cards>
-  <Card title="الحسابات" href="/docs/core/accounts">
-    كيف تخزن سولانا البيانات
-  </Card>
-  <Card title="الرسوم على سولانا" href="/docs/core/fees">
-    تكاليف إرسال المعاملات على سولانا
-  </Card>
-  <Card title="المعاملات" href="/docs/core/transactions">
-    كيفية التفاعل مع شبكة سولانا
-  </Card>
-  <Card title="البرامج" href="/docs/core/programs">
-    العقود الذكية على سولانا
-  </Card>
-  <Card title="عنوان مشتق من البرنامج" href="/docs/core/pda">
-    كيفية إنشاء عناوين حتمية
-  </Card>
-  <Card title="الاستدعاء عبر البرامج" href="/docs/core/cpi">
-    كيفية استدعاء برنامج من برنامج آخر
-  </Card>
-</Cards>
-
-### التطوير من جانب العميل
-
-حزم SDK التالية هي حزم SDK الرسمية لسولانا التي بناها [Anza](https://anza.xyz).
-
-#### حزم SDK الرسمية
-
-| اللغة                | SDK                                                                |
-| -------------------- | ------------------------------------------------------------------ |
-| Rust                 | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (موصى به) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (قديم)    | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### حزم SDK المجتمعية
-
-التالي هي حزم SDK التي ساهم بها المجتمع لمختلف اللغات:
-
-| اللغة    | SDK                                                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                         |
-| Java     | [sava](https://sava.software) أو [solanaj](https://github.com/skynetcap/solanaj) أو [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) أو [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                               |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                    |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) أو [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                    |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                               |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                            |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                  |
-
-<Callout type="warn">
-  حزم SDK المجتمعية غير مضمونة لتكون محدثة أو تتضمن جميع ميزات حزم SDK الرسمية.
-</Callout>
-
-## تشغيل validator
-
-استكشف ما يتطلبه تشغيل validator على شبكة سولانا والمساعدة في تأمين الشبكة.
-
-<Cards>
-  <Card title="Validators" href="https://docs.anza.xyz/validator/anatomy">
-    العقد الفردية التي تؤمن شبكة سولانا
-  </Card>
-  <Card
-    title="متطلبات النظام"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    متطلبات الأجهزة الموصى بها وكمية SOL المطلوبة لتشغيل validator
-  </Card>
-  <Card
-    title="إعداد Validator"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    إعداد validator والاتصال بمجموعة عقد لأول مرة
-  </Card>
-</Cards>
-
-## الحصول على الدعم
-
-احصل على المساعدة من مجتمع سولانا على
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/de/index.mdx
+++ b/apps/docs/content/docs/de/index.mdx
@@ -1,45 +1,44 @@
 ---
-title: Solana Dokumentation
-seoTitle: Erfahren Sie, wie die Solana-Blockchain funktioniert
+title: Hier starten
+seoTitle: Mit der Entwicklung auf Solana beginnen
 description:
-  Solana ist die leistungsstarke Blockchain, die für die Massenadoption
-  konzipiert wurde. Erfahren Sie, warum Solana die erste Wahl für Entwickler
-  ist, die skalierbare Blockchain-Anwendungen erstellen möchten.
+  Wähle den Schnellstart, programmiere mit einem KI-Agenten oder erfahre, wie
+  Solana funktioniert.
 ---
 
-## Erste Schritte
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Alltägliche Apps verbinden sich mit Solana, einem gemeinsamen Netzwerk, das von Computern auf der ganzen Welt betrieben wird"
+/>
 
-<Cards>
-  <Card title="Schnellstart" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Erstellen Sie Ihr erstes Solana-Programm direkt im Browser
-  </Card>
-  <Card
-    title="Lokale Umgebung einrichten"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Installieren Sie Abhängigkeiten für die Solana-Entwicklung
-  </Card>
-</Cards>
+## Möchtest du direkt mit dem Entwickeln beginnen?
 
-### Schneller entwickeln mit Solana Developer Templates
-
-<Card title="Entdecke Developer Templates" href="/developers/templates">
-  Entwickle schneller mit einsatzbereiten Templates für dApps, DeFi-Protokolle,
-  NFT-Marktplätze und mehr. Starte mit bewährten Code-Patterns, die für das
-  Solana-Ökosystem optimiert sind.
+<Card
+  title="Schnellstart öffnen"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  Entwickle und veröffentliche dein erstes Solana-Projekt direkt im Browser.
 </Card>
 
-<Card title="Tools" href="/docs/tools">
-  Erkunden Sie die Dokumentation für Solana-Entwicklerwerkzeuge.
+## Möchtest du mit einem KI-Agenten programmieren?
+
+<Card title="Programmieren mit Agenten" href="/docs/intro/coding-with-agents">
+  Richte Solana MCP ein oder installiere den offiziellen Solana Skill für deinen
+  Programmieragenten.
 </Card>
 
-## Solana ausprobieren: Spielen Sie 2048
+## Möchtest du erfahren, wie Solana funktioniert?
 
-Spielen Sie 2048 auf Solana, wo jeder Zug eine Transaktion sendet. Klicken Sie
-auf "Spielen", um mit einem finanzierten Devnet-Wallet zu beginnen, und
-verwenden Sie die Pfeiltasten zum Spielen. Auf Mobilgeräten wischen Sie, um die
-Kacheln zu steuern.
+<Card title="Konzepte kennenlernen" href="/docs/core">
+  Lerne die grundlegenden Bausteine kennen, die Solana ermöglichen.
+</Card>
+
+### Solana ausprobieren: 2048 spielen
+
+Spiele 2048 auf Solana, wobei jeder Zug eine Transaktion sendet. Klicke auf
+„Spielen“, um mit einer finanzierten Devnet-Wallet zu starten, und verwende die
+Pfeiltasten oder wische auf dem Mobilgerät.
 
 <Accordions>
 <Accordion title="Solana 2048 spielen">
@@ -63,93 +62,3 @@ Kacheln zu steuern.
 
 Entwickelt von [Jonas](https://x.com/SolPlay_jonas) aus dem DevRel-Team der
 Solana Foundation.
-
-## Lernen beginnen
-
-Lernen Sie die wichtigsten Konzepte kennen, die spezifisch für die
-Solana-Entwicklung sind.
-
-<Cards>
-  <Card title="Accounts" href="/docs/core/accounts">
-    Wie Solana Daten speichert
-  </Card>
-  <Card title="Gebühren auf Solana" href="/docs/core/fees">
-    Kosten für das Senden von Transaktionen auf Solana
-  </Card>
-  <Card title="Transaktionen" href="/docs/core/transactions">
-    Wie man mit dem Solana-Netzwerk interagiert
-  </Card>
-  <Card title="Programme" href="/docs/core/programs">
-    Smart Contracts auf Solana
-  </Card>
-  <Card title="Program Derived Address" href="/docs/core/pda">
-    Wie man deterministische Adressen generiert
-  </Card>
-  <Card title="Cross Program Invocation" href="/docs/core/cpi">
-    Wie man ein Programm von einem anderen aus aufruft
-  </Card>
-</Cards>
-
-### Clientseitige Entwicklung
-
-Die folgenden SDKs sind die offiziellen SDKs für Solana, die von
-[Anza](https://anza.xyz) entwickelt wurden.
-
-#### Offizielle SDKs
-
-| Sprache                | SDK                                                                |
-| ---------------------- | ------------------------------------------------------------------ |
-| Rust                   | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Empfohlen) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Veraltet)  | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### Community-SDKs
-
-Die folgenden sind von der Community beigesteuerte SDKs für verschiedene
-Sprachen:
-
-| Sprache  | SDK                                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                             |
-| Java     | [sava](https://sava.software) oder [solanaj](https://github.com/skynetcap/solanaj) oder [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) oder [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                                 |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                        |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) oder [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                      |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                                   |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                                |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                      |
-
-<Callout type="warn">
-  Community-SDKs sind möglicherweise nicht auf dem neuesten Stand oder enthalten
-  möglicherweise nicht alle Funktionen der offiziellen SDKs.
-</Callout>
-
-## Einen Validator betreiben
-
-Erfahren Sie, was erforderlich ist, um einen Solana-Validator zu betreiben und
-das Netzwerk abzusichern.
-
-<Cards>
-  <Card title="Validatoren" href="https://docs.anza.xyz/validator/anatomy">
-    Einzelne Knoten, die das Solana-Netzwerk absichern
-  </Card>
-  <Card
-    title="Systemanforderungen"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Empfohlene Hardwareanforderungen und erforderliche SOL zum Betrieb eines
-    Validator
-  </Card>
-  <Card
-    title="Validator-Einrichtung"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Richten Sie einen Validator ein und verbinden Sie sich zum ersten Mal mit
-    einem Cluster
-  </Card>
-</Cards>
-
-## Support erhalten
-
-Erhalten Sie Hilfe von der Solana-Community auf
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/el/index.mdx
+++ b/apps/docs/content/docs/el/index.mdx
@@ -1,53 +1,45 @@
 ---
-title: Τεκμηρίωση Solana
-seoTitle: Μάθετε πώς λειτουργεί το blockchain του Solana
+title: Ξεκινήστε εδώ
+seoTitle: Ξεκινήστε να δημιουργείτε στο Solana
 description:
-  Το Solana είναι το blockchain υψηλής απόδοσης σχεδιασμένο για μαζική
-  υιοθέτηση. Μάθετε γιατί το Solana είναι η κορυφαία επιλογή για προγραμματιστές
-  που θέλουν να δημιουργήσουν κλιμακώσιμες εφαρμογές blockchain.
+  Επιλέξτε τον γρήγορο οδηγό, γράψτε κώδικα με έναν AI agent ή μάθετε πώς
+  λειτουργεί το Solana.
 ---
 
-## Ξεκινώντας
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Οι καθημερινές εφαρμογές συνδέονται στο Solana, ένα κοινό δίκτυο που διατηρούν υπολογιστές σε όλο τον κόσμο"
+/>
 
-<Cards>
-  <Card
-    title="Γρήγορη εκκίνηση"
-    href="/docs/intro/quick-start"
-    icon={<Rocket />}
-  >
-    Δημιουργήστε το πρώτο σας πρόγραμμα Solana απευθείας στο πρόγραμμα
-    περιήγησης
-  </Card>
-  <Card
-    title="Ρύθμιση τοπικού περιβάλλοντος"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Εγκαταστήστε τις εξαρτήσεις για ανάπτυξη στο Solana
-  </Card>
-</Cards>
-
-### Δημιουργήστε γρηγορότερα με τα πρότυπα προγραμματιστών Solana
+## Θέλετε να ξεκινήσετε να δημιουργείτε;
 
 <Card
-  title="Εξερευνήστε τα πρότυπα προγραμματιστών"
-  href="/developers/templates"
+  title="Ανοίξτε τον γρήγορο οδηγό"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
 >
-  Δημιουργήστε γρηγορότερα με έτοιμα για παραγωγή πρότυπα για dApps, πρωτόκολλα
-  DeFi, αγορές NFT και πολλά άλλα. Ξεκινήστε με δοκιμασμένα μοτίβα κώδικα
-  βελτιστοποιημένα για το οικοσύστημα Solana.
+  Δημιουργήστε και αναπτύξτε το πρώτο σας έργο Solana απευθείας στο πρόγραμμα
+  περιήγησης.
 </Card>
 
-<Card title="Εργαλεία" href="/docs/tools">
-  Εξερευνήστε την τεκμηρίωση για τα εργαλεία ανάπτυξης Solana.
+## Θέλετε να γράψετε κώδικα με έναν AI agent;
+
+<Card title="Προγραμματισμός με agents" href="/docs/intro/coding-with-agents">
+  Ρυθμίστε το Solana MCP ή εγκαταστήστε το επίσημο Solana skill για τον coding
+  agent σας.
 </Card>
 
-## Δοκιμάστε το Solana: Παίξτε 2048
+## Θέλετε να μάθετε πώς λειτουργεί το Solana;
 
-Παίξτε 2048 στο Solana όπου κάθε κίνηση στέλνει μια συναλλαγή. Κάντε κλικ στο
-"Παίξτε" για να ξεκινήσετε με ένα χρηματοδοτημένο πορτοφόλι devnet και
-χρησιμοποιήστε τα βέλη για να παίξετε. Αν είστε σε κινητή συσκευή, σύρετε για να
-ελέγξετε τα πλακίδια.
+<Card title="Μάθετε τις έννοιες" href="/docs/core">
+  Μάθετε τα θεμελιώδη στοιχεία που κάνουν το Solana να λειτουργεί.
+</Card>
+
+### Δοκιμάστε το Solana: Παίξτε 2048
+
+Παίξτε 2048 στο Solana, όπου κάθε κίνηση στέλνει μια συναλλαγή. Πατήστε
+«Παίξτε» για να ξεκινήσετε με ένα χρηματοδοτημένο Devnet wallet και
+χρησιμοποιήστε τα βέλη ή σύρετε στην οθόνη του κινητού.
 
 <Accordions>
 <Accordion title="Παίξτε Solana 2048">
@@ -71,91 +63,3 @@ description:
 
 Δημιουργήθηκε από τον [Jonas](https://x.com/SolPlay_jonas), από την ομάδα DevRel
 του Solana Foundation.
-
-## Ξεκινήστε να Μαθαίνετε
-
-Μάθετε τις βασικές έννοιες που αφορούν ειδικά την ανάπτυξη στο Solana.
-
-<Cards>
-  <Card title="Λογαριασμοί" href="/docs/core/accounts">
-    Πώς το Solana αποθηκεύει δεδομένα
-  </Card>
-  <Card title="Χρεώσεις στο Solana" href="/docs/core/fees">
-    Κόστος αποστολής συναλλαγών στο Solana
-  </Card>
-  <Card title="Συναλλαγές" href="/docs/core/transactions">
-    Πώς να αλληλεπιδράσετε με το δίκτυο Solana
-  </Card>
-  <Card title="Προγράμματα" href="/docs/core/programs">
-    Έξυπνα συμβόλαια στο Solana
-  </Card>
-  <Card title="Διευθύνσεις Παραγόμενες από Προγράμματα" href="/docs/core/pda">
-    Πώς να δημιουργήσετε ντετερμινιστικές διευθύνσεις
-  </Card>
-  <Card title="Κλήση Μεταξύ Προγραμμάτων" href="/docs/core/cpi">
-    Πώς να καλέσετε ένα πρόγραμμα από ένα άλλο
-  </Card>
-</Cards>
-
-### Ανάπτυξη στην Πλευρά του Πελάτη
-
-Τα ακόλουθα SDK είναι τα επίσημα SDK για το Solana που έχουν αναπτυχθεί από την
-[Anza](https://anza.xyz).
-
-#### Επίσημα SDK
-
-| Γλώσσα                    | SDK                                                                |
-| ------------------------- | ------------------------------------------------------------------ |
-| Rust                      | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Προτεινόμενο) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Παλαιό)       | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### SDK Κοινότητας
-
-Τα ακόλουθα είναι SDK που έχουν συνεισφέρει μέλη της κοινότητας για διάφορες
-γλώσσες:
-
-| Γλώσσα   | SDK                                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                       |
-| Java     | [sava](https://sava.software) ή [solanaj](https://github.com/skynetcap/solanaj) ή [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) ή [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                              |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                  |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) ή [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                   |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                             |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                          |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                |
-
-<Callout type="warn">
-  Τα SDK της κοινότητας δεν εγγυώνται ότι είναι ενημερωμένα ή περιλαμβάνουν όλες
-  τις λειτουργίες των επίσημων SDK.
-</Callout>
-
-## Εκτέλεση ενός validator
-
-Εξερευνήστε τι απαιτείται για τη λειτουργία ενός validator του Solana και
-συμβάλετε στην ασφάλεια του δικτύου.
-
-<Cards>
-  <Card title="Validators" href="https://docs.anza.xyz/validator/anatomy">
-    Μεμονωμένοι κόμβοι που εξασφαλίζουν το δίκτυο Solana
-  </Card>
-  <Card
-    title="Απαιτήσεις Συστήματος"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Προτεινόμενες απαιτήσεις υλικού και SOL που απαιτούνται για τη λειτουργία
-    ενός validator
-  </Card>
-  <Card
-    title="Εγκατάσταση Validator"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Ρυθμίστε έναν validator και συνδεθείτε σε ένα cluster για πρώτη φορά
-  </Card>
-</Cards>
-
-## Λήψη Υποστήριξης
-
-Λάβετε βοήθεια από την κοινότητα του Solana στο
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/en/index.mdx
+++ b/apps/docs/content/docs/en/index.mdx
@@ -2,8 +2,7 @@
 title: Start Here
 seoTitle: Start building on Solana
 description:
-  See where Solana fits, start building with the quickstart, or learn how Solana
-  works.
+  Choose a quickstart, code with an AI agent, or learn how Solana works.
 ---
 
 <DocsDiagram
@@ -21,20 +20,42 @@ description:
   Build and deploy your first Solana project directly in the browser.
 </Card>
 
+## Coding with an AI agent?
+
+<Card title="Coding with agents" href="/docs/intro/coding-with-agents">
+  Set up Solana MCP or install the official Solana skill for your coding agent.
+</Card>
+
 ## Want to learn how Solana works?
 
 <Card title="Learn the Concepts" href="/docs/core">
   Learn the building blocks that make Solana work.
 </Card>
 
-## Ready to start building with an agent?
+### Try Solana: Play 2048
 
-Copy this to your agent. It installs the official Solana skill, giving the agent
-the context it needs to write correct Solana code:
+Play 2048 on Solana, where every move sends a transaction. Click "Play" to start
+with a funded devnet wallet, then use the arrow keys or swipe on mobile.
 
-```bash
-npx skills add https://github.com/solana-foundation/solana-dev-skill
-```
+<Accordions>
+<Accordion title="Play Solana 2048">
 
-Every page in these docs is also available as raw Markdown. Append `.md` to any
-URL.
+<iframe
+  src="https://solplay.de/solana-2048/"
+  width="100%"
+  height="500"
+  style={{
+    borderRadius: "12px",
+    border: "2px solid rgba(0, 0, 0, 0.2)",
+    maxWidth: "100%",
+    minHeight: "300px",
+    aspectRatio: "1"
+  }}
+  scrolling="no"
+/>
+
+</Accordion>
+</Accordions>
+
+Built by [Jonas](https://x.com/SolPlay_jonas), from the Solana Foundation DevRel
+team.

--- a/apps/docs/content/docs/es/index.mdx
+++ b/apps/docs/content/docs/es/index.mdx
@@ -1,47 +1,45 @@
 ---
-title: Documentación de Solana
-seoTitle: Aprende cómo funciona la blockchain de Solana
+title: Empieza aquí
+seoTitle: Empieza a desarrollar en Solana
 description:
-  Solana es la blockchain de alto rendimiento diseñada para la adopción masiva.
-  Descubre por qué Solana es la opción preferida por los desarrolladores que
-  buscan crear aplicaciones blockchain escalables.
+  Elige un inicio rápido, programa con un agente de IA o aprende cómo funciona
+  Solana.
 ---
 
-## Primeros pasos
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Las aplicaciones cotidianas se conectan a Solana, una red compartida que mantienen computadoras de todo el mundo"
+/>
 
-<Cards>
-  <Card title="Inicio rápido" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Construye tu primer programa de Solana directamente en el navegador
-  </Card>
-  <Card
-    title="Configurar entorno local"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Instala las dependencias para el desarrollo en Solana
-  </Card>
-</Cards>
-
-### Construye más rápido con las plantillas para desarrolladores de Solana
+## ¿Quieres empezar a crear?
 
 <Card
-  title="Explorar plantillas para desarrolladores"
-  href="/developers/templates"
+  title="Abrir el inicio rápido"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
 >
-  Construye más rápido con plantillas listas para producción para dApps,
-  protocolos DeFi, mercados de NFT y más. Comienza con patrones de código
-  probados en batalla optimizados para el ecosistema Solana.
+  Construye y despliega tu primer proyecto de Solana directamente en el
+  navegador.
 </Card>
 
-<Card title="Herramientas" href="/docs/tools">
-  Explora la documentación de las herramientas para desarrolladores de Solana.
+## ¿Quieres programar con un agente de IA?
+
+<Card title="Programar con agentes" href="/docs/intro/coding-with-agents">
+  Configura Solana MCP o instala la skill oficial de Solana para tu agente de
+  programación.
 </Card>
 
-## Prueba Solana: Juega 2048
+## ¿Quieres aprender cómo funciona Solana?
 
-Juega 2048 en Solana donde cada movimiento envía una transacción. Haz clic en
+<Card title="Aprende los conceptos" href="/docs/core">
+  Aprende los componentes fundamentales que hacen funcionar a Solana.
+</Card>
+
+### Prueba Solana: Juega 2048
+
+Juega 2048 en Solana, donde cada movimiento envía una transacción. Haz clic en
 "Jugar" para comenzar con una wallet de devnet financiada y usa las flechas del
-teclado para jugar. Si estás en móvil, desliza para controlar las fichas.
+teclado o desliza en el móvil.
 
 <Accordions>
 <Accordion title="Juega Solana 2048">
@@ -65,89 +63,3 @@ teclado para jugar. Si estás en móvil, desliza para controlar las fichas.
 
 Creado por [Jonas](https://x.com/SolPlay_jonas), del equipo DevRel de Solana
 Foundation.
-
-## Comienza a Aprender
-
-Aprende los conceptos clave específicos del desarrollo en Solana.
-
-<Cards>
-  <Card title="Cuentas" href="/docs/core/accounts">
-    Cómo Solana almacena datos
-  </Card>
-  <Card title="Tarifas en Solana" href="/docs/core/fees">
-    Costos para enviar transacciones en Solana
-  </Card>
-  <Card title="Transacciones" href="/docs/core/transactions">
-    Cómo interactuar con la red de Solana
-  </Card>
-  <Card title="Programas" href="/docs/core/programs">
-    Contratos inteligentes en Solana
-  </Card>
-  <Card title="Dirección Derivada de Programa" href="/docs/core/pda">
-    Cómo generar direcciones determinísticas
-  </Card>
-  <Card title="Invocación Entre Programas" href="/docs/core/cpi">
-    Cómo llamar a un programa desde otro
-  </Card>
-</Cards>
-
-### Desarrollo del Lado del Cliente
-
-Los siguientes SDKs son los SDKs oficiales para Solana desarrollados por
-[Anza](https://anza.xyz).
-
-#### SDKs Oficiales
-
-| Lenguaje                 | SDK                                                                |
-| ------------------------ | ------------------------------------------------------------------ |
-| Rust                     | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Recomendado) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Heredado)    | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### SDKs de la Comunidad
-
-Los siguientes son SDKs contribuidos por la comunidad para varios lenguajes:
-
-| Lenguaje | SDK                                                                                                                                     |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                       |
-| Java     | [sava](https://sava.software) o [solanaj](https://github.com/skynetcap/solanaj) o [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) o [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                              |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                  |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) o [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                   |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                             |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                          |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                |
-
-<Callout type="warn">
-  Los SDK de la comunidad no están garantizados de estar actualizados o incluir
-  todas las características de los SDK oficiales.
-</Callout>
-
-## Ejecutar un validador
-
-Descubre lo que se necesita para operar un validador de Solana y ayudar a
-asegurar la red.
-
-<Cards>
-  <Card title="Validadores" href="https://docs.anza.xyz/validator/anatomy">
-    Nodos individuales que aseguran la red de Solana
-  </Card>
-  <Card
-    title="Requisitos del Sistema"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Requisitos de hardware recomendados y SOL necesario para operar un validator
-  </Card>
-  <Card
-    title="Configuración del Validador"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Configura un validador y conéctate a un clúster por primera vez
-  </Card>
-</Cards>
-
-## Obtener Soporte
-
-Obtén ayuda de la comunidad de Solana en
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/fi/index.mdx
+++ b/apps/docs/content/docs/fi/index.mdx
@@ -1,44 +1,44 @@
 ---
-title: Solana-dokumentaatio
-seoTitle: Opi miten Solana-lohkoketju toimii
+title: Aloita tästä
+seoTitle: Aloita rakentaminen Solanassa
 description:
-  Solana on suorituskykyinen lohkoketju, joka on suunniteltu laajaan
-  käyttöönottoon. Opi miksi Solana on kehittäjien ykkösvalinta skaalautuvien
-  lohkoketjusovellusten rakentamiseen.
+  Valitse pika-aloitus, ohjelmoi tekoälyagentin kanssa tai opi, miten Solana
+  toimii.
 ---
 
-## Aloittaminen
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Arjen sovellukset muodostavat yhteyden Solanaan, maailmanlaajuisten tietokoneiden ylläpitämään yhteiseen verkkoon"
+/>
 
-<Cards>
-  <Card title="Pika-aloitus" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Rakenna ensimmäinen Solana-ohjelmasi suoraan selaimessa
-  </Card>
-  <Card
-    title="Asenna paikallinen ympäristö"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Asenna riippuvuudet Solana-kehitystä varten
-  </Card>
-</Cards>
+## Haluatko aloittaa rakentamisen?
 
-### Rakenna nopeammin Solanan kehittäjämalleilla
-
-<Card title="Tutustu kehittäjämalleihin" href="/developers/templates">
-  Rakenna nopeammin tuotantovalmiilla malleilla dApp-sovelluksille,
-  DeFi-protokollille, NFT-markkinapaikoille ja muille. Aloita
-  taistelukoetelluilla koodipohjilla, jotka on optimoitu Solana-ekosysteemille.
+<Card
+  title="Avaa pika-aloitus"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  Rakenna ja ota käyttöön ensimmäinen Solana-projektisi suoraan selaimessa.
 </Card>
 
-<Card title="Työkalut" href="/docs/tools">
-  Tutustu Solana-kehittäjätyökalujen dokumentaatioon.
+## Haluatko ohjelmoida tekoälyagentin kanssa?
+
+<Card title="Ohjelmointi agenttien kanssa" href="/docs/intro/coding-with-agents">
+  Ota Solana MCP käyttöön tai asenna virallinen Solana-skill
+  ohjelmointiagentillesi.
 </Card>
 
-## Kokeile Solanaa: Pelaa 2048
+## Haluatko oppia, miten Solana toimii?
 
-Pelaa 2048-peliä Solanassa, jossa jokainen siirto lähettää tapahtuman. Napsauta
-"Pelaa" aloittaaksesi rahoitetulla devnet-lompakolla ja käytä nuolinäppäimiä
-pelataksesi. Mobiililaitteella pyyhkäise ohjataksesi laattoja.
+<Card title="Opi käsitteet" href="/docs/core">
+  Opi Solanan toiminnan mahdollistavat perusosat.
+</Card>
+
+### Kokeile Solanaa: Pelaa 2048
+
+Pelaa 2048-peliä Solanassa, jossa jokainen siirto lähettää tapahtuman. Aloita
+rahoitetulla Devnet-lompakolla napsauttamalla ”Pelaa” ja käytä nuolinäppäimiä
+tai pyyhkäise mobiililaitteella.
 
 <Accordions>
 <Accordion title="Pelaa Solana 2048">
@@ -62,89 +62,3 @@ pelataksesi. Mobiililaitteella pyyhkäise ohjataksesi laattoja.
 
 Kehittäjä [Jonas](https://x.com/SolPlay_jonas), Solana Foundationin
 DevRel-tiimistä.
-
-## Aloita oppiminen
-
-Opi Solana-kehitykselle ominaiset keskeiset käsitteet.
-
-<Cards>
-  <Card title="Tilit" href="/docs/core/accounts">
-    Miten Solana tallentaa dataa
-  </Card>
-  <Card title="Maksut Solanassa" href="/docs/core/fees">
-    Tapahtumien lähettämisen kustannukset Solanassa
-  </Card>
-  <Card title="Tapahtumat" href="/docs/core/transactions">
-    Miten olla vuorovaikutuksessa Solana-verkon kanssa
-  </Card>
-  <Card title="Ohjelmat" href="/docs/core/programs">
-    Älykkäät sopimukset Solanassa
-  </Card>
-  <Card title="Ohjelmasta johdettu osoite" href="/docs/core/pda">
-    Miten luoda deterministisiä osoitteita
-  </Card>
-  <Card title="Ohjelmien välinen kutsu" href="/docs/core/cpi">
-    Miten kutsua yhtä ohjelmaa toisesta
-  </Card>
-</Cards>
-
-### Asiakaspuolen kehitys
-
-Seuraavat SDK:t ovat Solanan virallisia SDK:ita, jotka on kehittänyt
-[Anza](https://anza.xyz).
-
-#### Viralliset SDK:t
-
-| Kieli                   | SDK                                                                |
-| ----------------------- | ------------------------------------------------------------------ |
-| Rust                    | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Suositeltu) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Vanha)      | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### Yhteisön SDK:t
-
-Seuraavat ovat yhteisön tarjoamia SDK:ita eri kielille:
-
-| Kieli    | SDK                                                                                                                                         |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                           |
-| Java     | [sava](https://sava.software) tai [solanaj](https://github.com/skynetcap/solanaj) tai [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) tai [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                                |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                      |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) tai [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                     |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                                 |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                              |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                    |
-
-<Callout type="warn">
-  Yhteisön SDK:t eivät ole taattuja olevan ajan tasalla tai sisältämään kaikkia
-  virallisten SDK:iden ominaisuuksia.
-</Callout>
-
-## Validatorin ajaminen
-
-Tutustu siihen, mitä Solana-validatorin käyttäminen vaatii ja miten voit auttaa
-verkon turvaamisessa.
-
-<Cards>
-  <Card title="Validatorit" href="https://docs.anza.xyz/validator/anatomy">
-    Yksittäiset solmut, jotka turvaavat Solana-verkkoa
-  </Card>
-  <Card
-    title="Järjestelmävaatimukset"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Suositellut laitteistovaatimukset ja validatorin käyttämiseen tarvittava SOL
-  </Card>
-  <Card
-    title="Validatorin asennus"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Asenna validator ja yhdistä se klusteriin ensimmäistä kertaa
-  </Card>
-</Cards>
-
-## Tuen saaminen
-
-Saat apua Solana-yhteisöltä
-[Solana StackExchangessa](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/fr/index.mdx
+++ b/apps/docs/content/docs/fr/index.mdx
@@ -1,51 +1,44 @@
 ---
-title: Documentation Solana
-seoTitle: Découvrez comment fonctionne la blockchain Solana
+title: Commencez ici
+seoTitle: Commencez à développer sur Solana
 description:
-  Solana est la blockchain haute performance conçue pour une adoption massive.
-  Découvrez pourquoi Solana est le premier choix des développeurs qui souhaitent
-  créer des applications blockchain évolutives.
+  Choisissez le démarrage rapide, codez avec un agent IA ou découvrez comment
+  fonctionne Solana.
 ---
 
-## Premiers pas
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Les applications du quotidien se connectent à Solana, un réseau partagé entretenu par des ordinateurs du monde entier"
+/>
 
-<Cards>
-  <Card
-    title="Démarrage rapide"
-    href="/docs/intro/quick-start"
-    icon={<Rocket />}
-  >
-    Créez votre premier programme Solana directement dans le navigateur
-  </Card>
-  <Card
-    title="Configurer l'environnement local"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Installez les dépendances pour le développement Solana
-  </Card>
-</Cards>
-
-### Construisez plus rapidement avec les modèles de développement Solana
+## Vous voulez commencer à développer ?
 
 <Card
-  title="Explorer les modèles de développement"
-  href="/developers/templates"
+  title="Ouvrir le démarrage rapide"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
 >
-  Construisez plus rapidement avec des modèles prêts pour la production pour les
-  dApps, les protocoles DeFi, les marketplaces NFT et plus encore. Démarrez avec
-  des modèles de code éprouvés optimisés pour l'écosystème Solana.
+  Créez et déployez votre premier projet Solana directement dans le navigateur.
 </Card>
 
-<Card title="Outils" href="/docs/tools">
-  Explorez la documentation des outils de développement Solana.
+## Vous voulez coder avec un agent IA ?
+
+<Card title="Coder avec des agents" href="/docs/intro/coding-with-agents">
+  Configurez Solana MCP ou installez le skill Solana officiel pour votre agent de
+  programmation.
 </Card>
 
-## Essayez Solana : Jouez à 2048
+## Vous voulez comprendre comment fonctionne Solana ?
 
-Jouez à 2048 sur Solana où chaque mouvement envoie une transaction. Cliquez sur
-« Jouer » pour commencer avec un portefeuille devnet financé et utilisez les
-touches fléchées pour jouer. Sur mobile, balayez pour contrôler les tuiles.
+<Card title="Découvrir les concepts" href="/docs/core">
+  Découvrez les éléments fondamentaux qui font fonctionner Solana.
+</Card>
+
+### Essayez Solana : Jouez à 2048
+
+Jouez à 2048 sur Solana, où chaque mouvement envoie une transaction. Cliquez sur
+« Jouer » pour commencer avec un wallet Devnet approvisionné, puis utilisez les
+flèches ou balayez l'écran sur mobile.
 
 <Accordions>
 <Accordion title="Jouer à Solana 2048">
@@ -69,91 +62,3 @@ touches fléchées pour jouer. Sur mobile, balayez pour contrôler les tuiles.
 
 Développé par [Jonas](https://x.com/SolPlay_jonas), de l'équipe DevRel de la
 Solana Foundation.
-
-## Commencer l'apprentissage
-
-Apprenez les concepts clés spécifiques au développement Solana.
-
-<Cards>
-  <Card title="Comptes" href="/docs/core/accounts">
-    Comment Solana stocke les données
-  </Card>
-  <Card title="Frais sur Solana" href="/docs/core/fees">
-    Coûts d'envoi de transactions sur Solana
-  </Card>
-  <Card title="Transactions" href="/docs/core/transactions">
-    Comment interagir avec le réseau Solana
-  </Card>
-  <Card title="Programmes" href="/docs/core/programs">
-    Contrats intelligents sur Solana
-  </Card>
-  <Card title="Adresse dérivée de programme" href="/docs/core/pda">
-    Comment générer des adresses déterministes
-  </Card>
-  <Card title="Invocation inter-programmes" href="/docs/core/cpi">
-    Comment appeler un programme depuis un autre
-  </Card>
-</Cards>
-
-### Développement côté client
-
-Les SDK suivants sont les SDK officiels pour Solana développés par
-[Anza](https://anza.xyz).
-
-#### SDK officiels
-
-| Langage                 | SDK                                                                |
-| ----------------------- | ------------------------------------------------------------------ |
-| Rust                    | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Recommandé) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Hérité)     | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### SDK communautaires
-
-Les SDK suivants sont des contributions de la communauté pour différents
-langages :
-
-| Langage  | SDK                                                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                         |
-| Java     | [sava](https://sava.software) ou [solanaj](https://github.com/skynetcap/solanaj) ou [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) ou [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                               |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                    |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) ou [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                    |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                               |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                            |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                  |
-
-<Callout type="warn">
-  Les SDK communautaires ne sont pas garantis d'être à jour ou d'inclure toutes
-  les fonctionnalités des SDK officiels.
-</Callout>
-
-## Exécuter un validateur
-
-Découvrez ce qu'il faut pour exploiter un validateur Solana et contribuer à
-sécuriser le réseau.
-
-<Cards>
-  <Card title="Validateurs" href="https://docs.anza.xyz/validator/anatomy">
-    Nœuds individuels sécurisant le réseau Solana
-  </Card>
-  <Card
-    title="Configuration système requise"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Exigences matérielles recommandées et SOL requis pour exploiter un validator
-  </Card>
-  <Card
-    title="Configuration du validateur"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Configurez un validateur et connectez-vous à un cluster pour la première
-    fois
-  </Card>
-</Cards>
-
-## Obtenir de l'aide
-
-Obtenez de l'aide de la communauté Solana sur
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/id/index.mdx
+++ b/apps/docs/content/docs/id/index.mdx
@@ -1,44 +1,43 @@
 ---
-title: Dokumentasi Solana
-seoTitle: Pelajari cara kerja blockchain Solana
+title: Mulai di sini
+seoTitle: Mulai membangun di Solana
 description:
-  Solana adalah blockchain berkinerja tinggi yang dirancang untuk adopsi massal.
-  Pelajari mengapa Solana menjadi pilihan utama bagi pengembang yang ingin
-  membangun aplikasi blockchain yang dapat diskalakan.
+  Pilih panduan mulai cepat, buat kode dengan agen AI, atau pelajari cara kerja
+  Solana.
 ---
 
-## Memulai
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Aplikasi sehari-hari terhubung ke Solana, jaringan bersama yang dijalankan oleh komputer di seluruh dunia"
+/>
 
-<Cards>
-  <Card title="Mulai Cepat" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Bangun program Solana pertama Anda langsung di browser
-  </Card>
-  <Card
-    title="Siapkan Lingkungan Lokal"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Instal dependensi untuk pengembangan Solana
-  </Card>
-</Cards>
+## Ingin langsung mulai membangun?
 
-### Bangun lebih cepat dengan template developer Solana
-
-<Card title="Jelajahi template developer" href="/developers/templates">
-  Bangun lebih cepat dengan template siap produksi untuk dApps, protokol DeFi,
-  marketplace NFT, dan lainnya. Mulai dengan pola kode yang telah teruji dan
-  dioptimalkan untuk ekosistem Solana.
+<Card
+  title="Buka panduan mulai cepat"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  Bangun dan deploy proyek Solana pertama Anda langsung di browser.
 </Card>
 
-<Card title="Alat" href="/docs/tools">
-  Jelajahi dokumentasi untuk alat pengembang Solana.
+## Ingin membuat kode dengan agen AI?
+
+<Card title="Membuat kode dengan agen" href="/docs/intro/coding-with-agents">
+  Siapkan Solana MCP atau instal skill resmi Solana untuk agen pemrograman Anda.
 </Card>
 
-## Coba Solana: Main 2048
+## Ingin mempelajari cara kerja Solana?
 
-Mainkan 2048 di Solana di mana setiap gerakan mengirim transaksi. Klik "Main"
-untuk memulai dengan dompet devnet yang telah didanai dan gunakan tombol panah
-untuk bermain. Jika menggunakan perangkat seluler, geser untuk mengontrol ubin.
+<Card title="Pelajari konsep" href="/docs/core">
+  Pelajari komponen dasar yang membuat Solana bekerja.
+</Card>
+
+### Coba Solana: Main 2048
+
+Mainkan 2048 di Solana, tempat setiap gerakan mengirim transaksi. Klik "Main"
+untuk memulai dengan wallet Devnet yang didanai, lalu gunakan tombol panah atau
+geser di perangkat seluler.
 
 <Accordions>
 <Accordion title="Main Solana 2048">
@@ -62,90 +61,3 @@ untuk bermain. Jika menggunakan perangkat seluler, geser untuk mengontrol ubin.
 
 Dibuat oleh [Jonas](https://x.com/SolPlay_jonas), dari tim DevRel Solana
 Foundation.
-
-## Mulai Belajar
-
-Pelajari konsep-konsep kunci yang spesifik untuk pengembangan Solana.
-
-<Cards>
-  <Card title="Akun" href="/docs/core/accounts">
-    Cara Solana menyimpan data
-  </Card>
-  <Card title="Biaya di Solana" href="/docs/core/fees">
-    Biaya untuk mengirim transaksi di Solana
-  </Card>
-  <Card title="Transaksi" href="/docs/core/transactions">
-    Cara berinteraksi dengan jaringan Solana
-  </Card>
-  <Card title="Program" href="/docs/core/programs">
-    Smart contract di Solana
-  </Card>
-  <Card title="Program Derived Address" href="/docs/core/pda">
-    Cara menghasilkan alamat deterministik
-  </Card>
-  <Card title="Cross Program Invocation" href="/docs/core/cpi">
-    Cara memanggil satu program dari program lain
-  </Card>
-</Cards>
-
-### Pengembangan Sisi Klien
-
-SDK berikut adalah SDK resmi untuk Solana yang dibangun oleh
-[Anza](https://anza.xyz).
-
-#### SDK Resmi
-
-| Bahasa                        | SDK                                                                |
-| ----------------------------- | ------------------------------------------------------------------ |
-| Rust                          | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Direkomendasikan) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Lama)             | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### SDK Komunitas
-
-Berikut adalah SDK yang dikontribusikan oleh komunitas untuk berbagai bahasa:
-
-| Bahasa   | SDK                                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                             |
-| Java     | [sava](https://sava.software) atau [solanaj](https://github.com/skynetcap/solanaj) atau [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) atau [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                                 |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                        |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) atau [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                      |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                                   |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                                |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                      |
-
-<Callout type="warn">
-  SDK Komunitas tidak dijamin selalu diperbarui atau mencakup semua fitur dari
-  SDK resmi.
-</Callout>
-
-## Menjalankan validator
-
-Jelajahi apa yang diperlukan untuk mengoperasikan validator Solana dan membantu
-mengamankan jaringan.
-
-<Cards>
-  <Card title="Validators" href="https://docs.anza.xyz/validator/anatomy">
-    Node individual yang mengamankan jaringan Solana
-  </Card>
-  <Card
-    title="Persyaratan Sistem"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Persyaratan perangkat keras yang direkomendasikan dan SOL yang diperlukan
-    untuk mengoperasikan validator
-  </Card>
-  <Card
-    title="Pengaturan Validator"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Siapkan validator dan terhubung ke kluster untuk pertama kalinya
-  </Card>
-</Cards>
-
-## Mendapatkan Dukungan
-
-Dapatkan bantuan dari komunitas Solana di
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/it/index.mdx
+++ b/apps/docs/content/docs/it/index.mdx
@@ -1,44 +1,44 @@
 ---
-title: Documentazione Solana
-seoTitle: Scopri come funziona la blockchain Solana
+title: Inizia qui
+seoTitle: Inizia a sviluppare su Solana
 description:
-  Solana è la blockchain ad alte prestazioni progettata per l'adozione di massa.
-  Scopri perché Solana è la scelta principale per gli sviluppatori che cercano
-  di creare applicazioni blockchain scalabili.
+  Scegli l'avvio rapido, programma con un agente IA oppure scopri come funziona
+  Solana.
 ---
 
-## Per iniziare
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Le app di tutti i giorni si connettono a Solana, una rete condivisa mantenuta da computer in tutto il mondo"
+/>
 
-<Cards>
-  <Card title="Avvio rapido" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Crea il tuo primo programma Solana direttamente nel browser
-  </Card>
-  <Card
-    title="Configura l'ambiente locale"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Installa le dipendenze per lo sviluppo su Solana
-  </Card>
-</Cards>
+## Vuoi iniziare a sviluppare?
 
-### Costruisci più velocemente con i template per sviluppatori Solana
-
-<Card title="Esplora i template per sviluppatori" href="/developers/templates">
-  Costruisci più velocemente con template pronti per la produzione per dApp,
-  protocolli DeFi, marketplace NFT e altro ancora. Inizia con pattern di codice
-  testati e ottimizzati per l'ecosistema Solana.
+<Card
+  title="Apri l'avvio rapido"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  Crea e distribuisci il tuo primo progetto Solana direttamente nel browser.
 </Card>
 
-<Card title="Strumenti" href="/docs/tools">
-  Esplora la documentazione per gli strumenti di sviluppo Solana.
+## Vuoi programmare con un agente IA?
+
+<Card title="Programmare con gli agenti" href="/docs/intro/coding-with-agents">
+  Configura Solana MCP o installa la skill ufficiale di Solana per il tuo agente
+  di programmazione.
 </Card>
 
-## Prova Solana: Gioca a 2048
+## Vuoi scoprire come funziona Solana?
 
-Gioca a 2048 su Solana dove ogni mossa invia una transazione. Clicca su "Gioca"
-per iniziare con un wallet devnet finanziato e usa i tasti freccia per giocare.
-Se sei su mobile, scorri per controllare le tessere.
+<Card title="Impara i concetti" href="/docs/core">
+  Scopri gli elementi fondamentali che fanno funzionare Solana.
+</Card>
+
+### Prova Solana: Gioca a 2048
+
+Gioca a 2048 su Solana, dove ogni mossa invia una transazione. Fai clic su
+«Gioca» per iniziare con un wallet Devnet finanziato, quindi usa i tasti freccia
+o scorri sul dispositivo mobile.
 
 <Accordions>
 <Accordion title="Gioca a Solana 2048">
@@ -62,89 +62,3 @@ Se sei su mobile, scorri per controllare le tessere.
 
 Creato da [Jonas](https://x.com/SolPlay_jonas), del team DevRel di Solana
 Foundation.
-
-## Inizia a Imparare
-
-Scopri i concetti chiave specifici dello sviluppo su Solana.
-
-<Cards>
-  <Card title="Account" href="/docs/core/accounts">
-    Come Solana memorizza i dati
-  </Card>
-  <Card title="Commissioni su Solana" href="/docs/core/fees">
-    Costi per inviare transazioni su Solana
-  </Card>
-  <Card title="Transazioni" href="/docs/core/transactions">
-    Come interagire con la rete Solana
-  </Card>
-  <Card title="Programmi" href="/docs/core/programs">
-    Smart contract su Solana
-  </Card>
-  <Card title="Indirizzo Derivato da Programma" href="/docs/core/pda">
-    Come generare indirizzi deterministici
-  </Card>
-  <Card title="Invocazione tra Programmi" href="/docs/core/cpi">
-    Come chiamare un programma da un altro
-  </Card>
-</Cards>
-
-### Sviluppo Lato Client
-
-I seguenti SDK sono gli SDK ufficiali per Solana sviluppati da
-[Anza](https://anza.xyz).
-
-#### SDK Ufficiali
-
-| Linguaggio               | SDK                                                                |
-| ------------------------ | ------------------------------------------------------------------ |
-| Rust                     | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Consigliato) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Legacy)      | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### SDK della Community
-
-I seguenti sono SDK sviluppati dalla community per vari linguaggi:
-
-| Linguaggio | SDK                                                                                                                                     |
-| ---------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| Python     | [solders](https://github.com/kevinheavey/solders)                                                                                       |
-| Java       | [sava](https://sava.software) o [solanaj](https://github.com/skynetcap/solanaj) o [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++        | [solcpp](https://github.com/mschneider/solcpp) o [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                              |
-| Go         | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                  |
-| Kotlin     | [sol4k](https://github.com/sol4k/sol4k) o [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                   |
-| Dart       | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                             |
-| C#         | [solnet](https://github.com/bmresearch/Solnet)                                                                                          |
-| GdScript   | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                |
-
-<Callout type="warn">
-  Gli SDK della community non sono garantiti per essere aggiornati o includere
-  tutte le funzionalità degli SDK ufficiali.
-</Callout>
-
-## Eseguire un validator
-
-Scopri cosa serve per gestire un validator Solana e contribuire alla sicurezza
-della rete.
-
-<Cards>
-  <Card title="Validator" href="https://docs.anza.xyz/validator/anatomy">
-    Singoli nodi che proteggono la rete Solana
-  </Card>
-  <Card
-    title="Requisiti di sistema"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Requisiti hardware consigliati e SOL necessari per gestire un validator
-  </Card>
-  <Card
-    title="Configurazione validator"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Configura un validator e connettiti a un cluster per la prima volta
-  </Card>
-</Cards>
-
-## Ottenere supporto
-
-Ricevi aiuto dalla community Solana su
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/ja/index.mdx
+++ b/apps/docs/content/docs/ja/index.mdx
@@ -1,41 +1,40 @@
 ---
-title: Solanaドキュメント
-seoTitle: Solanaブロックチェーンの仕組みを学ぶ
-description: Solanaは大規模採用向けに設計された高性能ブロックチェーンです。スケーラブルなブロックチェーンアプリケーションを構築しようとする開発者がSolanaを最優先に選ぶ理由を学びましょう。
+title: ここから始める
+seoTitle: Solanaでの開発を始める
+description: クイックスタート、AIエージェントとのコーディング、またはSolanaの仕組みの学習から選べます。
 ---
 
-## はじめに
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="日常のアプリが、世界中のコンピューターによって稼働する共有ネットワークSolanaに接続する様子"
+/>
 
-<Cards>
-  <Card
-    title="クイックスタート"
-    href="/docs/intro/quick-start"
-    icon={<Rocket />}
-  >
-    ブラウザ上で直接初めてのSolanaプログラムを構築する
-  </Card>
-  <Card
-    title="ローカル環境のセットアップ"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Solana開発に必要な依存関係をインストールする
-  </Card>
-</Cards>
+## さっそく開発を始めますか？
 
-### Solana開発者テンプレートでより速く構築
-
-<Card title="開発者テンプレートを探索" href="/developers/templates">
-  dApps、DeFiプロトコル、NFTマーケットプレイスなどの本番環境対応テンプレートでより速く構築できます。Solanaエコシステムに最適化された実証済みのコードパターンで開発を始めましょう。
+<Card
+  title="クイックスタートを開く"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  ブラウザ上で最初のSolanaプロジェクトを構築し、デプロイします。
 </Card>
 
-<Card title="ツール" href="/docs/tools">
-  Solana開発者ツールのドキュメントを探索する。
+## AIエージェントとコーディングしますか？
+
+<Card title="エージェントとのコーディング" href="/docs/intro/coding-with-agents">
+  Solana MCPを設定するか、コーディングエージェントに公式Solana
+  skillをインストールします。
 </Card>
 
-## Solanaを試す：2048をプレイ
+## Solanaの仕組みを学びますか？
 
-Solana上で2048をプレイしましょう。すべての動きがトランザクションを送信します。「プレイ」をクリックして、資金が入ったdevnetウォレットで開始し、矢印キーを使ってプレイしてください。モバイルの場合は、スワイプしてタイルを操作します。
+<Card title="コンセプトを学ぶ" href="/docs/core">
+  Solanaを動かす基本的な構成要素を学びます。
+</Card>
+
+### Solanaを試す：2048をプレイ
+
+Solana上で2048をプレイしましょう。すべての動きがトランザクションを送信します。「プレイ」をクリックして資金が入ったDevnetウォレットで開始し、矢印キーまたはモバイルでのスワイプを使用します。
 
 <Accordions>
 <Accordion title="Solana 2048をプレイ">
@@ -59,86 +58,3 @@ Solana上で2048をプレイしましょう。すべての動きがトランザ�
 
 Solana
 FoundationのDevRelチームの[Jonas](https://x.com/SolPlay_jonas)により構築されました。
-
-## 学習を開始する
-
-Solana開発に特有の主要な概念を学びましょう。
-
-<Cards>
-  <Card title="アカウント" href="/docs/core/accounts">
-    Solanaがデータを保存する方法
-  </Card>
-  <Card title="Solanaの手数料" href="/docs/core/fees">
-    Solanaでトランザクションを送信するコスト
-  </Card>
-  <Card title="トランザクション" href="/docs/core/transactions">
-    Solanaネットワークと対話する方法
-  </Card>
-  <Card title="プログラム" href="/docs/core/programs">
-    Solanaのスマートコントラクト
-  </Card>
-  <Card title="プログラム派生アドレス" href="/docs/core/pda">
-    決定論的アドレスを生成する方法
-  </Card>
-  <Card title="クロスプログラム呼び出し" href="/docs/core/cpi">
-    あるプログラムから別のプログラムを呼び出す方法
-  </Card>
-</Cards>
-
-### クライアントサイド開発
-
-以下のSDKは、[Anza](https://anza.xyz)によって構築されたSolanaの公式SDKです。
-
-#### 公式SDK
-
-| 言語                  | SDK                                                                |
-| --------------------- | ------------------------------------------------------------------ |
-| Rust                  | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (推奨)     | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (レガシー) | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### コミュニティSDK
-
-以下は、さまざまな言語向けのコミュニティ貢献SDKです：
-
-| 言語     | SDK                                                                                                                                               |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                                 |
-| Java     | [sava](https://sava.software) または [solanaj](https://github.com/skynetcap/solanaj) または [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) または [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                                   |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                            |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) または [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                        |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                                       |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                                    |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                          |
-
-<Callout type="warn">
-  コミュニティSDKは、最新の状態が保証されていない場合や、公式SDKのすべての機能を含んでいない場合があります。
-</Callout>
-
-## validatorの運用
-
-Solana
-validatorを運用し、ネットワークのセキュリティ確保に貢献するために必要なことを探ります。
-
-<Cards>
-  <Card title="Validators" href="https://docs.anza.xyz/validator/anatomy">
-    Solanaネットワークを保護する個々のノード
-  </Card>
-  <Card
-    title="システム要件"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    validatorを運用するために推奨されるハードウェア要件と必要なSOL
-  </Card>
-  <Card
-    title="Validatorのセットアップ"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    validatorをセットアップし、初めてクラスターに接続する
-  </Card>
-</Cards>
-
-## サポートを受ける
-
-[Solana StackExchange](https://solana.stackexchange.com)でSolanaコミュニティからサポートを受けることができます。

--- a/apps/docs/content/docs/ko/index.mdx
+++ b/apps/docs/content/docs/ko/index.mdx
@@ -1,44 +1,44 @@
 ---
-title: Solana 문서
-seoTitle: Solana 블록체인의 작동 방식 알아보기
+title: 여기에서 시작
+seoTitle: Solana에서 개발 시작하기
 description:
-  Solana는 대규모 채택을 위해 설계된 고성능 블록체인입니다. 확장 가능한 블록체인
-  애플리케이션을 구축하려는 개발자들이 Solana를 최고의 선택으로 삼는 이유를
-  알아보세요.
+  빠른 시작, AI 에이전트와 코딩하기 또는 Solana의 작동 방식 알아보기 중
+  하나를 선택하세요.
 ---
 
-## 시작하기
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="일상적인 앱이 전 세계 컴퓨터가 함께 운영하는 공유 네트워크 Solana에 연결되는 모습"
+/>
 
-<Cards>
-  <Card title="빠른 시작" href="/docs/intro/quick-start" icon={<Rocket />}>
-    브라우저에서 직접 첫 번째 Solana 프로그램 구축하기
-  </Card>
-  <Card
-    title="로컬 환경 설정"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Solana 개발을 위한 종속성 설치하기
-  </Card>
-</Cards>
+## 바로 빌드를 시작하고 싶으신가요?
 
-### Solana 개발자 템플릿으로 더 빠르게 구축하기
-
-<Card title="개발자 템플릿 살펴보기" href="/developers/templates">
-  dApp, DeFi 프로토콜, NFT 마켓플레이스 등을 위한 프로덕션 준비 완료 템플릿으로
-  더 빠르게 구축하세요. Solana 생태계에 최적화된 검증된 코드 패턴으로
-  시작하세요.
+<Card
+  title="빠른 시작 열기"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  브라우저에서 첫 번째 Solana 프로젝트를 빌드하고 배포하세요.
 </Card>
 
-<Card title="도구" href="/docs/tools">
-  Solana 개발자 도구 문서를 살펴보세요.
+## AI 에이전트와 코딩하고 싶으신가요?
+
+<Card title="에이전트와 코딩하기" href="/docs/intro/coding-with-agents">
+  Solana MCP를 설정하거나 코딩 에이전트에 공식 Solana skill을
+  설치하세요.
 </Card>
 
-## Solana 체험하기: 2048 게임
+## Solana의 작동 방식을 알고 싶으신가요?
+
+<Card title="핵심 개념 알아보기" href="/docs/core">
+  Solana를 작동하게 하는 기본 구성 요소를 알아보세요.
+</Card>
+
+### Solana 체험하기: 2048 게임
 
 모든 움직임이 트랜잭션을 전송하는 Solana 기반 2048 게임을 플레이하세요.
-"플레이"를 클릭하면 devnet 지갑에 자금이 지급되며, 방향키로 플레이할 수
-있습니다. 모바일에서는 스와이프로 타일을 조작하세요.
+“플레이”를 클릭하여 자금이 지원된 Devnet wallet으로 시작한 다음 방향키를
+사용하거나 모바일에서 스와이프하세요.
 
 <Accordions>
 <Accordion title="Solana 2048 플레이">
@@ -62,88 +62,3 @@ description:
 
 Solana Foundation DevRel 팀의 [Jonas](https://x.com/SolPlay_jonas)가
 제작했습니다.
-
-## 학습 시작하기
-
-Solana 개발에 특화된 핵심 개념을 배워보세요.
-
-<Cards>
-  <Card title="계정" href="/docs/core/accounts">
-    Solana가 데이터를 저장하는 방식
-  </Card>
-  <Card title="Solana의 수수료" href="/docs/core/fees">
-    Solana에서 트랜잭션 전송 비용
-  </Card>
-  <Card title="트랜잭션" href="/docs/core/transactions">
-    Solana 네트워크와 상호작용하는 방법
-  </Card>
-  <Card title="프로그램" href="/docs/core/programs">
-    Solana의 스마트 컨트랙트
-  </Card>
-  <Card title="프로그램 파생 주소" href="/docs/core/pda">
-    결정론적 주소를 생성하는 방법
-  </Card>
-  <Card title="크로스 프로그램 호출" href="/docs/core/cpi">
-    한 프로그램에서 다른 프로그램을 호출하는 방법
-  </Card>
-</Cards>
-
-### 클라이언트 측 개발
-
-다음 SDK는 [Anza](https://anza.xyz)에서 제작한 Solana 공식 SDK입니다.
-
-#### 공식 SDK
-
-| 언어                | SDK                                                                |
-| ------------------- | ------------------------------------------------------------------ |
-| Rust                | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (권장)   | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (레거시) | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### 커뮤니티 SDK
-
-다음은 커뮤니티에서 기여한 다양한 언어의 SDK입니다:
-
-| 언어     | SDK                                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                             |
-| Java     | [sava](https://sava.software) 또는 [solanaj](https://github.com/skynetcap/solanaj) 또는 [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) 또는 [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                                 |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                        |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) 또는 [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                      |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                                   |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                                |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                      |
-
-<Callout type="warn">
-  커뮤니티 SDK는 최신 상태를 보장하지 않으며 공식 SDK의 모든 기능을 포함하지
-  않을 수 있습니다.
-</Callout>
-
-## validator 운영하기
-
-Solana validator를 운영하고 네트워크 보안에 기여하기 위해 필요한 사항을
-알아보세요.
-
-<Cards>
-  <Card title="Validators" href="https://docs.anza.xyz/validator/anatomy">
-    Solana 네트워크를 보호하는 개별 노드
-  </Card>
-  <Card
-    title="시스템 요구사항"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    validator 운영에 필요한 권장 하드웨어 요구사항 및 SOL
-  </Card>
-  <Card
-    title="Validator 설정"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    validator를 설정하고 처음으로 클러스터에 연결하기
-  </Card>
-</Cards>
-
-## 지원받기
-
-[Solana StackExchange](https://solana.stackexchange.com)에서 Solana
-커뮤니티로부터 도움을 받으세요.

--- a/apps/docs/content/docs/nl/index.mdx
+++ b/apps/docs/content/docs/nl/index.mdx
@@ -1,44 +1,43 @@
 ---
-title: Solana Documentatie
-seoTitle: Leer hoe de Solana blockchain werkt
+title: Begin hier
+seoTitle: Begin met bouwen op Solana
 description:
-  Solana is de hoogwaardige blockchain ontworpen voor massale adoptie. Ontdek
-  waarom Solana de topkeuze is voor ontwikkelaars die schaalbare
-  blockchain-applicaties willen bouwen.
+  Kies de snelstart, programmeer met een AI-agent of leer hoe Solana werkt.
 ---
 
-## Aan de slag
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Alledaagse apps maken verbinding met Solana, een gedeeld netwerk dat door computers over de hele wereld draaiende wordt gehouden"
+/>
 
-<Cards>
-  <Card title="Snelstart" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Bouw je eerste Solana-programma direct in de browser
-  </Card>
-  <Card
-    title="Lokale omgeving opzetten"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Installeer afhankelijkheden voor Solana-ontwikkeling
-  </Card>
-</Cards>
+## Wil je meteen beginnen met bouwen?
 
-### Bouw sneller met Solana ontwikkelaarstemplates
-
-<Card title="Verken ontwikkelaarstemplates" href="/developers/templates">
-  Bouw sneller met productie-klare templates voor dApps, DeFi-protocollen,
-  NFT-marktplaatsen en meer. Ga aan de slag met beproefde codepatronen
-  geoptimaliseerd voor het Solana-ecosysteem.
+<Card
+  title="Open de snelstart"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  Bouw en implementeer je eerste Solana-project rechtstreeks in de browser.
 </Card>
 
-<Card title="Hulpmiddelen" href="/docs/tools">
-  Verken documentatie voor Solana-ontwikkeltools.
+## Wil je coderen met een AI-agent?
+
+<Card title="Coderen met agents" href="/docs/intro/coding-with-agents">
+  Stel Solana MCP in of installeer de officiële Solana-skill voor je
+  programmeeragent.
 </Card>
 
-## Probeer Solana: Speel 2048
+## Wil je leren hoe Solana werkt?
 
-Speel 2048 op Solana waar elke zet een transactie verstuurt. Klik op "Spelen" om
-te beginnen met een gefinancierde devnet-wallet en gebruik de pijltjestoetsen om
-te spelen. Als je op mobiel bent, veeg om de tegels te besturen.
+<Card title="Leer de concepten" href="/docs/core">
+  Leer de fundamentele bouwstenen kennen die Solana laten werken.
+</Card>
+
+### Probeer Solana: Speel 2048
+
+Speel 2048 op Solana, waarbij elke zet een transactie verstuurt. Klik op
+„Spelen” om te beginnen met een gefinancierde Devnet-wallet en gebruik de
+pijltjestoetsen of veeg op mobiel.
 
 <Accordions>
 <Accordion title="Speel Solana 2048">
@@ -62,89 +61,3 @@ te spelen. Als je op mobiel bent, veeg om de tegels te besturen.
 
 Gebouwd door [Jonas](https://x.com/SolPlay_jonas), van het Solana Foundation
 DevRel-team.
-
-## Begin met leren
-
-Leer de belangrijkste concepten die specifiek zijn voor Solana-ontwikkeling.
-
-<Cards>
-  <Card title="Accounts" href="/docs/core/accounts">
-    Hoe Solana gegevens opslaat
-  </Card>
-  <Card title="Vergoedingen op Solana" href="/docs/core/fees">
-    Kosten voor het versturen van transacties op Solana
-  </Card>
-  <Card title="Transacties" href="/docs/core/transactions">
-    Hoe te communiceren met het Solana-netwerk
-  </Card>
-  <Card title="Programma's" href="/docs/core/programs">
-    Slimme contracten op Solana
-  </Card>
-  <Card title="Program Derived Address" href="/docs/core/pda">
-    Hoe deterministische adressen te genereren
-  </Card>
-  <Card title="Cross Program Invocation" href="/docs/core/cpi">
-    Hoe het ene programma vanuit een ander aan te roepen
-  </Card>
-</Cards>
-
-### Client-side ontwikkeling
-
-De volgende SDK's zijn de officiële SDK's voor Solana gebouwd door
-[Anza](https://anza.xyz).
-
-#### Officiële SDK's
-
-| Taal                    | SDK                                                                |
-| ----------------------- | ------------------------------------------------------------------ |
-| Rust                    | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Aanbevolen) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Legacy)     | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### Community SDK's
-
-De volgende zijn door de community bijgedragen SDK's voor diverse talen:
-
-| Taal     | SDK                                                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                         |
-| Java     | [sava](https://sava.software) of [solanaj](https://github.com/skynetcap/solanaj) of [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) of [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                               |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                    |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) of [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                    |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                               |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                            |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                  |
-
-<Callout type="warn">
-  Community SDK's zijn niet gegarandeerd up-to-date of bevatten mogelijk niet
-  alle functies van de officiële SDK's.
-</Callout>
-
-## Een validator uitvoeren
-
-Ontdek wat er nodig is om een Solana validator te bedienen en het netwerk te
-helpen beveiligen.
-
-<Cards>
-  <Card title="Validators" href="https://docs.anza.xyz/validator/anatomy">
-    Individuele nodes die het Solana-netwerk beveiligen
-  </Card>
-  <Card
-    title="Systeemvereisten"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Aanbevolen hardwarevereisten en benodigde SOL om een validator te bedienen
-  </Card>
-  <Card
-    title="Validator-configuratie"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Configureer een validator en maak voor het eerst verbinding met een cluster
-  </Card>
-</Cards>
-
-## Ondersteuning krijgen
-
-Krijg hulp van de Solana-community op
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/pl/index.mdx
+++ b/apps/docs/content/docs/pl/index.mdx
@@ -1,44 +1,44 @@
 ---
-title: Dokumentacja Solana
-seoTitle: Dowiedz się, jak działa blockchain Solana
+title: Zacznij tutaj
+seoTitle: Zacznij tworzyć na Solanie
 description:
-  Solana to blockchain o wysokiej wydajności zaprojektowany z myślą o masowej
-  adopcji. Dowiedz się, dlaczego Solana jest najlepszym wyborem dla deweloperów
-  budujących skalowalne aplikacje blockchain.
+  Wybierz szybki start, programuj z agentem AI lub dowiedz się, jak działa
+  Solana.
 ---
 
-## Pierwsze kroki
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Codzienne aplikacje łączą się z Solaną, wspólną siecią utrzymywaną przez komputery na całym świecie"
+/>
 
-<Cards>
-  <Card title="Szybki start" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Zbuduj swój pierwszy program Solana bezpośrednio w przeglądarce
-  </Card>
-  <Card
-    title="Konfiguracja lokalnego środowiska"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Zainstaluj zależności potrzebne do rozwoju na Solana
-  </Card>
-</Cards>
+## Chcesz od razu zacząć tworzyć?
 
-### Twórz szybciej dzięki szablonom deweloperskim Solana
-
-<Card title="Odkryj szablony deweloperskie" href="/developers/templates">
-  Twórz szybciej, korzystając z gotowych do produkcji szablonów dla dApps,
-  protokołów DeFi, marketplace’ów NFT i nie tylko. Zacznij od sprawdzonych
-  wzorców kodu zoptymalizowanych pod ekosystem Solana.
+<Card
+  title="Otwórz szybki start"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  Zbuduj i wdróż swój pierwszy projekt Solana bezpośrednio w przeglądarce.
 </Card>
 
-<Card title="Narzędzia" href="/docs/tools">
-  Przeglądaj dokumentację narzędzi deweloperskich Solana.
+## Chcesz programować z agentem AI?
+
+<Card title="Programowanie z agentami" href="/docs/intro/coding-with-agents">
+  Skonfiguruj Solana MCP lub zainstaluj oficjalny skill Solana dla swojego agenta
+  programistycznego.
 </Card>
 
-## Wypróbuj Solanę: Zagraj w 2048
+## Chcesz dowiedzieć się, jak działa Solana?
 
-Zagraj w 2048 na Solanie, gdzie każdy ruch wysyła transakcję. Kliknij "Graj",
-aby rozpocząć z finansowanym portfelem devnet i użyj klawiszy strzałek do gry.
-Na urządzeniach mobilnych przesuwaj palcem, aby sterować kafelkami.
+<Card title="Poznaj koncepcje" href="/docs/core">
+  Poznaj podstawowe elementy, dzięki którym działa Solana.
+</Card>
+
+### Wypróbuj Solanę: Zagraj w 2048
+
+Zagraj w 2048 na Solanie, gdzie każdy ruch wysyła transakcję. Kliknij „Graj”,
+aby rozpocząć z zasilonym portfelem Devnet, a następnie użyj klawiszy strzałek
+lub przesuwaj palcem na urządzeniu mobilnym.
 
 <Accordions>
 <Accordion title="Zagraj w Solana 2048">
@@ -62,89 +62,3 @@ Na urządzeniach mobilnych przesuwaj palcem, aby sterować kafelkami.
 
 Stworzone przez [Jonasa](https://x.com/SolPlay_jonas) z zespołu DevRel Solana
 Foundation.
-
-## Rozpocznij naukę
-
-Poznaj kluczowe koncepcje specyficzne dla rozwoju na Solanie.
-
-<Cards>
-  <Card title="Konta" href="/docs/core/accounts">
-    Jak Solana przechowuje dane
-  </Card>
-  <Card title="Opłaty na Solanie" href="/docs/core/fees">
-    Koszty wysyłania transakcji na Solanie
-  </Card>
-  <Card title="Transakcje" href="/docs/core/transactions">
-    Jak wchodzić w interakcję z siecią Solana
-  </Card>
-  <Card title="Programy" href="/docs/core/programs">
-    Inteligentne kontrakty na Solanie
-  </Card>
-  <Card title="Adres Pochodny Programu" href="/docs/core/pda">
-    Jak generować deterministyczne adresy
-  </Card>
-  <Card title="Wywołanie Międzyprogramowe" href="/docs/core/cpi">
-    Jak wywołać jeden program z innego
-  </Card>
-</Cards>
-
-### Rozwój po stronie klienta
-
-Poniższe SDK to oficjalne SDK dla Solany stworzone przez
-[Anza](https://anza.xyz).
-
-#### Oficjalne SDK
-
-| Język                 | SDK                                                                |
-| --------------------- | ------------------------------------------------------------------ |
-| Rust                  | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Zalecany) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Starszy)  | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### SDK społecznościowe
-
-Poniżej znajdują się SDK stworzone przez społeczność dla różnych języków:
-
-| Język    | SDK                                                                                                                                         |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                           |
-| Java     | [sava](https://sava.software) lub [solanaj](https://github.com/skynetcap/solanaj) lub [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) lub [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                                |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                      |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) lub [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                     |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                                 |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                              |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                    |
-
-<Callout type="warn">
-  SDK społeczności nie gwarantują aktualności ani nie zawierają wszystkich
-  funkcji oficjalnych SDK.
-</Callout>
-
-## Uruchamianie validatora
-
-Dowiedz się, co jest potrzebne do obsługi validatora Solana i pomocy w
-zabezpieczeniu sieci.
-
-<Cards>
-  <Card title="Validatory" href="https://docs.anza.xyz/validator/anatomy">
-    Poszczególne węzły zabezpieczające sieć Solana
-  </Card>
-  <Card
-    title="Wymagania systemowe"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Zalecane wymagania sprzętowe i ilość SOL wymagana do obsługi validatora
-  </Card>
-  <Card
-    title="Konfiguracja validatora"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Skonfiguruj validator i połącz się z klastrem po raz pierwszy
-  </Card>
-</Cards>
-
-## Uzyskiwanie wsparcia
-
-Uzyskaj pomoc od społeczności Solana na
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/pt/index.mdx
+++ b/apps/docs/content/docs/pt/index.mdx
@@ -1,44 +1,44 @@
 ---
-title: Documentação Solana
-seoTitle: Aprenda como funciona a blockchain Solana
+title: Comece aqui
+seoTitle: Comece a desenvolver na Solana
 description:
-  Solana é a blockchain de alto desempenho projetada para adoção em massa.
-  Descubra por que a Solana é a principal escolha para desenvolvedores que
-  buscam criar aplicações blockchain escaláveis.
+  Escolha o início rápido, programe com um agente de IA ou aprenda como a Solana
+  funciona.
 ---
 
-## Primeiros passos
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Aplicativos do dia a dia se conectam à Solana, uma rede compartilhada mantida por computadores em todo o mundo"
+/>
 
-<Cards>
-  <Card title="Início rápido" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Construa seu primeiro programa Solana diretamente no navegador
-  </Card>
-  <Card
-    title="Configurar ambiente local"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Instale as dependências para desenvolvimento em Solana
-  </Card>
-</Cards>
+## Quer começar a construir?
 
-### Construa mais rápido com os modelos de desenvolvimento Solana
-
-<Card title="Explorar modelos de desenvolvimento" href="/developers/templates">
-  Construa mais rápido com modelos prontos para produção para dApps, protocolos
-  DeFi, mercados de NFT e muito mais. Comece com padrões de código testados em
-  batalha e otimizados para o ecossistema Solana.
+<Card
+  title="Abrir o início rápido"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  Crie e implante seu primeiro projeto Solana diretamente no navegador.
 </Card>
 
-<Card title="Ferramentas" href="/docs/tools">
-  Explore a documentação das ferramentas de desenvolvimento da Solana.
+## Quer programar com um agente de IA?
+
+<Card title="Programar com agentes" href="/docs/intro/coding-with-agents">
+  Configure o Solana MCP ou instale a skill oficial da Solana para seu agente de
+  programação.
 </Card>
 
-## Experimente a Solana: Jogue 2048
+## Quer aprender como a Solana funciona?
 
-Jogue 2048 na Solana onde cada movimento envia uma transação. Clique em "Jogar"
-para começar com uma carteira da devnet financiada e use as setas do teclado
-para jogar. Se estiver no celular, deslize para controlar as peças.
+<Card title="Aprenda os conceitos" href="/docs/core">
+  Aprenda os elementos fundamentais que fazem a Solana funcionar.
+</Card>
+
+### Experimente a Solana: Jogue 2048
+
+Jogue 2048 na Solana, onde cada movimento envia uma transação. Clique em
+“Jogar” para começar com uma wallet Devnet financiada e use as teclas de seta ou
+deslize no celular.
 
 <Accordions>
 <Accordion title="Jogar Solana 2048">
@@ -62,90 +62,3 @@ para jogar. Se estiver no celular, deslize para controlar as peças.
 
 Desenvolvido por [Jonas](https://x.com/SolPlay_jonas), da equipe DevRel da
 Solana Foundation.
-
-## Comece a Aprender
-
-Aprenda os conceitos-chave específicos do desenvolvimento na Solana.
-
-<Cards>
-  <Card title="Contas" href="/docs/core/accounts">
-    Como a Solana armazena dados
-  </Card>
-  <Card title="Taxas na Solana" href="/docs/core/fees">
-    Custos para enviar transações na Solana
-  </Card>
-  <Card title="Transações" href="/docs/core/transactions">
-    Como interagir com a rede Solana
-  </Card>
-  <Card title="Programas" href="/docs/core/programs">
-    Contratos inteligentes na Solana
-  </Card>
-  <Card title="Endereço Derivado de Programa" href="/docs/core/pda">
-    Como gerar endereços determinísticos
-  </Card>
-  <Card title="Invocação de Programa Cruzado" href="/docs/core/cpi">
-    Como chamar um programa a partir de outro
-  </Card>
-</Cards>
-
-### Desenvolvimento do Lado do Cliente
-
-Os seguintes SDKs são os SDKs oficiais para Solana desenvolvidos pela
-[Anza](https://anza.xyz).
-
-#### SDKs Oficiais
-
-| Linguagem                | SDK                                                                |
-| ------------------------ | ------------------------------------------------------------------ |
-| Rust                     | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Recomendado) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Legado)      | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### SDKs da Comunidade
-
-Os seguintes são SDKs contribuídos pela comunidade para várias linguagens:
-
-| Linguagem | SDK                                                                                                                                       |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Python    | [solders](https://github.com/kevinheavey/solders)                                                                                         |
-| Java      | [sava](https://sava.software) ou [solanaj](https://github.com/skynetcap/solanaj) ou [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++       | [solcpp](https://github.com/mschneider/solcpp) ou [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                               |
-| Go        | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                    |
-| Kotlin    | [sol4k](https://github.com/sol4k/sol4k) ou [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                    |
-| Dart      | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                               |
-| C#        | [solnet](https://github.com/bmresearch/Solnet)                                                                                            |
-| GdScript  | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                  |
-
-<Callout type="warn">
-  Os SDKs comunitários não são garantidos como atualizados ou com todos os
-  recursos dos SDKs oficiais.
-</Callout>
-
-## Executando um validator
-
-Explore o que é necessário para operar um validator Solana e ajudar a proteger a
-rede.
-
-<Cards>
-  <Card title="Validadores" href="https://docs.anza.xyz/validator/anatomy">
-    Nós individuais que protegem a rede Solana
-  </Card>
-  <Card
-    title="Requisitos de Sistema"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Requisitos de hardware recomendados e SOL necessário para operar um
-    validator
-  </Card>
-  <Card
-    title="Configuração de Validator"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Configure um validator e conecte-se a um cluster pela primeira vez
-  </Card>
-</Cards>
-
-## Obtendo Suporte
-
-Obtenha ajuda da comunidade Solana no
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/ru/index.mdx
+++ b/apps/docs/content/docs/ru/index.mdx
@@ -1,45 +1,44 @@
 ---
-title: Документация Solana
-seoTitle: Узнайте, как работает блокчейн Solana
+title: Начните здесь
+seoTitle: Начните разработку на Solana
 description:
-  Solana — это высокопроизводительный блокчейн, разработанный для массового
-  использования. Узнайте, почему Solana является лучшим выбором для
-  разработчиков, стремящихся создавать масштабируемые блокчейн-приложения.
+  Выберите быстрый старт, программирование с ИИ-агентом или знакомство с
+  принципами работы Solana.
 ---
 
-## Начало работы
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Повседневные приложения подключаются к Solana — общей сети, которую поддерживают компьютеры по всему миру"
+/>
 
-<Cards>
-  <Card title="Быстрый старт" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Создайте свою первую программу на Solana прямо в браузере
-  </Card>
-  <Card
-    title="Настройка локальной среды"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Установите зависимости для разработки на Solana
-  </Card>
-</Cards>
+## Хотите сразу начать разработку?
 
-### Разрабатывайте быстрее с шаблонами для разработчиков Solana
-
-<Card title="Изучить шаблоны для разработчиков" href="/developers/templates">
-  Разрабатывайте быстрее с готовыми к использованию шаблонами для dApps,
-  DeFi-протоколов, NFT-маркетплейсов и других решений. Начните с проверенных
-  временем паттернов кода, оптимизированных для экосистемы Solana.
+<Card
+  title="Открыть быстрый старт"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  Создайте и разверните свой первый проект Solana прямо в браузере.
 </Card>
 
-<Card title="Инструменты" href="/docs/tools">
-  Изучите документацию по инструментам для разработчиков Solana.
+## Хотите программировать с ИИ-агентом?
+
+<Card title="Программирование с агентами" href="/docs/intro/coding-with-agents">
+  Настройте Solana MCP или установите официальный Solana skill для своего
+  программирующего агента.
 </Card>
 
-## Попробуйте Solana: Играйте в 2048
+## Хотите узнать, как работает Solana?
 
-Играйте в 2048 на Solana, где каждый ход отправляет транзакцию. Нажмите
-«Играть», чтобы начать с финансируемым devnet-кошельком, и используйте
-клавиши-стрелки для игры. Если вы на мобильном устройстве, смахивайте для
-управления плитками.
+<Card title="Изучить основные концепции" href="/docs/core">
+  Изучите основные компоненты, благодаря которым работает Solana.
+</Card>
+
+### Попробуйте Solana: Играйте в 2048
+
+Играйте в 2048 на Solana, где каждый ход отправляет транзакцию. Нажмите «Играть»,
+чтобы начать с пополненным Devnet wallet, затем используйте клавиши со стрелками
+или свайпы на мобильном устройстве.
 
 <Accordions>
 <Accordion title="Играть в Solana 2048">
@@ -63,90 +62,3 @@ description:
 
 Создано [Йонасом](https://x.com/SolPlay_jonas) из команды DevRel Solana
 Foundation.
-
-## Начните обучение
-
-Изучите ключевые концепции, специфичные для разработки на Solana.
-
-<Cards>
-  <Card title="Аккаунты" href="/docs/core/accounts">
-    Как Solana хранит данные
-  </Card>
-  <Card title="Комиссии в Solana" href="/docs/core/fees">
-    Стоимость отправки транзакций в Solana
-  </Card>
-  <Card title="Транзакции" href="/docs/core/transactions">
-    Как взаимодействовать с сетью Solana
-  </Card>
-  <Card title="Программы" href="/docs/core/programs">
-    Смарт-контракты на Solana
-  </Card>
-  <Card title="Адрес, производный от программы" href="/docs/core/pda">
-    Как генерировать детерминированные адреса
-  </Card>
-  <Card title="Кросс-программный вызов" href="/docs/core/cpi">
-    Как вызывать одну программу из другой
-  </Card>
-</Cards>
-
-### Клиентская разработка
-
-Следующие SDK являются официальными SDK для Solana, созданными
-[Anza](https://anza.xyz).
-
-#### Официальные SDK
-
-| Язык                       | SDK                                                                |
-| -------------------------- | ------------------------------------------------------------------ |
-| Rust                       | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Рекомендуется) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Устаревший)    | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### Комьюнити SDK
-
-Следующие SDK созданы сообществом для различных языков:
-
-| Язык     | SDK                                                                                                                                         |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                           |
-| Java     | [sava](https://sava.software) или [solanaj](https://github.com/skynetcap/solanaj) или [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) или [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                                |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                      |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) или [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                     |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                                 |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                              |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                    |
-
-<Callout type="warn">
-  Сообщественные SDK не гарантированно обновлены или включают все функции
-  официальных SDK.
-</Callout>
-
-## Запуск validator
-
-Узнайте, что требуется для управления validator Solana и помощи в обеспечении
-безопасности сети.
-
-<Cards>
-  <Card title="Validators" href="https://docs.anza.xyz/validator/anatomy">
-    Отдельные узлы, обеспечивающие безопасность сети Solana
-  </Card>
-  <Card
-    title="Системные требования"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Рекомендуемые аппаратные требования и количество SOL, необходимое для работы
-    validator
-  </Card>
-  <Card
-    title="Настройка validator"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Настройте validator и впервые подключитесь к кластеру
-  </Card>
-</Cards>
-
-## Получение поддержки
-
-Получите помощь от сообщества Solana на
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/tr/index.mdx
+++ b/apps/docs/content/docs/tr/index.mdx
@@ -1,51 +1,47 @@
 ---
-title: Solana Dokümantasyonu
-seoTitle: Solana blok zincirinin nasıl çalıştığını öğrenin
+title: Buradan başlayın
+seoTitle: Solana üzerinde geliştirmeye başlayın
 description:
-  Solana, kitlesel benimseme için tasarlanmış yüksek performanslı bir blok
-  zinciridir. Ölçeklenebilir blok zinciri uygulamaları geliştirmek isteyen
-  geliştiricilerin neden Solana'yı tercih ettiğini öğrenin.
+  Hızlı başlangıcı seçin, bir yapay zekâ aracısıyla kod yazın veya Solana'nın
+  nasıl çalıştığını öğrenin.
 ---
 
-## Başlarken
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Günlük uygulamalar, dünyanın dört bir yanındaki bilgisayarların birlikte çalıştırdığı ortak Solana ağına bağlanır"
+/>
 
-<Cards>
-  <Card
-    title="Hızlı Başlangıç"
-    href="/docs/intro/quick-start"
-    icon={<Rocket />}
-  >
-    İlk Solana programınızı doğrudan tarayıcıda oluşturun
-  </Card>
-  <Card
-    title="Yerel Ortam Kurulumu"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Solana geliştirme için bağımlılıkları yükleyin
-  </Card>
-</Cards>
+## Hemen geliştirmeye başlamak ister misiniz?
 
-### Solana geliştirici şablonlarıyla daha hızlı geliştirin
-
-<Card title="Geliştirici şablonlarını keşfedin" href="/developers/templates">
-  dApp'ler, DeFi protokolleri, NFT pazaryerleri ve daha fazlası için üretime
-  hazır şablonlarla daha hızlı geliştirin. Solana ekosistemi için optimize
-  edilmiş, savaş testinden geçmiş kod kalıplarıyla başlayın.
+<Card
+  title="Hızlı başlangıcı açın"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  İlk Solana projenizi doğrudan tarayıcıda oluşturun ve dağıtın.
 </Card>
 
-<Card title="Araçlar" href="/docs/tools">
-  Solana geliştirici araçları için dokümantasyonu keşfedin.
+## Bir yapay zekâ aracısıyla kod yazmak ister misiniz?
+
+<Card title="Aracılarla kod yazma" href="/docs/intro/coding-with-agents">
+  Solana MCP'yi kurun veya kodlama aracınız için resmi Solana skill'ini
+  yükleyin.
 </Card>
 
-## Solana'yı Deneyin: 2048 Oynayın
+## Solana'nın nasıl çalıştığını öğrenmek ister misiniz?
 
-Solana üzerinde 2048 oynayın; her hamle bir işlem gönderir. Fonlanmış bir devnet
-cüzdanıyla başlamak için "Oyna"ya tıklayın ve oynamak için ok tuşlarını
-kullanın. Mobil cihazdaysanız, karoları kontrol etmek için kaydırın.
+<Card title="Kavramları öğrenin" href="/docs/core">
+  Solana'nın çalışmasını sağlayan temel yapı taşlarını öğrenin.
+</Card>
+
+### Solana'yı deneyin: 2048 oynayın
+
+Her hamlenin bir işlem gönderdiği Solana 2048'i oynayın. Finanse edilmiş bir
+Devnet wallet ile başlamak için “Oyna”ya tıklayın, ardından ok tuşlarını kullanın
+veya mobil cihazda kaydırın.
 
 <Accordions>
-<Accordion title="Solana 2048 Oyna">
+<Accordion title="Solana 2048 oyna">
 
 <iframe
   src="https://solplay.de/solana-2048/"
@@ -65,91 +61,4 @@ kullanın. Mobil cihazdaysanız, karoları kontrol etmek için kaydırın.
 </Accordions>
 
 Solana Foundation DevRel ekibinden [Jonas](https://x.com/SolPlay_jonas)
-tarafından geliştirilmiştir.
-
-## Öğrenmeye Başlayın
-
-Solana geliştirmeye özgü temel kavramları öğrenin.
-
-<Cards>
-  <Card title="Hesaplar" href="/docs/core/accounts">
-    Solana'nın veri saklama yöntemi
-  </Card>
-  <Card title="Solana'da Ücretler" href="/docs/core/fees">
-    Solana'da işlem gönderme maliyetleri
-  </Card>
-  <Card title="İşlemler" href="/docs/core/transactions">
-    Solana ağıyla nasıl etkileşim kurulur
-  </Card>
-  <Card title="Programlar" href="/docs/core/programs">
-    Solana'da akıllı kontratlar
-  </Card>
-  <Card title="Program Türevli Adres" href="/docs/core/pda">
-    Deterministik adresler nasıl oluşturulur
-  </Card>
-  <Card title="Programlar Arası Çağırma" href="/docs/core/cpi">
-    Bir programdan diğerine nasıl çağrı yapılır
-  </Card>
-</Cards>
-
-### İstemci Taraflı Geliştirme
-
-Aşağıdaki SDK'lar, [Anza](https://anza.xyz) tarafından geliştirilen Solana için
-resmi SDK'lardır.
-
-#### Resmi SDK'lar
-
-| Dil                   | SDK                                                                |
-| --------------------- | ------------------------------------------------------------------ |
-| Rust                  | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Önerilen) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Eski)     | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### Topluluk SDK'ları
-
-Aşağıdakiler, çeşitli diller için topluluk tarafından geliştirilmiş SDK'lardır:
-
-| Dil      | SDK                                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                             |
-| Java     | [sava](https://sava.software) veya [solanaj](https://github.com/skynetcap/solanaj) veya [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) veya [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                                 |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                        |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) veya [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                      |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                                   |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                                |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                      |
-
-<Callout type="warn">
-  Topluluk SDK'ları güncel olma veya resmi SDK'ların tüm özelliklerini içerme
-  garantisi vermez.
-</Callout>
-
-## Validator çalıştırma
-
-Bir Solana validator'ı çalıştırmanın gerekliliklerini keşfedin ve ağın
-güvenliğine katkıda bulunun.
-
-<Cards>
-  <Card title="Validator'lar" href="https://docs.anza.xyz/validator/anatomy">
-    Solana ağını güvence altına alan bireysel düğümler
-  </Card>
-  <Card
-    title="Sistem Gereksinimleri"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Bir validator çalıştırmak için önerilen donanım gereksinimleri ve gerekli
-    SOL miktarı
-  </Card>
-  <Card
-    title="Validator Kurulumu"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Bir validator kurun ve ilk kez bir kümeye bağlanın
-  </Card>
-</Cards>
-
-## Destek Alma
-
-[Solana StackExchange](https://solana.stackexchange.com) üzerinden Solana
-topluluğundan yardım alın.
+tarafından geliştirildi.

--- a/apps/docs/content/docs/uk/index.mdx
+++ b/apps/docs/content/docs/uk/index.mdx
@@ -1,45 +1,44 @@
 ---
-title: Документація Solana
-seoTitle: Дізнайтеся, як працює блокчейн Solana
+title: Почніть тут
+seoTitle: Почніть розробку на Solana
 description:
-  Solana — це високопродуктивний блокчейн, розроблений для масового
-  впровадження. Дізнайтеся, чому Solana є найкращим вибором для розробників, які
-  прагнуть створювати масштабовані блокчейн-додатки.
+  Виберіть швидкий старт, програмування з ШІ-агентом або знайомство з принципами
+  роботи Solana.
 ---
 
-## Початок роботи
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Повсякденні застосунки підключаються до Solana — спільної мережі, яку підтримують комп'ютери по всьому світу"
+/>
 
-<Cards>
-  <Card title="Швидкий старт" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Створіть свою першу програму Solana безпосередньо у браузері
-  </Card>
-  <Card
-    title="Налаштування локального середовища"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Встановіть залежності для розробки на Solana
-  </Card>
-</Cards>
+## Хочете одразу почати розробку?
 
-### Створюйте швидше з шаблонами розробника Solana
-
-<Card title="Огляд шаблонів розробника" href="/developers/templates">
-  Створюйте швидше з готовими до продакшену шаблонами для dApps, DeFi
-  протоколів, NFT маркетплейсів та іншого. Почніть з перевірених у бою патернів
-  коду, оптимізованих для екосистеми Solana.
+<Card
+  title="Відкрити швидкий старт"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  Створіть і розгорніть свій перший проєкт Solana безпосередньо в браузері.
 </Card>
 
-<Card title="Інструменти" href="/docs/tools">
-  Ознайомтеся з документацією інструментів розробника Solana.
+## Хочете програмувати з ШІ-агентом?
+
+<Card title="Програмування з агентами" href="/docs/intro/coding-with-agents">
+  Налаштуйте Solana MCP або встановіть офіційний Solana skill для свого агента
+  програмування.
 </Card>
 
-## Спробуйте Solana: Зіграйте в 2048
+## Хочете дізнатися, як працює Solana?
 
-Зіграйте в 2048 на Solana, де кожен хід надсилає транзакцію. Натисніть "Грати",
-щоб почати з профінансованого гаманця devnet, та використовуйте клавіші зі
-стрілками для гри. Якщо ви на мобільному пристрої, проведіть пальцем, щоб
-керувати плитками.
+<Card title="Вивчити основні концепції" href="/docs/core">
+  Вивчіть основні компоненти, завдяки яким працює Solana.
+</Card>
+
+### Спробуйте Solana: Зіграйте в 2048
+
+Зіграйте в 2048 на Solana, де кожен хід надсилає транзакцію. Натисніть «Грати»,
+щоб почати з поповненим Devnet wallet, а потім використовуйте клавіші зі
+стрілками або свайпи на мобільному пристрої.
 
 <Accordions>
 <Accordion title="Грати в Solana 2048">
@@ -63,89 +62,3 @@ description:
 
 Створено [Jonas](https://x.com/SolPlay_jonas) з команди DevRel Solana
 Foundation.
-
-## Почніть навчання
-
-Вивчіть ключові концепції, специфічні для розробки на Solana.
-
-<Cards>
-  <Card title="Акаунти" href="/docs/core/accounts">
-    Як Solana зберігає дані
-  </Card>
-  <Card title="Комісії на Solana" href="/docs/core/fees">
-    Витрати на відправку транзакцій на Solana
-  </Card>
-  <Card title="Транзакції" href="/docs/core/transactions">
-    Як взаємодіяти з мережею Solana
-  </Card>
-  <Card title="Програми" href="/docs/core/programs">
-    Смарт-контракти на Solana
-  </Card>
-  <Card title="Адреси, похідні від програм" href="/docs/core/pda">
-    Як генерувати детерміновані адреси
-  </Card>
-  <Card title="Міжпрограмний виклик" href="/docs/core/cpi">
-    Як викликати одну програму з іншої
-  </Card>
-</Cards>
-
-### Розробка на стороні клієнта
-
-Наступні SDK є офіційними SDK для Solana, створеними [Anza](https://anza.xyz).
-
-#### Офіційні SDK
-
-| Мова                       | SDK                                                                |
-| -------------------------- | ------------------------------------------------------------------ |
-| Rust                       | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Рекомендовано) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Застаріле)     | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### Спільнотні SDK
-
-Нижче наведено SDK, створені спільнотою для різних мов:
-
-| Мова     | SDK                                                                                                                                         |
-| -------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                           |
-| Java     | [sava](https://sava.software) або [solanaj](https://github.com/skynetcap/solanaj) або [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) або [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                                |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                      |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) або [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                     |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                                 |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                              |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                    |
-
-<Callout type="warn">
-  Спільнотні SDK не гарантовано є актуальними або включають усі функції
-  офіційних SDK.
-</Callout>
-
-## Робота validator
-
-Дізнайтеся, що потрібно для роботи validator Solana та як допомогти захистити
-мережу.
-
-<Cards>
-  <Card title="Validators" href="https://docs.anza.xyz/validator/anatomy">
-    Окремі вузли, які забезпечують безпеку мережі Solana
-  </Card>
-  <Card
-    title="Системні вимоги"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Рекомендовані апаратні вимоги та кількість SOL, необхідна для роботи
-    validator
-  </Card>
-  <Card
-    title="Налаштування validator"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Налаштуйте validator та підключіться до кластера вперше
-  </Card>
-</Cards>
-
-## Отримання підтримки
-
-Отримайте допомогу від спільноти Solana на
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/vi/index.mdx
+++ b/apps/docs/content/docs/vi/index.mdx
@@ -1,47 +1,44 @@
 ---
-title: Tài liệu Solana
-seoTitle: Tìm hiểu cách thức hoạt động của blockchain Solana
+title: Bắt đầu tại đây
+seoTitle: Bắt đầu xây dựng trên Solana
 description:
-  Solana là blockchain hiệu suất cao được thiết kế cho việc áp dụng đại trà. Tìm
-  hiểu tại sao Solana là lựa chọn hàng đầu cho các nhà phát triển muốn xây dựng
-  các ứng dụng blockchain có khả năng mở rộng.
+  Chọn hướng dẫn bắt đầu nhanh, lập trình với tác nhân AI hoặc tìm hiểu cách
+  Solana hoạt động.
 ---
 
-## Bắt đầu
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="Các ứng dụng hằng ngày kết nối với Solana, một mạng dùng chung được vận hành bởi các máy tính trên khắp thế giới"
+/>
 
-<Cards>
-  <Card title="Bắt đầu nhanh" href="/docs/intro/quick-start" icon={<Rocket />}>
-    Xây dựng chương trình Solana đầu tiên của bạn trực tiếp trên trình duyệt
-  </Card>
-  <Card
-    title="Thiết lập môi trường cục bộ"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    Cài đặt các phụ thuộc cho phát triển Solana
-  </Card>
-</Cards>
-
-### Xây dựng nhanh hơn với các mẫu dành cho nhà phát triển Solana
+## Bạn muốn bắt đầu xây dựng ngay?
 
 <Card
-  title="Khám phá các mẫu dành cho nhà phát triển"
-  href="/developers/templates"
+  title="Mở hướng dẫn bắt đầu nhanh"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
 >
-  Xây dựng nhanh hơn với các mẫu sẵn sàng cho sản xuất dành cho dApps, giao thức
-  DeFi, thị trường NFT và nhiều hơn nữa. Bắt đầu với các mẫu mã đã được kiểm
-  nghiệm thực tế, được tối ưu hóa cho hệ sinh thái Solana.
+  Xây dựng và triển khai dự án Solana đầu tiên ngay trong trình duyệt.
 </Card>
 
-<Card title="Công cụ" href="/docs/tools">
-  Khám phá tài liệu về các công cụ phát triển Solana.
+## Bạn muốn lập trình với tác nhân AI?
+
+<Card title="Lập trình với tác nhân" href="/docs/intro/coding-with-agents">
+  Thiết lập Solana MCP hoặc cài đặt skill Solana chính thức cho tác nhân lập
+  trình của bạn.
 </Card>
 
-## Trải nghiệm Solana: Chơi 2048
+## Bạn muốn tìm hiểu cách Solana hoạt động?
 
-Chơi 2048 trên Solana, nơi mỗi nước đi gửi một giao dịch. Nhấp "Chơi" để bắt đầu
-với ví devnet đã được nạp tiền và sử dụng các phím mũi tên để chơi. Nếu dùng di
-động, vuốt để điều khiển các ô.
+<Card title="Tìm hiểu các khái niệm" href="/docs/core">
+  Tìm hiểu những thành phần cơ bản giúp Solana hoạt động.
+</Card>
+
+### Trải nghiệm Solana: Chơi 2048
+
+Chơi 2048 trên Solana, nơi mỗi nước đi gửi một giao dịch. Nhấp “Chơi” để bắt đầu
+với wallet Devnet đã được cấp tiền, sau đó dùng các phím mũi tên hoặc vuốt trên
+thiết bị di động.
 
 <Accordions>
 <Accordion title="Chơi Solana 2048">
@@ -65,90 +62,3 @@ với ví devnet đã được nạp tiền và sử dụng các phím mũi tên
 
 Được xây dựng bởi [Jonas](https://x.com/SolPlay_jonas), từ đội ngũ DevRel của
 Solana Foundation.
-
-## Bắt đầu học
-
-Tìm hiểu các khái niệm chính đặc thù trong phát triển Solana.
-
-<Cards>
-  <Card title="Tài khoản" href="/docs/core/accounts">
-    Cách Solana lưu trữ dữ liệu
-  </Card>
-  <Card title="Phí trên Solana" href="/docs/core/fees">
-    Chi phí để gửi giao dịch trên Solana
-  </Card>
-  <Card title="Giao dịch" href="/docs/core/transactions">
-    Cách tương tác với mạng Solana
-  </Card>
-  <Card title="Chương trình" href="/docs/core/programs">
-    Hợp đồng thông minh trên Solana
-  </Card>
-  <Card title="Địa chỉ phái sinh từ chương trình" href="/docs/core/pda">
-    Cách tạo địa chỉ xác định
-  </Card>
-  <Card title="Gọi chương trình chéo" href="/docs/core/cpi">
-    Cách gọi một chương trình từ chương trình khác
-  </Card>
-</Cards>
-
-### Phát triển phía Client
-
-Các SDK sau đây là SDK chính thức cho Solana được xây dựng bởi
-[Anza](https://anza.xyz).
-
-#### SDK chính thức
-
-| Ngôn ngữ                      | SDK                                                                |
-| ----------------------------- | ------------------------------------------------------------------ |
-| Rust                          | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript (Được khuyến nghị) | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript (Kế thừa)          | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### SDK cộng đồng
-
-Sau đây là các SDK do cộng đồng đóng góp cho nhiều ngôn ngữ khác nhau:
-
-| Ngôn ngữ | SDK                                                                                                                                           |
-| -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                             |
-| Java     | [sava](https://sava.software) hoặc [solanaj](https://github.com/skynetcap/solanaj) hoặc [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) hoặc [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                                 |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                        |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) hoặc [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                      |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                                   |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                                |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                      |
-
-<Callout type="warn">
-  Các SDK của cộng đồng không được đảm bảo luôn cập nhật hoặc bao gồm tất cả các
-  tính năng của các SDK chính thức.
-</Callout>
-
-## Vận hành một validator
-
-Khám phá những gì cần thiết để vận hành một validator Solana và giúp bảo mật
-mạng lưới.
-
-<Cards>
-  <Card title="Validators" href="https://docs.anza.xyz/validator/anatomy">
-    Các nút riêng lẻ bảo mật mạng lưới Solana
-  </Card>
-  <Card
-    title="Yêu cầu hệ thống"
-    href="https://docs.anza.xyz/operations/requirements"
-  >
-    Yêu cầu phần cứng được khuyến nghị và lượng SOL cần thiết để vận hành một
-    validator
-  </Card>
-  <Card
-    title="Thiết lập Validator"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    Thiết lập một validator và kết nối với cluster lần đầu tiên
-  </Card>
-</Cards>
-
-## Nhận hỗ trợ
-
-Nhận trợ giúp từ cộng đồng Solana trên
-[Solana StackExchange](https://solana.stackexchange.com).

--- a/apps/docs/content/docs/zh/index.mdx
+++ b/apps/docs/content/docs/zh/index.mdx
@@ -1,41 +1,40 @@
 ---
-title: Solana 文档
-seoTitle: 了解 Solana 区块链的工作原理
-description:
-  Solana 是为大规模应用设计的高性能区块链。了解为什么 Solana
-  是开发者构建可扩展区块链应用的首选。
+title: 从这里开始
+seoTitle: 开始在 Solana 上构建
+description: 选择快速入门、使用 AI 智能体编程，或了解 Solana 的工作原理。
 ---
 
-## 入门指南
+<DocsDiagram
+  src="/assets/docs/diagrams/solana-overview.svg"
+  alt="日常应用连接到 Solana，一个由世界各地计算机共同运行的共享网络"
+/>
 
-<Cards>
-  <Card title="快速开始" href="/docs/intro/quick-start" icon={<Rocket />}>
-    直接在浏览器中构建您的第一个 Solana 程序
-  </Card>
-  <Card
-    title="设置本地环境"
-    href="/docs/intro/installation"
-    icon={<Download />}
-  >
-    安装 Solana 开发所需的依赖项
-  </Card>
-</Cards>
+## 想直接开始构建？
 
-### 使用 Solana 开发者模板加速构建
-
-<Card title="探索开发者模板" href="/developers/templates">
-  利用为 dApp、DeFi 协议、NFT
-  市场等量身打造的生产级模板，加快开发进度。立即上手，体验为 Solana
-  生态优化、经过实战检验的代码模式。
+<Card
+  title="打开快速入门"
+  href="/docs/intro/quick-start"
+  icon={<Rocket />}
+>
+  直接在浏览器中构建并部署你的第一个 Solana 项目。
 </Card>
 
-<Card title="工具" href="/docs/tools">
-  探索 Solana 开发者工具文档。
+## 想使用 AI 智能体编程？
+
+<Card title="使用智能体编程" href="/docs/intro/coding-with-agents">
+  为你的编程智能体设置 Solana MCP，或安装官方 Solana skill。
 </Card>
 
-## 尝试 Solana：玩 2048
+## 想了解 Solana 的工作原理？
 
-在 Solana 上玩 2048，每一步操作都会发送一笔交易。点击"开始"使用已充值的开发网钱包开始游戏，使用方向键进行游戏。如果在移动设备上，滑动屏幕来控制方块。
+<Card title="学习核心概念" href="/docs/core">
+  了解支撑 Solana 运行的基本构成。
+</Card>
+
+### 尝试 Solana：玩 2048
+
+在 Solana 上玩 2048，每一步操作都会发送一笔交易。点击“开始”，使用已充值的
+Devnet wallet 开始游戏，然后使用方向键或在移动设备上滑动。
 
 <Accordions>
 <Accordion title="玩 Solana 2048">
@@ -58,83 +57,3 @@ description:
 </Accordions>
 
 由 Solana 基金会开发者关系团队的 [Jonas](https://x.com/SolPlay_jonas) 构建。
-
-## 开始学习
-
-学习 Solana 开发的核心概念。
-
-<Cards>
-  <Card title="账户" href="/docs/core/accounts">
-    Solana 如何存储数据
-  </Card>
-  <Card title="Solana 上的费用" href="/docs/core/fees">
-    在 Solana 上发送交易的成本
-  </Card>
-  <Card title="交易" href="/docs/core/transactions">
-    如何与 Solana 网络交互
-  </Card>
-  <Card title="程序" href="/docs/core/programs">
-    Solana 上的智能合约
-  </Card>
-  <Card title="程序派生地址" href="/docs/core/pda">
-    如何生成确定性地址
-  </Card>
-  <Card title="跨程序调用" href="/docs/core/cpi">
-    如何从一个程序调用另一个程序
-  </Card>
-</Cards>
-
-### 客户端开发
-
-以下 SDK 是由 [Anza](https://anza.xyz) 构建的 Solana 官方 SDK。
-
-#### 官方 SDK
-
-| 语言               | SDK                                                                |
-| ------------------ | ------------------------------------------------------------------ |
-| Rust               | [solana_sdk](/docs/clients/official/rust)                          |
-| Typescript（推荐） | [@solana/kit](/docs/clients/official/javascript#solana-kit)        |
-| Typescript（旧版） | [@solana/web3.js](/docs/clients/official/javascript#solana-web3js) |
-
-#### 社区 SDK
-
-以下是社区贡献的各种语言 SDK：
-
-| 语言     | SDK                                                                                                                                       |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| Python   | [solders](https://github.com/kevinheavey/solders)                                                                                         |
-| Java     | [sava](https://sava.software) 或 [solanaj](https://github.com/skynetcap/solanaj) 或 [solana4j](https://github.com/LMAX-Exchange/solana4j) |
-| C++      | [solcpp](https://github.com/mschneider/solcpp) 或 [solana-c](https://github.com/VAR-META-Tech/solana-c-sdk)                               |
-| Go       | [solana-go](https://github.com/gagliardetto/solana-go)                                                                                    |
-| Kotlin   | [sol4k](https://github.com/sol4k/sol4k) 或 [solanaKT](https://github.com/metaplex-foundation/SolanaKT)                                    |
-| Dart     | [solana](https://github.com/espresso-cash/espresso-cash-public/tree/master/packages/solana)                                               |
-| C#       | [solnet](https://github.com/bmresearch/Solnet)                                                                                            |
-| GdScript | [godot](https://github.com/Virus-Axel/godot-solana-sdk/)                                                                                  |
-
-<Callout type="warn">
-  社区 SDK 不保证与官方 SDK 保持同步更新或包含所有功能。
-</Callout>
-
-## 运行 validator
-
-探索运营 Solana validator 所需的条件，并帮助保护网络安全。
-
-<Cards>
-  <Card title="Validators" href="https://docs.anza.xyz/validator/anatomy">
-    保护 Solana 网络安全的独立节点
-  </Card>
-  <Card title="系统要求" href="https://docs.anza.xyz/operations/requirements">
-    运营 validator 所需的推荐硬件要求和 SOL 数量
-  </Card>
-  <Card
-    title="Validator 设置"
-    href="https://docs.anza.xyz/operations/setup-a-validator"
-  >
-    设置 validator 并首次连接到集群
-  </Card>
-</Cards>
-
-## 获取支持
-
-在 [Solana StackExchange](https://solana.stackexchange.com)
-上从 Solana 社区获得帮助。


### PR DESCRIPTION
Updates every localized docs homepage to use the same concise Start Here structure.

- Adds Quickstart, Coding with agents, and Concepts entry points
- Embeds Solana 2048 in the learning section
- Removes the legacy homepage sections so all 19 locales stay structurally aligned