### PR TITLE
feat(breakpoint): schedule ticket price increase

### DIFF
--- a/apps/breakpoint/src/app/[locale]/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/page.tsx
@@ -16,12 +16,15 @@ import Footer from "@/components/sections/Footer";
 import { GENERAL_ADMISSION_HREF } from "@/content/links";
 import { buildBreakpointJsonLd } from "@/lib/structured-data";
 
+export const dynamic = "force-dynamic";
+
 export default async function HomePage({
   params,
 }: {
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
+  const initialNow = Date.now();
   const jsonLd = buildBreakpointJsonLd(locale);
 
   return (
@@ -41,7 +44,7 @@ export default async function HomePage({
       <HeroSection />
       <NarrativeSection />
       <Marquee />
-      <TicketsSection />
+      <TicketsSection initialNow={initialNow} />
       <ParticipateSection />
       <WhyAttendSection />
       <SponsorsSection />

--- a/apps/breakpoint/src/app/[locale]/registration/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/registration/page.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import RegistrationPage from "@/components/pages/registration/RegistrationPage";
 import { getPageMetadata } from "@/app/metadata";
 
+export const dynamic = "force-dynamic";
+
 const pageMetadata = {
   path: "/registration",
   title: "Registration",

--- a/apps/breakpoint/src/app/page.tsx
+++ b/apps/breakpoint/src/app/page.tsx
@@ -7,6 +7,8 @@ import { getBaseMetadata } from "./metadata";
 import { FabMenu } from "@/components/FabMenu";
 import { loadBreakpointMessages } from "@/i18n/request";
 
+export const dynamic = "force-dynamic";
+
 const displayFont = localFont({
   src: "../../public/fonts/bp26-extended/BP26-Extended.woff2",
   variable: "--font-bp26",

--- a/apps/breakpoint/src/components/TicketPriceChange.tsx
+++ b/apps/breakpoint/src/components/TicketPriceChange.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import {
+  GENERAL_ADMISSION_PRICE_INCREASE_AT,
+  getTicketPriceCountdownParts,
+  hasGeneralAdmissionPriceIncreased,
+} from "@/content/ticket-pricing";
+
+type GeneralAdmissionPriceProps = {
+  currentPrice: string;
+  increasedPrice: string;
+};
+
+type TicketPriceChangeCountdownProps = {
+  className?: string;
+  label: string;
+};
+
+function usePriceChangeClock() {
+  const [now, setNow] = useState<number | null>(null);
+
+  useEffect(() => {
+    let intervalId: number | undefined;
+
+    const tick = () => {
+      const currentTime = Date.now();
+      setNow(currentTime);
+
+      if (
+        hasGeneralAdmissionPriceIncreased(currentTime) &&
+        intervalId !== undefined
+      ) {
+        window.clearInterval(intervalId);
+      }
+    };
+
+    tick();
+
+    if (Date.now() < GENERAL_ADMISSION_PRICE_INCREASE_AT) {
+      intervalId = window.setInterval(tick, 1000);
+    }
+
+    return () => {
+      if (intervalId !== undefined) {
+        window.clearInterval(intervalId);
+      }
+    };
+  }, []);
+
+  return now;
+}
+
+function ClockIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-[18px] shrink-0"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeWidth="2" />
+      <path
+        d="M12 7v5l3 2"
+        stroke="currentColor"
+        strokeLinecap="square"
+        strokeWidth="2"
+      />
+    </svg>
+  );
+}
+
+export function GeneralAdmissionPrice({
+  currentPrice,
+  increasedPrice,
+}: GeneralAdmissionPriceProps) {
+  const now = usePriceChangeClock();
+  const price =
+    now !== null && hasGeneralAdmissionPriceIncreased(now)
+      ? increasedPrice
+      : currentPrice;
+
+  return <>{price}</>;
+}
+
+export function TicketPriceChangeCountdown({
+  className = "",
+  label,
+}: TicketPriceChangeCountdownProps) {
+  const now = usePriceChangeClock();
+
+  if (now === null || hasGeneralAdmissionPriceIncreased(now)) {
+    return null;
+  }
+
+  const { days, hours, minutes, seconds } = getTicketPriceCountdownParts(now);
+  const countdown = [
+    ...(days > 0 ? [`${days}D`] : []),
+    `${hours}H`,
+    `${minutes}M`,
+    `${seconds}S`,
+  ].join(" ");
+
+  return (
+    <div
+      aria-label={`${label} ${countdown}`}
+      className={`type-caption inline-flex items-center gap-2 border border-stroke-secondary bg-neutral-800 px-3 py-3 text-white md:px-4 md:text-[length:var(--text-button)] md:font-normal md:leading-[var(--text-eyebrow--line-height)] md:tracking-[var(--text-eyebrow--letter-spacing)] ${className}`}
+      role="timer"
+    >
+      <ClockIcon />
+      <span className="whitespace-nowrap">{label}</span>
+      <span aria-hidden="true" className="whitespace-nowrap">
+        {countdown}
+      </span>
+    </div>
+  );
+}

--- a/apps/breakpoint/src/components/TicketPriceChange.tsx
+++ b/apps/breakpoint/src/components/TicketPriceChange.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "@workspace/i18n/client";
 import {
   GENERAL_ADMISSION_PRICE_INCREASE_AT,
   getTicketPriceCountdownParts,
@@ -9,16 +10,28 @@ import {
 
 type GeneralAdmissionPriceProps = {
   currentPrice: string;
+  initialNow: number;
   increasedPrice: string;
 };
 
 type TicketPriceChangeCountdownProps = {
   className?: string;
+  initialNow: number;
   label: string;
 };
 
-function usePriceChangeClock() {
-  const [now, setNow] = useState<number | null>(null);
+type LocalizedTicketPriceChangeCountdownProps = Omit<
+  TicketPriceChangeCountdownProps,
+  "label"
+>;
+
+type LocalizedGeneralAdmissionPriceProps = Pick<
+  GeneralAdmissionPriceProps,
+  "initialNow"
+>;
+
+function usePriceChangeClock(initialNow: number) {
+  const [now, setNow] = useState(initialNow);
 
   useEffect(() => {
     let intervalId: number | undefined;
@@ -72,24 +85,25 @@ function ClockIcon() {
 
 export function GeneralAdmissionPrice({
   currentPrice,
+  initialNow,
   increasedPrice,
 }: GeneralAdmissionPriceProps) {
-  const now = usePriceChangeClock();
-  const price =
-    now !== null && hasGeneralAdmissionPriceIncreased(now)
-      ? increasedPrice
-      : currentPrice;
+  const now = usePriceChangeClock(initialNow);
+  const price = hasGeneralAdmissionPriceIncreased(now)
+    ? increasedPrice
+    : currentPrice;
 
   return <>{price}</>;
 }
 
 export function TicketPriceChangeCountdown({
   className = "",
+  initialNow,
   label,
 }: TicketPriceChangeCountdownProps) {
-  const now = usePriceChangeClock();
+  const now = usePriceChangeClock(initialNow);
 
-  if (now === null || hasGeneralAdmissionPriceIncreased(now)) {
+  if (hasGeneralAdmissionPriceIncreased(now)) {
     return null;
   }
 
@@ -104,7 +118,7 @@ export function TicketPriceChangeCountdown({
   return (
     <div
       aria-label={`${label} ${countdown}`}
-      className={`type-caption inline-flex items-center gap-2 border border-stroke-secondary bg-neutral-800 px-3 py-3 text-white md:px-4 md:text-[length:var(--text-button)] md:font-normal md:leading-[var(--text-eyebrow--line-height)] md:tracking-[var(--text-eyebrow--letter-spacing)] ${className}`}
+      className={`type-caption inline-flex max-w-full flex-wrap items-center justify-center gap-2 border border-stroke-secondary bg-neutral-800 px-3 py-3 text-white md:px-4 md:text-[length:var(--text-button)] md:font-normal md:leading-[var(--text-eyebrow--line-height)] md:tracking-[var(--text-eyebrow--letter-spacing)] ${className}`}
       role="timer"
     >
       <ClockIcon />
@@ -113,5 +127,32 @@ export function TicketPriceChangeCountdown({
         {countdown}
       </span>
     </div>
+  );
+}
+
+export function LocalizedTicketPriceChangeCountdown(
+  props: LocalizedTicketPriceChangeCountdownProps,
+) {
+  const t = useTranslations("breakpoint");
+
+  return (
+    <TicketPriceChangeCountdown
+      {...props}
+      label={t("tickets.priceIncreaseCountdown")}
+    />
+  );
+}
+
+export function LocalizedGeneralAdmissionPrice({
+  initialNow,
+}: LocalizedGeneralAdmissionPriceProps) {
+  const t = useTranslations("breakpoint");
+
+  return (
+    <GeneralAdmissionPrice
+      currentPrice={t("tickets.categories.general.price")}
+      initialNow={initialNow}
+      increasedPrice={t("tickets.categories.general.priceAfterIncrease")}
+    />
   );
 }

--- a/apps/breakpoint/src/components/pages/registration/RegistrationPage.tsx
+++ b/apps/breakpoint/src/components/pages/registration/RegistrationPage.tsx
@@ -5,8 +5,8 @@ import PageShell from "@/components/PageShell";
 import RegistrationTicketButton from "@/components/pages/registration/RegistrationTicketButton";
 import SubpageHero from "@/components/SubpageHero";
 import {
-  GeneralAdmissionPrice,
-  TicketPriceChangeCountdown,
+  LocalizedGeneralAdmissionPrice,
+  LocalizedTicketPriceChangeCountdown,
 } from "@/components/TicketPriceChange";
 import {
   DEVELOPER_APPLICATION_HREF,
@@ -88,7 +88,13 @@ function PriceCut({ value }: { value: string }) {
   );
 }
 
-function RegistrationTicketCard({ ticket }: { ticket: RegistrationTicket }) {
+function RegistrationTicketCard({
+  initialNow,
+  ticket,
+}: {
+  initialNow: number;
+  ticket: RegistrationTicket;
+}) {
   const isFeatured = ticket.tone === "featured";
   const isDisabled = ticket.tone === "disabled";
 
@@ -125,10 +131,7 @@ function RegistrationTicketCard({ ticket }: { ticket: RegistrationTicket }) {
         {ticket.originalPrice && <PriceCut value={ticket.originalPrice} />}
         <p className={`type-h2 ${isFeatured ? "text-black" : "text-white"}`}>
           {ticket.priceAfterIncrease ? (
-            <GeneralAdmissionPrice
-              currentPrice={ticket.price}
-              increasedPrice={ticket.priceAfterIncrease}
-            />
+            <LocalizedGeneralAdmissionPrice initialNow={initialNow} />
           ) : (
             ticket.price
           )}
@@ -144,17 +147,21 @@ function RegistrationTicketCard({ ticket }: { ticket: RegistrationTicket }) {
   );
 }
 
-function TicketsGrid() {
+function TicketsGrid({ initialNow }: { initialNow: number }) {
   return (
     <section className="bg-black pt-2xl md:pt-[120px]">
       <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-xs md:px-8">
-        <TicketPriceChangeCountdown
+        <LocalizedTicketPriceChangeCountdown
           className="self-center"
-          label="Prices increase in"
+          initialNow={initialNow}
         />
         <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
           {tickets.map((ticket) => (
-            <RegistrationTicketCard key={ticket.title} ticket={ticket} />
+            <RegistrationTicketCard
+              key={ticket.title}
+              initialNow={initialNow}
+              ticket={ticket}
+            />
           ))}
         </div>
       </div>
@@ -206,6 +213,8 @@ function ExpectationsSection() {
 }
 
 export default function RegistrationPage() {
+  const initialNow = Date.now();
+
   return (
     <PageShell
       contentId="registration-content"
@@ -224,7 +233,7 @@ export default function RegistrationPage() {
         highlightClassName="text-green"
         highlights={REGISTRATION_MARQUEE_HIGHLIGHTS}
       />
-      <TicketsGrid />
+      <TicketsGrid initialNow={initialNow} />
       <ExpectationsSection />
       <Footer />
     </PageShell>

--- a/apps/breakpoint/src/components/pages/registration/RegistrationPage.tsx
+++ b/apps/breakpoint/src/components/pages/registration/RegistrationPage.tsx
@@ -5,10 +5,15 @@ import PageShell from "@/components/PageShell";
 import RegistrationTicketButton from "@/components/pages/registration/RegistrationTicketButton";
 import SubpageHero from "@/components/SubpageHero";
 import {
+  GeneralAdmissionPrice,
+  TicketPriceChangeCountdown,
+} from "@/components/TicketPriceChange";
+import {
   DEVELOPER_APPLICATION_HREF,
   GENERAL_ADMISSION_HREF,
   STUDENT_APPLICATION_HREF,
 } from "@/content/links";
+import { GENERAL_ADMISSION_PRICE_CHANGE } from "@/content/ticket-pricing";
 const REGISTRATION_MARQUEE_HIGHLIGHTS = [
   "BP26",
   "LDN",
@@ -20,15 +25,16 @@ const REGISTRATION_MARQUEE_HIGHLIGHTS = [
 const tickets = [
   {
     title: "General Admission",
-    description: "Price available until May 31, 2026",
-    price: "$450",
+    description: "General admission to Breakpoint 2026.",
+    price: GENERAL_ADMISSION_PRICE_CHANGE.current.display,
+    priceAfterIncrease: GENERAL_ADMISSION_PRICE_CHANGE.increased.display,
     ctaLabel: "Get tickets",
     href: GENERAL_ADMISSION_HREF,
     tone: "featured",
   },
   {
     title: "Late Bird",
-    description: "General admission pricing after May 31, 2026",
+    description: "Final general admission pricing.",
     price: "$800",
     ctaLabel: "Coming soon",
     tone: "disabled",
@@ -65,6 +71,7 @@ type RegistrationTicket = {
   href?: string;
   originalPrice?: string;
   price: string;
+  priceAfterIncrease?: string;
   title: string;
   tone: "disabled" | "featured" | "standard";
 };
@@ -117,7 +124,14 @@ function RegistrationTicketCard({ ticket }: { ticket: RegistrationTicket }) {
       <div className="flex flex-col gap-2 md:gap-3">
         {ticket.originalPrice && <PriceCut value={ticket.originalPrice} />}
         <p className={`type-h2 ${isFeatured ? "text-black" : "text-white"}`}>
-          {ticket.price}
+          {ticket.priceAfterIncrease ? (
+            <GeneralAdmissionPrice
+              currentPrice={ticket.price}
+              increasedPrice={ticket.priceAfterIncrease}
+            />
+          ) : (
+            ticket.price
+          )}
         </p>
         <RegistrationTicketButton
           disabled={isDisabled}
@@ -133,10 +147,16 @@ function RegistrationTicketCard({ ticket }: { ticket: RegistrationTicket }) {
 function TicketsGrid() {
   return (
     <section className="bg-black pt-2xl md:pt-[120px]">
-      <div className="mx-auto grid w-full max-w-[1440px] grid-cols-1 gap-6 px-xs md:grid-cols-2 md:px-8">
-        {tickets.map((ticket) => (
-          <RegistrationTicketCard key={ticket.title} ticket={ticket} />
-        ))}
+      <div className="mx-auto flex w-full max-w-[1440px] flex-col gap-6 px-xs md:px-8">
+        <TicketPriceChangeCountdown
+          className="self-center"
+          label="Prices increase in"
+        />
+        <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+          {tickets.map((ticket) => (
+            <RegistrationTicketCard key={ticket.title} ticket={ticket} />
+          ))}
+        </div>
       </div>
     </section>
   );

--- a/apps/breakpoint/src/components/sections/TicketsSection.tsx
+++ b/apps/breakpoint/src/components/sections/TicketsSection.tsx
@@ -4,6 +4,10 @@ import React, { useEffect } from "react";
 import { useTranslations } from "@workspace/i18n/client";
 import ArrowUpRightIcon from "@/components/ArrowUpRightIcon";
 import {
+  GeneralAdmissionPrice,
+  TicketPriceChangeCountdown,
+} from "@/components/TicketPriceChange";
+import {
   BREAKPOINT_LUMA_EVENT_ID,
   DEVELOPER_APPLICATION_HREF,
   GENERAL_ADMISSION_HREF,
@@ -28,6 +32,7 @@ type TicketCardProps = {
   lumaEventId?: string;
   originalPrice?: string;
   price: string;
+  priceAfterIncrease?: string;
 };
 
 function PriceCut({ value }: { value: string }) {
@@ -103,6 +108,7 @@ function FeaturedTicketCard({
   lumaEventId,
   originalPrice,
   price,
+  priceAfterIncrease,
 }: TicketCardProps) {
   return (
     <TicketLink
@@ -120,7 +126,16 @@ function FeaturedTicketCard({
 
       <div className="flex flex-col gap-2xs md:gap-3">
         {originalPrice && <PriceCut value={originalPrice} />}
-        <p className="type-h2 text-black">{price}</p>
+        <p className="type-h2 text-black">
+          {priceAfterIncrease ? (
+            <GeneralAdmissionPrice
+              currentPrice={price}
+              increasedPrice={priceAfterIncrease}
+            />
+          ) : (
+            price
+          )}
+        </p>
       </div>
 
       <ArrowGlyph className="absolute bottom-m right-m size-[26px] text-black transition-transform group-hover:translate-x-1 group-hover:-translate-y-1 md:bottom-[40px] md:right-[40px] md:size-[35px]" />
@@ -196,6 +211,10 @@ export default function TicketsSection() {
               {variant.ticketsStrapline}
             </p>
           )}
+          <TicketPriceChangeCountdown
+            className="self-center"
+            label={t("tickets.priceIncreaseCountdown")}
+          />
         </div>
 
         <div className="grid grid-cols-1 gap-xs md:grid-cols-bp-desktop md:gap-s">
@@ -203,6 +222,9 @@ export default function TicketsSection() {
             heading={t("tickets.categories.general.label")}
             description={t("tickets.categories.general.description")}
             price={t("tickets.categories.general.price")}
+            priceAfterIncrease={t(
+              "tickets.categories.general.priceAfterIncrease",
+            )}
             href={lumaHref}
             lumaEventId={lumaEventId}
           />

--- a/apps/breakpoint/src/components/sections/TicketsSection.tsx
+++ b/apps/breakpoint/src/components/sections/TicketsSection.tsx
@@ -35,6 +35,10 @@ type TicketCardProps = {
   priceAfterIncrease?: string;
 };
 
+type FeaturedTicketCardProps = TicketCardProps & {
+  initialNow: number;
+};
+
 function PriceCut({ value }: { value: string }) {
   return (
     <span className="relative inline-flex self-start">
@@ -105,11 +109,12 @@ function FeaturedTicketCard({
   description,
   heading,
   href,
+  initialNow,
   lumaEventId,
   originalPrice,
   price,
   priceAfterIncrease,
-}: TicketCardProps) {
+}: FeaturedTicketCardProps) {
   return (
     <TicketLink
       href={href}
@@ -130,6 +135,7 @@ function FeaturedTicketCard({
           {priceAfterIncrease ? (
             <GeneralAdmissionPrice
               currentPrice={price}
+              initialNow={initialNow}
               increasedPrice={priceAfterIncrease}
             />
           ) : (
@@ -188,7 +194,7 @@ function HorizontalTicketCard({
   );
 }
 
-export default function TicketsSection() {
+export default function TicketsSection({ initialNow }: { initialNow: number }) {
   const t = useTranslations("breakpoint");
   const variant = useVariant();
 
@@ -213,6 +219,7 @@ export default function TicketsSection() {
           )}
           <TicketPriceChangeCountdown
             className="self-center"
+            initialNow={initialNow}
             label={t("tickets.priceIncreaseCountdown")}
           />
         </div>
@@ -221,6 +228,7 @@ export default function TicketsSection() {
           <FeaturedTicketCard
             heading={t("tickets.categories.general.label")}
             description={t("tickets.categories.general.description")}
+            initialNow={initialNow}
             price={t("tickets.categories.general.price")}
             priceAfterIncrease={t(
               "tickets.categories.general.priceAfterIncrease",

--- a/apps/breakpoint/src/content/page.ts
+++ b/apps/breakpoint/src/content/page.ts
@@ -28,6 +28,7 @@ export type BreakpointMessages = {
   tickets: {
     eyebrow: string;
     headline: string;
+    priceIncreaseCountdown: string;
     categories: Record<
       string,
       {
@@ -35,6 +36,7 @@ export type BreakpointMessages = {
         description: string;
         originalPrice?: string;
         price: string;
+        priceAfterIncrease?: string;
         ctaLabel?: string;
         href?: string;
       }

--- a/apps/breakpoint/src/content/ticket-pricing.ts
+++ b/apps/breakpoint/src/content/ticket-pricing.ts
@@ -1,0 +1,41 @@
+export const GENERAL_ADMISSION_PRICE_CHANGE = {
+  current: {
+    amount: 450,
+    display: "$450",
+  },
+  increased: {
+    amount: 550,
+    display: "$550",
+  },
+  increasesAt: "2026-08-01T09:00:00Z",
+} as const;
+
+export const GENERAL_ADMISSION_PRICE_INCREASE_AT = Date.parse(
+  GENERAL_ADMISSION_PRICE_CHANGE.increasesAt,
+);
+
+export type TicketPriceCountdownParts = {
+  days: number;
+  hours: number;
+  minutes: number;
+  seconds: number;
+};
+
+export function hasGeneralAdmissionPriceIncreased(now: number): boolean {
+  return now >= GENERAL_ADMISSION_PRICE_INCREASE_AT;
+}
+
+export function getTicketPriceCountdownParts(
+  now: number,
+): TicketPriceCountdownParts {
+  const remainingSeconds = Math.ceil(
+    Math.max(0, GENERAL_ADMISSION_PRICE_INCREASE_AT - now) / 1000,
+  );
+
+  return {
+    days: Math.floor(remainingSeconds / 86400),
+    hours: Math.floor((remainingSeconds % 86400) / 3600),
+    minutes: Math.floor((remainingSeconds % 3600) / 60),
+    seconds: remainingSeconds % 60,
+  };
+}

--- a/apps/breakpoint/src/lib/structured-data.ts
+++ b/apps/breakpoint/src/lib/structured-data.ts
@@ -1,13 +1,16 @@
 import { config, publicLocalizedRouteUrl } from "@/config";
 import { homepageFaqItems } from "@/content/faq-page";
 import { GENERAL_ADMISSION_HREF } from "@/content/links";
+import { GENERAL_ADMISSION_PRICE_CHANGE } from "@/content/ticket-pricing";
 
 type JsonLd = Record<string, unknown>;
 
 type OfferSeed = {
   name: string;
   price: number;
+  priceValidUntil?: string;
   url: string;
+  validFrom: string;
 };
 
 function asPlainTextMessage(value: unknown) {
@@ -17,8 +20,16 @@ function asPlainTextMessage(value: unknown) {
 const TICKET_OFFERS: OfferSeed[] = [
   {
     name: "General Admission",
-    price: 450,
+    price: GENERAL_ADMISSION_PRICE_CHANGE.current.amount,
+    priceValidUntil: "2026-08-01T08:59:59Z",
     url: GENERAL_ADMISSION_HREF,
+    validFrom: "2026-01-01",
+  },
+  {
+    name: "General Admission",
+    price: GENERAL_ADMISSION_PRICE_CHANGE.increased.amount,
+    url: GENERAL_ADMISSION_HREF,
+    validFrom: GENERAL_ADMISSION_PRICE_CHANGE.increasesAt,
   },
 ];
 
@@ -59,7 +70,10 @@ export function buildBreakpointJsonLd(locale: string): JsonLd {
       priceCurrency: "USD",
       url: offer.url,
       availability: "https://schema.org/InStock",
-      validFrom: "2026-01-01",
+      validFrom: offer.validFrom,
+      ...(offer.priceValidUntil
+        ? { priceValidUntil: offer.priceValidUntil }
+        : {}),
     })),
   };
 

--- a/apps/breakpoint/src/tests/ticket-pricing.test.tsx
+++ b/apps/breakpoint/src/tests/ticket-pricing.test.tsx
@@ -1,0 +1,69 @@
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  GeneralAdmissionPrice,
+  TicketPriceChangeCountdown,
+} from "@/components/TicketPriceChange";
+import {
+  GENERAL_ADMISSION_PRICE_INCREASE_AT,
+  getTicketPriceCountdownParts,
+  hasGeneralAdmissionPriceIncreased,
+} from "@/content/ticket-pricing";
+
+describe("Breakpoint general admission price change", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("switches at 2:00 AM Pacific on August 1, 2026", () => {
+    expect(GENERAL_ADMISSION_PRICE_INCREASE_AT).toBe(
+      Date.parse("2026-08-01T09:00:00Z"),
+    );
+    expect(
+      hasGeneralAdmissionPriceIncreased(
+        GENERAL_ADMISSION_PRICE_INCREASE_AT - 1,
+      ),
+    ).toBe(false);
+    expect(
+      hasGeneralAdmissionPriceIncreased(GENERAL_ADMISSION_PRICE_INCREASE_AT),
+    ).toBe(true);
+  });
+
+  it("returns countdown parts without reaching zero early", () => {
+    expect(
+      getTicketPriceCountdownParts(
+        GENERAL_ADMISSION_PRICE_INCREASE_AT -
+          (24 * 60 * 60 + 2 * 60 * 60 + 3 * 60 + 4) * 1000,
+      ),
+    ).toEqual({ days: 1, hours: 2, minutes: 3, seconds: 4 });
+
+    expect(
+      getTicketPriceCountdownParts(GENERAL_ADMISSION_PRICE_INCREASE_AT - 1),
+    ).toEqual({ days: 0, hours: 0, minutes: 0, seconds: 1 });
+  });
+
+  it("updates the displayed price and removes the timer at the cutoff", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-01T08:59:58Z"));
+
+    render(
+      <>
+        <GeneralAdmissionPrice currentPrice="$450" increasedPrice="$550" />
+        <TicketPriceChangeCountdown label="Prices increase in" />
+      </>,
+    );
+
+    expect(screen.getByText("$450")).toBeInTheDocument();
+    expect(screen.getByRole("timer")).toHaveAccessibleName(
+      "Prices increase in 0H 0M 2S",
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+
+    expect(screen.getByText("$550")).toBeInTheDocument();
+    expect(screen.queryByRole("timer")).not.toBeInTheDocument();
+  });
+});

--- a/apps/breakpoint/src/tests/ticket-pricing.test.tsx
+++ b/apps/breakpoint/src/tests/ticket-pricing.test.tsx
@@ -1,4 +1,5 @@
 import { act, cleanup, render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   GeneralAdmissionPrice,
@@ -49,8 +50,15 @@ describe("Breakpoint general admission price change", () => {
 
     render(
       <>
-        <GeneralAdmissionPrice currentPrice="$450" increasedPrice="$550" />
-        <TicketPriceChangeCountdown label="Prices increase in" />
+        <GeneralAdmissionPrice
+          currentPrice="$450"
+          initialNow={Date.now()}
+          increasedPrice="$550"
+        />
+        <TicketPriceChangeCountdown
+          initialNow={Date.now()}
+          label="Prices increase in"
+        />
       </>,
     );
 
@@ -65,5 +73,27 @@ describe("Breakpoint general admission price change", () => {
 
     expect(screen.getByText("$550")).toBeInTheDocument();
     expect(screen.queryByRole("timer")).not.toBeInTheDocument();
+  });
+
+  it("renders the increased price in post-cutoff server HTML", () => {
+    const postCutoff = GENERAL_ADMISSION_PRICE_INCREASE_AT + 1;
+
+    expect(
+      renderToStaticMarkup(
+        <GeneralAdmissionPrice
+          currentPrice="$450"
+          initialNow={postCutoff}
+          increasedPrice="$550"
+        />,
+      ),
+    ).toContain("$550");
+    expect(
+      renderToStaticMarkup(
+        <TicketPriceChangeCountdown
+          initialNow={postCutoff}
+          label="Prices increase in"
+        />,
+      ),
+    ).toBe("");
   });
 });

--- a/packages/i18n/messages/breakpoint/ar/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/ar/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "التذاكر",
+      "priceIncreaseCountdown": "ترتفع الأسعار خلال",
       "categories": {
         "general": {
           "label": "الدخول العام",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "احصل على التذاكر",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/de/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/de/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Tickets",
+      "priceIncreaseCountdown": "Preise steigen in",
       "categories": {
         "general": {
           "label": "Allgemeiner Einlass",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Tickets kaufen",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/el/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/el/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Εισιτήρια",
+      "priceIncreaseCountdown": "Οι τιμές αυξάνονται σε",
       "categories": {
         "general": {
           "label": "Γενική Είσοδος",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Αγορά Εισιτηρίων",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/en/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/en/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Tickets",
+      "priceIncreaseCountdown": "Prices increase in",
       "categories": {
         "general": {
           "label": "General Admission",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Get Tickets",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/es/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/es/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Entradas",
+      "priceIncreaseCountdown": "Los precios aumentan en",
       "categories": {
         "general": {
           "label": "Entrada General",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Conseguir entradas",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/fi/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/fi/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Liput",
+      "priceIncreaseCountdown": "Hinnat nousevat",
       "categories": {
         "general": {
           "label": "Yleinen pääsy",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Osta liput",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/fr/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/fr/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Billets",
+      "priceIncreaseCountdown": "Hausse des prix dans",
       "categories": {
         "general": {
           "label": "Entrée générale",
           "description": "",
           "price": "450 $",
+          "priceAfterIncrease": "550 $",
           "ctaLabel": "Obtenir des billets",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/id/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/id/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Tiket",
+      "priceIncreaseCountdown": "Harga naik dalam",
       "categories": {
         "general": {
           "label": "Tiket Umum",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Beli Tiket",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/it/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/it/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Biglietti",
+      "priceIncreaseCountdown": "I prezzi aumentano tra",
       "categories": {
         "general": {
           "label": "Ingresso Generale",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Acquista Biglietti",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/ja/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/ja/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "チケット",
+      "priceIncreaseCountdown": "価格改定まで",
       "categories": {
         "general": {
           "label": "一般入場",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "チケットを購入",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/ko/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/ko/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "티켓",
+      "priceIncreaseCountdown": "가격 인상까지",
       "categories": {
         "general": {
           "label": "일반 입장",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "티켓 구매",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/nl/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/nl/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Tickets",
+      "priceIncreaseCountdown": "Prijzen stijgen over",
       "categories": {
         "general": {
           "label": "Algemene Toegang",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Koop tickets",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/pl/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/pl/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Bilety",
+      "priceIncreaseCountdown": "Ceny wzrosną za",
       "categories": {
         "general": {
           "label": "Wstęp ogólny",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Kup bilety",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/pt/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/pt/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Bilhetes",
+      "priceIncreaseCountdown": "Os preços aumentam em",
       "categories": {
         "general": {
           "label": "Admissão Geral",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Obter Bilhetes",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/ru/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/ru/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Билеты",
+      "priceIncreaseCountdown": "Цены повысятся через",
       "categories": {
         "general": {
           "label": "Общий доступ",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Купить билеты",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/tr/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/tr/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Biletler",
+      "priceIncreaseCountdown": "Fiyat artışına kalan",
       "categories": {
         "general": {
           "label": "Genel Giriş",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Bilet Al",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/uk/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/uk/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Квитки",
+      "priceIncreaseCountdown": "Ціни зростуть через",
       "categories": {
         "general": {
           "label": "Загальний вхід",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Придбати квитки",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/vi/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/vi/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "Vé",
+      "priceIncreaseCountdown": "Giá sẽ tăng sau",
       "categories": {
         "general": {
           "label": "Vé Phổ Thông",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "Mua Vé",
           "href": "https://luma.com/breakpoint2026"
         },

--- a/packages/i18n/messages/breakpoint/zh/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/zh/breakpoint.json
@@ -29,11 +29,13 @@
     "tickets": {
       "eyebrow": "",
       "headline": "门票",
+      "priceIncreaseCountdown": "距离涨价还有",
       "categories": {
         "general": {
           "label": "普通票",
           "description": "",
           "price": "$450",
+          "priceAfterIncrease": "$550",
           "ctaLabel": "购票",
           "href": "https://luma.com/breakpoint2026"
         },


### PR DESCRIPTION
## Summary

- add a compact price-increase countdown to the homepage and registration ticket sections
- switch general admission from 450 USD to 550 USD at 2:00 AM Pacific on August 1, 2026
- keep event offer structured data aligned with the scheduled price change
- replace stale May 31 registration copy

## Validation

- pnpm --filter solana-com-breakpoint test
- pnpm --filter solana-com-breakpoint check-types
- pnpm --filter solana-com-breakpoint lint
- pnpm --filter solana-com-breakpoint build
- Playwright review at desktop, 390px, and 320px widths before the cutoff
- Playwright verification of the 550 USD/no-countdown state after the cutoff