### PR TITLE
feat: add Solana page design skill

### DIFF
--- a/skills/design-solana-page/SKILL.md
+++ b/skills/design-solana-page/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: design-solana-page
+description:
+  Design, implement, redesign, or review production-grade Solana.com marketing
+  and solution pages in apps/web using the homepage and tokenization page as
+  brand precedents. Use when creating a route or section, translating a brief or
+  visual reference into frontend code, improving an existing page, or auditing
+  brand alignment, responsive behavior, accessibility, motion, and UI quality.
+  Preserve the Solana design foundations while allowing subject-specific art
+  direction, composition, interaction, and functionality.
+---
+
+# Design Solana Page
+
+Create an evolution of the Solana visual language, not a clone of an existing
+page and not a generic dark-technology template. Produce working, integrated
+code unless the user explicitly asks for concepts or an audit only.
+
+Use this as a runtime-neutral Agent Skills procedure. Do not depend on a
+particular agent product, proprietary tool name, or invocation syntax. Use the
+host agent's equivalent file-reading, search, editing, shell, browser, and
+screenshot capabilities. If the host does not discover skills automatically,
+load this file and its linked references directly.
+
+## Load the right references
+
+- Read [references/brand-system.md](references/brand-system.md) before making
+  visual decisions or editing UI. Treat the checked-out repository as final
+  authority when it differs from the snapshot.
+- Read [references/design-workflow.md](references/design-workflow.md) before
+  creating, substantially redesigning, or art-directing a page.
+- Read [references/quality-gates.md](references/quality-gates.md) before review,
+  visual QA, or handoff.
+- Read [references/sources.md](references/sources.md) only when maintaining this
+  skill or tracing its external design guidance.
+
+## Follow the workflow
+
+### 1. Resolve the page and its job
+
+Start from the repository root.
+
+1. Read the root `AGENTS.md`, `apps/web/AGENTS.md`, `apps/web/package.json`, and
+   `apps/web/next.config.ts`.
+2. Resolve the route, audience, single primary job, required content, required
+   functionality, and success action. Ask one concise question only when
+   plausible answers would lead to materially different pages.
+3. Inspect the target route, its nearest current peer, shared components, data
+   sources, message catalogs, and route metadata.
+4. Check the worktree and preserve unrelated user changes.
+5. Confirm whether the request is a new page, a targeted evolution, or an
+   explicit overhaul. Preserve working identity and behavior unless the user
+   authorizes replacement.
+
+### 2. Recalibrate against current precedent
+
+Inspect the current homepage and `/solutions/tokenization` implementation every
+time. Do not rely on remembered screenshots or copy this skill's token snapshot
+blindly. Also inspect rendered pages at representative viewport sizes when the
+environment supports it.
+
+Extract the current:
+
+- typography roles and shared type classes
+- semantic colors, surface hierarchy, borders, and selected accent
+- container, gutters, breakpoints, vertical rhythm, and radius rules
+- hero logic, proof patterns, section transitions, and CTA hierarchy
+- motion technology, static fallbacks, responsive transformations, and states
+
+Use the design grammar and quality bar. Do not repeat the same section order,
+hero geometry, decorative assets, or animation concept by default.
+
+### 3. Set a design read
+
+Before implementation, establish:
+
+- page kind and audience
+- the page's one-sentence thesis and primary action
+- design variance, motion intensity, and visual density
+- one signature element rooted in the subject matter
+- the fixed brand foundation and the creative choices for this page
+
+Keep this reasoning internal unless surfacing it helps the user evaluate a
+meaningful tradeoff. Use the calibration method in the design workflow. Revise
+any choice that could be pasted unchanged into an unrelated crypto page.
+
+### 4. Lock the foundation and free the concept
+
+Hold these foundations stable for core `apps/web` pages:
+
+- Diatype for display/body and DSemi for technical or data utility roles
+- the semantic `nd-*` dark palette, accessible contrast, and a coherent
+  subject-specific accent strategy
+- the shared 1440px framing, responsive gutters, type scale, section rhythm,
+  surface rules, and CTA hierarchy
+- shared chrome, locale routing, message catalogs, metadata, and cross-app link
+  behavior
+
+Vary these deliberately:
+
+- hero composition and signature interaction
+- accent selection within or derived from the brand palette
+- editorial structure, grid, media direction, information density, and pacing
+- useful animation, data visualization, progressive disclosure, and page
+  functionality
+
+Deviate from a foundation only for an explicit campaign, microsite, or approved
+brand extension. Scope the exception locally and document why it serves the
+brief.
+
+### 5. Design content and structure together
+
+- Build with real approved content and data. Never invent partners, metrics,
+  testimonials, dates, or product claims.
+- Make the hero a thesis, not a stack of generic badges, stats, and buttons.
+- Use structural devices only when they convey real hierarchy, sequence, state,
+  or comparison.
+- Use cards only when a bounded surface communicates grouping or interaction.
+  Prefer typography, spacing, dividers, grids, and media when elevation adds no
+  meaning.
+- Spend visual boldness on one signature idea. Keep surrounding elements
+  disciplined enough for it to land.
+- Write plain, specific, active copy. Keep action labels consistent with the
+  outcome they trigger.
+
+### 6. Implement repository-first
+
+- Reuse current components, utilities, icons, tokens, and dependencies before
+  adding abstractions or packages.
+- Check `package.json` before importing any third-party library. Do not install
+  or replace a design system for a page-scoped task without explicit need.
+- Keep static layout and data work server-side. Isolate state, browser APIs,
+  motion, and modal behavior in the smallest practical client components.
+- Use semantic elements and correct link/button behavior. Preserve keyboard,
+  focus, touch, loading, empty, error, success, and reduced-motion states.
+- Add English source messages through the repository i18n system rather than
+  hard-coding user-facing copy. Use the `localize-page` skill when the task also
+  calls for full localization work.
+- Use the shared chrome and URL helpers. Inspect route ownership and rewrites
+  before changing navigation behavior.
+- Build responsive behavior intentionally; do not treat mobile as a compressed
+  desktop layout.
+
+### 7. Critique, render, and verify
+
+Perform two critiques:
+
+1. Before coding, remove choices that feel generic, decorative, or unrelated to
+   the subject.
+2. After rendering, remove one unnecessary accessory and fix the largest issue
+   in hierarchy, rhythm, contrast, or interaction before polishing details.
+
+Render narrow mobile, tablet, laptop, and wide desktop views. Exercise actual
+interactions and non-happy states. Apply every relevant quality gate, then run
+the narrowest useful workspace lint, type, and test commands. Report any checks
+that could not run.
+
+## Handle review-only requests
+
+Do not edit files when the user asks only for an audit or review. Inspect the
+rendered result and implementation, then report high-signal findings grouped by
+file in `path:line - severity - issue - suggested fix` form. Prioritize broken
+behavior, accessibility, brand divergence, and responsive failures over taste
+nits. State when no material findings remain.

