### PR TITLE
fix: bump pnpm to 11.13.1 across the monorepo (11.13.0 is a broken release)

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -55,7 +55,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -91,7 +91,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/docs-examples-deps-drift.yml
+++ b/.github/workflows/docs-examples-deps-drift.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/docs-examples.yml
+++ b/.github/workflows/docs-examples.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/media-image-check.yml
+++ b/.github/workflows/media-image-check.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/publish-fab-menu.yml
+++ b/.github/workflows/publish-fab-menu.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -75,7 +75,7 @@ jobs:
           steps.dependency-changes.outputs.changed == 'true'
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
       - name: Install Node.js
         if:

--- a/.github/workflows/staging-media-format.yml
+++ b/.github/workflows/staging-media-format.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ solana-com/
 
 ## Tech Stack
 
-- **Runtime**: Node.js 24 with pnpm 11.13.0 (workspace protocol)
+- **Runtime**: Node.js 24 with pnpm 11.13.1 (workspace protocol)
 - **Framework**: Next.js 15.5.9 with App Router
 - **Language**: TypeScript 5.8.3
 - **UI Library**: React 19.1.2

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Shared packages worth checking early:
 
 ## Setup
 
-Requires Node.js 24 (pinned in `.node-version`) and pnpm 11.13.0. Corepack will
+Requires Node.js 24 (pinned in `.node-version`) and pnpm 11.13.1. Corepack will
 use the pnpm version declared by the repository.
 
 1. Clone the repo:

--- a/apps/accelerate/package.json
+++ b/apps/accelerate/package.json
@@ -54,5 +54,5 @@
     "tsx": "^4.19.4",
     "typescript": "5.8.3"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/breakpoint/package.json
+++ b/apps/breakpoint/package.json
@@ -43,5 +43,5 @@
     "typescript": "5.8.3",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -97,5 +97,5 @@
     "add:radix": "npx @radix-ui/scripts",
     "clean": "node ../../scripts/clean.mjs ."
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/media/package.json
+++ b/apps/media/package.json
@@ -87,5 +87,5 @@
     "typescript": "5.8.3",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/templates/package.json
+++ b/apps/templates/package.json
@@ -52,5 +52,5 @@
     "typescript": "5.8.3",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -124,5 +124,5 @@
     "add:radix": "npx @radix-ui/scripts",
     "clean": "node ../../scripts/clean.mjs ."
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/package.json
+++ b/package.json
@@ -45,5 +45,5 @@
     "media:check-images": "pnpm --filter solana-com-media exec node scripts/check-images.mjs",
     "prepare": "husky"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,14 @@ catalogs:
 overrides:
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   immutable@>=5.0.0-beta.1 <5.1.8: 5.1.9
-  fast-uri@>=3.0.0 <3.1.4: 3.1.4
+  fast-uri@>=3.0.0 <3.1.5: 3.1.5
   postcss@<=8.5.17: 8.5.18
   glob@9.3.5>minimatch: 9.0.7
-  brace-expansion@>=5.0.0 <5.0.8: 5.0.8
+  brace-expansion@>=4.0.0 <5.0.9: 5.0.9
   sharp@<0.35.0: 0.35.3
   seti-icons@0.0.4>svgo: 2.8.3
   thrift@0.23.0>uuid: 11.1.1
+  undici@>=7.0.0 <7.29.0: 7.29.0
 
 importers:
   .:
@@ -9953,10 +9954,10 @@ packages:
         integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==,
       }
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     resolution:
       {
-        integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==,
+        integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==,
       }
     engines: { node: 20 || >=22 }
 
@@ -11966,10 +11967,10 @@ packages:
         integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==,
       }
 
-  fast-uri@3.1.4:
+  fast-uri@3.1.5:
     resolution:
       {
-        integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==,
+        integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==,
       }
 
   fastestsmallesttextencoderdecoder@1.0.22:
@@ -17877,10 +17878,10 @@ packages:
         integrity: sha512-uciYZ5yCmf+QJb18kJw10HjquzM7K0z992vWcI+84KeBpTfXT4hfgfGJ5DQbf/mCBPACofkrjvqgcjZfuujjFA==,
       }
 
-  undici@7.28.0:
+  undici@7.29.0:
     resolution:
       {
-        integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==,
+        integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==,
       }
     engines: { node: ">=20.18.1" }
 
