### PR TITLE
fix: restore Vercel app skipping and reduce docs build memory

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -55,7 +55,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -91,7 +91,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -18,7 +18,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.1
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -55,7 +54,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.1
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4
@@ -91,7 +89,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.1
           run_install: false
       - name: Install Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/docs-examples-deps-drift.yml
+++ b/.github/workflows/docs-examples-deps-drift.yml
@@ -27,7 +27,6 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.13.1
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/docs-examples-deps-drift.yml
+++ b/.github/workflows/docs-examples-deps-drift.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/docs-examples.yml
+++ b/.github/workflows/docs-examples.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/docs-examples.yml
+++ b/.github/workflows/docs-examples.yml
@@ -30,7 +30,6 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 11.13.1
           run_install: false
 
       - uses: actions/setup-node@v4

--- a/.github/workflows/media-image-check.yml
+++ b/.github/workflows/media-image-check.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/media-image-check.yml
+++ b/.github/workflows/media-image-check.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/publish-fab-menu.yml
+++ b/.github/workflows/publish-fab-menu.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/publish-fab-menu.yml
+++ b/.github/workflows/publish-fab-menu.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -75,7 +75,7 @@ jobs:
           steps.dependency-changes.outputs.changed == 'true'
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
       - name: Install Node.js
         if:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -75,7 +75,6 @@ jobs:
           steps.dependency-changes.outputs.changed == 'true'
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.1
           run_install: false
       - name: Install Node.js
         if:

--- a/.github/workflows/staging-media-format.yml
+++ b/.github/workflows/staging-media-format.yml
@@ -31,7 +31,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/staging-media-format.yml
+++ b/.github/workflows/staging-media-format.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v6
         with:
-          version: 11.13.0
+          version: 11.13.1
           run_install: false
 
       - name: Install Node.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ solana-com/
 
 ## Tech Stack
 
-- **Runtime**: Node.js 24 with pnpm 11.13.0 (workspace protocol)
+- **Runtime**: Node.js 24 with pnpm 11.13.1 (workspace protocol)
 - **Framework**: Next.js 15.5.9 with App Router
 - **Language**: TypeScript 5.8.3
 - **UI Library**: React 19.1.2

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Shared packages worth checking early:
 
 ## Setup
 
-Requires Node.js 24 (pinned in `.node-version`) and pnpm 11.13.0. Corepack will
+Requires Node.js 24 (pinned in `.node-version`) and pnpm 11.13.1. Corepack will
 use the pnpm version declared by the repository.
 
 1. Clone the repo:

--- a/apps/accelerate/package.json
+++ b/apps/accelerate/package.json
@@ -54,5 +54,5 @@
     "tsx": "^4.19.4",
     "typescript": "5.8.3"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/accelerate/vercel.json
+++ b/apps/accelerate/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "node ../../scripts/vercel-ignore.mjs solana-com-accelerate"
+}

--- a/apps/breakpoint/package.json
+++ b/apps/breakpoint/package.json
@@ -43,5 +43,5 @@
     "typescript": "5.8.3",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/breakpoint/vercel.json
+++ b/apps/breakpoint/vercel.json
@@ -1,3 +1,4 @@
 {
+  "ignoreCommand": "node ../../scripts/vercel-ignore.mjs solana-com-breakpoint",
   "relatedProjects": ["prj_40kDwTp9P4bvvGlaoU8U0cp4VG6N"]
 }

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -31,6 +31,7 @@ if (process.env.NEXT_PUBLIC_VERCEL_ENV === "preview") {
 }
 
 const prefix = "/docs-assets";