--- a/skills/design-solana-page/references/brand-system.md
+++ b/skills/design-solana-page/references/brand-system.md
@@ -1,0 +1,190 @@
+# Solana Web Brand System
+
+Use this as a calibrated snapshot, not a substitute for repository inspection.
+It was derived from `main` at commit `d7ddd692c3d6c19960b4894cb5234216b9a3b0b5`
+on 2026-07-31. Re-read the source files before implementation and let current
+code win.
+
+## Source hierarchy
+
+Inspect these sources in order:
+
+1. Target route and its nearest current peer
+2. `apps/web/src/app/[locale]/home.tsx` and `apps/web/src/components/index/`
+3. `apps/web/src/app/[locale]/solutions/tokenization/` and the imported
+   `apps/web/src/components/solutions/*.v2.tsx` modules
+4. `apps/web/src/app/globals.css`, `apps/web/tailwind.config.js`,
+   `apps/web/src/fonts/fonts.css`, and `apps/web/src/scss/_solana.scss`
+5. `apps/web/src/component-library/container.tsx`, shared button components,
+   `packages/ui`, and `packages/ui-chrome`
+6. `packages/i18n/messages/web/en/common.json` and route metadata helpers
+
+Use semantic classes and shared components when they express the intended
+design. Avoid copying long Tailwind strings when a current `nd-*` class already
+owns the token.
+
+## Precedent anatomy
+
+### Homepage
+
+Treat the homepage as the broad ecosystem precedent:
+
+- Open with a large left-aligned thesis over an art-directed animated field with
+  a static image fallback.
+- Establish trust through real logos, network performance, projects, events,
+  current news, videos, and community rather than unsupported marketing claims.
+- Alternate immersive moments with modular grids, carousels, dividers, and
+  quieter proof sections.
+- Use strong typographic hierarchy, a white primary CTA, restrained translucent
+  surfaces, and subject-specific color moments.
+- Keep one coherent black canvas while varying pace and density by section.
+
+### Tokenization
+
+Treat `/solutions/tokenization` as the focused solution-story precedent:
+
+- Use a product-specific accent (`#CA9FF5` in the snapshot) within the common
+  dark foundation.
+- Turn the hero into a proposition plus useful proof: key statistics and a
+  relevant report action occupy the lower frame.
+- Move from explanation to ecosystem evidence, implementation products, real
+  builders, current news, and adjacent next steps.
+- Reuse a consistent immersive section rhythm and max-width frame while changing
+  layout modes to avoid repetition.
+- Pair animated backgrounds with reliable fallbacks and keep content usable
+  without motion.
+
+Neither precedent is a page template. Preserve its grammar: confident type,
+credible content, disciplined dark surfaces, purposeful motion, responsive
+composition, and a clear action hierarchy.
+
+## Fixed foundation
+
+### Typography
+
+- Use `Diatype` for display and body copy through `font-brand` or inherited body
+  styling.
+- Use `DSemi` through `font-brand-mono` for data, compact technical labels,
+  code-adjacent utility text, and occasional uppercase metadata.
+- Use the shipped weights 200, 300, 400, 500, and 700. Keep
+  `font-display: swap`.
+- Do not introduce a generic web font or a decorative serif into a core page.
+  Treat other bundled faces such as Monument as campaign-specific, not default.
+- Prefer the shared responsive classes in `globals.css`:
+
+| Role             | Snapshot scale | Typical use                    |
+| ---------------- | -------------- | ------------------------------ |
+| `nd-heading-2xl` | 40 / 56 / 88px | Primary hero statement         |
+| `nd-heading-xl`  | 40 / 48 / 80px | Large editorial statement      |
+| `nd-heading-l`   | 32 / 40 / 64px | Main section heading           |
+| `nd-heading-m`   | 18 / 32 / 36px | Feature or subsection heading  |
+| `nd-body-xl`     | 18 / 24px      | Hero or section lead           |
+| `nd-body-l`      | 16 / 18 / 20px | Prominent body copy            |
+| `nd-body-m`      | 16 / 18px      | Actions and standard body copy |
+| `nd-body-s`      | 14 / 16px      | Supporting labels and metadata |
+
+The classes also encode line-height and tracking. Use their current definitions
+instead of treating this table as a parallel token source. Balance or
+pretty-wrap large headings and test translated expansion.
+
+### Color
+
+Use the semantic `nd-*` colors from Tailwind before raw values:
+
+| Token                       | Snapshot value | Role                                  |
+| --------------------------- | -------------- | ------------------------------------- |
+| `nd-bg`, `nd-inverse`       | `#000000`      | Page canvas and inverse surfaces      |
+| `nd-high-em-text`, `nd-cta` | `#FFFFFF`      | Primary text and primary CTA          |
+| `nd-mid-em-text`            | `#ABABBA`      | Secondary copy                        |
+| `nd-mid-em-text-alpha`      | `#FFFFFFA3`    | Translucent secondary copy            |
+| `nd-border-light`           | `#ECE4FD1F`    | Dividers and quiet surfaces           |
+| `nd-border-prominent`       | `#ECE4FD33`    | Interactive or stronger borders       |
+| `nd-border-hovered`         | `#ECE4FD52`    | Hovered boundary                      |
+| `nd-highlight-lavendar`     | `#CA9FF5`      | Lavender accent; keep config spelling |
+| `nd-highlight-blue`         | `#6693F7`      | Blue accent                           |
+| `nd-highlight-gold`         | `#FFC526`      | Gold accent                           |
+| `nd-highlight-orange`       | `#F48252`      | Orange accent                         |
+| `nd-highlight-green`        | `#55E9AB`      | Green accent                          |
+| `nd-highlight-lime`         | `#CFF15E`      | Lime accent                           |
+
+Select one dominant accent family based on the subject. Extend it with tints or
+transparent variants. Add supporting highlight colors when they encode real
+categories, data, or illustration logic; do not introduce unrelated accents
+section by section. Use the multi-stop Solana logo gradient only when the brand
+gradient has meaning; a purple-blue glow is not automatically brand aligned
+merely because Solana uses purple.
+
+Keep primary text at full white, secondary copy near the shared muted tone, and
+boundaries subtle. Verify contrast for every text/surface pair, selection color,
+focus state, overlay, and text over media.
+
+### Layout and rhythm
+
+- Frame main content at `max-w-screen-2xl` / 1440px.
+- Use shared responsive gutters: 20px mobile, 32px from `md`, and 40px from
+  `xl`.
+- Treat 768px, 1280px, and the custom 1440px `2xl` breakpoint as deliberate
+  composition changes, not only font-size changes.
+- Choose a primary vertical rhythm for the page:
+  - Use the compact homepage rhythm (`py-10` and its component-specific
+    extensions) for denser modular sequences.
+  - Use the solution-story rhythm (64 / 112 / 160px) for immersive narrative
+    sections.
+- Mix rhythms only to create an intentional tempo change. Do not assign random
+  padding to every section.
+- Let full-bleed backgrounds and media extend beyond the content frame while
+  preserving aligned copy and controls.
+
+### Shapes, borders, and surfaces
+
+- Use `rounded-xl` as the common media/card surface, `rounded-2xl` for a major
+  grouped container, and full pills for actions.
+- Keep a documented radius rule. Do not scatter unrelated corner sizes.
+- Prefer thin translucent borders, dividers, negative space, and background
+  contrast over heavy shadows.
+- Use backdrop blur sparingly where layering is real. Do not glass every card.
+- Use cards only for meaningful grouping, navigation, controls, reports, or
+  bounded media.
+
+### Actions
+
+- Use a white-on-black or black-on-white pill as the primary CTA, commonly 48px
+  tall on larger viewports.
+- Use the shared button primitives and their focus behavior.
+- Use the inverse circular icon treatment when it strengthens a primary action;
+  do not attach it mechanically to every button.
+- Use an outlined/translucent secondary action and a text link for tertiary
+  navigation.
+- Keep labels specific, consistent, and on one line at desktop. Render
+  navigation as links and operations as buttons.
+
+### Media, iconography, and motion
+
+- Prefer real brand assets, product visuals, documentary photography, data
+  graphics, and subject-derived art direction over generic crypto imagery.
+- Use `next/image` with intrinsic dimensions or `fill` plus `sizes`. Prioritize
+  critical above-fold media and lazy-load below-fold assets.
+- Give informative media useful alt text and decorative media `alt=""`.
+- Reuse the existing icon family and `@solana-com/ui-chrome/icons`. Do not mix
+  icon styles or hand-draw a new family for one page.
+- Animate to explain hierarchy, progress, state, scale, or narrative. Favor one
+  orchestrated signature over constant unrelated movement.
+- Use `SafeUnicornScene` only when immersive artwork justifies it. Supply a
+  stable fallback and keep content independent of the canvas.
+- Animate compositor-friendly properties where practical, make motion
+  interruptible, and honor reduced-motion preferences.
+
+## Creative range
+
+Keep the following open to the brief:
+
+- asymmetrical, split, editorial, centered manifesto, pinned, or data-led hero
+- restrained or cinematic motion
+- dense technical proof or spacious brand storytelling
+- bespoke interactive explainers, charts, filters, calculators, video, and
+  progressive disclosure
+- grids, lists, timelines, carousels, comparison structures, or full-bleed media
+  when they match the content
+
+Make one design decision that is memorable and defensible in the subject's own
+world. Keep every other decision coherent with it and with the fixed foundation.

