### PR TITLE
fix(docs): render childless sidebar folders as plain links

### DIFF
--- a/apps/docs/src/app/components/docs-layout.tsx
+++ b/apps/docs/src/app/components/docs-layout.tsx
@@ -12,6 +12,23 @@ import { getTranslations } from "next-intl/server";
 import { DocsSidebarTogglePortal } from "./docs-sidebar-toggle-portal";
 import type { PageTree } from "fumadocs-core/server";
 
+function flattenChildlessFolders(nodes: PageTree.Node[]): PageTree.Node[] {
+  return nodes.map((node) => {
+    if (node.type !== "folder") return node;
+
+    const children = flattenChildlessFolders(node.children);
+
+    if (node.index && children.length === 0) {
+      return {
+        ...node.index,
+        icon: node.index.icon ?? node.icon,
+      } satisfies PageTree.Item;
+    }
+
+    return { ...node, children };
+  });
+}
+
 export async function DocsLayout({
   children,
   tree,
@@ -24,6 +41,10 @@ export async function DocsLayout({
   locale?: string;
 }) {
   const t = await getTranslations();
+  const sidebarTree: PageTree.Root = {
+    ...tree,
+    children: flattenChildlessFolders(tree.children),
+  };
   const translations = {
     toc: t("shared.general.toc"),
     editOnGithub: t("shared.general.edit-page"),
@@ -39,7 +60,7 @@ export async function DocsLayout({
       >
         <div className="container-xl fumadocs">
           <FumaDocsLayout
-            tree={tree}
+            tree={sidebarTree}
             nav={{ enabled: false }}
             sidebar={{
               enabled: sidebarEnabled,


### PR DESCRIPTION
## Problem

Sidebar sections whose only content is an index page (no sub-pages) rendered as collapsible toggles with an empty body. Clicking expanded nothing instead of navigating to the page.

## Changes

- `flattenChildlessFolders` walks the page tree in the docs layout and rewrites any folder with an `index` and zero children into a plain page node, so Fumadocs renders it as a clickable link. Runs recursively at any nesting depth and preserves the folder icon.