### PR TITLE
docs: fix broken program-examples links

### DIFF
--- a/apps/docs/content/docs/ar/programs/examples.mdx
+++ b/apps/docs/content/docs/ar/programs/examples.mdx
@@ -6,11 +6,11 @@ description:
 ---
 
 يقدم مستودع
-[أمثلة برامج سولانا](https://github.com/solana-developers/program-examples) على
+[أمثلة برامج سولانا](https://github.com/solana-foundation/program-examples) على
 GitHub العديد من المجلدات الفرعية، كل منها يحتوي على أمثلة برمجية لمساعدة
 المطورين على التعلم والتجربة في تطوير بلوكتشين سولانا.
 
-يمكنك العثور على الأمثلة في `solana-developers/program-examples` مع ملفات README
+يمكنك العثور على الأمثلة في `solana-foundation/program-examples` مع ملفات README
 التي تشرح لك كيفية تشغيل الأمثلة المختلفة. معظم الأمثلة مستقلة ومتاحة بلغة Rust
 الأصلية (أي بدون إطار عمل)
 و[Anchor](https://www.anchor-lang.com/docs/installation).
@@ -32,20 +32,19 @@ GitHub العديد من المجلدات الفرعية، كل منها يحت�
 
 | اسم المثال                                                                                                                    | الوصف                                                                                  | اللغة                     |
 | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | حفظ عنوان يتضمن الاسم ورقم المنزل والشارع والمدينة في حساب.                            | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | دروس أمنية توضح كيفية إجراء فحوصات الحسابات                                            | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | يوضح لك كيفية إغلاق الحسابات لاسترداد rent الخاص بها.                                  | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | برنامج عداد بسيط بجميع الأنماط المعمارية المختلفة.                                     | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | كيفية إنشاء حساب نظام داخل برنامج.                                                     | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | باستخدام تشبيه اليد والرافعة، يوضح هذا المثال كيفية استدعاء برنامج آخر من داخل برنامج. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | مثال "مرحبا بالعالم" الذي يطبع فقط عبارة مرحبا بالعالم في سجلات المعاملات.             | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | يوضح لك كيفية استخدام lamport من PDA لدفع تكلفة حساب جديد.                             | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | يوضح لك كيفية التعامل مع instruction data من نوع string و u32.                         | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | يوضح كيفية استخدام البذور للإشارة إلى Program Derived Address وحفظ البيانات فيه.       | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | يوضح لك كيفية زيادة وتقليص حجم حساب موجود.                                             | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | هنا ستتعلم كيفية حساب متطلبات rent داخل برنامج.                                        | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | توصيات حول كيفية هيكلة تخطيط برنامجك.                                                  | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | طرق مختلفة لتحويل SOL لحسابات النظام و PDAs.                                           | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | حفظ عنوان يتضمن الاسم ورقم المنزل والشارع والمدينة في حساب.                            | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | دروس أمنية توضح كيفية إجراء فحوصات الحسابات                                            | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | يوضح لك كيفية إغلاق الحسابات لاسترداد rent الخاص بها.                                  | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | برنامج عداد بسيط بجميع الأنماط المعمارية المختلفة.                                     | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | كيفية إنشاء حساب نظام داخل برنامج.                                                     | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | باستخدام تشبيه اليد والرافعة، يوضح هذا المثال كيفية استدعاء برنامج آخر من داخل برنامج. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | مثال "مرحبا بالعالم" الذي يطبع فقط عبارة مرحبا بالعالم في سجلات المعاملات.             | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | يوضح لك كيفية استخدام lamport من PDA لدفع تكلفة حساب جديد.                             | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | يوضح لك كيفية التعامل مع instruction data من نوع string و u32.                         | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | يوضح كيفية استخدام البذور للإشارة إلى Program Derived Address وحفظ البيانات فيه.       | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | يوضح لك كيفية زيادة وتقليص حجم حساب موجود.                                             | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | توصيات حول كيفية هيكلة تخطيط برنامجك.                                                  | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | طرق مختلفة لتحويل SOL لحسابات النظام و PDAs.                                           | Native, Anchor, Seahorse  |
 
 ## الرموز المميزة (Tokens)
 
@@ -55,13 +54,12 @@ GitHub العديد من المجلدات الفرعية، كل منها يحت�
 
 | اسم المثال                                                                                                   | الوصف                                                                        | اللغة          |
 | ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------- | -------------- |
-| [إنشاء رمز مميز](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)        | كيفية إنشاء رمز مميز وإضافة بيانات Metaplex الوصفية إليه.                    | Anchor, Native |
-| [ساك NFT](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | سك كمية واحدة فقط من الرمز المميز ثم إزالة صلاحية السك.                      | Anchor, Native |
-| [صلاحية سك PDA](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority)   | يوضح كيفية تغيير صلاحية السك لعملية سك، لسك الرموز المميزة من داخل البرنامج. | Anchor, Native |
-| [ساك رمز SPL](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)       | يشرح كيفية استخدام Associated Token Accounts لتتبع token account.            | Anchor, Native |
-| [تبادل الرموز المميزة](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)    | مثال شامل يوضح كيفية بناء تجمع AMM (صانع سوق آلي) لرموز SPL.                 | Anchor         |
-| [نقل الرموز المميزة](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens) | يوضح كيفية نقل رمز SPL المميز باستخدام CPIs إلى Token Program.               | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)              | راجع Token 2022 (Token Extensions).                                          | Anchor, Native |
+| [إنشاء رمز مميز](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)        | كيفية إنشاء رمز مميز وإضافة بيانات Metaplex الوصفية إليه.                    | Anchor, Native |
+| [ساك NFT](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | سك كمية واحدة فقط من الرمز المميز ثم إزالة صلاحية السك.                      | Anchor, Native |
+| [صلاحية سك PDA](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority)   | يوضح كيفية تغيير صلاحية السك لعملية سك، لسك الرموز المميزة من داخل البرنامج. | Anchor, Native |
+| [تبادل الرموز المميزة](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)    | مثال شامل يوضح كيفية بناء تجمع AMM (صانع سوق آلي) لرموز SPL.                 | Anchor         |
+| [نقل الرموز المميزة](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens) | يوضح كيفية نقل رمز SPL المميز باستخدام CPIs إلى Token Program.               | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)              | راجع Token 2022 (Token Extensions).                                          | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -72,14 +70,14 @@ Token 2022 هو معيار جديد للرموز المميزة على سولا�
 
 | اسم المثال                                                                                                                          | الوصف                                                                                            | اللغة          |
 | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------- |
-| [الأساسيات](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | كيفية إنشاء رمز مميز وسكه ونقله.                                                                 | Anchor         |
-| [الحالة الافتراضية للحساب](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | يتيح لك هذا الامتداد إنشاء token account بحالة معينة، كالتجميد مثلاً.                            | Anchor, Native |
-| [صلاحية إغلاق السك](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)         | مع Token Program القديم لم يكن بالإمكان إغلاق عملية السك، أما الآن فأصبح ذلك ممكناً.             | Anchor, Native |
-| [امتدادات متعددة](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)            | يوضح كيف يمكنك إضافة امتدادات متعددة إلى عملية سك واحدة.                                         | Native         |
-| [مؤشر بيانات NFT الوصفية](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | من الممكن استخدام امتداد البيانات الوصفية لإنشاء NFTs وإضافة بيانات وصفية ديناميكية على السلسلة. | Anchor         |
-| [غير قابل للنقل](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)                | مفيد على سبيل المثال للإنجازات وبرامج الإحالة أو أي رموز مميزة مرتبطة بالروح.                    | Anchor, Native |
-| [رسوم النقل](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                        | يحتجز كل نقل للرموز المميزة بعض الرموز في token account ويمكن جمعها لاحقاً.                      | Anchor, Native |
-| [خطاف النقل](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                       | أربعة أمثلة لإضافة وظائف إضافية إلى رمزك المميز باستخدام CPI من Token Program إلى برنامجك.       | Anchor         |
+| [الأساسيات](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | كيفية إنشاء رمز مميز وسكه ونقله.                                                                 | Anchor         |
+| [الحالة الافتراضية للحساب](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | يتيح لك هذا الامتداد إنشاء token account بحالة معينة، كالتجميد مثلاً.                            | Anchor, Native |
+| [صلاحية إغلاق السك](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)         | مع Token Program القديم لم يكن بالإمكان إغلاق عملية السك، أما الآن فأصبح ذلك ممكناً.             | Anchor, Native |
+| [امتدادات متعددة](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)            | يوضح كيف يمكنك إضافة امتدادات متعددة إلى عملية سك واحدة.                                         | Native         |
+| [مؤشر بيانات NFT الوصفية](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | من الممكن استخدام امتداد البيانات الوصفية لإنشاء NFTs وإضافة بيانات وصفية ديناميكية على السلسلة. | Anchor         |
+| [غير قابل للنقل](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)                | مفيد على سبيل المثال للإنجازات وبرامج الإحالة أو أي رموز مميزة مرتبطة بالروح.                    | Anchor, Native |
+| [رسوم النقل](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                        | يحتجز كل نقل للرموز المميزة بعض الرموز في token account ويمكن جمعها لاحقاً.                      | Anchor, Native |
+| [خطاف النقل](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                       | أربعة أمثلة لإضافة وظائف إضافية إلى رمزك المميز باستخدام CPI من Token Program إلى برنامجك.       | Anchor         |
 
 ## أمثلة برامج سولانا في النظام البيئي
 

--- a/apps/docs/content/docs/de/programs/examples.mdx
+++ b/apps/docs/content/docs/de/programs/examples.mdx
@@ -7,12 +7,12 @@ description:
 ---
 
 Das
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 Repository auf GitHub bietet mehrere Unterordner, die jeweils Codebeispiele
 enthalten, um Entwicklern beim Lernen und Experimentieren mit der
 Solana-Blockchain-Entwicklung zu helfen.
 
-Die Beispiele finden Sie im `solana-developers/program-examples` zusammen mit
+Die Beispiele finden Sie im `solana-foundation/program-examples` zusammen mit
 README-Dateien, die erklären, wie Sie die verschiedenen Beispiele ausführen. Die
 meisten Beispiele sind eigenständig und sind in nativem Rust (d. h. ohne
 Framework) und [Anchor](https://www.anchor-lang.com/docs/installation)
@@ -36,20 +36,19 @@ zu verstehen.
 
 | Beispielname                                                                                                                  | Beschreibung                                                                                                       | Sprache                   |
 | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Speichern einer Adresse mit Name, Hausnummer, Straße und Stadt in einem Konten.                                    | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Sicherheitslektionen, die zeigen, wie Konten-Prüfungen durchgeführt werden                                         | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Zeigt, wie Konten geschlossen werden, um das rent zurückzuerhalten.                                                | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Ein einfaches Zählerprogramm in allen verschiedenen Architekturen.                                                 | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Wie man ein Systemkonto innerhalb eines Programms erstellt.                                                        | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Anhand einer Hand-und-Hebel-Analogie wird gezeigt, wie man ein anderes Programm aus einem Programm heraus aufruft. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Hello-World-Beispiel, das lediglich „Hello World“ in den Transaktionsprotokollen ausgibt.                          | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Zeigt, wie die lamport aus einer PDA verwendet werden können, um ein neues Konten zu bezahlen.                     | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Zeigt, wie instruction data vom Typ String und u32 verarbeitet werden.                                             | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Zeigt, wie Seeds verwendet werden, um auf eine PDA zu verweisen und Daten darin zu speichern.                      | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Zeigt, wie die Größe eines bestehenden Konten vergrößert und verkleinert werden kann.                              | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Hier lernen Sie, wie rent-Anforderungen innerhalb eines Programms berechnet werden.                                | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Empfehlungen zur Strukturierung Ihres Programmlayouts.                                                             | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Verschiedene Methoden zur Übertragung von SOL für Systemkonten und PDAs.                                           | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Speichern einer Adresse mit Name, Hausnummer, Straße und Stadt in einem Konten.                                    | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Sicherheitslektionen, die zeigen, wie Konten-Prüfungen durchgeführt werden                                         | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Zeigt, wie Konten geschlossen werden, um das rent zurückzuerhalten.                                                | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Ein einfaches Zählerprogramm in allen verschiedenen Architekturen.                                                 | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Wie man ein Systemkonto innerhalb eines Programms erstellt.                                                        | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Anhand einer Hand-und-Hebel-Analogie wird gezeigt, wie man ein anderes Programm aus einem Programm heraus aufruft. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Hello-World-Beispiel, das lediglich „Hello World“ in den Transaktionsprotokollen ausgibt.                          | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Zeigt, wie die lamport aus einer PDA verwendet werden können, um ein neues Konten zu bezahlen.                     | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Zeigt, wie instruction data vom Typ String und u32 verarbeitet werden.                                             | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Zeigt, wie Seeds verwendet werden, um auf eine PDA zu verweisen und Daten darin zu speichern.                      | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Zeigt, wie die Größe eines bestehenden Konten vergrößert und verkleinert werden kann.                              | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Empfehlungen zur Strukturierung Ihres Programmlayouts.                                                             | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Verschiedene Methoden zur Übertragung von SOL für Systemkonten und PDAs.                                           | Native, Anchor, Seahorse  |
 
 ## Token
 
@@ -59,13 +58,12 @@ verbrennt und wie man in Programmen mit ihnen interagiert.
 
 | Beispielname                                                                                                    | Beschreibung                                                                                                     | Sprache        |
 | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Token erstellen](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)          | So erstellen Sie einen Token und fügen Metaplex-Metadaten hinzu.                                                 | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Nur eine Einheit eines Tokens prägen und anschließend die Mint-Autorität entfernen.                              | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Zeigt, wie die Mint-Autorität eines Mints geändert wird, um Token innerhalb eines Programms zu prägen.           | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Erklärt, wie Associated Token Accounts verwendet werden, um token accounts im Überblick zu behalten.             | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Umfangreiches Beispiel, das zeigt, wie ein AMM-Pool (automatisierter Market Maker) für SPL-Token aufgebaut wird. | Anchor         |
-| [Token übertragen](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)      | Zeigt, wie SPL-Token mithilfe von CPIs in das Token Program übertragen werden.                                   | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Siehe Token 2022 (Token Extensions).                                                                             | Anchor, Native |
+| [Token erstellen](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)          | So erstellen Sie einen Token und fügen Metaplex-Metadaten hinzu.                                                 | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Nur eine Einheit eines Tokens prägen und anschließend die Mint-Autorität entfernen.                              | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Zeigt, wie die Mint-Autorität eines Mints geändert wird, um Token innerhalb eines Programms zu prägen.           | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Umfangreiches Beispiel, das zeigt, wie ein AMM-Pool (automatisierter Market Maker) für SPL-Token aufgebaut wird. | Anchor         |
+| [Token übertragen](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)      | Zeigt, wie SPL-Token mithilfe von CPIs in das Token Program übertragen werden.                                   | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Siehe Token 2022 (Token Extensions).                                                                             | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -76,14 +74,14 @@ Erweiterungen finden Sie im [Einstiegsleitfaden](/docs/tokens/extensions)
 
 | Beispielname                                                                                                                      | Beschreibung                                                                                                                 | Sprache        |
 | --------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Grundlagen](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                     | So erstellen, prägen und übertragen Sie einen Token.                                                                         | Anchor         |
-| [Standard-Konten-Status](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Diese Erweiterung ermöglicht es Ihnen, token accounts mit einem bestimmten Status zu erstellen, z. B. eingefroren.           | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)    | Mit dem alten Token Program war es nicht möglich, einen Mint zu schließen. Jetzt ist es möglich.                             | Anchor, Native |
-| [Mehrere Erweiterungen](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)    | Zeigt, wie mehrere Erweiterungen zu einem einzelnen Mint hinzugefügt werden können.                                          | Native         |
-| [NFT Metadata Pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)   | Es ist möglich, die Metadaten-Erweiterung zu verwenden, um NFTs zu erstellen und dynamische On-Chain-Metadaten hinzuzufügen. | Anchor         |
-| [Nicht übertragbar](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Nützlich beispielsweise für Errungenschaften, Empfehlungsprogramme oder soulbound Token.                                     | Anchor, Native |
-| [Transfergebühr](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                  | Bei jeder Übertragung der Token wird ein Teil der Token im token account zurückgehalten, der dann eingesammelt werden kann.  | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                  | Vier Beispiele, um Ihrem Token mithilfe eines CPI vom Token Program in Ihr Programm zusätzliche Funktionalität hinzuzufügen. | Anchor         |
+| [Grundlagen](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                     | So erstellen, prägen und übertragen Sie einen Token.                                                                         | Anchor         |
+| [Standard-Konten-Status](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Diese Erweiterung ermöglicht es Ihnen, token accounts mit einem bestimmten Status zu erstellen, z. B. eingefroren.           | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)    | Mit dem alten Token Program war es nicht möglich, einen Mint zu schließen. Jetzt ist es möglich.                             | Anchor, Native |
+| [Mehrere Erweiterungen](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)    | Zeigt, wie mehrere Erweiterungen zu einem einzelnen Mint hinzugefügt werden können.                                          | Native         |
+| [NFT Metadata Pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)   | Es ist möglich, die Metadaten-Erweiterung zu verwenden, um NFTs zu erstellen und dynamische On-Chain-Metadaten hinzuzufügen. | Anchor         |
+| [Nicht übertragbar](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Nützlich beispielsweise für Errungenschaften, Empfehlungsprogramme oder soulbound Token.                                     | Anchor, Native |
+| [Transfergebühr](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                  | Bei jeder Übertragung der Token wird ein Teil der Token im token account zurückgehalten, der dann eingesammelt werden kann.  | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                  | Vier Beispiele, um Ihrem Token mithilfe eines CPI vom Token Program in Ihr Programm zusätzliche Funktionalität hinzuzufügen. | Anchor         |
 
 ## Ökosystem-Beispielprogramme für Solana
 

--- a/apps/docs/content/docs/el/programs/examples.mdx
+++ b/apps/docs/content/docs/el/programs/examples.mdx
@@ -7,12 +7,12 @@ description:
 ---
 
 Το αποθετήριο
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 στο GitHub προσφέρει αρκετούς υποφακέλους, καθένας από τους οποίους περιέχει
 παραδείγματα κώδικα για να βοηθήσει τους προγραμματιστές να μάθουν και να
 πειραματιστούν με την ανάπτυξη στο blockchain του Solana.
 
-Μπορείτε να βρείτε τα παραδείγματα στο `solana-developers/program-examples` μαζί
+Μπορείτε να βρείτε τα παραδείγματα στο `solana-foundation/program-examples` μαζί
 με αρχεία README που εξηγούν πώς να εκτελέσετε τα διάφορα παραδείγματα. Τα
 περισσότερα παραδείγματα είναι αυτόνομα και είναι διαθέσιμα σε εγγενή Rust
 (δηλαδή, χωρίς framework) και
@@ -37,20 +37,19 @@ description:
 
 | Όνομα Παραδείγματος                                                                                                           | Περιγραφή                                                                                                                 | Γλώσσα                    |
 | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Αποθήκευση διεύθυνσης με όνομα, αριθμό κατοικίας, οδό και πόλη σε έναν λογαριασμό.                                        | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Μαθήματα ασφαλείας που δείχνουν πώς να πραγματοποιείτε ελέγχους λογαριασμών                                               | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Σας δείχνει πώς να κλείνετε λογαριασμούς για να ανακτήσετε το rent τους.                                                  | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Ένα απλό πρόγραμμα μετρητή σε όλες τις διαφορετικές αρχιτεκτονικές.                                                       | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Πώς να δημιουργήσετε έναν λογαριασμό συστήματος μέσα σε ένα πρόγραμμα.                                                    | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Χρησιμοποιώντας μια αναλογία χεριού και μοχλού, σας δείχνει πώς να καλέσετε ένα άλλο πρόγραμμα από μέσα σε ένα πρόγραμμα. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Παράδειγμα hello world που απλώς εκτυπώνει hello world στα αρχεία καταγραφής συναλλαγών.                                  | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Σας δείχνει πώς μπορείτε να χρησιμοποιήσετε τα lamport από ένα PDA για να πληρώσετε για έναν νέο λογαριασμό.              | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Σας δείχνει πώς να χειρίζεστε instruction data τύπου string και u32.                                                      | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Δείχνει πώς να χρησιμοποιείτε seeds για να αναφερθείτε σε ένα PDA και να αποθηκεύσετε δεδομένα σε αυτό.                   | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Σας δείχνει πώς να αυξάνετε και να μειώνετε το μέγεθος ενός υπάρχοντος λογαριασμού.                                       | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Εδώ θα μάθετε πώς να υπολογίζετε τις απαιτήσεις rent μέσα σε ένα πρόγραμμα.                                               | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Συστάσεις για το πώς να δομείτε τη διάταξη του προγράμματός σας.                                                          | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Διαφορετικές μέθοδοι μεταφοράς SOL για λογαριασμούς συστήματος και PDA.                                                   | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Αποθήκευση διεύθυνσης με όνομα, αριθμό κατοικίας, οδό και πόλη σε έναν λογαριασμό.                                        | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Μαθήματα ασφαλείας που δείχνουν πώς να πραγματοποιείτε ελέγχους λογαριασμών                                               | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Σας δείχνει πώς να κλείνετε λογαριασμούς για να ανακτήσετε το rent τους.                                                  | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Ένα απλό πρόγραμμα μετρητή σε όλες τις διαφορετικές αρχιτεκτονικές.                                                       | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Πώς να δημιουργήσετε έναν λογαριασμό συστήματος μέσα σε ένα πρόγραμμα.                                                    | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Χρησιμοποιώντας μια αναλογία χεριού και μοχλού, σας δείχνει πώς να καλέσετε ένα άλλο πρόγραμμα από μέσα σε ένα πρόγραμμα. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Παράδειγμα hello world που απλώς εκτυπώνει hello world στα αρχεία καταγραφής συναλλαγών.                                  | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Σας δείχνει πώς μπορείτε να χρησιμοποιήσετε τα lamport από ένα PDA για να πληρώσετε για έναν νέο λογαριασμό.              | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Σας δείχνει πώς να χειρίζεστε instruction data τύπου string και u32.                                                      | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Δείχνει πώς να χρησιμοποιείτε seeds για να αναφερθείτε σε ένα PDA και να αποθηκεύσετε δεδομένα σε αυτό.                   | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Σας δείχνει πώς να αυξάνετε και να μειώνετε το μέγεθος ενός υπάρχοντος λογαριασμού.                                       | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Συστάσεις για το πώς να δομείτε τη διάταξη του προγράμματός σας.                                                          | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Διαφορετικές μέθοδοι μεταφοράς SOL για λογαριασμούς συστήματος και PDA.                                                   | Native, Anchor, Seahorse  |
 
 ## Tokens
 
@@ -61,13 +60,12 @@ Program Library (SPL). Εδώ μπορείτε να βρείτε πολλά πα
 
 | Όνομα Παραδείγματος                                                                                             | Περιγραφή                                                                                                       | Γλώσσα         |
 | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | Πώς να δημιουργήσετε ένα token και να προσθέσετε metaplex metadata σε αυτό.                                     | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Κάνει mint μόνο μία μονάδα ενός token και στη συνέχεια αφαιρεί την εξουσιοδότηση mint.                          | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Σας δείχνει πώς να αλλάξετε την εξουσιοδότηση mint ενός mint, για να κάνετε mint tokens μέσα από ένα πρόγραμμα. | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Εξηγεί πώς να χρησιμοποιείτε Associated Token Accounts για να παρακολουθείτε τα token accounts.                 | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Εκτενές παράδειγμα που δείχνει πώς να δημιουργήσετε ένα AMM (automated market maker) pool για SPL tokens.       | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Δείχνει πώς να μεταφέρετε SPL token χρησιμοποιώντας CPIs στο token program.                                     | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Δείτε Token 2022 (Token extensions).                                                                            | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | Πώς να δημιουργήσετε ένα token και να προσθέσετε metaplex metadata σε αυτό.                                     | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Κάνει mint μόνο μία μονάδα ενός token και στη συνέχεια αφαιρεί την εξουσιοδότηση mint.                          | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Σας δείχνει πώς να αλλάξετε την εξουσιοδότηση mint ενός mint, για να κάνετε mint tokens μέσα από ένα πρόγραμμα. | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Εκτενές παράδειγμα που δείχνει πώς να δημιουργήσετε ένα AMM (automated market maker) pool για SPL tokens.       | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Δείχνει πώς να μεταφέρετε SPL token χρησιμοποιώντας CPIs στο token program.                                     | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Δείτε Token 2022 (Token extensions).                                                                            | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -78,14 +76,14 @@ Program Library (SPL). Εδώ μπορείτε να βρείτε πολλά πα
 
 | Όνομα Παραδείγματος                                                                                                              | Περιγραφή                                                                                                                                 | Γλώσσα         |
 | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Πώς να δημιουργήσετε ένα token, να κάνετε mint και transfer.                                                                              | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Αυτό το extension σας επιτρέπει να δημιουργείτε token accounts με συγκεκριμένη κατάσταση, για παράδειγμα frozen.                          | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Με το παλιό Token Program δεν ήταν δυνατό το κλείσιμο ενός mint. Τώρα είναι.                                                              | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Σας δείχνει πώς μπορείτε να προσθέσετε πολλαπλά extensions σε ένα μεμονωμένο mint.                                                        | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Είναι δυνατή η χρήση του metadata extension για τη δημιουργία NFTs και την προσθήκη δυναμικών on-chain metadata.                          | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Χρήσιμο για παράδειγμα για επιτεύγματα, προγράμματα παραπομπής ή οποιαδήποτε soul bound tokens.                                           | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Κάθε μεταφορά tokens κρατά κάποια tokens στο token account, τα οποία μπορούν στη συνέχεια να συλλεχθούν.                                  | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Τέσσερα παραδείγματα για την προσθήκη επιπλέον λειτουργικότητας στο token σας χρησιμοποιώντας CPI από το Token Program στο πρόγραμμά σας. | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Πώς να δημιουργήσετε ένα token, να κάνετε mint και transfer.                                                                              | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Αυτό το extension σας επιτρέπει να δημιουργείτε token accounts με συγκεκριμένη κατάσταση, για παράδειγμα frozen.                          | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Με το παλιό Token Program δεν ήταν δυνατό το κλείσιμο ενός mint. Τώρα είναι.                                                              | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Σας δείχνει πώς μπορείτε να προσθέσετε πολλαπλά extensions σε ένα μεμονωμένο mint.                                                        | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Είναι δυνατή η χρήση του metadata extension για τη δημιουργία NFTs και την προσθήκη δυναμικών on-chain metadata.                          | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Χρήσιμο για παράδειγμα για επιτεύγματα, προγράμματα παραπομπής ή οποιαδήποτε soul bound tokens.                                           | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Κάθε μεταφορά tokens κρατά κάποια tokens στο token account, τα οποία μπορούν στη συνέχεια να συλλεχθούν.                                  | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Τέσσερα παραδείγματα για την προσθήκη επιπλέον λειτουργικότητας στο token σας χρησιμοποιώντας CPI από το Token Program στο πρόγραμμά σας. | Anchor         |
 
 ## Παραδείγματα προγραμμάτων Solana του οικοσυστήματος
 

--- a/apps/docs/content/docs/en/programs/examples.mdx
+++ b/apps/docs/content/docs/en/programs/examples.mdx
@@ -6,11 +6,11 @@ description:
 ---
 
 The
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 repository on GitHub offers several subfolders, each containing code examples to
 help developers learn and experiment with Solana blockchain development.
 
-You can find the examples in the `solana-developers/program-examples` together
+You can find the examples in the `solana-foundation/program-examples` together
 with README files that explain you how to run the different examples. Most
 examples are self-contained and are available in native Rust (ie, with no
 framework) and [Anchor](https://www.anchor-lang.com/docs/installation).
@@ -32,20 +32,19 @@ designed to help developers understand the core concepts of Solana programming.
 
 | Example Name                                                                                                                  | Description                                                                                      | Language                  |
 | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Saving an address with name, house number, street and city in an account.                        | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Security lessons that shows how to do account checks                                             | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Show you how to close accounts to get its rent back.                                             | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | A simple counter program in all the different architectures.                                     | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | How to create a system account within a program.                                                 | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Using a hand and lever analogy this shows you how to call another program from within a program. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Hello world example which just prints hello world in the transaction logs.                       | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Shows you how you can use the lamports from a PDA to pay for a new account.                      | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Shows you how to handle instruction data string and u32.                                         | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Shows how to use seeds to refer to a PDA and save data in it.                                    | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Shows you how to increase and decrease the size of an existing account.                          | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Here you will learn how to calculate rent requirements within a program.                         | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Recommendations on how to structure your program layout.                                         | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Different methods of transferring SOL for system accounts and PDAs.                              | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Saving an address with name, house number, street and city in an account.                        | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Security lessons that shows how to do account checks                                             | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Show you how to close accounts to get its rent back.                                             | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | A simple counter program in all the different architectures.                                     | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | How to create a system account within a program.                                                 | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Using a hand and lever analogy this shows you how to call another program from within a program. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Hello world example which just prints hello world in the transaction logs.                       | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Shows you how you can use the lamports from a PDA to pay for a new account.                      | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Shows you how to handle instruction data string and u32.                                         | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Shows how to use seeds to refer to a PDA and save data in it.                                    | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Shows you how to increase and decrease the size of an existing account.                          | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Recommendations on how to structure your program layout.                                         | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Different methods of transferring SOL for system accounts and PDAs.                              | Native, Anchor, Seahorse  |
 
 ## Tokens
 
@@ -55,13 +54,12 @@ interact with them in programs.
 
 | Example Name                                                                                                    | Description                                                                                        | Language       |
 | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | How to create a token and add metaplex metadata to it.                                             | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Minting only one amount of a token and then removing the mint authority.                           | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Shows you how to change the mint authority of a mint, to mint tokens from within a program.        | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Explains how to use Associated Token Accounts to be able to keep track of token accounts.          | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Extensive example that shows you how to build an AMM (automated market maker) pool for SPL tokens. | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Shows how to transfer SPL token using CPIs into the token program.                                 | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | See Token 2022 (Token extensions).                                                                 | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | How to create a token and add metaplex metadata to it.                                             | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)             | Minting only one amount of a token and then removing the mint authority.                           | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Shows you how to change the mint authority of a mint, to mint tokens from within a program.        | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Extensive example that shows you how to build an AMM (automated market maker) pool for SPL tokens. | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Shows how to transfer SPL token using CPIs into the token program.                                 | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | See Token 2022 (Token extensions).                                                                 | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -72,14 +70,14 @@ to it. A full list of the extensions can be found in the
 
 | Example Name                                                                                                                     | Description                                                                                                       | Language       |
 | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | How to create a token, mint and transfer it.                                                                      | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | This extension lets you create token accounts with a certain state, for example frozen.                           | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | With the old token program it was not possible to close a mint. Now it is.                                        | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Shows you how you can add multiple extensions to a single mint                                                    | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | It is possible to use the metadata extension to create NFTs and add dynamic on chain metadata.                    | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Useful for example for achievements, referral programs or any soul bound tokens.                                  | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Every transfer of the tokens hold some tokens back in the token account which can then be collected.              | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Four examples to add additional functionality to your token using a CPI from the token program into your program. | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | How to create a token, mint and transfer it.                                                                      | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | This extension lets you create token accounts with a certain state, for example frozen.                           | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | With the old token program it was not possible to close a mint. Now it is.                                        | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Shows you how you can add multiple extensions to a single mint                                                    | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | It is possible to use the metadata extension to create NFTs and add dynamic on chain metadata.                    | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Useful for example for achievements, referral programs or any soul bound tokens.                                  | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Every transfer of the tokens hold some tokens back in the token account which can then be collected.              | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Four examples to add additional functionality to your token using a CPI from the token program into your program. | Anchor         |
 
 ## Ecosystem Solana program examples
 

--- a/apps/docs/content/docs/es/programs/examples.mdx
+++ b/apps/docs/content/docs/es/programs/examples.mdx
@@ -7,12 +7,12 @@ description:
 ---
 
 El
-[repositorio de ejemplos de programas de Solana](https://github.com/solana-developers/program-examples)
+[repositorio de ejemplos de programas de Solana](https://github.com/solana-foundation/program-examples)
 en GitHub ofrece varias subcarpetas, cada una con ejemplos de código para ayudar
 a los desarrolladores a aprender y experimentar con el desarrollo en la
 blockchain de Solana.
 
-Puedes encontrar los ejemplos en el `solana-developers/program-examples` junto
+Puedes encontrar los ejemplos en el `solana-foundation/program-examples` junto
 con archivos README que te explican cómo ejecutar los diferentes ejemplos. La
 mayoría de los ejemplos son autocontenidos y están disponibles en Rust nativo
 (es decir, sin framework) y
@@ -37,20 +37,19 @@ conceptos principales de la programación en Solana.
 
 | Nombre del ejemplo                                                                                                            | Descripción                                                                                                     | Lenguaje                  |
 | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Guardar una dirección con nombre, número de casa, calle y ciudad en una cuenta.                                 | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Lecciones de seguridad que muestran cómo realizar verificaciones de cuentas.                                    | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Te muestra cómo cerrar cuentas para recuperar su rent.                                                          | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Un programa contador simple en todas las diferentes arquitecturas.                                              | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Cómo crear una cuenta del sistema dentro de un programa.                                                        | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Usando una analogía de mano y palanca, esto te muestra cómo llamar a otro programa desde dentro de un programa. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Ejemplo de hola mundo que simplemente imprime hola mundo en los registros de transacciones.                     | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Te muestra cómo puedes usar los lamport de un PDA para pagar una nueva cuenta.                                  | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Te muestra cómo manejar instruction data de tipo string y u32.                                                  | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Muestra cómo usar semillas para referirse a un PDA y guardar datos en él.                                       | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Te muestra cómo aumentar y disminuir el tamaño de una cuenta existente.                                         | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Aquí aprenderás a calcular los requisitos de rent dentro de un programa.                                        | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Recomendaciones sobre cómo estructurar el diseño de tu programa.                                                | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Diferentes métodos para transferir SOL en cuentas del sistema y PDAs.                                           | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Guardar una dirección con nombre, número de casa, calle y ciudad en una cuenta.                                 | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Lecciones de seguridad que muestran cómo realizar verificaciones de cuentas.                                    | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Te muestra cómo cerrar cuentas para recuperar su rent.                                                          | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Un programa contador simple en todas las diferentes arquitecturas.                                              | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Cómo crear una cuenta del sistema dentro de un programa.                                                        | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Usando una analogía de mano y palanca, esto te muestra cómo llamar a otro programa desde dentro de un programa. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Ejemplo de hola mundo que simplemente imprime hola mundo en los registros de transacciones.                     | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Te muestra cómo puedes usar los lamport de un PDA para pagar una nueva cuenta.                                  | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Te muestra cómo manejar instruction data de tipo string y u32.                                                  | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Muestra cómo usar semillas para referirse a un PDA y guardar datos en él.                                       | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Te muestra cómo aumentar y disminuir el tamaño de una cuenta existente.                                         | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Recomendaciones sobre cómo estructurar el diseño de tu programa.                                                | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Diferentes métodos para transferir SOL en cuentas del sistema y PDAs.                                           | Native, Anchor, Seahorse  |
 
 ## Tokens
 
@@ -60,13 +59,12 @@ transferir y quemar tokens, e incluso cómo interactuar con ellos en programas.
 
 | Nombre del ejemplo                                                                                              | Descripción                                                                                                  | Lenguaje       |
 | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | Cómo crear un token y añadirle metadatos de Metaplex.                                                        | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Acuña una única unidad de un token y luego elimina la autoridad de acuñación.                                | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Muestra cómo cambiar la autoridad de acuñación de un mint para acuñar tokens desde dentro de un programa.    | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Explica cómo usar Associated Token Accounts para poder hacer seguimiento de token accounts.                  | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Ejemplo exhaustivo que muestra cómo construir un pool AMM (creador de mercado automatizado) para tokens SPL. | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Muestra cómo transferir tokens SPL usando CPIs hacia el token program.                                       | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Ver Token 2022 (Token extensions).                                                                           | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | Cómo crear un token y añadirle metadatos de Metaplex.                                                        | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Acuña una única unidad de un token y luego elimina la autoridad de acuñación.                                | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Muestra cómo cambiar la autoridad de acuñación de un mint para acuñar tokens desde dentro de un programa.    | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Ejemplo exhaustivo que muestra cómo construir un pool AMM (creador de mercado automatizado) para tokens SPL. | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Muestra cómo transferir tokens SPL usando CPIs hacia el token program.                                       | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Ver Token 2022 (Token extensions).                                                                           | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -77,14 +75,14 @@ en la [Guía de introducción](/docs/tokens/extensions)
 
 | Nombre del ejemplo                                                                                                               | Descripción                                                                                                                          | Lenguaje       |
 | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Cómo crear un token, acuñarlo y transferirlo.                                                                                        | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Esta extensión te permite crear token accounts con un estado determinado, por ejemplo, congeladas.                                   | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Con el antiguo token program no era posible cerrar un mint. Ahora sí lo es.                                                          | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Muestra cómo puedes añadir múltiples extensiones a un único mint.                                                                    | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Es posible usar la extensión de metadatos para crear NFTs y añadir metadatos dinámicos en cadena.                                    | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Útil, por ejemplo, para logros, programas de referidos o tokens vinculados al alma (soul bound tokens).                              | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Cada transferencia de tokens retiene una parte de los tokens en el token account, los cuales pueden ser recolectados posteriormente. | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Cuatro ejemplos para añadir funcionalidad adicional a tu token mediante un CPI desde el token program hacia tu programa.             | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Cómo crear un token, acuñarlo y transferirlo.                                                                                        | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Esta extensión te permite crear token accounts con un estado determinado, por ejemplo, congeladas.                                   | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Con el antiguo token program no era posible cerrar un mint. Ahora sí lo es.                                                          | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Muestra cómo puedes añadir múltiples extensiones a un único mint.                                                                    | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Es posible usar la extensión de metadatos para crear NFTs y añadir metadatos dinámicos en cadena.                                    | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Útil, por ejemplo, para logros, programas de referidos o tokens vinculados al alma (soul bound tokens).                              | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Cada transferencia de tokens retiene una parte de los tokens en el token account, los cuales pueden ser recolectados posteriormente. | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Cuatro ejemplos para añadir funcionalidad adicional a tu token mediante un CPI desde el token program hacia tu programa.             | Anchor         |
 
 ## Ejemplos de programas Solana del ecosistema
 

--- a/apps/docs/content/docs/fi/programs/examples.mdx
+++ b/apps/docs/content/docs/fi/programs/examples.mdx
@@ -5,12 +5,12 @@ description:
   auttaa sinua oppimaan ja käyttämään niitä referenssinä omissa projekteissasi.
 ---
 
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 -arkisto GitHubissa tarjoaa useita alihakemistoja, joista kukin sisältää
 koodiesimerkkejä auttaakseen kehittäjiä oppimaan ja kokeilemaan
 Solana-lohkoketjukehitystä.
 
-Löydät esimerkit `solana-developers/program-examples` -kansiosta yhdessä
+Löydät esimerkit `solana-foundation/program-examples` -kansiosta yhdessä
 README-tiedostojen kanssa, jotka selittävät, miten eri esimerkkejä ajetaan.
 Useimmat esimerkit ovat itsenäisiä ja saatavilla natiivina Rustina (eli ilman
 frameworkia) sekä
@@ -34,20 +34,19 @@ suunniteltu auttamaan kehittäjiä ymmärtämään Solana-ohjelmoinnin ydinkäsi
 
 | Esimerkin nimi                                                                                                                | Kuvaus                                                                                                          | Kieli                     |
 | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Osoitteen tallentaminen nimellä, talon numerolla, kadulla ja kaupungilla tilille.                               | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Tietoturvaoppitunteja, jotka näyttävät kuinka tehdä tilitarkistukset                                            | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Näyttää kuinka sulkea tilejä saadaksesi rent takaisin.                                                          | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Yksinkertainen laskuriohjelma kaikissa eri arkkitehtuureissa.                                                   | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Kuinka luoda järjestelmätili ohjelman sisällä.                                                                  | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Käden ja vivun analogiaa käyttäen tämä näyttää kuinka kutsua toista ohjelmaa ohjelman sisältä.                  | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Hello world -esimerkki, joka tulostaa vain "hello world" transaktiolokeihin.                                    | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Näyttää kuinka voit käyttää PDA:n lamport-yksiköitä uuden tilin maksamiseen.                                    | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Näyttää kuinka käsitellä instruction data -merkkijonoa ja u32-arvoa.                                            | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Näyttää kuinka käyttää siemeniä viittaamaan Program Derived Address -osoitteeseen ja tallentamaan dataa siihen. | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Näyttää kuinka kasvattaa ja pienentää olemassa olevan tilin kokoa.                                              | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Täällä opit laskemaan rent-vaatimukset ohjelman sisällä.                                                        | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Suosituksia ohjelman rakenteen järjestämiseen.                                                                  | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Eri menetelmät SOL:n siirtämiseen järjestelmätileille ja PDA:ille.                                              | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Osoitteen tallentaminen nimellä, talon numerolla, kadulla ja kaupungilla tilille.                               | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Tietoturvaoppitunteja, jotka näyttävät kuinka tehdä tilitarkistukset                                            | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Näyttää kuinka sulkea tilejä saadaksesi rent takaisin.                                                          | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Yksinkertainen laskuriohjelma kaikissa eri arkkitehtuureissa.                                                   | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Kuinka luoda järjestelmätili ohjelman sisällä.                                                                  | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Käden ja vivun analogiaa käyttäen tämä näyttää kuinka kutsua toista ohjelmaa ohjelman sisältä.                  | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Hello world -esimerkki, joka tulostaa vain "hello world" transaktiolokeihin.                                    | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Näyttää kuinka voit käyttää PDA:n lamport-yksiköitä uuden tilin maksamiseen.                                    | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Näyttää kuinka käsitellä instruction data -merkkijonoa ja u32-arvoa.                                            | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Näyttää kuinka käyttää siemeniä viittaamaan Program Derived Address -osoitteeseen ja tallentamaan dataa siihen. | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Näyttää kuinka kasvattaa ja pienentää olemassa olevan tilin kokoa.                                              | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Suosituksia ohjelman rakenteen järjestämiseen.                                                                  | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Eri menetelmät SOL:n siirtämiseen järjestelmätileille ja PDA:ille.                                              | Native, Anchor, Seahorse  |
 
 ## Tokenit
 
@@ -58,13 +57,12 @@ ohjelmissa.
 
 | Esimerkin nimi                                                                                                  | Kuvaus                                                                                            | Kieli          |
 | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | Kuinka luoda token ja lisätä sille Metaplex-metadata.                                             | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Lyödään vain yksi määrä tokenia ja poistetaan sen jälkeen lyöntiauktoriteetti.                    | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Näyttää, kuinka voit muuttaa mintin lyöntiauktoriteettia lyödäksesi tokeneita ohjelman sisältä.   | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Selittää, kuinka Associated Token Accounteja käytetään token accountien seurantaan.               | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Laaja esimerkki, joka näyttää kuinka rakentaa AMM (automated market maker) -pooli SPL-tokeneille. | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Näyttää, kuinka SPL-tokeneita siirretään CPI-kutsujen avulla token programiin.                    | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Katso Token 2022 (Token extensions).                                                              | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | Kuinka luoda token ja lisätä sille Metaplex-metadata.                                             | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Lyödään vain yksi määrä tokenia ja poistetaan sen jälkeen lyöntiauktoriteetti.                    | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Näyttää, kuinka voit muuttaa mintin lyöntiauktoriteettia lyödäksesi tokeneita ohjelman sisältä.   | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Laaja esimerkki, joka näyttää kuinka rakentaa AMM (automated market maker) -pooli SPL-tokeneille. | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Näyttää, kuinka SPL-tokeneita siirretään CPI-kutsujen avulla token programiin.                    | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Katso Token 2022 (Token extensions).                                                              | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -75,14 +73,14 @@ toiminnallisuutta. Täydellinen luettelo laajennuksista löytyy
 
 | Esimerkin nimi                                                                                                                   | Kuvaus                                                                                                                     | Kieli          |
 | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Kuinka luoda token, lyödä se ja siirtää se.                                                                                | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Tämä laajennus mahdollistaa token accountien luomisen tietyssä tilassa, esimerkiksi jäädytettynä.                          | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Vanhalla Token Programilla mintin sulkeminen ei ollut mahdollista. Nyt se on.                                              | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Näyttää, kuinka voit lisätä useita laajennuksia yhteen mintiin.                                                            | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Metadata-laajennusta on mahdollista käyttää NFT:iden luomiseen ja dynaamisen on-chain-metadatan lisäämiseen.               | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Hyödyllinen esimerkiksi saavutuksiin, suositusohjelmiin tai soul bound -tokeneihin.                                        | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Jokaisesta tokeninsiirrosta pidätetään osa tokeneista token accountissa, mistä ne voidaan myöhemmin kerätä.                | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Neljä esimerkkiä lisätoiminnallisuuden lisäämiseksi tokenillesi käyttämällä CPI-kutsua Token Programista omaan ohjelmaasi. | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Kuinka luoda token, lyödä se ja siirtää se.                                                                                | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Tämä laajennus mahdollistaa token accountien luomisen tietyssä tilassa, esimerkiksi jäädytettynä.                          | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Vanhalla Token Programilla mintin sulkeminen ei ollut mahdollista. Nyt se on.                                              | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Näyttää, kuinka voit lisätä useita laajennuksia yhteen mintiin.                                                            | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Metadata-laajennusta on mahdollista käyttää NFT:iden luomiseen ja dynaamisen on-chain-metadatan lisäämiseen.               | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Hyödyllinen esimerkiksi saavutuksiin, suositusohjelmiin tai soul bound -tokeneihin.                                        | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Jokaisesta tokeninsiirrosta pidätetään osa tokeneista token accountissa, mistä ne voidaan myöhemmin kerätä.                | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Neljä esimerkkiä lisätoiminnallisuuden lisäämiseksi tokenillesi käyttämällä CPI-kutsua Token Programista omaan ohjelmaasi. | Anchor         |
 
 ## Ekosysteemi – Solana-ohjelmaesimerkkejä
 

--- a/apps/docs/content/docs/fr/programs/examples.mdx
+++ b/apps/docs/content/docs/fr/programs/examples.mdx
@@ -7,12 +7,12 @@ description:
 ---
 
 Le dépôt
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 sur GitHub propose plusieurs sous-dossiers, chacun contenant des exemples de
 code pour aider les développeurs à apprendre et expérimenter le développement
 sur la blockchain Solana.
 
-Vous pouvez trouver les exemples dans le `solana-developers/program-examples`
+Vous pouvez trouver les exemples dans le `solana-foundation/program-examples`
 accompagnés de fichiers README qui vous expliquent comment exécuter les
 différents exemples. La plupart des exemples sont autonomes et sont disponibles
 en Rust natif (c'est-à-dire sans framework) et
@@ -37,20 +37,19 @@ fondamentaux de la programmation Solana.
 
 | Nom de l'exemple                                                                                                              | Description                                                                                                                    | Langage                   |
 | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Enregistrement d'une adresse avec nom, numéro de maison, rue et ville dans un compte.                                          | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Leçons de sécurité montrant comment effectuer des vérifications de compte.                                                     | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Montre comment fermer des comptes pour récupérer leur rent.                                                                    | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Un programme de compteur simple dans toutes les architectures disponibles.                                                     | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Comment créer un compte système au sein d'un programme.                                                                        | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | À l'aide d'une analogie avec une main et un levier, cet exemple montre comment appeler un autre programme depuis un programme. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Exemple « hello world » qui affiche simplement hello world dans les journaux de transaction.                                   | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Montre comment utiliser les lamport d'un PDA pour payer un nouveau compte.                                                     | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Montre comment traiter une chaîne instruction data et un u32.                                                                  | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Montre comment utiliser des seeds pour référencer un PDA et y enregistrer des données.                                         | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Montre comment augmenter et réduire la taille d'un compte existant.                                                            | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Vous apprendrez ici à calculer les exigences de rent au sein d'un programme.                                                   | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Recommandations sur la façon de structurer la mise en page de votre programme.                                                 | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Différentes méthodes de transfert de SOL pour les comptes système et les PDA.                                                  | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Enregistrement d'une adresse avec nom, numéro de maison, rue et ville dans un compte.                                          | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Leçons de sécurité montrant comment effectuer des vérifications de compte.                                                     | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Montre comment fermer des comptes pour récupérer leur rent.                                                                    | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Un programme de compteur simple dans toutes les architectures disponibles.                                                     | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Comment créer un compte système au sein d'un programme.                                                                        | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | À l'aide d'une analogie avec une main et un levier, cet exemple montre comment appeler un autre programme depuis un programme. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Exemple « hello world » qui affiche simplement hello world dans les journaux de transaction.                                   | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Montre comment utiliser les lamport d'un PDA pour payer un nouveau compte.                                                     | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Montre comment traiter une chaîne instruction data et un u32.                                                                  | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Montre comment utiliser des seeds pour référencer un PDA et y enregistrer des données.                                         | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Montre comment augmenter et réduire la taille d'un compte existant.                                                            | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Recommandations sur la façon de structurer la mise en page de votre programme.                                                 | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Différentes méthodes de transfert de SOL pour les comptes système et les PDA.                                                  | Native, Anchor, Seahorse  |
 
 ## Tokens
 
@@ -61,13 +60,12 @@ avec eux dans des programmes.
 
 | Nom de l'exemple                                                                                                | Description                                                                                            | Langage        |
 | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | Comment créer un token et lui ajouter des métadonnées Metaplex.                                        | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Créer une seule unité d'un token puis supprimer l'autorité de création.                                | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Montre comment modifier l'autorité de création d'un mint afin de créer des tokens depuis un programme. | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Explique comment utiliser les associated token accounts pour assurer le suivi des token accounts.      | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Exemple complet montrant comment créer un pool AMM (automated market maker) pour les tokens SPL.       | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Montre comment transférer un token SPL en utilisant des CPIs vers le token program.                    | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Voir Token 2022 (Token extensions).                                                                    | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | Comment créer un token et lui ajouter des métadonnées Metaplex.                                        | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Créer une seule unité d'un token puis supprimer l'autorité de création.                                | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Montre comment modifier l'autorité de création d'un mint afin de créer des tokens depuis un programme. | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Exemple complet montrant comment créer un pool AMM (automated market maker) pour les tokens SPL.       | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Montre comment transférer un token SPL en utilisant des CPIs vers le token program.                    | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Voir Token 2022 (Token extensions).                                                                    | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -78,14 +76,14 @@ extensions est disponible dans le [Guide de démarrage](/docs/tokens/extensions)
 
 | Nom de l'exemple                                                                                                                 | Description                                                                                                                                      | Langage        |
 | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Comment créer un token, le créer et le transférer.                                                                                               | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Cette extension vous permet de créer des token accounts avec un état particulier, par exemple gelé.                                              | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Avec l'ancien Token Program, il n'était pas possible de fermer un mint. Désormais, c'est possible.                                               | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Montre comment ajouter plusieurs extensions à un seul mint.                                                                                      | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Il est possible d'utiliser l'extension de métadonnées pour créer des NFT et ajouter des métadonnées dynamiques on-chain.                         | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Utile par exemple pour les succès, les programmes de parrainage ou tout token soul bound.                                                        | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Chaque transfert de tokens retient une partie des tokens dans le token account, lesquels peuvent ensuite être collectés.                         | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Quatre exemples pour ajouter des fonctionnalités supplémentaires à votre token en utilisant un CPI depuis le Token Program vers votre programme. | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Comment créer un token, le créer et le transférer.                                                                                               | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Cette extension vous permet de créer des token accounts avec un état particulier, par exemple gelé.                                              | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Avec l'ancien Token Program, il n'était pas possible de fermer un mint. Désormais, c'est possible.                                               | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Montre comment ajouter plusieurs extensions à un seul mint.                                                                                      | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Il est possible d'utiliser l'extension de métadonnées pour créer des NFT et ajouter des métadonnées dynamiques on-chain.                         | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Utile par exemple pour les succès, les programmes de parrainage ou tout token soul bound.                                                        | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Chaque transfert de tokens retient une partie des tokens dans le token account, lesquels peuvent ensuite être collectés.                         | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Quatre exemples pour ajouter des fonctionnalités supplémentaires à votre token en utilisant un CPI depuis le Token Program vers votre programme. | Anchor         |
 
 ## Exemples de programmes Solana de l'écosystème
 

--- a/apps/docs/content/docs/id/programs/examples.mdx
+++ b/apps/docs/content/docs/id/programs/examples.mdx
@@ -7,12 +7,12 @@ description:
 ---
 
 Repositori
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 di GitHub menawarkan beberapa subfolder, masing-masing berisi contoh kode untuk
 membantu pengembang belajar dan bereksperimen dengan pengembangan blockchain
 Solana.
 
-Anda dapat menemukan contoh-contoh di `solana-developers/program-examples`
+Anda dapat menemukan contoh-contoh di `solana-foundation/program-examples`
 bersama dengan file README yang menjelaskan cara menjalankan berbagai contoh
 tersebut. Sebagian besar contoh bersifat mandiri dan tersedia dalam Rust native
 (yaitu, tanpa framework) dan
@@ -35,20 +35,19 @@ dirancang untuk membantu pengembang memahami konsep inti pemrograman Solana.
 
 | Nama Contoh                                                                                                                   | Deskripsi                                                                                                   | Bahasa                    |
 | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Menyimpan alamat dengan nama, nomor rumah, jalan, dan kota dalam sebuah akun.                               | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Pelajaran keamanan yang menunjukkan cara melakukan pemeriksaan akun                                         | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Menunjukkan cara menutup akun untuk mendapatkan kembali rent-nya.                                           | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Program penghitung sederhana dalam semua arsitektur yang berbeda.                                           | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Cara membuat akun sistem di dalam sebuah program.                                                           | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Menggunakan analogi tangan dan tuas, ini menunjukkan cara memanggil program lain dari dalam sebuah program. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Contoh hello world yang hanya mencetak hello world di log transaksi.                                        | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Menunjukkan cara menggunakan lamport dari PDA untuk membayar akun baru.                                     | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Menunjukkan cara menangani instruction data string dan u32.                                                 | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Menunjukkan cara menggunakan seed untuk merujuk ke PDA dan menyimpan data di dalamnya.                      | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Menunjukkan cara menambah dan mengurangi ukuran akun yang sudah ada.                                        | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Di sini Anda akan mempelajari cara menghitung persyaratan rent di dalam sebuah program.                     | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Rekomendasi tentang cara menyusun tata letak program Anda.                                                  | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Berbagai metode transfer SOL untuk akun sistem dan PDA.                                                     | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Menyimpan alamat dengan nama, nomor rumah, jalan, dan kota dalam sebuah akun.                               | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Pelajaran keamanan yang menunjukkan cara melakukan pemeriksaan akun                                         | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Menunjukkan cara menutup akun untuk mendapatkan kembali rent-nya.                                           | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Program penghitung sederhana dalam semua arsitektur yang berbeda.                                           | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Cara membuat akun sistem di dalam sebuah program.                                                           | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Menggunakan analogi tangan dan tuas, ini menunjukkan cara memanggil program lain dari dalam sebuah program. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Contoh hello world yang hanya mencetak hello world di log transaksi.                                        | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Menunjukkan cara menggunakan lamport dari PDA untuk membayar akun baru.                                     | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Menunjukkan cara menangani instruction data string dan u32.                                                 | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Menunjukkan cara menggunakan seed untuk merujuk ke PDA dan menyimpan data di dalamnya.                      | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Menunjukkan cara menambah dan mengurangi ukuran akun yang sudah ada.                                        | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Rekomendasi tentang cara menyusun tata letak program Anda.                                                  | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Berbagai metode transfer SOL untuk akun sistem dan PDA.                                                     | Native, Anchor, Seahorse  |
 
 ## Token
 
@@ -59,13 +58,12 @@ program.
 
 | Nama Contoh                                                                                                     | Deskripsi                                                                                          | Bahasa         |
 | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | Cara membuat token dan menambahkan metadata metaplex ke dalamnya.                                  | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Mencetak hanya satu jumlah token kemudian menghapus otoritas mint.                                 | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Menunjukkan cara mengubah otoritas mint dari sebuah mint, untuk mencetak token dari dalam program. | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Menjelaskan cara menggunakan Associated Token Accounts untuk dapat melacak token account.          | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Contoh lengkap yang menunjukkan cara membangun pool AMM (automated market maker) untuk token SPL.  | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Menunjukkan cara mentransfer token SPL menggunakan CPI ke dalam token program.                     | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Lihat Token 2022 (Token extensions).                                                               | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | Cara membuat token dan menambahkan metadata metaplex ke dalamnya.                                  | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Mencetak hanya satu jumlah token kemudian menghapus otoritas mint.                                 | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Menunjukkan cara mengubah otoritas mint dari sebuah mint, untuk mencetak token dari dalam program. | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Contoh lengkap yang menunjukkan cara membangun pool AMM (automated market maker) untuk token SPL.  | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Menunjukkan cara mentransfer token SPL menggunakan CPI ke dalam token program.                     | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Lihat Token 2022 (Token extensions).                                                               | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -76,14 +74,14 @@ lengkap ekstensi dapat ditemukan di [Panduan Memulai](/docs/tokens/extensions)
 
 | Nama Contoh                                                                                                                      | Deskripsi                                                                                                                        | Bahasa         |
 | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Cara membuat token, mencetak, dan mentransfernya.                                                                                | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Ekstensi ini memungkinkan Anda membuat token account dengan status tertentu, misalnya dibekukan.                                 | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Dengan Token Program lama tidak mungkin untuk menutup sebuah mint. Kini hal itu bisa dilakukan.                                  | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Menunjukkan cara menambahkan beberapa ekstensi ke dalam satu mint                                                                | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Memungkinkan penggunaan ekstensi metadata untuk membuat NFT dan menambahkan metadata on-chain yang dinamis.                      | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Berguna misalnya untuk pencapaian, program referral, atau token soul bound apa pun.                                              | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Setiap transfer token menyimpan sejumlah token di dalam token account yang kemudian dapat dikumpulkan.                           | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Empat contoh untuk menambahkan fungsionalitas tambahan pada token Anda menggunakan CPI dari token program ke dalam program Anda. | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Cara membuat token, mencetak, dan mentransfernya.                                                                                | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Ekstensi ini memungkinkan Anda membuat token account dengan status tertentu, misalnya dibekukan.                                 | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Dengan Token Program lama tidak mungkin untuk menutup sebuah mint. Kini hal itu bisa dilakukan.                                  | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Menunjukkan cara menambahkan beberapa ekstensi ke dalam satu mint                                                                | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Memungkinkan penggunaan ekstensi metadata untuk membuat NFT dan menambahkan metadata on-chain yang dinamis.                      | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Berguna misalnya untuk pencapaian, program referral, atau token soul bound apa pun.                                              | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Setiap transfer token menyimpan sejumlah token di dalam token account yang kemudian dapat dikumpulkan.                           | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Empat contoh untuk menambahkan fungsionalitas tambahan pada token Anda menggunakan CPI dari token program ke dalam program Anda. | Anchor         |
 
 ## Contoh program Solana dari Ekosistem
 

--- a/apps/docs/content/docs/it/programs/examples.mdx
+++ b/apps/docs/content/docs/it/programs/examples.mdx
@@ -7,12 +7,12 @@ description:
 ---
 
 Il repository
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 su GitHub offre diverse sottocartelle, ognuna contenente esempi di codice per
 aiutare gli sviluppatori ad apprendere e sperimentare con lo sviluppo sulla
 blockchain Solana.
 
-Puoi trovare gli esempi in `solana-developers/program-examples` insieme ai file
+Puoi trovare gli esempi in `solana-foundation/program-examples` insieme ai file
 README che spiegano come eseguire i diversi esempi. La maggior parte degli
 esempi è autonoma ed è disponibile in Rust nativo (cioè, senza framework) e
 [Anchor](https://www.anchor-lang.com/docs/installation).
@@ -36,20 +36,19 @@ fondamentali della programmazione su Solana.
 
 | Nome Esempio                                                                                                                  | Descrizione                                                                                                     | Linguaggio                |
 | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Salvataggio di un indirizzo con nome, numero civico, via e città in un account.                                 | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Lezioni di sicurezza che mostrano come eseguire i controlli sugli account                                       | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Mostra come chiudere gli account per recuperare il rent.                                                        | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Un semplice programma contatore in tutte le diverse architetture.                                               | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Come creare un account di sistema all'interno di un programma.                                                  | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Usando l'analogia di una mano e una leva, mostra come chiamare un altro programma dall'interno di un programma. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Esempio Hello World che stampa semplicemente "hello world" nei log delle transazioni.                           | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Mostra come utilizzare i lamport di un PDA per pagare un nuovo account.                                         | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Mostra come gestire instruction data di tipo stringa e u32.                                                     | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Mostra come usare i seed per fare riferimento a un Program Derived Address e salvare dati al suo interno.       | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Mostra come aumentare e ridurre la dimensione di un account esistente.                                          | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Qui imparerai come calcolare i requisiti di rent all'interno di un programma.                                   | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Raccomandazioni su come strutturare il layout del tuo programma.                                                | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Diversi metodi per trasferire SOL per account di sistema e PDA.                                                 | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Salvataggio di un indirizzo con nome, numero civico, via e città in un account.                                 | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Lezioni di sicurezza che mostrano come eseguire i controlli sugli account                                       | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Mostra come chiudere gli account per recuperare il rent.                                                        | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Un semplice programma contatore in tutte le diverse architetture.                                               | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Come creare un account di sistema all'interno di un programma.                                                  | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Usando l'analogia di una mano e una leva, mostra come chiamare un altro programma dall'interno di un programma. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Esempio Hello World che stampa semplicemente "hello world" nei log delle transazioni.                           | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Mostra come utilizzare i lamport di un PDA per pagare un nuovo account.                                         | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Mostra come gestire instruction data di tipo stringa e u32.                                                     | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Mostra come usare i seed per fare riferimento a un Program Derived Address e salvare dati al suo interno.       | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Mostra come aumentare e ridurre la dimensione di un account esistente.                                          | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Raccomandazioni su come strutturare il layout del tuo programma.                                                | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Diversi metodi per trasferire SOL per account di sistema e PDA.                                                 | Native, Anchor, Seahorse  |
 
 ## Token
 
@@ -60,13 +59,12 @@ programmi.
 
 | Nome Esempio                                                                                                    | Descrizione                                                                                            | Linguaggio     |
 | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | Come creare un token e aggiungere metadati metaplex.                                                   | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Conia una sola unità di un token e successivamente rimuove l'autorità di conio.                        | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Mostra come modificare l'autorità di conio di un mint, per coniare token dall'interno di un programma. | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Spiega come utilizzare gli associated token account per tenere traccia dei token account.              | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Esempio completo che mostra come costruire un pool AMM (automated market maker) per token SPL.         | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Mostra come trasferire token SPL tramite CPI nel token program.                                        | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Vedi Token 2022 (Token Extensions).                                                                    | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | Come creare un token e aggiungere metadati metaplex.                                                   | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Conia una sola unità di un token e successivamente rimuove l'autorità di conio.                        | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Mostra come modificare l'autorità di conio di un mint, per coniare token dall'interno di un programma. | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Esempio completo che mostra come costruire un pool AMM (automated market maker) per token SPL.         | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Mostra come trasferire token SPL tramite CPI nel token program.                                        | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Vedi Token 2022 (Token Extensions).                                                                    | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -77,14 +75,14 @@ funzionalità. Un elenco completo delle estensioni è disponibile nella
 
 | Nome Esempio                                                                                                                     | Descrizione                                                                                                            | Linguaggio     |
 | -------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Come creare un token, coniarlo e trasferirlo.                                                                          | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Questa estensione consente di creare token account con un determinato stato, ad esempio bloccati.                      | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Con il vecchio token program non era possibile chiudere un mint. Ora è possibile.                                      | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Mostra come aggiungere più estensioni a un singolo mint.                                                               | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | È possibile utilizzare l'estensione metadata per creare NFT e aggiungere metadati dinamici on-chain.                   | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Utile, ad esempio, per achievement, programmi di referral o token soul bound.                                          | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Ad ogni trasferimento, una parte dei token viene trattenuta nel token account e può essere successivamente raccolta.   | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Quattro esempi per aggiungere funzionalità aggiuntive al tuo token tramite una CPI dal token program al tuo programma. | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Come creare un token, coniarlo e trasferirlo.                                                                          | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Questa estensione consente di creare token account con un determinato stato, ad esempio bloccati.                      | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Con il vecchio token program non era possibile chiudere un mint. Ora è possibile.                                      | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Mostra come aggiungere più estensioni a un singolo mint.                                                               | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | È possibile utilizzare l'estensione metadata per creare NFT e aggiungere metadati dinamici on-chain.                   | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Utile, ad esempio, per achievement, programmi di referral o token soul bound.                                          | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Ad ogni trasferimento, una parte dei token viene trattenuta nel token account e può essere successivamente raccolta.   | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Quattro esempi per aggiungere funzionalità aggiuntive al tuo token tramite una CPI dal token program al tuo programma. | Anchor         |
 
 ## Esempi di programmi Solana dell'ecosistema
 

--- a/apps/docs/content/docs/ja/programs/examples.mdx
+++ b/apps/docs/content/docs/ja/programs/examples.mdx
@@ -3,9 +3,9 @@ title: プログラム例
 description: 異なる言語やフレームワークで書かれたSolanaプログラムの例のリストで、学習や自分のプロジェクトの参考として役立ちます。
 ---
 
-GitHub上の[Solana Program Examples](https://github.com/solana-developers/program-examples)リポジトリには、開発者がSolanaブロックチェーン開発を学び、実験するのに役立つコード例を含むいくつかのサブフォルダがあります。
+GitHub上の[Solana Program Examples](https://github.com/solana-foundation/program-examples)リポジトリには、開発者がSolanaブロックチェーン開発を学び、実験するのに役立つコード例を含むいくつかのサブフォルダがあります。
 
-例は `solana-developers/program-examples`
+例は `solana-foundation/program-examples`
 にあり、さまざまな例の実行方法を説明するREADMEファイルも含まれています。ほとんどの例は自己完結型で、ネイティブRust（つまり、フレームワークなし）と[Anchor](https://www.anchor-lang.com/docs/installation)の両方で利用できます。
 
 リポジトリ内には、以下のサブフォルダがあり、それぞれに様々なサンプルプログラムが含まれています：
@@ -22,20 +22,19 @@ GitHub上の[Solana Program Examples](https://github.com/solana-developers/progr
 
 | サンプル名                                                                                                                    | 説明                                                                                     | 言語                      |
 | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | 名前、番地、通り、市区町村をアカウントに保存する。                                       | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | アカウントチェックの方法を示すセキュリティの基礎                                         | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | アカウントを閉じてrentを取り戻す方法。                                                   | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | さまざまなアーキテクチャで実装されたシンプルなカウンタープログラム。                     | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | プログラム内でシステムアカウントを作成する方法。                                         | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | 手とレバーのアナロジーを使って、プログラム内から別のプログラムを呼び出す方法を示します。 | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | トランザクションログにHello Worldを出力するだけのHello Worldサンプル。                   | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | PDAのlamportを使って新しいアカウントのrentを支払う方法。                                 | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | instruction dataの文字列とu32の処理方法を示します。                                      | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | シードを使用してPDAを参照し、データを保存する方法を示します。                            | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | 既存のアカウントのサイズを増減する方法を示します。                                       | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | プログラム内でrentの要件を計算する方法を学びます。                                       | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | プログラムのレイアウト構成に関する推奨事項。                                             | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | システムアカウントとPDAでSOLを送金するさまざまな方法。                                   | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | 名前、番地、通り、市区町村をアカウントに保存する。                                       | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | アカウントチェックの方法を示すセキュリティの基礎                                         | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | アカウントを閉じてrentを取り戻す方法。                                                   | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | さまざまなアーキテクチャで実装されたシンプルなカウンタープログラム。                     | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | プログラム内でシステムアカウントを作成する方法。                                         | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | 手とレバーのアナロジーを使って、プログラム内から別のプログラムを呼び出す方法を示します。 | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | トランザクションログにHello Worldを出力するだけのHello Worldサンプル。                   | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | PDAのlamportを使って新しいアカウントのrentを支払う方法。                                 | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | instruction dataの文字列とu32の処理方法を示します。                                      | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | シードを使用してPDAを参照し、データを保存する方法を示します。                            | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | 既存のアカウントのサイズを増減する方法を示します。                                       | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | プログラムのレイアウト構成に関する推奨事項。                                             | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | システムアカウントとPDAでSOLを送金するさまざまな方法。                                   | Native, Anchor, Seahorse  |
 
 ## トークン
 
@@ -44,13 +43,12 @@ Library（SPL）トークン標準を使用しています。ここでは、ト�
 
 | サンプル名                                                                                                      | 説明                                                                                     | 言語           |
 | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | トークンを作成し、Metaplexメタデータを追加する方法。                                     | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | トークンを1つだけミントし、ミント権限を削除する方法。                                    | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | ミントのミント権限を変更し、プログラム内からトークンをミントする方法。                   | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | associated token accountを使用してtoken accountを管理する方法の解説。                    | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | SPLトークン向けのAMM（自動マーケットメーカー）プールを構築する方法を示す詳細なサンプル。 | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | token programへのCPIを使用してSPLトークンを転送する方法。                                | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Token 2022（Token extensions）を参照。                                                   | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | トークンを作成し、Metaplexメタデータを追加する方法。                                     | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | トークンを1つだけミントし、ミント権限を削除する方法。                                    | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | ミントのミント権限を変更し、プログラム内からトークンをミントする方法。                   | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | SPLトークン向けのAMM（自動マーケットメーカー）プールを構築する方法を示す詳細なサンプル。 | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | token programへのCPIを使用してSPLトークンを転送する方法。                                | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Token 2022（Token extensions）を参照。                                                   | Anchor, Native |
 
 ## Token Extensions（Token 2022）
 
@@ -60,14 +58,14 @@ Extensionsを追加して機能を拡張することができます。拡張機�
 
 | サンプル名                                                                                                                       | 説明                                                                                            | 言語           |
 | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | トークンの作成、ミント、転送の方法。                                                            | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | この拡張機能を使用すると、フリーズなど特定の状態でtoken accountを作成できます。                 | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | 旧Token Programではミントをクローズすることができませんでしたが、現在は可能です。               | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | 単一のミントに複数の拡張機能を追加する方法。                                                    | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | メタデータ拡張機能を使用してNFTを作成し、動的なオンチェーンメタデータを追加することができます。 | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | 実績、紹介プログラム、ソウルバウンドトークンなどに有用です。                                    | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | トークンの転送ごとに一部のトークンがtoken accountに保留され、後から回収できます。               | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | token programからプログラムへのCPIを使用してトークンに追加機能を実装する4つのサンプル。         | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | トークンの作成、ミント、転送の方法。                                                            | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | この拡張機能を使用すると、フリーズなど特定の状態でtoken accountを作成できます。                 | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | 旧Token Programではミントをクローズすることができませんでしたが、現在は可能です。               | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | 単一のミントに複数の拡張機能を追加する方法。                                                    | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | メタデータ拡張機能を使用してNFTを作成し、動的なオンチェーンメタデータを追加することができます。 | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | 実績、紹介プログラム、ソウルバウンドトークンなどに有用です。                                    | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | トークンの転送ごとに一部のトークンがtoken accountに保留され、後から回収できます。               | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | token programからプログラムへのCPIを使用してトークンに追加機能を実装する4つのサンプル。         | Anchor         |
 
 ## エコシステム Solanaプログラムの例
 

--- a/apps/docs/content/docs/ko/programs/examples.mdx
+++ b/apps/docs/content/docs/ko/programs/examples.mdx
@@ -6,11 +6,11 @@ description:
 ---
 
 GitHub의
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 저장소는 개발자들이 Solana 블록체인 개발을 배우고 실험하는 데 도움이 되는 코드
 예제가 포함된 여러 하위 폴더를 제공합니다.
 
-예제는 `solana-developers/program-examples`에서 찾을 수 있으며, 각 예제를
+예제는 `solana-foundation/program-examples`에서 찾을 수 있으며, 각 예제를
 실행하는 방법을 설명하는 README 파일이 함께 제공됩니다. 대부분의 예제는
 독립적으로 실행 가능하며 네이티브 Rust(즉, 프레임워크 없이)와
 [Anchor](https://www.anchor-lang.com/docs/installation) 버전으로 제공됩니다.
@@ -32,20 +32,19 @@ GitHub의
 
 | 예제 이름                                                                                                                     | 설명                                                                                  | 언어                      |
 | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | 계정에 이름, 번지수, 거리, 도시가 포함된 주소를 저장합니다.                           | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | 계정 검사를 수행하는 방법을 보여주는 보안 강의                                        | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | rent를 돌려받기 위해 계정을 닫는 방법을 보여줍니다.                                   | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | 다양한 아키텍처로 구현된 간단한 카운터 프로그램입니다.                                | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | 프로그램 내에서 시스템 계정을 생성하는 방법입니다.                                    | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | 손과 레버 비유를 사용하여 프로그램 내에서 다른 프로그램을 호출하는 방법을 보여줍니다. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | 트랜잭션 로그에 hello world를 출력하는 Hello world 예제입니다.                        | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | PDA의 lamport를 사용하여 새 계정 비용을 지불하는 방법을 보여줍니다.                   | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | instruction data 문자열과 u32를 처리하는 방법을 보여줍니다.                           | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | 시드를 사용하여 PDA를 참조하고 데이터를 저장하는 방법을 보여줍니다.                   | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | 기존 계정의 크기를 늘리거나 줄이는 방법을 보여줍니다.                                 | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | 프로그램 내에서 rent 요구사항을 계산하는 방법을 배웁니다.                             | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | 프로그램 레이아웃을 구성하는 방법에 대한 권장사항입니다.                              | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | 시스템 계정과 PDA에서 SOL을 전송하는 다양한 방법입니다.                               | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | 계정에 이름, 번지수, 거리, 도시가 포함된 주소를 저장합니다.                           | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | 계정 검사를 수행하는 방법을 보여주는 보안 강의                                        | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | rent를 돌려받기 위해 계정을 닫는 방법을 보여줍니다.                                   | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | 다양한 아키텍처로 구현된 간단한 카운터 프로그램입니다.                                | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | 프로그램 내에서 시스템 계정을 생성하는 방법입니다.                                    | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | 손과 레버 비유를 사용하여 프로그램 내에서 다른 프로그램을 호출하는 방법을 보여줍니다. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | 트랜잭션 로그에 hello world를 출력하는 Hello world 예제입니다.                        | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | PDA의 lamport를 사용하여 새 계정 비용을 지불하는 방법을 보여줍니다.                   | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | instruction data 문자열과 u32를 처리하는 방법을 보여줍니다.                           | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | 시드를 사용하여 PDA를 참조하고 데이터를 저장하는 방법을 보여줍니다.                   | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | 기존 계정의 크기를 늘리거나 줄이는 방법을 보여줍니다.                                 | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | 프로그램 레이아웃을 구성하는 방법에 대한 권장사항입니다.                              | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | 시스템 계정과 PDA에서 SOL을 전송하는 다양한 방법입니다.                               | Native, Anchor, Seahorse  |
 
 ## 토큰
 
@@ -55,13 +54,12 @@ Solana의 대부분의 토큰은 Solana Program Library(SPL) 토큰 표준을 �
 
 | 예제 이름                                                                                                  | 설명                                                                               | 언어           |
 | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------------- |
-| [토큰 생성](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)           | 토큰을 생성하고 Metaplex 메타데이터를 추가하는 방법.                               | Anchor, Native |
-| [NFT 민터](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)              | 토큰을 하나만 민팅한 후 민트 권한을 제거하는 방법.                                 | Anchor, Native |
-| [PDA 민트 권한](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | 민트의 민트 권한을 변경하여 프로그램 내에서 토큰을 민팅하는 방법.                  | Anchor, Native |
-| [SPL Token 민터](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)  | associated token account를 사용하여 token account를 추적하는 방법.                 | Anchor, Native |
-| [토큰 스왑](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)             | SPL 토큰을 위한 AMM(자동화된 시장 조성자) 풀을 구축하는 방법을 보여주는 심화 예제. | Anchor         |
-| [토큰 전송](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)        | Token Program으로의 CPI를 사용하여 SPL 토큰을 전송하는 방법.                       | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)            | Token 2022(Token Extensions) 참조.                                                 | Anchor, Native |
+| [토큰 생성](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)           | 토큰을 생성하고 Metaplex 메타데이터를 추가하는 방법.                               | Anchor, Native |
+| [NFT 민터](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)              | 토큰을 하나만 민팅한 후 민트 권한을 제거하는 방법.                                 | Anchor, Native |
+| [PDA 민트 권한](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | 민트의 민트 권한을 변경하여 프로그램 내에서 토큰을 민팅하는 방법.                  | Anchor, Native |
+| [토큰 스왑](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)             | SPL 토큰을 위한 AMM(자동화된 시장 조성자) 풀을 구축하는 방법을 보여주는 심화 예제. | Anchor         |
+| [토큰 전송](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)        | Token Program으로의 CPI를 사용하여 SPL 토큰을 전송하는 방법.                       | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)            | Token 2022(Token Extensions) 참조.                                                 | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -72,14 +70,14 @@ Token 2022는 Solana의 새로운 토큰 표준입니다. 더욱 유연한 구�
 
 | 예제 이름                                                                                                                        | 설명                                                                                    | 언어           |
 | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- | -------------- |
-| [기본](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                          | 토큰을 생성하고 민팅하며 전송하는 방법.                                                 | Anchor         |
-| [기본 계정 상태](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state)        | 이 확장 기능을 사용하면 특정 상태(예: 동결 상태)로 token account를 생성할 수 있습니다.  | Anchor, Native |
-| [민트 종료 권한](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)         | 기존 Token Program에서는 민트를 종료할 수 없었지만, 이제는 가능합니다.                  | Anchor, Native |
-| [다중 확장](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)               | 단일 민트에 여러 Token Extensions을 추가하는 방법.                                      | Native         |
-| [NFT 메타데이터 포인터](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer) | 메타데이터 확장을 사용하여 NFT를 생성하고 동적 온체인 메타데이터를 추가하는 방법.       | Anchor         |
-| [전송 불가](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)                  | 업적, 추천 프로그램 또는 소울바운드 토큰 등에 유용합니다.                               | Anchor, Native |
-| [전송 수수료](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                    | 토큰을 전송할 때마다 일부 토큰이 token account에 보류되며, 이후 수집할 수 있습니다.     | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Token Program에서 프로그램으로의 CPI를 활용하여 토큰에 추가 기능을 부여하는 4가지 예제. | Anchor         |
+| [기본](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                          | 토큰을 생성하고 민팅하며 전송하는 방법.                                                 | Anchor         |
+| [기본 계정 상태](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state)        | 이 확장 기능을 사용하면 특정 상태(예: 동결 상태)로 token account를 생성할 수 있습니다.  | Anchor, Native |
+| [민트 종료 권한](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)         | 기존 Token Program에서는 민트를 종료할 수 없었지만, 이제는 가능합니다.                  | Anchor, Native |
+| [다중 확장](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)               | 단일 민트에 여러 Token Extensions을 추가하는 방법.                                      | Native         |
+| [NFT 메타데이터 포인터](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer) | 메타데이터 확장을 사용하여 NFT를 생성하고 동적 온체인 메타데이터를 추가하는 방법.       | Anchor         |
+| [전송 불가](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)                  | 업적, 추천 프로그램 또는 소울바운드 토큰 등에 유용합니다.                               | Anchor, Native |
+| [전송 수수료](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                    | 토큰을 전송할 때마다 일부 토큰이 token account에 보류되며, 이후 수집할 수 있습니다.     | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Token Program에서 프로그램으로의 CPI를 활용하여 토큰에 추가 기능을 부여하는 4가지 예제. | Anchor         |
 
 ## 에코시스템 Solana 프로그램 예제
 

--- a/apps/docs/content/docs/nl/programs/examples.mdx
+++ b/apps/docs/content/docs/nl/programs/examples.mdx
@@ -7,12 +7,12 @@ description:
 ---
 
 De
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 repository op GitHub biedt verschillende submappen, elk met codevoorbeelden om
 ontwikkelaars te helpen bij het leren en experimenteren met Solana
 blockchain-ontwikkeling.
 
-Je kunt de voorbeelden vinden in de `solana-developers/program-examples` samen
+Je kunt de voorbeelden vinden in de `solana-foundation/program-examples` samen
 met README-bestanden die uitleggen hoe je de verschillende voorbeelden kunt
 uitvoeren. De meeste voorbeelden zijn op zichzelf staand en zijn beschikbaar in
 native Rust (d.w.z. zonder framework) en
@@ -37,20 +37,19 @@ Solana-programmering te begrijpen.
 
 | Voorbeeldnaam                                                                                                                 | Beschrijving                                                                                                     | Taal                      |
 | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Een adres opslaan met naam, huisnummer, straat en stad in een account.                                           | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Beveiligingslessen die laten zien hoe je accountcontroles uitvoert                                               | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Laat zien hoe je accounts kunt sluiten om de rent terug te krijgen.                                              | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Een eenvoudig tellerprogramma in alle verschillende architecturen.                                               | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Hoe je een systeemaccount aanmaakt binnen een programma.                                                         | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Met behulp van een hand-en-hefboomanalogietoont dit je hoe je een ander programma aanroept vanuit een programma. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Hello world-voorbeeld dat alleen hello world afdrukt in de transactielogboeken.                                  | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Laat zien hoe je de lamports van een PDA kunt gebruiken om een nieuw account te betalen.                         | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Laat zien hoe je instruction data van het type string en u32 verwerkt.                                           | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Laat zien hoe je seeds gebruikt om te verwijzen naar een PDA en gegevens daarin op te slaan.                     | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Laat zien hoe je de grootte van een bestaand account kunt vergroten en verkleinen.                               | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Hier leer je hoe je rent-vereisten berekent binnen een programma.                                                | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Aanbevelingen voor het structureren van je programma-indeling.                                                   | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Verschillende methoden voor het overdragen van SOL voor systeemaccounts en PDA's.                                | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Een adres opslaan met naam, huisnummer, straat en stad in een account.                                           | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Beveiligingslessen die laten zien hoe je accountcontroles uitvoert                                               | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Laat zien hoe je accounts kunt sluiten om de rent terug te krijgen.                                              | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Een eenvoudig tellerprogramma in alle verschillende architecturen.                                               | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Hoe je een systeemaccount aanmaakt binnen een programma.                                                         | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Met behulp van een hand-en-hefboomanalogietoont dit je hoe je een ander programma aanroept vanuit een programma. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Hello world-voorbeeld dat alleen hello world afdrukt in de transactielogboeken.                                  | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Laat zien hoe je de lamports van een PDA kunt gebruiken om een nieuw account te betalen.                         | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Laat zien hoe je instruction data van het type string en u32 verwerkt.                                           | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Laat zien hoe je seeds gebruikt om te verwijzen naar een PDA en gegevens daarin op te slaan.                     | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Laat zien hoe je de grootte van een bestaand account kunt vergroten en verkleinen.                               | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Aanbevelingen voor het structureren van je programma-indeling.                                                   | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Verschillende methoden voor het overdragen van SOL voor systeemaccounts en PDA's.                                | Native, Anchor, Seahorse  |
 
 ## Tokens
 
@@ -60,13 +59,12 @@ overdragen en verbranden, en zelfs hoe je er mee kunt werken in programma's.
 
 | Voorbeeldnaam                                                                                                   | Beschrijving                                                                                             | Taal           |
 | --------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- | -------------- |
-| [Token aanmaken](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)           | Hoe je een token aanmaakt en Metaplex-metadata toevoegt.                                                 | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Slechts één exemplaar van een token minten en vervolgens de mint-autoriteit verwijderen.                 | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Laat zien hoe je de mint-autoriteit van een mint kunt wijzigen om tokens vanuit een programma te minten. | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Legt uit hoe je Associated Token Accounts gebruikt om token accounts bij te houden.                      | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Uitgebreid voorbeeld dat laat zien hoe je een AMM (automated market maker) pool bouwt voor SPL-tokens.   | Anchor         |
-| [Tokens overdragen](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)     | Laat zien hoe je SPL-tokens overdraagt via CPI's naar het Token Program.                                 | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Zie Token 2022 (Token extensions).                                                                       | Anchor, Native |
+| [Token aanmaken](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)           | Hoe je een token aanmaakt en Metaplex-metadata toevoegt.                                                 | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Slechts één exemplaar van een token minten en vervolgens de mint-autoriteit verwijderen.                 | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Laat zien hoe je de mint-autoriteit van een mint kunt wijzigen om tokens vanuit een programma te minten. | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Uitgebreid voorbeeld dat laat zien hoe je een AMM (automated market maker) pool bouwt voor SPL-tokens.   | Anchor         |
+| [Tokens overdragen](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)     | Laat zien hoe je SPL-tokens overdraagt via CPI's naar het Token Program.                                 | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Zie Token 2022 (Token extensions).                                                                       | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -77,14 +75,14 @@ de [Aan de slag-gids](/docs/tokens/extensions)
 
 | Voorbeeldnaam                                                                                                                      | Beschrijving                                                                                                                   | Taal           |
 | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | -------------- |
-| [Basisprincipes](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                  | Hoe je een token aanmaakt, mint en overdraagt.                                                                                 | Anchor         |
-| [Standaard accountstatus](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Met deze extensie kun je token accounts aanmaken met een bepaalde status, bijvoorbeeld bevroren.                               | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)     | Met het oude Token Program was het niet mogelijk een mint te sluiten. Nu wel.                                                  | Anchor, Native |
-| [Meerdere extensies](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)        | Laat zien hoe je meerdere extensies aan één enkele mint kunt toevoegen.                                                        | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)    | Het is mogelijk de metadata-extensie te gebruiken om NFT's aan te maken en dynamische on-chain metadata toe te voegen.         | Anchor         |
-| [Niet-overdraagbaar](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Handig voor bijvoorbeeld prestaties, verwijzingsprogramma's of soulbound tokens.                                               | Anchor, Native |
-| [Overdrachtskosten](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                | Bij elke overdracht worden tokens achtergehouden in het token account, die vervolgens kunnen worden opgehaald.                 | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                   | Vier voorbeelden om extra functionaliteit aan je token toe te voegen via een CPI vanuit het Token Program naar jouw programma. | Anchor         |
+| [Basisprincipes](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                  | Hoe je een token aanmaakt, mint en overdraagt.                                                                                 | Anchor         |
+| [Standaard accountstatus](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Met deze extensie kun je token accounts aanmaken met een bepaalde status, bijvoorbeeld bevroren.                               | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)     | Met het oude Token Program was het niet mogelijk een mint te sluiten. Nu wel.                                                  | Anchor, Native |
+| [Meerdere extensies](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)        | Laat zien hoe je meerdere extensies aan één enkele mint kunt toevoegen.                                                        | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)    | Het is mogelijk de metadata-extensie te gebruiken om NFT's aan te maken en dynamische on-chain metadata toe te voegen.         | Anchor         |
+| [Niet-overdraagbaar](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Handig voor bijvoorbeeld prestaties, verwijzingsprogramma's of soulbound tokens.                                               | Anchor, Native |
+| [Overdrachtskosten](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                | Bij elke overdracht worden tokens achtergehouden in het token account, die vervolgens kunnen worden opgehaald.                 | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                   | Vier voorbeelden om extra functionaliteit aan je token toe te voegen via een CPI vanuit het Token Program naar jouw programma. | Anchor         |
 
 ## Ecosysteem Solana-programmavoorbeelden
 

--- a/apps/docs/content/docs/pl/programs/examples.mdx
+++ b/apps/docs/content/docs/pl/programs/examples.mdx
@@ -6,11 +6,11 @@ description:
 ---
 
 Repozytorium
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 na GitHubie zawiera kilka podfolderów, z których każdy zawiera przykłady kodu,
 aby pomóc deweloperom w nauce i eksperymentowaniu z rozwojem blockchaina Solana.
 
-Przykłady znajdziesz w `solana-developers/program-examples` wraz z plikami
+Przykłady znajdziesz w `solana-foundation/program-examples` wraz z plikami
 README, które wyjaśniają, jak uruchomić poszczególne przykłady. Większość
 przykładów jest samodzielna i dostępna w natywnym Rust (czyli bez frameworka)
 oraz z użyciem Anchor ([Anchor](https://www.anchor-lang.com/docs/installation)).
@@ -34,20 +34,19 @@ programowania na Solanie.
 
 | Nazwa przykładu                                                                                                               | Opis                                                                                           | Język                     |
 | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Zapisywanie adresu z imieniem, numerem domu, ulicą i miastem na koncie.                        | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Lekcje bezpieczeństwa pokazujące, jak przeprowadzać weryfikację kont.                          | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Pokazuje, jak zamknąć konta, aby odzyskać ich rent.                                            | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Prosty program licznika we wszystkich różnych architekturach.                                  | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Jak utworzyć konto systemowe w ramach programu.                                                | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Na przykładzie analogii dłoni i dźwigni pokazuje, jak wywołać inny program z poziomu programu. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Przykład „hello world“, który wypisuje hello world w logach transakcji.                        | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Pokazuje, jak można użyć lamport z PDA do opłacenia nowego konta.                              | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Pokazuje, jak obsługiwać instruction data w postaci ciągu znaków i u32.                        | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Pokazuje, jak używać seedów do odwoływania się do PDA i zapisywania w nim danych.              | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Pokazuje, jak zwiększać i zmniejszać rozmiar istniejącego konta.                               | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Tutaj dowiesz się, jak obliczać wymagania dotyczące rent w ramach programu.                    | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Zalecenia dotyczące strukturyzowania układu programu.                                          | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Różne metody transferu SOL dla kont systemowych i PDA.                                         | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Zapisywanie adresu z imieniem, numerem domu, ulicą i miastem na koncie.                        | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Lekcje bezpieczeństwa pokazujące, jak przeprowadzać weryfikację kont.                          | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Pokazuje, jak zamknąć konta, aby odzyskać ich rent.                                            | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Prosty program licznika we wszystkich różnych architekturach.                                  | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Jak utworzyć konto systemowe w ramach programu.                                                | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Na przykładzie analogii dłoni i dźwigni pokazuje, jak wywołać inny program z poziomu programu. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Przykład „hello world“, który wypisuje hello world w logach transakcji.                        | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Pokazuje, jak można użyć lamport z PDA do opłacenia nowego konta.                              | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Pokazuje, jak obsługiwać instruction data w postaci ciągu znaków i u32.                        | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Pokazuje, jak używać seedów do odwoływania się do PDA i zapisywania w nim danych.              | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Pokazuje, jak zwiększać i zmniejszać rozmiar istniejącego konta.                               | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Zalecenia dotyczące strukturyzowania układu programu.                                          | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Różne metody transferu SOL dla kont systemowych i PDA.                                         | Native, Anchor, Seahorse  |
 
 ## Tokeny
 
@@ -57,13 +56,12 @@ przesyłania i spalania tokenów, a także interakcji z nimi w programach.
 
 | Nazwa przykładu                                                                                                 | Opis                                                                                             | Język          |
 | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | Jak utworzyć token i dodać do niego metadane Metaplex.                                           | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Tworzenie dokładnie jednej jednostki tokena, a następnie usunięcie uprawnień do mintowania.      | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Pokazuje, jak zmienić uprawnienia mintowania, aby mintować tokeny z poziomu programu.            | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Wyjaśnia, jak używać Associated Token Accounts do śledzenia token accounts.                      | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Rozbudowany przykład pokazujący, jak zbudować pulę AMM (automated market maker) dla tokenów SPL. | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Pokazuje, jak przesyłać tokeny SPL przy użyciu CPI do token program.                             | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Zobacz Token 2022 (Token extensions).                                                            | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | Jak utworzyć token i dodać do niego metadane Metaplex.                                           | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Tworzenie dokładnie jednej jednostki tokena, a następnie usunięcie uprawnień do mintowania.      | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Pokazuje, jak zmienić uprawnienia mintowania, aby mintować tokeny z poziomu programu.            | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Rozbudowany przykład pokazujący, jak zbudować pulę AMM (automated market maker) dla tokenów SPL. | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Pokazuje, jak przesyłać tokeny SPL przy użyciu CPI do token program.                             | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Zobacz Token 2022 (Token extensions).                                                            | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -74,14 +72,14 @@ dodatkowe funkcjonalności. Pełna lista rozszerzeń znajduje się w
 
 | Nazwa przykładu                                                                                                                  | Opis                                                                                                                 | Język          |
 | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Jak utworzyć token, mintować go i przesyłać.                                                                         | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | To rozszerzenie pozwala tworzyć token accounts w określonym stanie, na przykład zamrożonym.                          | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | W starym Token Program zamknięcie mintu nie było możliwe. Teraz jest.                                                | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Pokazuje, jak dodać wiele rozszerzeń do jednego mintu.                                                               | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Możliwe jest użycie rozszerzenia metadanych do tworzenia NFT i dodawania dynamicznych metadanych on-chain.           | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Przydatne na przykład dla osiągnięć, programów poleceń lub tokenów soul bound.                                       | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Każdy transfer tokenów zatrzymuje pewną ich ilość w token account, która następnie może zostać odebrana.             | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Cztery przykłady dodawania dodatkowej funkcjonalności do tokena przy użyciu CPI z Token Program do Twojego programu. | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Jak utworzyć token, mintować go i przesyłać.                                                                         | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | To rozszerzenie pozwala tworzyć token accounts w określonym stanie, na przykład zamrożonym.                          | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | W starym Token Program zamknięcie mintu nie było możliwe. Teraz jest.                                                | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Pokazuje, jak dodać wiele rozszerzeń do jednego mintu.                                                               | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | Możliwe jest użycie rozszerzenia metadanych do tworzenia NFT i dodawania dynamicznych metadanych on-chain.           | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Przydatne na przykład dla osiągnięć, programów poleceń lub tokenów soul bound.                                       | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | Każdy transfer tokenów zatrzymuje pewną ich ilość w token account, która następnie może zostać odebrana.             | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Cztery przykłady dodawania dodatkowej funkcjonalności do tokena przy użyciu CPI z Token Program do Twojego programu. | Anchor         |
 
 ## Przykłady programów Solana w ekosystemie
 

--- a/apps/docs/content/docs/pt/programs/examples.mdx
+++ b/apps/docs/content/docs/pt/programs/examples.mdx
@@ -7,12 +7,12 @@ description:
 ---
 
 O repositório
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 no GitHub oferece várias subpastas, cada uma contendo exemplos de código para
 ajudar desenvolvedores a aprender e experimentar o desenvolvimento na blockchain
 Solana.
 
-Você pode encontrar os exemplos no `solana-developers/program-examples` junto
+Você pode encontrar os exemplos no `solana-foundation/program-examples` junto
 com arquivos README que explicam como executar os diferentes exemplos. A maioria
 dos exemplos é independente e está disponível em Rust nativo (ou seja, sem
 framework) e [Anchor](https://www.anchor-lang.com/docs/installation).
@@ -36,20 +36,19 @@ da programação em Solana.
 
 | Nome do Exemplo                                                                                                               | Descrição                                                                                                   | Linguagem                 |
 | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Guardar um endereço com nome, número de casa, rua e cidade numa conta.                                      | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Lições de segurança que mostram como realizar verificações de contas                                        | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Mostra como encerrar contas para recuperar o rent.                                                          | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Um programa de contador simples em todas as diferentes arquiteturas.                                        | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Como criar uma conta do sistema dentro de um programa.                                                      | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Usando uma analogia de mão e alavanca, mostra como chamar outro programa a partir de dentro de um programa. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Exemplo de hello world que apenas imprime hello world nos logs de transação.                                | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Mostra como usar os lamport de um PDA para pagar por uma nova conta.                                        | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Mostra como processar instruction data do tipo string e u32.                                                | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Mostra como usar seeds para referenciar um PDA e guardar dados nele.                                        | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Mostra como aumentar e diminuir o tamanho de uma conta existente.                                           | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Aqui você aprenderá como calcular os requisitos de rent dentro de um programa.                              | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Recomendações sobre como estruturar o layout do seu programa.                                               | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Diferentes métodos de transferência de SOL para contas do sistema e PDAs.                                   | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Guardar um endereço com nome, número de casa, rua e cidade numa conta.                                      | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Lições de segurança que mostram como realizar verificações de contas                                        | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Mostra como encerrar contas para recuperar o rent.                                                          | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Um programa de contador simples em todas as diferentes arquiteturas.                                        | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Como criar uma conta do sistema dentro de um programa.                                                      | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Usando uma analogia de mão e alavanca, mostra como chamar outro programa a partir de dentro de um programa. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Exemplo de hello world que apenas imprime hello world nos logs de transação.                                | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Mostra como usar os lamport de um PDA para pagar por uma nova conta.                                        | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Mostra como processar instruction data do tipo string e u32.                                                | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Mostra como usar seeds para referenciar um PDA e guardar dados nele.                                        | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Mostra como aumentar e diminuir o tamanho de uma conta existente.                                           | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Recomendações sobre como estruturar o layout do seu programa.                                               | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Diferentes métodos de transferência de SOL para contas do sistema e PDAs.                                   | Native, Anchor, Seahorse  |
 
 ## Tokens
 
@@ -59,13 +58,12 @@ queimar tokens, além de como interagir com eles em programas.
 
 | Nome do Exemplo                                                                                                 | Descrição                                                                                             | Linguagem      |
 | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | Como criar um token e adicionar metadados do Metaplex a ele.                                          | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Criação de apenas uma unidade de um token e remoção da autoridade de emissão.                         | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Demonstra como alterar a autoridade de emissão de um mint para emitir tokens a partir de um programa. | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Explica como usar associated token accounts para rastrear token accounts.                             | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Exemplo extenso que mostra como construir um pool AMM (automated market maker) para tokens SPL.       | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Demonstra como transferir tokens SPL usando CPIs para o token program.                                | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Veja Token 2022 (Token extensions).                                                                   | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | Como criar um token e adicionar metadados do Metaplex a ele.                                          | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Criação de apenas uma unidade de um token e remoção da autoridade de emissão.                         | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Demonstra como alterar a autoridade de emissão de um mint para emitir tokens a partir de um programa. | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Exemplo extenso que mostra como construir um pool AMM (automated market maker) para tokens SPL.       | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Demonstra como transferir tokens SPL usando CPIs para o token program.                                | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Veja Token 2022 (Token extensions).                                                                   | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -76,14 +74,14 @@ funcionalidade. Uma lista completa das extensões pode ser encontrada no
 
 | Nome do Exemplo                                                                                                                  | Descrição                                                                                                               | Linguagem      |
 | -------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Como criar um token, emiti-lo e transferi-lo.                                                                           | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Esta extensão permite criar token accounts com um determinado estado, por exemplo, congeladas.                          | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Com o antigo token program não era possível fechar um mint. Agora é possível.                                           | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Demonstra como adicionar múltiplas extensões a um único mint.                                                           | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | É possível usar a extensão de metadados para criar NFTs e adicionar metadados dinâmicos on-chain.                       | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Útil, por exemplo, para conquistas, programas de indicação ou tokens vinculados à alma (soul bound tokens).             | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | A cada transferência dos tokens, uma parte é retida na token account e pode ser coletada posteriormente.                | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Quatro exemplos para adicionar funcionalidades extras ao seu token usando uma CPI do token program para o seu programa. | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Como criar um token, emiti-lo e transferi-lo.                                                                           | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Esta extensão permite criar token accounts com um determinado estado, por exemplo, congeladas.                          | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | Com o antigo token program não era possível fechar um mint. Agora é possível.                                           | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Demonstra como adicionar múltiplas extensões a um único mint.                                                           | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | É possível usar a extensão de metadados para criar NFTs e adicionar metadados dinâmicos on-chain.                       | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Útil, por exemplo, para conquistas, programas de indicação ou tokens vinculados à alma (soul bound tokens).             | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | A cada transferência dos tokens, uma parte é retida na token account e pode ser coletada posteriormente.                | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Quatro exemplos para adicionar funcionalidades extras ao seu token usando uma CPI do token program para o seu programa. | Anchor         |
 
 ## Exemplos de programas Solana do ecossistema
 

--- a/apps/docs/content/docs/ru/programs/examples.mdx
+++ b/apps/docs/content/docs/ru/programs/examples.mdx
@@ -7,12 +7,12 @@ description:
 ---
 
 Репозиторий
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 на GitHub предлагает несколько подпапок, каждая из которых содержит примеры
 кода, чтобы помочь разработчикам изучать и экспериментировать с разработкой на
 блокчейне Solana.
 
-Вы можете найти примеры в `solana-developers/program-examples` вместе с файлами
+Вы можете найти примеры в `solana-foundation/program-examples` вместе с файлами
 README, которые объясняют, как запускать различные примеры. Большинство примеров
 являются самостоятельными и доступны как на чистом Rust (то есть без
 фреймворков), так и с использованием Anchor.
@@ -35,20 +35,19 @@ Solana.
 
 | Название примера                                                                                                              | Описание                                                                          | Язык                      |
 | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Сохранение адреса с именем, номером дома, улицей и городом в аккаунте.            | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Уроки по безопасности, показывающие как выполнять проверки аккаунтов.             | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Показывает, как закрывать аккаунты для возврата rent.                             | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Простая программа-счётчик во всех различных архитектурах.                         | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Как создать системный аккаунт внутри программы.                                   | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | На аналогии с рукой и рычагом показывает, как вызвать одну программу из другой.   | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Пример «Hello World», который просто выводит «hello world» в логах транзакции.    | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Показывает, как использовать lamport из PDA для оплаты нового аккаунта.           | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Показывает, как обрабатывать instruction data типов string и u32.                 | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Показывает, как использовать seeds для обращения к PDA и сохранения в нём данных. | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Показывает, как увеличивать и уменьшать размер существующего аккаунта.            | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Здесь вы узнаете, как рассчитывать требования к rent внутри программы.            | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Рекомендации по структурированию макета вашей программы.                          | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Различные методы перевода SOL для системных аккаунтов и PDA.                      | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Сохранение адреса с именем, номером дома, улицей и городом в аккаунте.            | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Уроки по безопасности, показывающие как выполнять проверки аккаунтов.             | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Показывает, как закрывать аккаунты для возврата rent.                             | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Простая программа-счётчик во всех различных архитектурах.                         | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Как создать системный аккаунт внутри программы.                                   | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | На аналогии с рукой и рычагом показывает, как вызвать одну программу из другой.   | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Пример «Hello World», который просто выводит «hello world» в логах транзакции.    | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Показывает, как использовать lamport из PDA для оплаты нового аккаунта.           | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Показывает, как обрабатывать instruction data типов string и u32.                 | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Показывает, как использовать seeds для обращения к PDA и сохранения в нём данных. | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Показывает, как увеличивать и уменьшать размер существующего аккаунта.            | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Рекомендации по структурированию макета вашей программы.                          | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Различные методы перевода SOL для системных аккаунтов и PDA.                      | Native, Anchor, Seahorse  |
 
 ## Токены
 
@@ -58,13 +57,12 @@ Program Library (SPL). Здесь вы найдёте множество при�
 
 | Название примера                                                                                                | Описание                                                                                            | Язык           |
 | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | Как создать токен и добавить к нему метаданные Metaplex.                                            | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Выпуск единственного экземпляра токена с последующим удалением права на эмиссию.                    | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Показывает, как изменить право на эмиссию минта для выпуска токенов внутри программы.               | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Объясняет, как использовать Associated Token Accounts для отслеживания token accounts.              | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Подробный пример, показывающий, как создать пул AMM (автоматический маркет-мейкер) для SPL-токенов. | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Показывает, как переводить SPL-токены с помощью CPI в token program.                                | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | См. Token 2022 (Token extensions).                                                                  | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | Как создать токен и добавить к нему метаданные Metaplex.                                            | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Выпуск единственного экземпляра токена с последующим удалением права на эмиссию.                    | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Показывает, как изменить право на эмиссию минта для выпуска токенов внутри программы.               | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Подробный пример, показывающий, как создать пул AMM (автоматический маркет-мейкер) для SPL-токенов. | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Показывает, как переводить SPL-токены с помощью CPI в token program.                                | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | См. Token 2022 (Token extensions).                                                                  | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -75,14 +73,14 @@ Token 2022 — это новый стандарт токенов на Solana. О
 
 | Название примера                                                                                                                 | Описание                                                                                                                   | Язык           |
 | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Как создать токен, выпустить и передать его.                                                                               | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Это расширение позволяет создавать token accounts с определённым состоянием, например замороженным.                        | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | В старом Token Program закрыть минт было невозможно. Теперь это стало возможным.                                           | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Показывает, как добавить несколько расширений к одному минту.                                                              | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | С помощью расширения метаданных можно создавать NFT и добавлять динамические метаданные прямо в блокчейн.                  | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Полезно, например, для достижений, реферальных программ или привязанных к душе (soul bound) токенов.                       | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | При каждой передаче токенов часть из них удерживается в token account, откуда их впоследствии можно собрать.               | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Четыре примера добавления дополнительной функциональности к токену с использованием CPI из Token Program в вашу программу. | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Как создать токен, выпустить и передать его.                                                                               | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Это расширение позволяет создавать token accounts с определённым состоянием, например замороженным.                        | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | В старом Token Program закрыть минт было невозможно. Теперь это стало возможным.                                           | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Показывает, как добавить несколько расширений к одному минту.                                                              | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | С помощью расширения метаданных можно создавать NFT и добавлять динамические метаданные прямо в блокчейн.                  | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Полезно, например, для достижений, реферальных программ или привязанных к душе (soul bound) токенов.                       | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | При каждой передаче токенов часть из них удерживается в token account, откуда их впоследствии можно собрать.               | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Четыре примера добавления дополнительной функциональности к токену с использованием CPI из Token Program в вашу программу. | Anchor         |
 
 ## Примеры программ экосистемы Solana
 

--- a/apps/docs/content/docs/tr/programs/examples.mdx
+++ b/apps/docs/content/docs/tr/programs/examples.mdx
@@ -7,13 +7,13 @@ description:
 ---
 
 GitHub'daki
-[Solana Program Örnekleri](https://github.com/solana-developers/program-examples)
+[Solana Program Örnekleri](https://github.com/solana-foundation/program-examples)
 deposu, geliştiricilerin Solana blok zinciri geliştirmesini öğrenmelerine ve
 denemelerine yardımcı olmak için kod örnekleri içeren çeşitli alt klasörler
 sunar.
 
 Örnekleri, farklı örneklerin nasıl çalıştırılacağını açıklayan README
-dosyalarıyla birlikte `solana-developers/program-examples` içinde
+dosyalarıyla birlikte `solana-foundation/program-examples` içinde
 bulabilirsiniz. Çoğu örnek bağımsızdır ve yerel Rust'ta (yani herhangi bir
 framework olmadan) ve [Anchor](https://www.anchor-lang.com/docs/installation)
 ile mevcuttur.
@@ -37,20 +37,19 @@ tasarlanmıştır.
 
 | Örnek Adı                                                                                                                     | Açıklama                                                                                                              | Dil                       |
 | ----------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Bir hesapta ad, bina numarası, sokak ve şehir bilgilerini kaydetme.                                                   | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Hesap kontrollerinin nasıl yapılacağını gösteren güvenlik dersleri                                                    | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | rent geri almak için hesapların nasıl kapatılacağını gösterir.                                                        | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Tüm farklı mimarilerde basit bir sayaç programı.                                                                      | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Bir program içinde sistem hesabının nasıl oluşturulacağı.                                                             | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | El ve kaldıraç analojisini kullanarak bir program içinden başka bir programın nasıl çağrılacağını gösterir.           | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | İşlem günlüklerine sadece "hello world" yazdıran merhaba dünya örneği.                                                | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Yeni bir hesap için ödeme yapmak amacıyla bir PDA'daki lamport'ların nasıl kullanılabileceğini gösterir.              | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | instruction data dizisi ve u32'nin nasıl işleneceğini gösterir.                                                       | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Bir Program Derived Address'e atıfta bulunmak ve içine veri kaydetmek için tohumların nasıl kullanılacağını gösterir. | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Mevcut bir hesabın boyutunu nasıl artıracağınızı ve azaltacağınızı gösterir.                                          | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Burada bir program içinde rent gereksinimlerinin nasıl hesaplanacağını öğreneceksiniz.                                | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Program düzeninizi nasıl yapılandıracağınıza dair öneriler.                                                           | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Sistem hesapları ve PDA'lar için SOL transferinin farklı yöntemleri.                                                  | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Bir hesapta ad, bina numarası, sokak ve şehir bilgilerini kaydetme.                                                   | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Hesap kontrollerinin nasıl yapılacağını gösteren güvenlik dersleri                                                    | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | rent geri almak için hesapların nasıl kapatılacağını gösterir.                                                        | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Tüm farklı mimarilerde basit bir sayaç programı.                                                                      | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Bir program içinde sistem hesabının nasıl oluşturulacağı.                                                             | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | El ve kaldıraç analojisini kullanarak bir program içinden başka bir programın nasıl çağrılacağını gösterir.           | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | İşlem günlüklerine sadece "hello world" yazdıran merhaba dünya örneği.                                                | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Yeni bir hesap için ödeme yapmak amacıyla bir PDA'daki lamport'ların nasıl kullanılabileceğini gösterir.              | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | instruction data dizisi ve u32'nin nasıl işleneceğini gösterir.                                                       | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Bir Program Derived Address'e atıfta bulunmak ve içine veri kaydetmek için tohumların nasıl kullanılacağını gösterir. | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Mevcut bir hesabın boyutunu nasıl artıracağınızı ve azaltacağınızı gösterir.                                          | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Program düzeninizi nasıl yapılandıracağınıza dair öneriler.                                                           | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Sistem hesapları ve PDA'lar için SOL transferinin farklı yöntemleri.                                                  | Native, Anchor, Seahorse  |
 
 ## Token'lar
 
@@ -61,13 +60,12 @@ bulabilirsiniz.
 
 | Örnek Adı                                                                                                     | Açıklama                                                                                                       | Dil            |
 | ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Token Oluşturma](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)        | Bir token nasıl oluşturulur ve üzerine metaplex metadata nasıl eklenir.                                        | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)               | Bir token'dan yalnızca bir adet basma ve ardından mint yetkisini kaldırma.                                     | Anchor, Native |
-| [PDA Mint Yetkisi](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Bir mint'in mint yetkisini değiştirerek program içinden token basımının nasıl yapılacağını gösterir.           | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)   | token account'ları takip edebilmek için Associated Token Accounts'un nasıl kullanılacağını açıklar.            | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)               | SPL token'ları için bir AMM (otomatik piyasa yapıcı) havuzunun nasıl oluşturulacağını gösteren kapsamlı örnek. | Anchor         |
-| [Token Transfer](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)      | Token programına CPI kullanarak SPL token transferinin nasıl yapılacağını gösterir.                            | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)               | Token 2022 (Token extensions) konusuna bakınız.                                                                | Anchor, Native |
+| [Token Oluşturma](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)        | Bir token nasıl oluşturulur ve üzerine metaplex metadata nasıl eklenir.                                        | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)               | Bir token'dan yalnızca bir adet basma ve ardından mint yetkisini kaldırma.                                     | Anchor, Native |
+| [PDA Mint Yetkisi](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Bir mint'in mint yetkisini değiştirerek program içinden token basımının nasıl yapılacağını gösterir.           | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)               | SPL token'ları için bir AMM (otomatik piyasa yapıcı) havuzunun nasıl oluşturulacağını gösteren kapsamlı örnek. | Anchor         |
+| [Token Transfer](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)      | Token programına CPI kullanarak SPL token transferinin nasıl yapılacağını gösterir.                            | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)               | Token 2022 (Token extensions) konusuna bakınız.                                                                | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -78,14 +76,14 @@ uzantı eklemenize olanak tanır. Uzantıların tam listesine
 
 | Örnek Adı                                                                                                                          | Açıklama                                                                                                      | Dil            |
 | ---------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Temel Bilgiler](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                  | Token nasıl oluşturulur, basılır ve transfer edilir.                                                          | Anchor         |
-| [Varsayılan Hesap Durumu](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Bu uzantı, belirli bir durumda (örneğin dondurulmuş) token account'ları oluşturmanıza olanak tanır.           | Anchor, Native |
-| [Mint Kapatma Yetkisi](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)     | Eski token program ile bir mint'i kapatmak mümkün değildi. Artık mümkün.                                      | Anchor, Native |
-| [Çoklu Uzantılar](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)           | Tek bir mint'e birden fazla uzantının nasıl eklenebileceğini gösterir.                                        | Native         |
-| [NFT Metadata İşaretçisi](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer) | Metadata uzantısını kullanarak NFT oluşturmak ve dinamik zincir üstü metadata eklemek mümkündür.              | Anchor         |
-| [Transfer Edilemez](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)            | Başarımlar, referans programları veya soul bound token'lar gibi kullanım senaryoları için idealdir.           | Anchor, Native |
-| [Transfer Ücreti](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                  | Her token transferinde bir miktar token, token account içinde tutulur ve daha sonra toplanabilir.             | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                   | Token programından programınıza CPI kullanarak token'ınıza ek işlevsellik kazandırmak için dört farklı örnek. | Anchor         |
+| [Temel Bilgiler](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                  | Token nasıl oluşturulur, basılır ve transfer edilir.                                                          | Anchor         |
+| [Varsayılan Hesap Durumu](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Bu uzantı, belirli bir durumda (örneğin dondurulmuş) token account'ları oluşturmanıza olanak tanır.           | Anchor, Native |
+| [Mint Kapatma Yetkisi](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)     | Eski token program ile bir mint'i kapatmak mümkün değildi. Artık mümkün.                                      | Anchor, Native |
+| [Çoklu Uzantılar](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)           | Tek bir mint'e birden fazla uzantının nasıl eklenebileceğini gösterir.                                        | Native         |
+| [NFT Metadata İşaretçisi](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer) | Metadata uzantısını kullanarak NFT oluşturmak ve dinamik zincir üstü metadata eklemek mümkündür.              | Anchor         |
+| [Transfer Edilemez](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)            | Başarımlar, referans programları veya soul bound token'lar gibi kullanım senaryoları için idealdir.           | Anchor, Native |
+| [Transfer Ücreti](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                  | Her token transferinde bir miktar token, token account içinde tutulur ve daha sonra toplanabilir.             | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                   | Token programından programınıza CPI kullanarak token'ınıza ek işlevsellik kazandırmak için dört farklı örnek. | Anchor         |
 
 ## Ekosistem Solana program örnekleri
 

--- a/apps/docs/content/docs/uk/programs/examples.mdx
+++ b/apps/docs/content/docs/uk/programs/examples.mdx
@@ -7,12 +7,12 @@ description:
 ---
 
 Репозиторій
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 на GitHub містить кілька підпапок, кожна з яких містить приклади коду, щоб
 допомогти розробникам вивчати та експериментувати з розробкою на блокчейні
 Solana.
 
-Ви можете знайти приклади в `solana-developers/program-examples` разом із
+Ви можете знайти приклади в `solana-foundation/program-examples` разом із
 файлами README, які пояснюють, як запускати різні приклади. Більшість прикладів
 є самодостатніми та доступні в нативному Rust (тобто без фреймворку) та
 [Anchor](https://www.anchor-lang.com/docs/installation).
@@ -34,20 +34,19 @@ Solana з використанням нативних бібліотек Rust. �
 
 | Назва прикладу                                                                                                                | Опис                                                                                            | Мова                      |
 | ----------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Збереження адреси з іменем, номером будинку, вулицею та містом в акаунті.                       | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Уроки безпеки, що показують, як виконувати перевірки акаунтів                                   | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Показує, як закрити акаунти, щоб повернути rent.                                                | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Проста програма-лічильник у різних архітектурах.                                                | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Як створити системний акаунт у межах програми.                                                  | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | На прикладі аналогії з рукою та важелем показує, як викликати іншу програму зсередини програми. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Приклад «Hello world», який просто виводить «hello world» у журналі транзакцій.                 | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Показує, як можна використовувати lamport з PDA для оплати нового акаунту.                      | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Показує, як обробляти instruction data типу string та u32.                                      | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Показує, як використовувати seeds для посилання на PDA та збереження в ньому даних.             | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Показує, як збільшити або зменшити розмір наявного акаунту.                                     | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Тут ви дізнаєтесь, як розраховувати вимоги до rent у межах програми.                            | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Рекомендації щодо структурування макету вашої програми.                                         | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Різні методи переказу SOL для системних акаунтів та PDA.                                        | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Збереження адреси з іменем, номером будинку, вулицею та містом в акаунті.                       | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Уроки безпеки, що показують, як виконувати перевірки акаунтів                                   | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Показує, як закрити акаунти, щоб повернути rent.                                                | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Проста програма-лічильник у різних архітектурах.                                                | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Як створити системний акаунт у межах програми.                                                  | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | На прикладі аналогії з рукою та важелем показує, як викликати іншу програму зсередини програми. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Приклад «Hello world», який просто виводить «hello world» у журналі транзакцій.                 | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Показує, як можна використовувати lamport з PDA для оплати нового акаунту.                      | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Показує, як обробляти instruction data типу string та u32.                                      | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Показує, як використовувати seeds для посилання на PDA та збереження в ньому даних.             | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Показує, як збільшити або зменшити розмір наявного акаунту.                                     | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Рекомендації щодо структурування макету вашої програми.                                         | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Різні методи переказу SOL для системних акаунтів та PDA.                                        | Native, Anchor, Seahorse  |
 
 ## Токени
 
@@ -57,13 +56,12 @@ Solana (SPL). Тут ви знайдете багато прикладів то�
 
 | Назва прикладу                                                                                                  | Опис                                                                                                    | Мова           |
 | --------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------- | -------------- |
-| [Create Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)             | Як створити токен і додати до нього метадані Metaplex.                                                  | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Карбування рівно одного екземпляра токена з подальшим видаленням повноважень на карбування.             | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Показує, як змінити повноваження карбування для карбування токенів зсередини програми.                  | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Пояснює, як використовувати Associated Token Accounts для відстеження token account.                    | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Розгорнутий приклад, що демонструє побудову пулу AMM (автоматизованого маркет-мейкера) для SPL-токенів. | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Показує, як передавати SPL-токени за допомогою CPI до token program.                                    | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Дивіться Token 2022 (Token Extensions).                                                                 | Anchor, Native |
+| [Create Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)             | Як створити токен і додати до нього метадані Metaplex.                                                  | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Карбування рівно одного екземпляра токена з подальшим видаленням повноважень на карбування.             | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Показує, як змінити повноваження карбування для карбування токенів зсередини програми.                  | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Розгорнутий приклад, що демонструє побудову пулу AMM (автоматизованого маркет-мейкера) для SPL-токенів. | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Показує, як передавати SPL-токени за допомогою CPI до token program.                                    | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Дивіться Token 2022 (Token Extensions).                                                                 | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -74,14 +72,14 @@ Token 2022 — це новий стандарт токенів на Solana. Ві
 
 | Назва прикладу                                                                                                                   | Опис                                                                                                                       | Мова           |
 | -------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Basics](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Як створити токен, викарбувати та передати його.                                                                           | Anchor         |
-| [Default account state](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Це розширення дозволяє створювати token account з певним станом, наприклад замороженим.                                    | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | У старому Token Program закрити карбування було неможливо. Тепер це можливо.                                               | Anchor, Native |
-| [Multiple Extensions](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Показує, як додати кілька розширень до одного карбування.                                                                  | Native         |
-| [NFT Metadata pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | За допомогою розширення метаданих можна створювати NFT і додавати динамічні метадані в мережі.                             | Anchor         |
-| [Not Transferable](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)           | Корисно, наприклад, для досягнень, реферальних програм або будь-яких прив'язаних до душі токенів.                          | Anchor, Native |
-| [Transfer fee](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | При кожній передачі токенів певна їх частина затримується у token account і може бути зібрана пізніше.                     | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Чотири приклади додавання додаткової функціональності до вашого токена за допомогою CPI з Token Program до вашої програми. | Anchor         |
+| [Basics](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                        | Як створити токен, викарбувати та передати його.                                                                           | Anchor         |
+| [Default account state](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Це розширення дозволяє створювати token account з певним станом, наприклад замороженим.                                    | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)   | У старому Token Program закрити карбування було неможливо. Тепер це можливо.                                               | Anchor, Native |
+| [Multiple Extensions](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)     | Показує, як додати кілька розширень до одного карбування.                                                                  | Native         |
+| [NFT Metadata pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)  | За допомогою розширення метаданих можна створювати NFT і додавати динамічні метадані в мережі.                             | Anchor         |
+| [Not Transferable](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)           | Корисно, наприклад, для досягнень, реферальних програм або будь-яких прив'язаних до душі токенів.                          | Anchor, Native |
+| [Transfer fee](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                   | При кожній передачі токенів певна їх частина затримується у token account і може бути зібрана пізніше.                     | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                 | Чотири приклади додавання додаткової функціональності до вашого токена за допомогою CPI з Token Program до вашої програми. | Anchor         |
 
 ## Приклади програм екосистеми Solana
 

--- a/apps/docs/content/docs/vi/programs/examples.mdx
+++ b/apps/docs/content/docs/vi/programs/examples.mdx
@@ -7,11 +7,11 @@ description:
 ---
 
 Kho lưu trữ
-[Solana Program Examples](https://github.com/solana-developers/program-examples)
+[Solana Program Examples](https://github.com/solana-foundation/program-examples)
 trên GitHub cung cấp nhiều thư mục con, mỗi thư mục chứa các ví dụ mã để giúp
 các nhà phát triển học tập và thử nghiệm với việc phát triển blockchain Solana.
 
-Bạn có thể tìm thấy các ví dụ trong `solana-developers/program-examples` cùng
+Bạn có thể tìm thấy các ví dụ trong `solana-foundation/program-examples` cùng
 với các tệp README giải thích cách chạy các ví dụ khác nhau. Hầu hết các ví dụ
 đều độc lập và có sẵn bằng Rust thuần túy (tức là không sử dụng framework) và
 [Anchor](https://www.anchor-lang.com/docs/installation).
@@ -34,20 +34,19 @@ phát triển hiểu các khái niệm cốt lõi của lập trình Solana.
 
 | Tên ví dụ                                                                                                                     | Mô tả                                                                                                                      | Ngôn ngữ                  |
 | ----------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | Lưu một địa chỉ với tên, số nhà, đường và thành phố vào một tài khoản.                                                     | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | Các bài học bảo mật hướng dẫn cách thực hiện kiểm tra tài khoản                                                            | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | Hướng dẫn cách đóng tài khoản để lấy lại rent.                                                                             | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | Một chương trình đếm đơn giản theo tất cả các kiến trúc khác nhau.                                                         | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | Cách tạo một tài khoản hệ thống trong một chương trình.                                                                    | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | Sử dụng phép so sánh bàn tay và đòn bẩy, ví dụ này hướng dẫn cách gọi một chương trình khác từ bên trong một chương trình. | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Ví dụ hello world chỉ in hello world vào nhật ký giao dịch.                                                                | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | Hướng dẫn cách sử dụng các lamport từ một PDA để thanh toán cho một tài khoản mới.                                         | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | Hướng dẫn cách xử lý instruction data dạng chuỗi và u32.                                                                   | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | Hướng dẫn cách sử dụng seeds để tham chiếu đến một PDA và lưu dữ liệu vào đó.                                              | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | Hướng dẫn cách tăng và giảm kích thước của một tài khoản hiện có.                                                          | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | Tại đây bạn sẽ học cách tính toán các yêu cầu rent trong một chương trình.                                                 | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | Các khuyến nghị về cách cấu trúc bố cục chương trình của bạn.                                                              | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | Các phương thức khác nhau để chuyển SOL cho tài khoản hệ thống và PDA.                                                     | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | Lưu một địa chỉ với tên, số nhà, đường và thành phố vào một tài khoản.                                                     | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | Các bài học bảo mật hướng dẫn cách thực hiện kiểm tra tài khoản                                                            | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | Hướng dẫn cách đóng tài khoản để lấy lại rent.                                                                             | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | Một chương trình đếm đơn giản theo tất cả các kiến trúc khác nhau.                                                         | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | Cách tạo một tài khoản hệ thống trong một chương trình.                                                                    | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | Sử dụng phép so sánh bàn tay và đòn bẩy, ví dụ này hướng dẫn cách gọi một chương trình khác từ bên trong một chương trình. | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Ví dụ hello world chỉ in hello world vào nhật ký giao dịch.                                                                | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | Hướng dẫn cách sử dụng các lamport từ một PDA để thanh toán cho một tài khoản mới.                                         | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | Hướng dẫn cách xử lý instruction data dạng chuỗi và u32.                                                                   | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | Hướng dẫn cách sử dụng seeds để tham chiếu đến một PDA và lưu dữ liệu vào đó.                                              | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | Hướng dẫn cách tăng và giảm kích thước của một tài khoản hiện có.                                                          | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | Các khuyến nghị về cách cấu trúc bố cục chương trình của bạn.                                                              | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | Các phương thức khác nhau để chuyển SOL cho tài khoản hệ thống và PDA.                                                     | Native, Anchor, Seahorse  |
 
 ## Token
 
@@ -57,13 +56,12 @@ token và cả cách tương tác với chúng trong các chương trình.
 
 | Tên Ví Dụ                                                                                                       | Mô Tả                                                                                                | Ngôn Ngữ       |
 | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | -------------- |
-| [Tạo Token](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)                | Cách tạo token và thêm metadata Metaplex vào đó.                                                     | Anchor, Native |
-| [NFT Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)                 | Mint duy nhất một lượng token rồi xóa quyền mint.                                                    | Anchor, Native |
-| [PDA Mint Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | Hướng dẫn cách thay đổi quyền mint của một mint để mint token từ bên trong chương trình.             | Anchor, Native |
-| [SPL Token Minter](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter)     | Giải thích cách sử dụng Associated Token Accounts để theo dõi các token account.                     | Anchor, Native |
-| [Token Swap](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)                 | Ví dụ toàn diện hướng dẫn cách xây dựng một pool AMM (nhà tạo lập thị trường tự động) cho SPL token. | Anchor         |
-| [Transfer Tokens](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)       | Hướng dẫn cách chuyển SPL token bằng CPI vào token program.                                          | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)                 | Xem Token 2022 (Token extensions).                                                                   | Anchor, Native |
+| [Tạo Token](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)                | Cách tạo token và thêm metadata Metaplex vào đó.                                                     | Anchor, Native |
+| [NFT Minter](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)                 | Mint duy nhất một lượng token rồi xóa quyền mint.                                                    | Anchor, Native |
+| [PDA Mint Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | Hướng dẫn cách thay đổi quyền mint của một mint để mint token từ bên trong chương trình.             | Anchor, Native |
+| [Token Swap](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)                 | Ví dụ toàn diện hướng dẫn cách xây dựng một pool AMM (nhà tạo lập thị trường tự động) cho SPL token. | Anchor         |
+| [Transfer Tokens](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)       | Hướng dẫn cách chuyển SPL token bằng CPI vào token program.                                          | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)                 | Xem Token 2022 (Token extensions).                                                                   | Anchor, Native |
 
 ## Token Extensions (Token 2022)
 
@@ -74,14 +72,14 @@ thêm chức năng cho nó. Danh sách đầy đủ các extension có thể tì
 
 | Tên Ví Dụ                                                                                                                                | Mô Tả                                                                                                          | Ngôn Ngữ       |
 | ---------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | -------------- |
-| [Cơ Bản](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                                | Cách tạo token, mint và chuyển token.                                                                          | Anchor         |
-| [Trạng thái tài khoản mặc định](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state) | Extension này cho phép bạn tạo token account với một trạng thái nhất định, ví dụ như bị đóng băng.             | Anchor, Native |
-| [Mint Close Authority](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)           | Với Token Program cũ, không thể đóng một mint. Giờ đây điều đó đã khả thi.                                     | Anchor, Native |
-| [Nhiều Extension](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)                 | Hướng dẫn cách thêm nhiều extension vào một mint duy nhất.                                                     | Native         |
-| [NFT Metadata Pointer](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)          | Có thể sử dụng metadata extension để tạo NFT và thêm metadata on-chain động.                                   | Anchor         |
-| [Không Thể Chuyển Nhượng](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)            | Hữu ích cho các trường hợp như thành tích, chương trình giới thiệu hoặc bất kỳ soul bound token nào.           | Anchor, Native |
-| [Phí Chuyển](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                             | Mỗi lần chuyển token sẽ giữ lại một lượng token trong token account, lượng này có thể được thu thập sau.       | Anchor, Native |
-| [Transfer Hook](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)                         | Bốn ví dụ về cách thêm chức năng bổ sung cho token của bạn bằng CPI từ token program vào chương trình của bạn. | Anchor         |
+| [Cơ Bản](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                                | Cách tạo token, mint và chuyển token.                                                                          | Anchor         |
+| [Trạng thái tài khoản mặc định](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state) | Extension này cho phép bạn tạo token account với một trạng thái nhất định, ví dụ như bị đóng băng.             | Anchor, Native |
+| [Mint Close Authority](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)           | Với Token Program cũ, không thể đóng một mint. Giờ đây điều đó đã khả thi.                                     | Anchor, Native |
+| [Nhiều Extension](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)                 | Hướng dẫn cách thêm nhiều extension vào một mint duy nhất.                                                     | Native         |
+| [NFT Metadata Pointer](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer)          | Có thể sử dụng metadata extension để tạo NFT và thêm metadata on-chain động.                                   | Anchor         |
+| [Không Thể Chuyển Nhượng](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)            | Hữu ích cho các trường hợp như thành tích, chương trình giới thiệu hoặc bất kỳ soul bound token nào.           | Anchor, Native |
+| [Phí Chuyển](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                             | Mỗi lần chuyển token sẽ giữ lại một lượng token trong token account, lượng này có thể được thu thập sau.       | Anchor, Native |
+| [Transfer Hook](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)                         | Bốn ví dụ về cách thêm chức năng bổ sung cho token của bạn bằng CPI từ token program vào chương trình của bạn. | Anchor         |
 
 ## Ví dụ chương trình Solana trong hệ sinh thái
 

--- a/apps/docs/content/docs/zh/programs/examples.mdx
+++ b/apps/docs/content/docs/zh/programs/examples.mdx
@@ -4,10 +4,10 @@ description:
   Solana 程序的多语言和多框架示例列表，可帮助您学习并作为您自己项目的参考。
 ---
 
-[Solana 程序示例](https://github.com/solana-developers/program-examples)
+[Solana 程序示例](https://github.com/solana-foundation/program-examples)
 GitHub 仓库提供了多个子文件夹，每个文件夹包含代码示例，帮助开发者学习和尝试 Solana 区块链开发。
 
-你可以在 `solana-developers/program-examples`
+你可以在 `solana-foundation/program-examples`
 中找到示例，并配有 README 文件，说明如何运行不同的示例。大多数示例都是自包含的，并且同时提供原生 Rust（即无框架）和 Anchor 版本。
 
 在该仓库中，您将找到以下子文件夹，每个文件夹中包含各种示例程序：
@@ -24,20 +24,19 @@ GitHub 仓库提供了多个子文件夹，每个文件夹包含代码示例，�
 
 | 示例名称                                                                                                                      | 描述                                                 | 语言                      |
 | ----------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------- | ------------------------- |
-| [Account Data](https://github.com/solana-developers/program-examples/tree/main/basics/account-data)                           | 在账户中保存包含姓名、门牌号、街道和城市的地址。     | Native, Anchor            |
-| [Checking Accounts](https://github.com/solana-developers/program-examples/tree/main/basics/checking-accounts)                 | 演示如何进行账户检查的安全课程。                     | Native, Anchor            |
-| [Close Account](https://github.com/solana-developers/program-examples/tree/main/basics/close-account)                         | 演示如何关闭账户以取回其 rent。                      | Native, Anchor            |
-| [Counter](https://github.com/solana-developers/program-examples/tree/main/basics/counter)                                     | 在所有不同架构中实现的简单计数器程序。               | Native, Anchor, mpl-stack |
-| [Create Account](https://github.com/solana-developers/program-examples/tree/main/basics/create-account)                       | 如何在程序内创建系统账户。                           | Native, Anchor            |
-| [Cross Program Invocation](https://github.com/solana-developers/program-examples/tree/main/basics/cross-program-invocation)   | 通过手与杠杆的类比，演示如何在程序内调用另一个程序。 | Native, Anchor            |
-| [hello solana](https://github.com/solana-developers/program-examples/tree/main/basics/hello-solana)                           | Hello world 示例，在交易日志中打印 hello world。     | Native, Anchor            |
-| [Pda Rent payer](https://github.com/solana-developers/program-examples/tree/main/basics/pda-rent-payer)                       | 演示如何使用 PDA 中的 lamport 为新账户支付费用。     | Native, Anchor            |
-| [Processing Instructions](https://github.com/solana-developers/program-examples/tree/main/basics/processing-instructions)     | 演示如何处理 instruction data 字符串和 u32。         | Native, Anchor            |
-| [Program Derived Addresses](https://github.com/solana-developers/program-examples/tree/main/basics/program-derived-addresses) | 演示如何使用种子引用 PDA 并在其中保存数据。          | Native, Anchor            |
-| [Realloc](https://github.com/solana-developers/program-examples/tree/main/basics/realloc)                                     | 演示如何增加或减少现有账户的大小。                   | Native, Anchor            |
-| [Rent](https://github.com/solana-developers/program-examples/tree/main/basics/rent)                                           | 学习如何在程序中计算 rent 要求。                     | Native, Anchor            |
-| [Repository Layout](https://github.com/solana-developers/program-examples/tree/main/basics/repository-layout)                 | 关于如何组织程序布局的建议。                         | Native, Anchor            |
-| [Transfer SOL](https://github.com/solana-developers/program-examples/tree/main/basics/transfer-sol)                           | 针对系统账户和 PDA 转账 SOL 的不同方法。             | Native, Anchor, Seahorse  |
+| [Account Data](https://github.com/solana-foundation/program-examples/tree/main/basics/account-data)                           | 在账户中保存包含姓名、门牌号、街道和城市的地址。     | Native, Anchor            |
+| [Checking Accounts](https://github.com/solana-foundation/program-examples/tree/main/basics/checking-accounts)                 | 演示如何进行账户检查的安全课程。                     | Native, Anchor            |
+| [Close Account](https://github.com/solana-foundation/program-examples/tree/main/basics/close-account)                         | 演示如何关闭账户以取回其 rent。                      | Native, Anchor            |
+| [Counter](https://github.com/solana-foundation/program-examples/tree/main/basics/counter)                                     | 在所有不同架构中实现的简单计数器程序。               | Native, Anchor, mpl-stack |
+| [Create Account](https://github.com/solana-foundation/program-examples/tree/main/basics/create-account)                       | 如何在程序内创建系统账户。                           | Native, Anchor            |
+| [Cross Program Invocation](https://github.com/solana-foundation/program-examples/tree/main/basics/cross-program-invocation)   | 通过手与杠杆的类比，演示如何在程序内调用另一个程序。 | Native, Anchor            |
+| [hello solana](https://github.com/solana-foundation/program-examples/tree/main/basics/hello-solana)                           | Hello world 示例，在交易日志中打印 hello world。     | Native, Anchor            |
+| [Pda Rent payer](https://github.com/solana-foundation/program-examples/tree/main/basics/pda-rent-payer)                       | 演示如何使用 PDA 中的 lamport 为新账户支付费用。     | Native, Anchor            |
+| [Processing Instructions](https://github.com/solana-foundation/program-examples/tree/main/basics/processing-instructions)     | 演示如何处理 instruction data 字符串和 u32。         | Native, Anchor            |
+| [Program Derived Addresses](https://github.com/solana-foundation/program-examples/tree/main/basics/program-derived-addresses) | 演示如何使用种子引用 PDA 并在其中保存数据。          | Native, Anchor            |
+| [Realloc](https://github.com/solana-foundation/program-examples/tree/main/basics/realloc)                                     | 演示如何增加或减少现有账户的大小。                   | Native, Anchor            |
+| [Repository Layout](https://github.com/solana-foundation/program-examples/tree/main/basics/repository-layout)                 | 关于如何组织程序布局的建议。                         | Native, Anchor            |
+| [Transfer SOL](https://github.com/solana-foundation/program-examples/tree/main/basics/transfer-sol)                           | 针对系统账户和 PDA 转账 SOL 的不同方法。             | Native, Anchor, Seahorse  |
 
 ## 代币
 
@@ -46,13 +45,12 @@ Solana 上的大多数代币使用 Solana Program Library
 
 | 示例名称                                                                                                  | 描述                                                          | 语言           |
 | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------- | -------------- |
-| [创建代币](https://github.com/solana-developers/program-examples/tree/main/tokens/create-token)           | 如何创建代币并为其添加 metaplex 元数据。                      | Anchor, Native |
-| [NFT 铸造器](https://github.com/solana-developers/program-examples/tree/main/tokens/nft-minter)           | 仅铸造一定数量的代币，然后移除铸造权限。                      | Anchor, Native |
-| [PDA 铸造权限](https://github.com/solana-developers/program-examples/tree/main/tokens/pda-mint-authority) | 展示如何更改铸造的铸造权限，以便在程序内部铸造代币。          | Anchor, Native |
-| [SPL 代币铸造器](https://github.com/solana-developers/program-examples/tree/main/tokens/spl-token-minter) | 解释如何使用 Associated Token Accounts 来追踪 token account。 | Anchor, Native |
-| [代币兑换](https://github.com/solana-developers/program-examples/tree/main/tokens/token-swap)             | 详细示例，展示如何为 SPL 代币构建 AMM（自动做市商）资金池。   | Anchor         |
-| [转移代币](https://github.com/solana-developers/program-examples/tree/main/tokens/transfer-tokens)        | 展示如何通过 CPI 调用 token program 来转移 SPL 代币。         | Anchor, Native |
-| [Token-2022](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022)           | 参见 Token 2022（Token extensions）。                         | Anchor, Native |
+| [创建代币](https://github.com/solana-foundation/program-examples/tree/main/tokens/create-token)           | 如何创建代币并为其添加 metaplex 元数据。                      | Anchor, Native |
+| [NFT 铸造器](https://github.com/solana-foundation/program-examples/tree/main/tokens/nft-operations)           | 仅铸造一定数量的代币，然后移除铸造权限。                      | Anchor, Native |
+| [PDA 铸造权限](https://github.com/solana-foundation/program-examples/tree/main/tokens/pda-mint-authority) | 展示如何更改铸造的铸造权限，以便在程序内部铸造代币。          | Anchor, Native |
+| [代币兑换](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-swap)             | 详细示例，展示如何为 SPL 代币构建 AMM（自动做市商）资金池。   | Anchor         |
+| [转移代币](https://github.com/solana-foundation/program-examples/tree/main/tokens/transfer-tokens)        | 展示如何通过 CPI 调用 token program 来转移 SPL 代币。         | Anchor, Native |
+| [Token-2022](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022)           | 参见 Token 2022（Token extensions）。                         | Anchor, Native |
 
 ## Token Extensions（Token 2022）
 
@@ -63,14 +61,14 @@ Extensions，从而扩展其功能。完整的扩展列表可在
 
 | 示例名称                                                                                                                  | 描述                                                                             | 语言           |
 | ------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | -------------- |
-| [基础](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/basics/anchor)                   | 如何创建代币、铸造并转移它。                                                     | Anchor         |
-| [默认账户状态](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/default-account-state)   | 此扩展允许您以特定状态创建 token account，例如冻结状态。                         | Anchor, Native |
-| [铸造关闭权限](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/mint-close-authority)    | 使用旧版 Token Program 无法关闭铸造，现在可以了。                                | Anchor, Native |
-| [多重扩展](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/multiple-extensions)         | 展示如何为单个铸造添加多个 Token Extensions。                                    | Native         |
-| [NFT 元数据指针](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer) | 可以使用元数据扩展来创建 NFT 并添加动态链上元数据。                              | Anchor         |
-| [不可转移](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/non-transferable)            | 适用于成就系统、推荐计划或任何灵魂绑定代币等场景。                               | Anchor, Native |
-| [转账费](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-fee)                  | 每次代币转账时，会在 token account 中保留一部分代币，随后可进行归集。            | Anchor, Native |
-| [转账钩子](https://github.com/solana-developers/program-examples/tree/main/tokens/token-2022/transfer-hook)               | 四个示例，展示如何通过从 Token Program 向您的程序发起 CPI 来为代币添加额外功能。 | Anchor         |
+| [基础](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/basics/anchor)                   | 如何创建代币、铸造并转移它。                                                     | Anchor         |
+| [默认账户状态](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/default-account-state)   | 此扩展允许您以特定状态创建 token account，例如冻结状态。                         | Anchor, Native |
+| [铸造关闭权限](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/mint-close-authority)    | 使用旧版 Token Program 无法关闭铸造，现在可以了。                                | Anchor, Native |
+| [多重扩展](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/multiple-extensions)         | 展示如何为单个铸造添加多个 Token Extensions。                                    | Native         |
+| [NFT 元数据指针](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/nft-meta-data-pointer) | 可以使用元数据扩展来创建 NFT 并添加动态链上元数据。                              | Anchor         |
+| [不可转移](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/non-transferable)            | 适用于成就系统、推荐计划或任何灵魂绑定代币等场景。                               | Anchor, Native |
+| [转账费](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-fee)                  | 每次代币转账时，会在 token account 中保留一部分代币，随后可进行归集。            | Anchor, Native |
+| [转账钩子](https://github.com/solana-foundation/program-examples/tree/main/tokens/token-2022/transfer-hook)               | 四个示例，展示如何通过从 Token Program 向您的程序发起 CPI 来为代币添加额外功能。 | Anchor         |
 
 ## 生态系统 Solana 程序示例
 


### PR DESCRIPTION
## Summary
- Fix 404 links on /docs/programs/examples caused by the program-examples consolidation (solana-foundation/program-examples#656)
- Drop the `basics/rent` row (merged into `create-account`) and the `tokens/spl-token-minter` row (byte-identical subset of `transfer-tokens`)
- Repoint `tokens/nft-minter` to `tokens/nft-operations`
- Update GitHub org in all links from `solana-developers` to `solana-foundation` (old org only works via redirect)
- Applied across `en` and all 18 locale copies

## Test Plan
- Every `program-examples/tree/main/...` path in the page was verified to exist on program-examples `main` via `git ls-tree`