--- a/skills/design-solana-page/references/design-workflow.md
+++ b/skills/design-solana-page/references/design-workflow.md
@@ -1,0 +1,170 @@
+# Design and Implementation Workflow
+
+## 1. Infer the brief
+
+Resolve these signals before choosing a layout:
+
+- page kind: solution, developer entry point, launch, event, editorial,
+  directory, tool, or campaign
+- audience: builder, institution, consumer, creator, ecosystem team, or mixed
+- single job: what the visitor should understand or do next
+- trust needs: proof, partners, network data, documentation, case studies, or
+  risk disclosures
+- content reality: approved copy, live data, assets, localization, and empty or
+  loading conditions
+- reference intent: which characteristics to preserve rather than which pixels
+  to imitate
+
+Ask one question only if the missing answer changes the page's design language,
+functionality, or content architecture. Otherwise state a reasonable assumption
+and proceed.
+
+## 2. Form the design read
+
+Use this compact working note:
+
+```text
+Page: <kind> for <audience>
+Job: <single primary outcome>
+Thesis: <one sentence the hero must establish>
+Brand mode: core | campaign extension
+Variance / motion / density: <1-10> / <1-10> / <1-10>
+Signature: <one subject-derived memorable element>
+Foundation: <tokens, components, and precedent being preserved>
+Creative range: <composition, accent, interaction, and media choices>
+```
+
+Treat the three dials as reasoning aids, not user-facing settings:
+
+- `VARIANCE` controls symmetry, grid disruption, and compositional surprise.
+- `MOTION` controls the depth of transitions, scroll choreography, and ambient
+  behavior.
+- `DENSITY` controls how much information appears per viewport.
+
+Use these starting points, then adapt to the actual brief:
+
+| Page type                      |      Variance |           Motion |       Density |
+| ------------------------------ | ------------: | ---------------: | ------------: |
+| Focused solution story         |             6 |                5 |             4 |
+| Developer landing page         |             5 |                4 |             5 |
+| Launch, event, or campaign     |             8 |                7 |             3 |
+| Editorial or research feature  |             7 |                4 |             3 |
+| Directory, comparison, or tool |             4 |                3 |             7 |
+| Targeted evolution             | Match current | Current + 0 or 1 | Match current |
+
+If motion cannot be implemented and verified reliably, lower the motion dial
+instead of describing an experience that the code does not deliver.
+
+## 3. Explore before coding
+
+Create two or three materially different composition options in short prose or
+small wireframes. Vary the information model, not merely alignment.
+
+For each option, check:
+
+- Does the hero express the subject through content, visual behavior, or useful
+  interaction?
+- Does the structure reflect how the audience decides or learns?
+- Can the same layout be pasted into an unrelated blockchain site unchanged?
+- Is the signature grounded in the subject rather than a fashionable effect?
+- Does the implementation effort match the value of the idea?
+
+Choose one direction. Define its color role, type roles, layout logic, section
+rhythm, surface rule, CTA hierarchy, motion purpose, and signature before
+writing UI code.
+
+## 4. Plan the narrative and functions
+
+Sequence sections around user questions. A focused solution page often needs:
+
+1. What is the proposition?
+2. Why should the visitor believe it?
+3. How does it work or what can they build?
+4. Who already uses it?
+5. What should they do next?
+
+Change or remove any step that does not serve the actual page. Do not force a
+homepage or tokenization-shaped sequence.
+
+Define interactive behavior and all states before implementation:
+
+- default, hover, active, focus, and disabled
+- loading, empty, error, success, and partial data
+- modal, drawer, carousel, tab, filter, or expanded state
+- reduced motion and no-canvas fallback
+- long translated text, missing media, and narrow viewport behavior
+
+Make URL-visible state deep-linkable when it changes what the page shows, such
+as filters, tabs, and pagination.
+
+## 5. Build in passes
+
+### Pass A: semantic skeleton
+
+- Establish metadata, one `h1`, landmarks, heading hierarchy, content order,
+  real links, real buttons, and data ownership.
+- Add English source messages and use semantic IDs for repeated content.
+- Keep server and client boundaries narrow.
+
+### Pass B: brand foundation
+
+- Apply the shared container, gutters, typography classes, semantic colors,
+  section rhythm, radius system, CTA hierarchy, and focus behavior.
+- Reuse current component-library pieces where their semantics and visuals fit.
+- Keep a declared accent strategy and one surface grammar.
+
+### Pass C: signature and motion
+
+- Implement the one memorable element with a static fallback.
+- Add motion only where it communicates hierarchy, feedback, state, scale, or
+  narrative sequence.
+- Keep animations interruptible and remove listeners or timelines on cleanup.
+
+### Pass D: real-world states
+
+- Connect real assets and data.
+- Exercise long strings, no data, failed data, slow media, keyboard navigation,
+  touch input, and reduced motion.
+- Prevent client-side fallbacks from causing layout jumps or hydration errors.
+
+## 6. Critique twice
+
+Before implementation, replace any default choice that ignores the brief:
+
+- a centered dark hero with an arbitrary purple-blue mesh
+- three equal feature cards regardless of content
+- glassmorphism on every surface
+- decorative numbering that implies no real sequence
+- meaningless monospace eyebrows or badges
+- generic cube, coin, network-node, or astronaut imagery
+- motion added only because a library is available
+
+Purple, gradients, technical labels, cards, and centered heroes are not banned.
+Use them when the Solana brand and page content make them the strongest choice,
+not as automatic crypto styling.
+
+After rendering, inspect screenshots from the whole page and the first viewport.
+Fix the largest issue first:
+
+1. broken behavior or accessibility
+2. unclear thesis or action
+3. weak hierarchy or responsive composition
+4. off-brand type, color, or rhythm
+5. inconsistent surfaces and states
+6. decorative polish
+
+Remove one accessory that competes with the signature or content.
+
+## 7. Preserve architecture
+
+- Keep route ownership in `apps/web` and inspect rewrites before changing public
+  navigation.
+- Use `@workspace/i18n`, `@workspace/ui`, and `@solana-com/ui-chrome` according
+  to existing patterns.
+- Reuse installed animation and component dependencies. Do not add a second
+  design system, icon family, or styling architecture for a single page.
+- Preserve Server Components where possible. Move only interactive leaves to the
+  client.
+- Prefer CSS grid and responsive layout primitives over JavaScript measurement.
+- Avoid broad shared-component changes unless the new behavior truly belongs to
+  every consumer. Validate all consumers when changing shared code.

