### PR TITLE
Add Solana Scholars program page and application form

### DIFF
--- a/apps/web/src/app/[locale]/scholars/apply/ApplyForm.tsx
+++ b/apps/web/src/app/[locale]/scholars/apply/ApplyForm.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import styles from "../scholars.module.css";
+
+/**
+ * Applications are appended as rows to a Google Sheet via a Google Apps
+ * Script web app (see google-apps-script/Code.gs in this package for the
+ * script and its 3-minute setup). To change where applications land,
+ * redeploy the script and update this URL.
+ */
+const SCRIPT_URL =
+  "https://script.google.com/macros/s/AKfycbwiG9GVMX2F14y8pDcvCmdYm3MYVrWuHV5hHoi5u_5wyUekJTIYMj3UqQEn7eiwuOb7ug/exec";
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "success" }
+  | { kind: "error"; message: string };
+
+export default function ApplyForm() {
+  const [status, setStatus] = useState<Status>({ kind: "idle" });
+
+  async function handleSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const form = e.currentTarget;
+
+    if (!form.checkValidity()) {
+      form.reportValidity();
+      return;
+    }
+
+    setStatus({ kind: "submitting" });
+    try {
+      const payload = Object.fromEntries(new FormData(form).entries());
+      // Content-Type text/plain keeps this a "simple" CORS request,
+      // which Google Apps Script accepts cross-origin without preflight.
+      const res = await fetch(SCRIPT_URL, {
+        method: "POST",
+        headers: { "Content-Type": "text/plain;charset=utf-8" },
+        body: JSON.stringify(payload),
+      });
+      const data = (await res.json()) as { ok: boolean; error?: string };
+      if (!data.ok) throw new Error(data.error || "Submission failed");
+      setStatus({ kind: "success" });
+    } catch {
+      setStatus({
+        kind: "error",
+        message: "Something went wrong. Please try again in a moment.",
+      });
+    }
+  }
+
+  if (status.kind === "success") {
+    return (
+      <div className={styles.formSuccess} role="status">
+        <strong>Application received — thank you!</strong>
+        <p>We read everything, and we&apos;ll be in touch.</p>
+      </div>
+    );
+  }
+
+  return (
+    <form className={styles.form} onSubmit={handleSubmit} noValidate>
+      <div className={styles.formRowTwo}>
+        <div className={styles.field}>
+          <label htmlFor="sch-name">Full name</label>
+          <input
+            id="sch-name"
+            name="name"
+            type="text"
+            autoComplete="name"
+            required
+          />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="sch-email">Email</label>
+          <input
+            id="sch-email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            required
+          />
+        </div>
+      </div>
+
+      <div className={styles.formRow}>
+        <div className={styles.field}>
+          <label htmlFor="sch-address">
+            Full address{" "}
+            <span className={styles.optional}>
+              — street, postal code, city, country
+            </span>
+          </label>
+          <textarea
+            id="sch-address"
+            name="address"
+            rows={2}
+            autoComplete="street-address"
+            required
+          />
+        </div>
+      </div>
+
+      <div className={styles.formRowTwo}>
+        <div className={styles.field}>
+          <label htmlFor="sch-institution">Institution &amp; PhD program</label>
+          <input id="sch-institution" name="institution" type="text" required />
+        </div>
+        <div className={styles.field}>
+          <label htmlFor="sch-advisor">Advisor</label>
+          <input id="sch-advisor" name="advisor" type="text" required />
+        </div>
+      </div>
+
+      <div className={styles.formRowTwo}>
+        <div className={styles.field}>
+          <label htmlFor="sch-format">Preferred format</label>
+          <select id="sch-format" name="format" required defaultValue="">
+            <option value="" disabled>
+              Select…
+            </option>
+            <option>On-site — Zurich, Switzerland</option>
+            <option>On-site — New York, USA</option>
+            <option>Virtual</option>
+            <option>Flexible / not sure yet</option>
+          </select>
+        </div>
+      </div>
+
+      <div className={styles.formRow}>
+        <div className={styles.field}>
+          <label htmlFor="sch-background">
+            Research background &amp; interests{" "}
+            <span className={styles.optional}>
+              — a few sentences, your publications, or a link to your
+              homepage / CV
+            </span>
+          </label>
+          <textarea id="sch-background" name="background" rows={4} required />
+        </div>
+      </div>
+
+      <div className={styles.formRow}>
+        <div className={styles.field}>
+          <label htmlFor="sch-topic">
+            What do you want to study? Why? How?{" "}
+            <span className={styles.optional}>
+              — a short pitch: the question, why it matters, and how
+              you&apos;d approach it
+            </span>
+          </label>
+          <textarea id="sch-topic" name="topic" rows={6} required />
+        </div>
+      </div>
+
+      <div className={styles.formActions}>
+        <button
+          className={styles.btn}
+          type="submit"
+          disabled={status.kind === "submitting"}
+        >
+          {status.kind === "submitting" ? "Submitting…" : "Submit application"}
+        </button>
+        <span
+          className={status.kind === "error" ? styles.noteError : styles.note}
+          role="status"
+        >
+          {status.kind === "error" ? status.message : "We read everything."}
+        </span>
+      </div>
+    </form>
+  );
+}