@@ -24775,7 +24776,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -25014,7 +25015,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -25160,7 +25161,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -26294,7 +26295,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
@@ -28058,7 +28059,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
@@ -28066,7 +28067,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass-collect@2.0.1:
     dependencies:
@@ -30432,7 +30433,7 @@ snapshots:
 
   undici-types@8.2.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,8 +18,9 @@ overrides:
   "esbuild@>=0.17.0 <0.28.1": 0.28.1
   # Pin transitive releases containing the latest Immutable.js 5 security fixes.
   "immutable@>=5.0.0-beta.1 <5.1.8": 5.1.9
-  # Keep AJV's URI parser on the release patched for GHSA-v2hh-gcrm-f6hx.
-  "fast-uri@>=3.0.0 <3.1.4": 3.1.4
+  # Keep AJV's URI parser on the release patched for GHSA-v2hh-gcrm-f6hx and
+  # GHSA-7p8r-x3mc-p8w7 (backslash authority host confusion).
+  "fast-uri@>=3.0.0 <3.1.5": 3.1.5
   # Keep transitive PostCSS consumers on a release patched for
   # GHSA-6g55-p6wh-862q and GHSA-r28c-9q8g-f849.
   "postcss@<=8.5.17": 8.5.18
@@ -28,8 +29,9 @@ overrides:
   # minimatch 9 release already present in the workspace instead.
   "glob@9.3.5>minimatch": 9.0.7
   # Keep its transitive brace expansion on the release patched for
-  # GHSA-mh99-v99m-4gvg.
-  "brace-expansion@>=5.0.0 <5.0.8": 5.0.8
+  # GHSA-mh99-v99m-4gvg and GHSA-rgw5-rvv9-x895 (unbounded intermediate
+  # arrays DoS).
+  "brace-expansion@>=4.0.0 <5.0.9": 5.0.9
   # Next.js 15 still requests Sharp 0.34, so force its optional dependency onto
   # the current patched release containing the updated libvips binaries.
   "sharp@<0.35.0": 0.35.3
@@ -39,6 +41,9 @@ overrides:
   # @databricks/sql 2 requires Thrift's UUID dependency to remain CJS-compatible.
   # Package-level overrides are not inherited by pnpm consumers.
   "thrift@0.23.0>uuid": 11.1.1
+  # Keep cheerio's fetch client on the release patched for
+  # GHSA-4cwx-7wf7-3272 (cross-user cache disclosure / parse-time crash).
+  "undici@>=7.0.0 <7.29.0": 7.29.0
 
 allowBuilds:
   "@parcel/watcher": true


### PR DESCRIPTION
## Problem

pnpm retroactively flagged v11.13.0 — the version pinned throughout this repo — as a broken release (its `@pnpm/exe` build shipped without a binary). This breaks `main` two ways:

1. **GitHub Actions**: `pnpm/action-setup` fails with `ERR_PNPM_BROKEN_PNPM_RELEASE` during setup, so all 15 pnpm-based checks fail on every commit (see the checks on `f63d282`).
2. **Vercel (corepack)**: a root-only bump (previously attempted as `419c324`) is not enough — with `ENABLE_EXPERIMENTAL_COREPACK=1`, corepack resolves pnpm from the app-level `package.json` (still 11.13.0) while pnpm's version check reads the workspace root (11.13.1), failing the build with `This project is configured to use 11.13.1 of pnpm. Your current pnpm is v11.13.0`.

Separately, three high-severity advisories published today (undici GHSA-4cwx-7wf7-3272, fast-uri GHSA-7p8r-x3mc-p8w7, brace-expansion GHSA-rgw5-rvv9-x895) fail `pnpm audit --audit-level high --prod` with no dependency changes on our side, so main's Dependency audit check goes red on its next run regardless of the pnpm fix.

## Summary of changes

1. Bump every pnpm pin to **11.13.1** (the fixed rebuild — `@pnpm/exe@11.13.1` is published and complete): the `packageManager` field in the root and all six app `package.json`s, nine `pnpm/action-setup` version pins across eight workflow files, plus the README and CLAUDE.md mentions. 17 files, version strings only.
2. Bump the pnpm-workspace.yaml security overrides to clear the three new high advisories: undici → 7.29.0 (new override; only affects cheerio's transitive undici@7.28.0), fast-uri → 3.1.5, brace-expansion → 5.0.9. Lockfile delta is 31 lines (the three packages and their integrity hashes).

Both changes are already validated green on #1828 (all 24 checks including the six Vercel deployments and the Dependency audit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)