--- a/skills/design-solana-page/references/quality-gates.md
+++ b/skills/design-solana-page/references/quality-gates.md
@@ -1,0 +1,132 @@
+# Production Quality Gates
+
+Apply every relevant gate before handoff. Treat a beautiful screenshot with
+broken semantics, slow loading, or incomplete states as unfinished.
+
+For a formal UI review, retrieve the latest Vercel Web Interface Guidelines at
+`https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md`
+when network access is available. Apply compatible current rules in addition to
+this offline baseline. Let repository conventions and explicit user requirements
+override generic stylistic advice, never accessibility or safety.
+
+## Brand and concept
+
+- [ ] Reinspect the current homepage, tokenization page, target route, global
+      tokens, and shared primitives.
+- [ ] State a clear audience, page job, thesis, primary action, and signature.
+- [ ] Use Diatype, DSemi, semantic colors, shared framing, and the selected
+      rhythm unless an approved exception is documented.
+- [ ] Keep one declared accent strategy, one radius rule, and one surface
+      grammar.
+- [ ] Avoid a layout that could be moved unchanged to an unrelated crypto page.
+- [ ] Use real approved copy, logos, partners, metrics, dates, and testimonials.
+- [ ] Make every visual decoration support subject, hierarchy, state, or mood.
+
+## Semantics and accessibility
+
+- [ ] Use one `h1`, hierarchical headings, landmarks, and a usable skip path to
+      main content through the app shell.
+- [ ] Use links for navigation and buttons for actions. Do not attach click
+      behavior to non-interactive elements.
+- [ ] Give icon-only controls accessible names and decorative icons
+      `aria-hidden="true"`.
+- [ ] Give form controls visible labels or accessible names, meaningful `name`,
+      correct `type`, `inputMode`, and appropriate `autoComplete`.
+- [ ] Keep labels and controls in one practical hit target. Never block paste.
+- [ ] Expose async status through visible text and an appropriate live region.
+- [ ] Keep visible `:focus-visible` states. Never remove outlines without a
+      clear replacement.
+- [ ] Verify keyboard order, modal focus management, Escape behavior, and focus
+      return.
+- [ ] Preserve browser zoom and use comfortable touch targets.
+- [ ] Meet WCAG AA contrast, including hover, focus, disabled, selection, text
+      over media, and ghost actions.
+
+## Responsive layout and content
+
+- [ ] Render at narrow mobile, tablet, laptop, 1440px, and a wider viewport.
+- [ ] Transform composition at breakpoints; do not merely shrink type.
+- [ ] Prevent horizontal overflow and account for full-bleed media and safe
+      areas.
+- [ ] Use grid or flex layout before JavaScript measurements.
+- [ ] Let flex children shrink with `min-width: 0` where needed.
+- [ ] Handle short, average, long, translated, and missing content without
+      clipping or overlapping.
+- [ ] Keep desktop CTA labels on one line and make mobile wrapping intentional.
+- [ ] Balance or pretty-wrap display headings without forcing fragile manual
+      breaks across locales.
+- [ ] Keep anchored headings visible below sticky chrome with scroll margin.
+
+## Interaction and state
+
+- [ ] Implement hover, active, focus, disabled, loading, empty, error, success,
+      and retry behavior relevant to each control or data surface.
+- [ ] Increase rather than reduce visual clarity on hover, active, and focus.
+- [ ] Keep destructive actions confirmable or recoverable.
+- [ ] Reflect meaningful filters, tabs, pagination, and expanded state in the
+      URL when deep linking benefits the visitor.
+- [ ] Keep animations interruptible and responsive to input.
+- [ ] Honor `prefers-reduced-motion`; provide a quiet but complete experience.
+- [ ] Animate transform and opacity when possible and never use
+      `transition: all`.
+- [ ] Justify perpetual animation and stop it when offscreen when practical.
+- [ ] Keep motion, pointer tracking, and scroll progress out of React render
+      state when a motion value or browser primitive is appropriate.
+
+## Images, fonts, and performance
+
+- [ ] Give images dimensions or stable aspect ratios to prevent layout shift.
+- [ ] Prioritize only critical above-fold media and lazy-load below-fold media.
+- [ ] Supply correct responsive `sizes`, useful alt text, and empty alt text for
+      decoration.
+- [ ] Preserve font preloading/display behavior and avoid new remote font
+      dependencies.
+- [ ] Supply static fallbacks for animated backgrounds, canvas, and video.
+- [ ] Avoid layout reads during render and batch DOM reads and writes.
+- [ ] Virtualize or progressively reveal genuinely large collections.
+- [ ] Keep client components, animation libraries, and media payloads scoped to
+      the experience that needs them.
+- [ ] Check for avoidable cumulative layout shift, sluggish interaction, and
+      oversized above-fold assets.
+
+## Locale, hydration, and copy
+
+- [ ] Put user-facing copy in the English source catalog and use ICU variables
+      or rich messages instead of concatenated fragments.
+- [ ] Format locale-sensitive dates, times, numbers, and currency with `Intl` or
+      repository helpers.
+- [ ] Keep brand names, code tokens, and identifiers stable where translation
+      would corrupt them.
+- [ ] Avoid server/client time, random, or browser-state mismatches.
+- [ ] Use `suppressHydrationWarning` only for an unavoidable, understood case.
+- [ ] Use active voice, sentence case consistent with nearby pages, and specific
+      action labels.
+- [ ] Make errors identify what happened and the next useful action.
+- [ ] Re-read every visible string and remove vague claims, filler, invented
+      facts, and inconsistent terminology.
+
+## Repository verification
+
+Run the narrowest useful commands from the repository root:
+
+```bash
+pnpm --filter solana-com lint
+pnpm --filter solana-com check-types
+pnpm --filter solana-com test
+```
+
+Add focused tests or browser checks for new behavior. Use a production build
+when the change affects routing, rendering boundaries, metadata, image handling,
+or build-time behavior. Do not claim a check passed when it did not run.
+
+## Review output
+
+For audit-only work, group actionable findings by file:
+
+```text
+path/to/file.tsx:42 - high - action is a div with no keyboard semantics - use a button
+path/to/file.tsx:88 - medium - accent diverges from the page palette - use the selected semantic accent
+```
+
+Order findings by user impact. Skip generic praise and low-value preference
+comments. State `No material findings` when the inspected scope passes.