--- a/apps/web/src/app/[locale]/scholars/apply/ApplyForm.tsx
+++ b/apps/web/src/app/[locale]/scholars/apply/ApplyForm.tsx
@@ -134,8 +134,8 @@ export default function ApplyForm() {
           <label htmlFor="sch-background">
             Research background &amp; interests{" "}
             <span className={styles.optional}>
-              — a few sentences, your publications, or a link to your
-              homepage / CV
+              — a few sentences, your publications, or a link to your homepage /
+              CV
             </span>
           </label>
           <textarea id="sch-background" name="background" rows={4} required />
@@ -147,8 +147,8 @@ export default function ApplyForm() {
           <label htmlFor="sch-topic">
             What do you want to study? Why? How?{" "}
             <span className={styles.optional}>
-              — a short pitch: the question, why it matters, and how
-              you&apos;d approach it
+              — a short pitch: the question, why it matters, and how you&apos;d
+              approach it
             </span>
           </label>
           <textarea id="sch-topic" name="topic" rows={6} required />

--- a/apps/web/src/app/[locale]/scholars/apply/page.tsx
+++ b/apps/web/src/app/[locale]/scholars/apply/page.tsx
@@ -1,0 +1,31 @@
+import type { Metadata } from "next";
+import styles from "../scholars.module.css";
+import ApplyForm from "./ApplyForm";
+
+export const metadata: Metadata = {
+  title: "Apply — Solana Scholars",
+  description:
+    "Apply to Solana Scholars, a research internship program for PhD students. No deadline — applications are accepted throughout the year.",
+};
+
+export default function ScholarsApplyPage() {
+  return (
+    <main className={styles.page}>
+      <header className={styles.hero}>
+        <p className={styles.eyebrow}>
+          Application · PhD students · Open year-round
+        </p>
+        <h1 className={styles.titleSmall}>
+          Apply to <span className={styles.grad}>Solana Scholars.</span>
+        </h1>
+        <p className={styles.intro}>
+          Applications are short — we care about your ideas and your fit, not
+          paperwork. There is no deadline; we accept applications throughout
+          the year. New here?{" "}
+          <a href="/scholars">Read about the program first.</a>
+        </p>
+      </header>
+      <ApplyForm />
+    </main>
+  );
+}

--- a/apps/web/src/app/[locale]/scholars/apply/page.tsx
+++ b/apps/web/src/app/[locale]/scholars/apply/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import styles from "../scholars.module.css";
 import ApplyForm from "./ApplyForm";
 
@@ -20,9 +21,9 @@ export default function ScholarsApplyPage() {
         </h1>
         <p className={styles.intro}>
           Applications are short — we care about your ideas and your fit, not
-          paperwork. There is no deadline; we accept applications throughout
-          the year. New here?{" "}
-          <a href="/scholars">Read about the program first.</a>
+          paperwork. There is no deadline; we accept applications throughout the
+          year. New here?{" "}
+          <Link href="/scholars">Read about the program first.</Link>
         </p>
       </header>
       <ApplyForm />

--- a/apps/web/src/app/[locale]/scholars/page.tsx
+++ b/apps/web/src/app/[locale]/scholars/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Link from "next/link";
 import styles from "./scholars.module.css";
 
 export const metadata: Metadata = {
@@ -25,16 +26,16 @@ export default function ScholarsPage() {
           <span className={styles.abstractLabel}>Abstract</span>
           <p>
             Solana Scholars builds a bridge between Solana and the academic
-            community. We fund focused research internships carried out in
-            close collaboration with the people building the system. Your work
-            doesn&apos;t end at a PDF. It ends up in production. We put the
-            ship in internship.
+            community. We fund focused research internships carried out in close
+            collaboration with the people building the system. Your work
+            doesn&apos;t end at a PDF. It ends up in production. We put the ship
+            in internship.
           </p>
         </div>
         <div className={styles.heroCta}>
-          <a className={styles.btn} href="/scholars/apply">
+          <Link className={styles.btn} href="/scholars/apply">
             Apply to the program
-          </a>
+          </Link>
           <span className={styles.note}>
             PhD students only · Rolling admissions
           </span>
@@ -48,10 +49,10 @@ export default function ScholarsPage() {
           <h2>Why this program exists</h2>
         </div>
         <p className={styles.lede}>
-          A lot of blockchain research never touches a real system, and a lot
-          of real systems never benefit from research. We think that&apos;s a
-          waste in both directions. Solana runs at a scale where open problems
-          in consensus, networking, cryptography, and economics aren&apos;t
+          A lot of blockchain research never touches a real system, and a lot of
+          real systems never benefit from research. We think that&apos;s a waste
+          in both directions. Solana runs at a scale where open problems in
+          consensus, networking, cryptography, and economics aren&apos;t
           hypothetical — they&apos;re on the roadmap.
         </p>
         <p className={styles.lede}>
@@ -73,8 +74,8 @@ export default function ScholarsPage() {
           <div className={styles.cell}>
             <h3>Close collaboration</h3>
             <p>
-              You work directly with Solana engineers and researchers
-              throughout the internship, not just at kickoff and final report.
+              You work directly with Solana engineers and researchers throughout
+              the internship, not just at kickoff and final report.
             </p>
           </div>
           <div className={styles.cell}>
@@ -95,16 +96,16 @@ export default function ScholarsPage() {
             <h3>On-site or virtual</h3>
             <p>
               Join us in person — for example in Zurich, Switzerland or New
-              York, USA — or work with us remotely from wherever your PhD
-              keeps you.
+              York, USA — or work with us remotely from wherever your PhD keeps
+              you.
             </p>
           </div>
           <div className={styles.cell}>
             <h3>Built around your PhD</h3>
             <p>
-              Internships run for 3 months, with a possible extension. Timing
-              is flexible and applications are open year-round, so it fits
-              your program instead of interrupting it.
+              Internships run for 3 months, with a possible extension. Timing is
+              flexible and applications are open year-round, so it fits your
+              program instead of interrupting it.
             </p>
           </div>
         </div>
@@ -174,8 +175,8 @@ export default function ScholarsPage() {
         </p>
         <p className={styles.lede}>
           We expect candidates to have already published at scientific
-          conferences in the area — at venues such as FC, AFT, PODC, DISC,
-          SOSP, OSDI, EuroSys, SIGCOMM, NSDI, SIGMETRICS, CCS, S&amp;P, USENIX
+          conferences in the area — at venues such as FC, AFT, PODC, DISC, SOSP,
+          OSDI, EuroSys, SIGCOMM, NSDI, SIGMETRICS, CCS, S&amp;P, USENIX
           Security, NDSS, CRYPTO, EUROCRYPT, EC, or WINE.
         </p>
         <p className={styles.lede}>
@@ -198,9 +199,9 @@ export default function ScholarsPage() {
           throughout the year. Whenever you&apos;re ready, we&apos;re ready.
         </p>
         <div className={styles.heroCta}>
-          <a className={styles.btn} href="/scholars/apply">
+          <Link className={styles.btn} href="/scholars/apply">
             Go to the application form
-          </a>
+          </Link>
           <span className={styles.note}>We read everything.</span>
         </div>
       </section>

--- a/apps/web/src/app/[locale]/scholars/page.tsx
+++ b/apps/web/src/app/[locale]/scholars/page.tsx
@@ -1,0 +1,209 @@
+import type { Metadata } from "next";
+import styles from "./scholars.module.css";
+
+export const metadata: Metadata = {
+  title: "Solana Scholars — Research Internships for PhD Students",
+  description:
+    "Solana Scholars offers focused research internships for PhD students — on-site or virtual — in close collaboration with Solana engineers. Apply now.",
+};
+
+export default function ScholarsPage() {
+  return (
+    <main className={styles.page}>
+      {/* Hero */}
+      <header className={styles.hero}>
+        <p className={styles.eyebrow}>
+          Call for applications · PhD students · Open year-round
+        </p>
+        <h1 className={styles.title}>
+          Do research that <span className={styles.grad}>ships.</span>
+        </h1>
+        <p className={styles.authors}>
+          Solana Scholars · Q. Kniep &amp; R. Wattenhofer
+        </p>
+        <div className={styles.abstract}>
+          <span className={styles.abstractLabel}>Abstract</span>
+          <p>
+            Solana Scholars builds a bridge between Solana and the academic
+            community. We fund focused research internships carried out in
+            close collaboration with the people building the system. Your work
+            doesn&apos;t end at a PDF. It ends up in production. We put the
+            ship in internship.
+          </p>
+        </div>
+        <div className={styles.heroCta}>
+          <a className={styles.btn} href="/scholars/apply">
+            Apply to the program
+          </a>
+          <span className={styles.note}>
+            PhD students only · Rolling admissions
+          </span>
+        </div>
+      </header>
+
+      {/* §1 Why */}
+      <section className={styles.section} id="program">
+        <div className={styles.secHead}>
+          <span className={styles.secNum}>§1</span>
+          <h2>Why this program exists</h2>
+        </div>
+        <p className={styles.lede}>
+          A lot of blockchain research never touches a real system, and a lot
+          of real systems never benefit from research. We think that&apos;s a
+          waste in both directions. Solana runs at a scale where open problems
+          in consensus, networking, cryptography, and economics aren&apos;t
+          hypothetical — they&apos;re on the roadmap.
+        </p>
+        <p className={styles.lede}>
+          So we&apos;re offering scoped, well-defined 3-month research
+          internships, pairing each scholar directly with the engineers and
+          researchers working on those problems. Internships are on-site — for
+          example in Zurich, Switzerland or New York, USA — or virtual. Every
+          topic is chosen because we genuinely want the answer.
+        </p>
+
+        <div className={styles.grid}>
+          <div className={styles.cell}>
+            <h3>Real problems</h3>
+            <p>
+              Internship topics come from what the system actually needs next —
+              not from a grab bag of &quot;interesting directions.&quot;
+            </p>
+          </div>
+          <div className={styles.cell}>
+            <h3>Close collaboration</h3>
+            <p>
+              You work directly with Solana engineers and researchers
+              throughout the internship, not just at kickoff and final report.
+            </p>
+          </div>
+          <div className={styles.cell}>
+            <h3>Publishable results</h3>
+            <p>
+              Internships are scoped so the outcome fits your PhD: papers,
+              artifacts, and results you can build a thesis chapter on.
+            </p>
+          </div>
+          <div className={styles.cell}>
+            <h3>Impact you can point to</h3>
+            <p>
+              The best outcome of an internship is code, protocol changes, or
+              analysis the ecosystem actually uses. That&apos;s the bar.
+            </p>
+          </div>
+          <div className={styles.cell}>
+            <h3>On-site or virtual</h3>
+            <p>
+              Join us in person — for example in Zurich, Switzerland or New
+              York, USA — or work with us remotely from wherever your PhD
+              keeps you.
+            </p>
+          </div>
+          <div className={styles.cell}>
+            <h3>Built around your PhD</h3>
+            <p>
+              Internships run for 3 months, with a possible extension. Timing
+              is flexible and applications are open year-round, so it fits
+              your program instead of interrupting it.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* §2 How */}
+      <section className={styles.section} id="how">
+        <div className={styles.secHead}>
+          <span className={styles.secNum}>§2</span>
+          <h2>How it works</h2>
+        </div>
+        <ol className={styles.steps}>
+          <li>
+            <div>
+              <h3>Apply with a direction</h3>
+              <p>
+                Tell us who you are, what you work on, and what you&apos;d want
+                to tackle — pitch your own idea or express interest in one of
+                our topic areas.
+              </p>
+            </div>
+          </li>
+          <li>
+            <div>
+              <h3>Scope the internship together</h3>
+              <p>
+                If there&apos;s a fit, we define a small, focused internship
+                with you: a concrete question, clear deliverables, a realistic
+                timeline — and whether you&apos;ll join on-site or virtually.
+              </p>
+            </div>
+          </li>
+          <li>
+            <div>
+              <h3>Research with us, not near us</h3>
+              <p>
+                The internship is funded, and you have regular working sessions
+                with the Solana-side collaborators. When you&apos;re blocked,
+                you know who to ask.
+              </p>
+            </div>
+          </li>
+          <li>
+            <div>
+              <h3>Ship the result</h3>
+              <p>
+                Publish the paper, release the artifact, present the findings —
+                and see the work feed directly into the system.
+              </p>
+            </div>
+          </li>
+        </ol>
+      </section>
+
+      {/* §3 Who */}
+      <section className={styles.section} id="eligibility">
+        <div className={styles.secHead}>
+          <span className={styles.secNum}>§3</span>
+          <h2>Who can apply</h2>
+        </div>
+        <p className={styles.lede}>
+          Right now, the program is open exclusively to{" "}
+          <em>excellent PhD students</em>. If you&apos;re currently enrolled in
+          a doctoral program and work in distributed systems, networking,
+          cryptography, economics, or a neighboring field, we&apos;d love to
+          hear from you.
+        </p>
+        <p className={styles.lede}>
+          We expect candidates to have already published at scientific
+          conferences in the area — at venues such as FC, AFT, PODC, DISC,
+          SOSP, OSDI, EuroSys, SIGCOMM, NSDI, SIGMETRICS, CCS, S&amp;P, USENIX
+          Security, NDSS, CRYPTO, EUROCRYPT, EC, or WINE.
+        </p>
+        <p className={styles.lede}>
+          You&apos;re a great fit if you want your research to run against a
+          real, live, planet-scale distributed system — and you&apos;re excited
+          by the idea that a good result doesn&apos;t just get cited, it gets
+          deployed.
+        </p>
+      </section>
+
+      {/* §4 Apply */}
+      <section className={styles.section} id="apply">
+        <div className={styles.secHead}>
+          <span className={styles.secNum}>§4</span>
+          <h2>How to apply</h2>
+        </div>
+        <p className={styles.lede}>
+          Applications are short — we care about your ideas and your fit, not
+          paperwork. There is no application deadline: we accept applications
+          throughout the year. Whenever you&apos;re ready, we&apos;re ready.
+        </p>
+        <div className={styles.heroCta}>
+          <a className={styles.btn} href="/scholars/apply">
+            Go to the application form
+          </a>
+          <span className={styles.note}>We read everything.</span>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/web/src/app/[locale]/scholars/scholars.module.css
+++ b/apps/web/src/app/[locale]/scholars/scholars.module.css
@@ -1,0 +1,338 @@
+/* Solana Scholars — scoped styles.
+   Fonts are inherited from the site (ABC Diatype via the app layout).
+   Colors use Solana brand purple/green; neutrals adapt to the page. */
+
+.page {
+  --sch-purple: #9945ff;
+  --sch-green: #14f195;
+  --sch-line: rgba(128, 138, 160, 0.25);
+  --sch-muted: rgba(128, 138, 160, 1);
+  --sch-surface: rgba(128, 138, 160, 0.08);
+
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 0 24px 96px;
+  line-height: 1.6;
+}
+
+/* ---------- hero ---------- */
+.hero {
+  padding: 80px 0 64px;
+}
+
+.eyebrow {
+  font-size: 0.8rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--sch-green);
+  margin: 0 0 24px;
+}
+
+.title {
+  font-size: clamp(2.5rem, 7vw, 4.2rem);
+  font-weight: 700;
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  margin: 0 0 20px;
+}
+
+
+.titleSmall {
+  font-size: clamp(2rem, 5.4vw, 3.2rem);
+  font-weight: 700;
+  line-height: 1.06;
+  letter-spacing: -0.02em;
+  margin: 0 0 18px;
+}
+
+.intro {
+  max-width: 640px;
+  color: var(--sch-muted);
+  margin: 0;
+}
+
+.intro a {
+  color: inherit;
+}
+
+.grad {
+  background: linear-gradient(100deg, var(--sch-purple) 20%, var(--sch-green) 80%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.authors {
+  font-size: 0.85rem;
+  color: var(--sch-muted);
+  margin: 0 0 36px;
+}
+
+.abstract {
+  border-left: 2px solid var(--sch-purple);
+  padding: 4px 0 4px 24px;
+  max-width: 640px;
+}
+
+.abstract p {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.abstractLabel {
+  display: block;
+  font-size: 0.72rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--sch-muted);
+  margin-bottom: 8px;
+}
+
+.heroCta {
+  margin-top: 40px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  display: inline-block;
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: #0b0d12;
+  text-decoration: none;
+  background: linear-gradient(100deg, var(--sch-purple), var(--sch-green));
+  padding: 12px 26px;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 24px rgba(20, 241, 149, 0.25);
+}
+
+.btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+  transform: none;
+  box-shadow: none;
+}
+
+.btn:focus-visible {
+  outline: 2px solid var(--sch-green);
+  outline-offset: 3px;
+}
+
+.note {
+  font-size: 0.8rem;
+  color: var(--sch-muted);
+}
+
+.noteError {
+  font-size: 0.8rem;
+  color: #ff5c7a;
+}
+
+/* ---------- sections ---------- */
+.section {
+  border-top: 1px solid var(--sch-line);
+  padding: 64px 0;
+}
+
+.secHead {
+  display: flex;
+  align-items: baseline;
+  gap: 16px;
+  margin-bottom: 30px;
+}
+
+.secHead h2 {
+  font-size: clamp(1.5rem, 3.4vw, 2rem);
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+
+.secNum {
+  font-size: 0.85rem;
+  color: var(--sch-green);
+}
+
+.lede {
+  max-width: 640px;
+  margin: 0 0 1em;
+}
+
+/* grid */
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  background: var(--sch-line);
+  border: 1px solid var(--sch-line);
+  margin-top: 36px;
+}
+
+.cell {
+  background: var(--sch-surface);
+  padding: 26px 24px;
+}
+
+.cell h3 {
+  font-size: 1rem;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.cell h3::before {
+  content: "→ ";
+  color: var(--sch-purple);
+}
+
+.cell p {
+  font-size: 0.95rem;
+  color: var(--sch-muted);
+  margin: 0;
+}
+
+/* steps */
+.steps {
+  list-style: none;
+  counter-reset: step;
+  margin: 0;
+  padding: 0;
+}
+
+.steps li {
+  counter-increment: step;
+  display: grid;
+  grid-template-columns: 64px 1fr;
+  gap: 20px;
+  padding: 24px 0;
+  border-bottom: 1px solid var(--sch-line);
+}
+
+.steps li:last-child {
+  border-bottom: none;
+}
+
+.steps li::before {
+  content: counter(step, decimal-leading-zero);
+  font-size: 1.4rem;
+  color: var(--sch-purple);
+  line-height: 1.3;
+  font-variant-numeric: tabular-nums;
+}
+
+.steps h3 {
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0 0 6px;
+}
+
+.steps p {
+  color: var(--sch-muted);
+  font-size: 0.97rem;
+  margin: 0;
+}
+
+/* ---------- form ---------- */
+.form {
+  margin-top: 32px;
+  max-width: 680px;
+  border: 1px solid var(--sch-line);
+  background: var(--sch-surface);
+  padding: 32px 30px;
+}
+
+.formRow,
+.formRowTwo {
+  display: grid;
+  gap: 22px;
+  margin-bottom: 22px;
+}
+
+.formRowTwo {
+  grid-template-columns: 1fr 1fr;
+}
+
+.field label {
+  display: block;
+  font-size: 0.88rem;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.optional {
+  color: var(--sch-muted);
+  font-weight: 400;
+}
+
+.field input,
+.field textarea,
+.field select {
+  width: 100%;
+  box-sizing: border-box;
+  background: transparent;
+  color: inherit;
+  border: 1px solid var(--sch-line);
+  border-radius: 6px;
+  font: inherit;
+  line-height: 1.5;
+  padding: 11px 13px;
+  resize: vertical;
+}
+
+.field select:invalid {
+  color: var(--sch-muted);
+}
+
+.field input:focus-visible,
+.field textarea:focus-visible,
+.field select:focus-visible {
+  outline: 2px solid var(--sch-green);
+  outline-offset: 1px;
+  border-color: transparent;
+}
+
+.formActions {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.formSuccess {
+  margin-top: 32px;
+  max-width: 680px;
+  border: 1px solid var(--sch-green);
+  border-radius: 8px;
+  padding: 28px 30px;
+}
+
+.formSuccess p {
+  margin: 6px 0 0;
+  color: var(--sch-muted);
+}
+
+/* ---------- responsive & motion ---------- */
+@media (max-width: 640px) {
+  .grid,
+  .formRowTwo {
+    grid-template-columns: 1fr;
+  }
+
+  .form {
+    padding: 22px 16px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn {
+    transition: none;
+  }
+}

--- a/apps/web/src/app/[locale]/scholars/scholars.module.css
+++ b/apps/web/src/app/[locale]/scholars/scholars.module.css
@@ -36,7 +36,6 @@
   margin: 0 0 20px;
 }
 
-
 .titleSmall {
   font-size: clamp(2rem, 5.4vw, 3.2rem);
   font-weight: 700;
@@ -56,7 +55,11 @@
 }
 
 .grad {
-  background: linear-gradient(100deg, var(--sch-purple) 20%, var(--sch-green) 80%);
+  background: linear-gradient(
+    100deg,
+    var(--sch-purple) 20%,
+    var(--sch-green) 80%
+  );
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
@@ -107,7 +110,9 @@
   border-radius: 999px;
   border: none;
   cursor: pointer;
-  transition: transform 120ms ease, box-shadow 120ms ease;
+  transition:
+    transform 120ms ease,
+    box-shadow 120ms ease;
 }
 
 .btn:hover {


### PR DESCRIPTION
### Problem

Solana Scholars — a funded 3-month research-internship program for PhD
students, run in collaboration with Solana engineers and researchers — had
no presence on solana.com. There was nowhere to point interested candidates
and no way to collect applications.

### Summary of Changes

Adds two routes to `apps/web`:

- `/scholars` — program information page
- `/scholars/apply` — application form

Both are self-contained (React/Next + one scoped CSS module, no
shared-package imports, no new env variables). The form posts applications
to the program's private Google Sheet via a Google Apps Script web app.
Security-relevant notes: the Apps Script endpoint URL appears in client
source by design — it is a write-only intake endpoint, not a credential;
the sheet itself stays private, and the endpoint can be rotated by
redeploying the script. Submissions are validated client-side and again
in the script (required fields, length caps).

---

### Change classification (SDLC §2)

- [ ] **Critical**
- [x] **Standard** — production-facing, non-critical (new public routes
      with a form)
- [ ] **Low**

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
      (The Apps Script URL in `ApplyForm.tsx` is a public intake endpoint,
      not a credential.)
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
      (Native constraint validation client-side; the Apps Script re-checks
      required fields and caps field length server-side.)
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — failed submissions surface an error
      state in the form; the intake script returns `{ok:false}` on invalid
      input.
- [ ] For **Critical** changes: n/a

<!-- New dependencies (name + why), or "none": -->
none

<!-- Threat-model note for Critical changes, or "n/a": -->
n/a