+const isVercelBuild = process.env.VERCEL === "1";
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   productionBrowserSourceMaps: false,
@@ -42,6 +43,14 @@ const nextConfig: NextConfig = {
   },
 
   webpack(config) {
+    if (isVercelBuild) {
+      // The docs bundle contains thousands of MDX modules. Keep Vercel builds
+      // from retaining compiled modules in Webpack's cache and bound how many
+      // modules Webpack processes at once.
+      config.cache = false;
+      config.parallelism = 4;
+    }
+
     config.module.rules.push({
       test: /\.inline\.svg$/,
       use: {
@@ -163,6 +172,8 @@ const nextConfig: NextConfig = {
   },
 
   experimental: {
+    // Keep Vercel page-data workers within the build container's memory budget.
+    cpus: isVercelBuild ? 2 : undefined,
     scrollRestoration: true,
     // Allow importing/transpiling code from the workspace package
     externalDir: true,

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -97,5 +97,5 @@
     "add:radix": "npx @radix-ui/scripts",
     "clean": "node ../../scripts/clean.mjs ."
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/docs/vercel.json
+++ b/apps/docs/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "node ../../scripts/vercel-ignore.mjs solana-docs",
   "relatedProjects": [
     "prj_40kDwTp9P4bvvGlaoU8U0cp4VG6N",
     "prj_sS1OQUbA5luVqKHn2M9yU2r4n4yo"

--- a/apps/media/package.json
+++ b/apps/media/package.json
@@ -87,5 +87,5 @@
     "typescript": "5.8.3",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/media/vercel.json
+++ b/apps/media/vercel.json
@@ -1,3 +1,4 @@
 {
+  "ignoreCommand": "node ../../scripts/vercel-ignore.mjs solana-com-media",
   "relatedProjects": ["prj_sS1OQUbA5luVqKHn2M9yU2r4n4yo"]
 }

--- a/apps/templates/package.json
+++ b/apps/templates/package.json
@@ -52,5 +52,5 @@
     "typescript": "5.8.3",
     "vitest": "catalog:"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/templates/vercel.json
+++ b/apps/templates/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "node ../../scripts/vercel-ignore.mjs solana-templates"
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -124,5 +124,5 @@
     "add:radix": "npx @radix-ui/scripts",
     "clean": "node ../../scripts/clean.mjs ."
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "node ../../scripts/vercel-ignore.mjs solana-com",
   "relatedProjects": [
     "prj_40kDwTp9P4bvvGlaoU8U0cp4VG6N",
     "prj_LZEuCRs2E1aDG7tLZ4tBJIv0jH8W",

--- a/package.json
+++ b/package.json
@@ -45,5 +45,5 @@
     "media:check-images": "pnpm --filter solana-com-media exec node scripts/check-images.mjs",
     "prepare": "husky"
   },
-  "packageManager": "pnpm@11.13.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,10 +25,8 @@ catalogs:
 overrides:
   esbuild@>=0.17.0 <0.28.1: 0.28.1
   immutable@>=5.0.0-beta.1 <5.1.8: 5.1.9
-  fast-uri@>=3.0.0 <3.1.4: 3.1.4
   postcss@<=8.5.17: 8.5.18
   glob@9.3.5>minimatch: 9.0.7
-  brace-expansion@>=5.0.0 <5.0.8: 5.0.8
   sharp@<0.35.0: 0.35.3
   seti-icons@0.0.4>svgo: 2.8.3
   thrift@0.23.0>uuid: 11.1.1
@@ -9953,10 +9951,10 @@ packages:
         integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==,
       }
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     resolution:
       {
-        integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==,
+        integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==,
       }
     engines: { node: 20 || >=22 }
 
@@ -11966,10 +11964,10 @@ packages:
         integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==,
       }
 
-  fast-uri@3.1.4:
+  fast-uri@3.1.5:
     resolution:
       {
-        integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==,
+        integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==,
       }
 
   fastestsmallesttextencoderdecoder@1.0.22:
@@ -12940,10 +12938,10 @@ packages:
         integrity: sha512-l323RCl3qJDVQ8U9j74ut/hVMdg3VPsOHpVMDvFfz9qiq4dPO5ooVYFNVUzzrpgG39a+RLzcXyJb8VFgIU+tUA==,
       }
 
-  ip-address@10.0.1:
+  ip-address@10.4.0:
     resolution:
       {
-        integrity: sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==,
+        integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==,
       }
     engines: { node: ">= 12" }
 
@@ -17877,10 +17875,10 @@ packages:
         integrity: sha512-uciYZ5yCmf+QJb18kJw10HjquzM7K0z992vWcI+84KeBpTfXT4hfgfGJ5DQbf/mCBPACofkrjvqgcjZfuujjFA==,
       }
 
-  undici@7.28.0:
+  undici@7.29.0:
     resolution:
       {
-        integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==,
+        integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==,
       }
     engines: { node: ">=20.18.1" }
 
@@ -24775,7 +24773,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -25014,7 +25012,7 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -25160,7 +25158,7 @@ snapshots:
       parse5: 7.3.0
       parse5-htmlparser2-tree-adapter: 7.1.0
       parse5-parser-stream: 7.1.2
-      undici: 7.28.0
+      undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
   chokidar@3.6.0:
@@ -26294,7 +26292,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
@@ -26977,7 +26975,7 @@ snapshots:
       "@formatjs/fast-memoize": 3.1.6
       "@formatjs/icu-messageformat-parser": 3.5.11
 
-  ip-address@10.0.1: {}
+  ip-address@10.4.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -28058,7 +28056,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
@@ -28066,7 +28064,7 @@ snapshots:
 
   minimatch@9.0.7:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minipass-collect@2.0.1:
     dependencies:
@@ -29814,7 +29812,7 @@ snapshots:
 
   socks@2.8.7:
     dependencies:
-      ip-address: 10.0.1
+      ip-address: 10.4.0
       smart-buffer: 4.2.0
 
   source-map-js@1.2.1: {}
@@ -30432,7 +30430,7 @@ snapshots:
 
   undici-types@8.2.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -18,8 +18,6 @@ overrides:
   "esbuild@>=0.17.0 <0.28.1": 0.28.1
   # Pin transitive releases containing the latest Immutable.js 5 security fixes.
   "immutable@>=5.0.0-beta.1 <5.1.8": 5.1.9
-  # Keep AJV's URI parser on the release patched for GHSA-v2hh-gcrm-f6hx.
-  "fast-uri@>=3.0.0 <3.1.4": 3.1.4
   # Keep transitive PostCSS consumers on a release patched for
   # GHSA-6g55-p6wh-862q and GHSA-r28c-9q8g-f849.
   "postcss@<=8.5.17": 8.5.18
@@ -27,9 +25,6 @@ overrides:
   # fix is still inside the package-age quarantine window. Use the compatible
   # minimatch 9 release already present in the workspace instead.
   "glob@9.3.5>minimatch": 9.0.7
-  # Keep its transitive brace expansion on the release patched for
-  # GHSA-mh99-v99m-4gvg.
-  "brace-expansion@>=5.0.0 <5.0.8": 5.0.8
   # Next.js 15 still requests Sharp 0.34, so force its optional dependency onto
   # the current patched release containing the updated libvips binaries.
   "sharp@<0.35.0": 0.35.3

--- a/scripts/vercel-ignore.mjs
+++ b/scripts/vercel-ignore.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const BUILD = 1;
+const SKIP = 0;
+const workspace = process.argv[2];
+
+function log(message) {
+  console.log(`[vercel-ignore] ${message}`);
+}
+
+function findRepositoryRoot(start) {
+  let directory = resolve(start);
+
+  while (true) {
+    if (
+      existsSync(resolve(directory, "package.json")) &&
+      existsSync(resolve(directory, "turbo.json"))
+    ) {
+      return directory;
+    }
+
+    const parent = dirname(directory);
+
+    if (parent === directory) return undefined;
+    directory = parent;
+  }
+}
+
+const repositoryRoot = findRepositoryRoot(process.cwd());
+
+if (!repositoryRoot) {
+  log("The repository root could not be found; proceeding with the build.");
+  process.exit(BUILD);
+}
+
+function refExists(ref) {
+  const result = spawnSync("git", ["cat-file", "-e", `${ref}^{commit}`], {
+    cwd: repositoryRoot,
+    stdio: "ignore",
+  });
+
+  return result.status === 0;
+}
+
+function getTurboVersion() {
+  const packageJson = JSON.parse(
+    readFileSync(resolve(repositoryRoot, "package.json"), "utf8"),
+  );
+
+  return packageJson.devDependencies?.turbo;
+}
+
+function getCurrentWorkspace() {
+  try {
+    const packageJson = JSON.parse(
+      readFileSync(resolve(process.cwd(), "package.json"), "utf8"),
+    );
+
+    return packageJson.name;
+  } catch {
+    return undefined;
+  }
+}
+
+if (!workspace || getCurrentWorkspace() !== workspace) {
+  log(
+    "The configured workspace does not match this project; proceeding with the build.",
+  );
+  process.exit(BUILD);
+}
+
+if (process.env.TURBO_FORCE === "true") {
+  log("TURBO_FORCE is set; proceeding with the build.");
+  process.exit(BUILD);
+}
+
+const base = process.env.TURBO_SCM_BASE ?? process.env.VERCEL_GIT_PREVIOUS_SHA;
+const head =
+  process.env.TURBO_SCM_HEAD ?? process.env.VERCEL_GIT_COMMIT_SHA ?? "HEAD";
+
+if (!base) {
+  log("No previous commit is available; proceeding with the build.");
+  process.exit(BUILD);
+}
+
+if (!refExists(base) || !refExists(head)) {
+  log(`Cannot compare ${base} with ${head}; proceeding with the build.`);
+  process.exit(BUILD);
+}
+
+const turboVersion = getTurboVersion();
+
+if (!turboVersion) {
+  log("The repository has no pinned Turbo version; proceeding with the build.");
+  process.exit(BUILD);
+}
+
+log(`Checking ${workspace}#build between ${base} and ${head}.`);
+
+const result = spawnSync(
+  "npx",
+  [
+    "--yes",
+    `turbo@${turboVersion}`,
+    "query",
+    "affected",
+    "--tasks",
+    "build",
+    "--packages",
+    workspace,
+    "--base",
+    base,
+    "--head",
+    head,
+    "--exit-code",
+    "--no-update-notifier",
+    "--no-color",
+  ],
+  {
+    cwd: repositoryRoot,
+    env: process.env,
+    stdio: "inherit",
+  },
+);
+
+if (result.status === SKIP) {
+  log(`${workspace}#build is unchanged; skipping the deployment.`);
+  process.exit(SKIP);
+}
+
+if (result.status === BUILD) {
+  log(`${workspace}#build is affected; proceeding with the build.`);
+  process.exit(BUILD);
+}
+
+log("The affected check failed; proceeding with the build.");
+process.exit(BUILD);


### PR DESCRIPTION
### Problem

Vercel's ignored build step was failing open and building every app, even when an app and its build dependencies were unchanged. The deprecated `turbo-ignore` command generated more dry-run JSON than its 1 MB child-process buffer could hold, then treated that error as a reason to deploy.

The docs app was also regularly being killed for exceeding the Vercel build container's memory during preview builds.

GitHub Actions and Vercel were additionally blocked by the broken pnpm 11.13.0 release, while four newly published high-severity production advisories caused the dependency audit to fail.

Supersedes #1829.

### Summary of Changes

- Add a repository-owned ignored-build command based on the pinned `turbo query affected` implementation.
- Stream Turbo output instead of buffering it and proceed with builds whenever refs, configuration, or the affected check are invalid.
- Configure all six Vercel app projects to check their exact `build` task and workspace dependencies.
- Disable the Webpack build cache and limit Webpack/page-data concurrency for docs builds on Vercel, covering both preview and production deployments.
- Replace pnpm 11.13.0 with 11.13.1 across the root and Vercel app manifests; GitHub Actions reads the root `packageManager` field rather than duplicating the version.
- Resolve the current high advisories through compatible transitive lockfile updates: undici 7.29.0, fast-uri 3.1.5, ip-address 10.4.0, and brace-expansion 5.0.9.
- Remove the now-unnecessary fast-uri and brace-expansion security overrides. No direct dependency range or application runtime behavior changed.

Fixes: n/a

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

Updated dependencies: no direct dependency ranges changed. Four transitive packages were refreshed to compatible patched releases already accepted by their parent semver ranges: undici 7.29.0, fast-uri 3.1.5, ip-address 10.4.0, and brace-expansion 5.0.9.

Threat-model note: n/a; the ignored-build command fails open, so invalid or unavailable comparison data always causes a build rather than skipping one.

### Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm audit --audit-level high --prod`
- `pnpm check-types`
- `pnpm test`
- ESLint for web, docs, and media
- Prettier and Git whitespace checks for all changed files
- Clean-tree integration check: a web-only commit skips `solana-docs#build` with exit 0 and builds `solana-com#build` with exit 1
- Cold Vercel preview-mode docs build completed successfully; measured peak RSS decreased from approximately 4.78 GB to 3.53 GB