--- a/skills/design-solana-page/references/sources.md
+++ b/skills/design-solana-page/references/sources.md
@@ -1,0 +1,32 @@
+# Guidance Sources
+
+Use this file to maintain the skill, not as a required runtime dependency. The
+skill paraphrases and reconciles these influences with the Solana repository; it
+does not copy an external skill wholesale.
+
+Sources consulted on 2026-07-31:
+
+- [Anthropic frontend-design](https://www.skills.sh/anthropics/skills/frontend-design)
+  and its upstream `SKILL.md`: ground design in the subject and audience, make
+  the hero a thesis, treat typography and structure as meaning, use motivated
+  motion, plan before coding, choose one signature risk, and critique twice.
+- [Vercel web-design-guidelines](https://www.skills.sh/vercel-labs/agent-skills/web-design-guidelines)
+  and the upstream Web Interface Guidelines: enforce semantic controls, visible
+  focus, form quality, reduced motion, stable images, responsive content,
+  performance, deep-linkable state, i18n, hydration safety, and terse audits.
+- [Leonxlnx design-taste-frontend](https://www.skills.sh/leonxlnx/taste-skill/design-taste-frontend)
+  and its upstream `SKILL.md`: infer the brief before designing, calibrate
+  variance/motion/density, audit before redesigning, resist templated AI
+  patterns, lock page-level design decisions, and run a strict preflight.
+
+Apply external rules contextually. In particular, generic advice to avoid purple
+or gradients cannot override Solana's established palette. The relevant lesson
+is to avoid arbitrary, interchangeable purple-blue effects and use brand color
+with a subject-specific purpose.
+
+Keep these current upstream references available for maintenance:
+
+- `https://raw.githubusercontent.com/anthropics/skills/main/skills/frontend-design/SKILL.md`
+- `https://raw.githubusercontent.com/vercel-labs/agent-skills/main/skills/web-design-guidelines/SKILL.md`
+- `https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md`
+- `https://raw.githubusercontent.com/Leonxlnx/taste-skill/main/skills/taste-skill/SKILL.md`


### PR DESCRIPTION
## Summary

- add an agent-agnostic workflow for designing, implementing, redesigning, and reviewing Solana.com pages
- capture the homepage and tokenization page typography, color, layout, surface, motion, and CTA precedents
- preserve creative range through design calibration, subject-led signatures, and contextual composition
- add production quality gates for accessibility, responsiveness, performance, i18n, hydration, and interaction states
- document the external design-skill sources used for the synthesis

## Validation

- skill-creator quick validation
- Prettier check
- reference and repository-path checks
- read-only forward test against a hypothetical new solution page