### PR TITLE
style(i18n): format web message JSON with prettier

### DIFF
--- a/packages/i18n/messages/web/ar/common.json
+++ b/packages/i18n/messages/web/ar/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "اكتشف كيف تقوم الشركات بتنفيذ الحلول على Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "جميع دراسات الحالة"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "جميع دراسات الحالة"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "ابدأ الآن",
       "body": "<p>مع الأدوات الجديدة والدورات التقنية الشاملة والترقيات المستمرة على مستوى الشبكة، الآن هو الوقت المثالي لبدء بناء مشروعك.</p>",
-      "buttons": [
-        "ما يمكن توقعه في عام 2024",
-        "اطلع على الوثائق"
-      ]
+      "buttons": ["ما يمكن توقعه في عام 2024", "اطلع على الوثائق"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "هل أنت مستعد للبناء؟ توجه إلى Github لبدء صنع أداتك.",
         "هل تريد الانطلاق؟ اكتشف كيف يمكنك جعل الحوكمة سهلة قدر الإمكان للمستخدمين النهائيين."
       ],
-      "ctaLabels": [
-        "اقرأ الوثائق",
-        "عرض المستودع",
-        "عرض المستودع"
-      ]
+      "ctaLabels": ["اقرأ الوثائق", "عرض المستودع", "عرض المستودع"]
     },
     "featureHighlight": {
       "eyebrow": "لماذا Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "انضم إلى المجتمع",
       "body": "",
-      "listItems": [
-        "Discord الخاص بـ Solana",
-        "منتديات Solana"
-      ]
+      "listItems": ["Discord الخاص بـ Solana", "منتديات Solana"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "التمويل اللامركزي",
       "headline": "التمويل اللامركزي السريع والسلس والسهل",
       "body": "<p>إنتاجية معاملات عالية. رسوم منخفضة للغاية. كمون منخفض. كفاءة رأس المال. Solana مصممة للبناة.</p>",
-      "buttons": [
-        "ابدأ البناء",
-        "اقرأ الوثائق"
-      ]
+      "buttons": ["ابدأ البناء", "اقرأ الوثائق"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "الكائن على السلسلة",
-          "Purpose"
-        ],
+        "headers": ["Piece", "الكائن على السلسلة", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/de/common.json
+++ b/packages/i18n/messages/web/de/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Onchain-Objekt",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Onchain-Objekt", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/el/common.json
+++ b/packages/i18n/messages/web/el/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Αντικείμενο Onchain",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Αντικείμενο Onchain", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/es/common.json
+++ b/packages/i18n/messages/web/es/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Objeto Onchain",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Objeto Onchain", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/fi/common.json
+++ b/packages/i18n/messages/web/fi/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Onchain-objekti",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Onchain-objekti", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/fr/common.json
+++ b/packages/i18n/messages/web/fr/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Objet onchain",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Objet onchain", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/id/common.json
+++ b/packages/i18n/messages/web/id/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Objek Onchain",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Objek Onchain", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/it/common.json
+++ b/packages/i18n/messages/web/it/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "Casi di studio",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Innovazione continua",
       "body": "Solana continua a evolversi e migliorare",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "In evidenza",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Pronto per iniziare?",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DeFi",
       "headline": "Finanza Decentralizzata",
       "body": "Costruisci il futuro della finanza su Solana",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "Performance",
       "headline": "Velocità senza compromessi",
       "body": "Transazioni veloci e economiche per DeFi",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "Inizia a costruire",
       "body": "Unisciti all'ecosistema DeFi di Solana",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Unisciti alla comunità",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Pagamenti di Nuova Generazione",
       "body": "Costruisci soluzioni di pagamento veloci ed economiche",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "Velocità",
       "headline": "Pagamenti in tempo reale",
       "body": "Transazioni confermate in secondi",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Unisciti alla comunità",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "PYUSD",
       "headline": "PayPal USD su Solana",
       "body": "Stablecoin di PayPal ora disponibile su Solana",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "NFT e Asset Digitali",
       "body": "Costruisci la prossima generazione di NFT su Solana",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Performance senza compromessi",
       "body": "NFT veloci ed economici",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Arte on-chain",
       "body": "Proprietà digitale verificabile",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Crea NFT",
       "body": "Inizia a creare i tuoi NFT",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "Perché Solana",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Contattaci",
       "body": "Hai domande? Contattaci",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "Gaming",
       "headline": "Il Futuro del Gaming",
       "body": "Costruisci giochi di nuova generazione su Solana",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "Strumenti per sviluppatori di giochi",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Finanziamenti",
         "body": "Supporto per progetti di gaming",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Comunità Gaming",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "In evidenza",
       "headline": "Gaming Web3",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "Performance",
       "headline": "Performance da gaming",
       "body": "Velocità e scalabilità per giochi blockchain",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Inizia",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "I client blockchain gestiscono la comunicazione con la rete",
     "typesOfClients": "Tipi di client",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "Client di consenso su Ethereum",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "Client su Solana",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "Consenso di Solana",
     "solanasConsensusBody": "Proof of Stake + Proof of History",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Ricerca e Innovazione",
       "body": "Scopri le ricerche più recenti su Solana",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "Vuoi contribuire?",
       "body": "Unisciti ai ricercatori di Solana",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Prelievo",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "Aggiornamento dello stato",
         "preview": "Anteprima"
@@ -10909,11 +10704,7 @@
         "conceptualMap": "Mappa concettuale"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Oggetto Onchain",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Oggetto Onchain", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/ja/common.json
+++ b/packages/i18n/messages/web/ja/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "オンチェーンオブジェクト",
-          "Purpose"
-        ],
+        "headers": ["Piece", "オンチェーンオブジェクト", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/ko/common.json
+++ b/packages/i18n/messages/web/ko/common.json
@@ -8358,12 +8358,7 @@
           "문서 접근하기",
           "해커톤 참여하기"
         ],
-        "user": [
-          "솔라나 101",
-          "지갑 찾기",
-          "SOL 스테이킹하기",
-          "일자리 찾기"
-        ]
+        "user": ["솔라나 101", "지갑 찾기", "SOL 스테이킹하기", "일자리 찾기"]
       }
     }
   },
@@ -8433,12 +8428,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8455,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8466,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8517,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8578,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8590,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8622,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8641,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8691,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8703,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8777,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8794,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8913,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +8995,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9023,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9102,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9123,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9140,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9187,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9401,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9416,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9446,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9455,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9464,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9495,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9655,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9722,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9833,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9845,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10006,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10174,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10683,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10699,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "온체인 객체",
-          "Purpose"
-        ],
+        "headers": ["Piece", "온체인 객체", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/nl/common.json
+++ b/packages/i18n/messages/web/nl/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Onchain Object",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Onchain Object", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/pl/common.json
+++ b/packages/i18n/messages/web/pl/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Obiekt onchain",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Obiekt onchain", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/pt/common.json
+++ b/packages/i18n/messages/web/pt/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Objeto Onchain",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Objeto Onchain", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/ru/common.json
+++ b/packages/i18n/messages/web/ru/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "Посмотрите, как компании внедряют решения на Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "Все кейс-стади"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "Все кейс-стади"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Начать работу",
       "body": "<p>С новыми инструментами, всесторонними техническими курсами и постоянными обновлениями сети сейчас идеальное время, чтобы начать создавать свой проект.</p>",
-      "buttons": [
-        "На что обратить внимание в 2024",
-        "Смотреть документацию"
-      ]
+      "buttons": ["На что обратить внимание в 2024", "Смотреть документацию"]
     }
   },
   "developers-dao": {
@@ -8600,10 +8587,7 @@
     "conversionPanel": {
       "heading": "Присоединяйтесь к сообществу",
       "body": "",
-      "listItems": [
-        "Discord Solana",
-        "Форум Solana"
-      ]
+      "listItems": ["Discord Solana", "Форум Solana"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8599,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi — быстро, удобно и легко",
       "body": "<p>Высокая пропускная способность транзакций. Сверхнизкие комиссии. Низкая задержка. Капитальная эффективность. Solana создана для строителей.</p>",
-      "buttons": [
-        "Начать создавать",
-        "Читать документацию"
-      ]
+      "buttons": ["Начать создавать", "Читать документацию"]
     },
     "stats": [
       {
@@ -8650,9 +8631,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8683,9 +8662,7 @@
     "conversionPanel": {
       "heading": "RPC-инфраструктура",
       "body": "Убедитесь, что ваши системы готовы к 500 000+ пользователей. Получите надёжную RPC-инфраструктуру.",
-      "buttons": [
-        "Документация"
-      ]
+      "buttons": ["Документация"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8707,7 @@
     "communityPanel": {
       "heading": "Присоединяйтесь к сообществу",
       "body": "",
-      "listItems": [
-        "Discord Solana",
-        "Форум Solana"
-      ]
+      "listItems": ["Discord Solana", "Форум Solana"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8719,7 @@
       "eyebrow": "",
       "headline": "Глобальные платежи в реальном времени",
       "body": "<p>Мгновенные расчёты с минимальными комиссиями делают Solana идеальным решением для платежей.</p>",
-      "buttons": [
-        "Начать",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Начать", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8793,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Присоединяйтесь к сообществу",
       "body": "",
-      "listItems": [
-        "Discord Solana",
-        "Форум Solana"
-      ]
+      "listItems": ["Discord Solana", "Форум Solana"]
     }
   },
   "pyusd": {
@@ -8844,9 +8810,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD на Solana",
       "body": "<p>PYUSD, стейблкоин PayPal, теперь доступен на Solana для быстрых и дешёвых транзакций.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8929,7 @@
       "eyebrow": "",
       "headline": "Создавайте и торгуйте NFT",
       "body": "<p>Solana предоставляет быструю и дешёвую инфраструктуру для NFT, делая цифровое искусство доступным для всех.</p>",
-      "buttons": [
-        "Начать"
-      ]
+      "buttons": ["Начать"]
     },
     "stats": [
       {
@@ -9049,9 +9011,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, и многим другим.</p>",
-      "buttons": [
-        "Узнайте more"
-      ]
+      "buttons": ["Узнайте more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9039,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9118,12 @@
     "switchback": {
       "headline": "Откройте инструменты, которые вдохновляют",
       "body": "<p>Откройте для себя ресурсы, руководства, отзывы и многое другое для художника-новатора в вас.</p>",
-      "buttons": [
-        "Начать работу"
-      ]
+      "buttons": ["Начать работу"]
     },
     "mintingPanel": {
       "heading": "Простой минтинг",
       "body": "Минтинг вашего цифрового произведения искусства на Solana — лучший способ выйти на новую аудиторию коллекционеров и поклонников, маркетплейсы и каналы для монетизации и владения вашей работой. На Solana художники могут сосредоточиться на своём творческом процессе, а не отвлекаться на сложные технические инструкции или нести высокие затраты на минтинг.",
-      "buttons": [
-        "Начать минтинг"
-      ]
+      "buttons": ["Начать минтинг"]
     },
     "whySolana": {
       "eyebrow": "Почему Solana?",
@@ -9185,18 +9139,12 @@
         "Протокол Solana открывает быстрое, безопасное, масштабируемое и удобное будущее — будущее, возможное только на Solana. Исследуйте ресурсы, подключайтесь к экосистеме и начните создавать.",
         "Solana — это дом глобального сообщества строителей, инноваторов и креативщиков. Ознакомьтесь с каналами и платформами для связи с единомышленниками."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Узнать больше"
-      ]
+      "ctaLabels": ["learn more", "Узнать больше"]
     },
     "contactPanel": {
       "heading": "Начать разговор",
       "body": "Свяжитесь напрямую с командой Solana или изучите кейс-стади ниже.",
-      "buttons": [
-        "Связаться с нами",
-        "Изучить кейс-стади"
-      ]
+      "buttons": ["Связаться с нами", "Изучить кейс-стади"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9156,30 @@
       "eyebrow": "gaming",
       "headline": "Создавайте игры следующего поколения",
       "body": "<p>Высокая скорость, низкие комиссии и отличный пользовательский опыт делают Solana идеальной платформой для игр.</p>",
-      "buttons": [
-        "Начать создавать",
-        "Reach out"
-      ]
+      "buttons": ["Начать создавать", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in экосистему Solana to empower game разработчиков and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Начать создавать",
-          "Узнать больше"
-        ]
+        "buttons": ["Начать создавать", "Узнать больше"]
       },
       "community": {
         "heading": "Присоединяйтесь к сообществу",
         "body": "",
-        "listItems": [
-          "Discord Solana",
-          "Форум Solana"
-        ]
+        "listItems": ["Discord Solana", "Форум Solana"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Начать создавать"
-      ],
+      "buttons": ["Начать создавать"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9203,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows без ущерба для устойчивости к цензуре или безопасности. It’s so fast, your players will definitely notice. Посмотрите, как Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9417,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9432,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9462,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9471,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9480,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9511,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9671,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here are the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>А вот список консенсус-клиентов для Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9738,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9849,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake>"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake>"]
         },
         {
           "cells": [
@@ -10043,10 +9861,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10022,7 @@
       "eyebrow": "",
       "headline": "Исследования Solana",
       "body": "<p>Углубитесь в технические исследования, отчёты о производительности и анализ экосистемы Solana.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10190,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer курсами and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10699,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to пользователей at signing time."
@@ -10909,11 +10715,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Объект на блокчейне",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Объект на блокчейне", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/tr/common.json
+++ b/packages/i18n/messages/web/tr/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Zincir Üstü Nesne",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Zincir Üstü Nesne", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/uk/common.json
+++ b/packages/i18n/messages/web/uk/common.json
@@ -8433,12 +8433,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8460,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8471,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8522,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8583,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8595,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8627,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8646,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8696,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8708,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8782,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8799,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8918,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +9000,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9028,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9107,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9128,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9145,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9192,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9406,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9421,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9451,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9460,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9469,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9500,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9660,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9727,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9838,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9850,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10011,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10179,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10688,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10704,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Об'єкт ончейн",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Об'єкт ончейн", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/vi/common.json
+++ b/packages/i18n/messages/web/vi/common.json
@@ -8358,12 +8358,7 @@
           "Truy cập tài liệu",
           "Tham gia hackathon"
         ],
-        "user": [
-          "Solana 101",
-          "Tìm ví",
-          "Stake SOL của bạn",
-          "Tìm việc làm"
-        ]
+        "user": ["Solana 101", "Tìm ví", "Stake SOL của bạn", "Tìm việc làm"]
       }
     }
   },
@@ -8433,12 +8428,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8455,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8466,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8517,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8578,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8590,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8622,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8641,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8691,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8703,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8777,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8794,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8913,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +8995,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9023,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9102,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9123,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9140,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9187,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9401,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9416,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9446,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9455,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9464,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9495,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9655,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9722,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9833,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9845,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10006,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10174,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10683,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10699,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "Đối tượng Onchain",
-          "Purpose"
-        ],
+        "headers": ["Piece", "Đối tượng Onchain", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",

--- a/packages/i18n/messages/web/zh/common.json
+++ b/packages/i18n/messages/web/zh/common.json
@@ -8358,12 +8358,7 @@
           "访问文档",
           "参加黑客松"
         ],
-        "user": [
-          "Solana 101",
-          "找到一个钱包",
-          "质押您的 SOL",
-          "寻找工作"
-        ]
+        "user": ["Solana 101", "找到一个钱包", "质押您的 SOL", "寻找工作"]
       }
     }
   },
@@ -8433,12 +8428,7 @@
       "caseStudies": {
         "heading": "See how businesses are implementing solutions on Solana",
         "body": "",
-        "labels": [
-          "Pyth",
-          "GainForest",
-          "Helium",
-          "All case studies"
-        ]
+        "labels": ["Pyth", "GainForest", "Helium", "All case studies"]
       }
     },
     "cardDecks": {
@@ -8465,12 +8455,7 @@
         ]
       },
       "videos": {
-        "headings": [
-          "Hivemapper",
-          "Orca",
-          "Helius",
-          "Dialect"
-        ]
+        "headings": ["Hivemapper", "Orca", "Helius", "Dialect"]
       }
     },
     "heading": {
@@ -8481,10 +8466,7 @@
     "switchback": {
       "headline": "Get started",
       "body": "<p>With new tooling, comprehensive technical courses, and consistent network-wide upgrades, now is the perfect time to start building your project.</p>",
-      "buttons": [
-        "What to look forward to in 2024",
-        "See the DOcs"
-      ]
+      "buttons": ["What to look forward to in 2024", "See the DOcs"]
     }
   },
   "developers-dao": {
@@ -8535,11 +8517,7 @@
         "Ready to build? Head on over to Github to start making your tool.",
         "Going public? See how you can make governance as easy as possible for your end users."
       ],
-      "ctaLabels": [
-        "Read The Docs",
-        "View Repo",
-        "View Repo"
-      ]
+      "ctaLabels": ["Read The Docs", "View Repo", "View Repo"]
     },
     "featureHighlight": {
       "eyebrow": "Why Solana",
@@ -8600,10 +8578,7 @@
     "conversionPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-defi": {
@@ -8615,10 +8590,7 @@
       "eyebrow": "DEFI",
       "headline": "DeFi made fast, seamless, and easy",
       "body": "<p>High transaction throughput. Ultra low fees. Low latency. Capital efficiency. Solana is made for builders.</p>",
-      "buttons": [
-        "Start Building",
-        "Read Docs"
-      ]
+      "buttons": ["Start Building", "Read Docs"]
     },
     "stats": [
       {
@@ -8650,9 +8622,7 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "-Write smart contracts with ease",
       "body": "<p>It shouldn't be hard to write smart contracts. Anchor is Solidity, web3.js, ethers.js, Truffle, and ganache all in one toolchain. Get started writing functional programs on Solana faster than ever.</p>",
-      "buttons": [
-        "Read Guide"
-      ]
+      "buttons": ["Read Guide"]
     },
     "cardDeck": {
       "eyebrows": [
@@ -8671,21 +8641,12 @@
         "Liquid staking with Marinade and Lido pools.",
         "Go to ETH and back with Wormhole and Allbridge."
       ],
-      "ctaLabels": [
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It",
-        "Try It"
-      ]
+      "ctaLabels": ["Try It", "Try It", "Try It", "Try It", "Try It", "Try It"]
     },
     "conversionPanel": {
       "heading": "RPC Infrastructure",
       "body": "Make sure your systems are prepared for 500,000+ users. Get reliable RPC infrastructure.",
-      "buttons": [
-        "Documentation"
-      ]
+      "buttons": ["Documentation"]
     },
     "communityGallery": {
       "cards": [
@@ -8730,10 +8691,7 @@
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "developers-payments": {
@@ -8745,10 +8703,7 @@
       "eyebrow": "",
       "headline": "Decentralized payments at scale",
       "body": "<p>Solana’s high throughput and low fees make it a perfect fit for merchants to accept stablecoin payments.</p>",
-      "buttons": [
-        "Get Started",
-        "LEARN MORE ABOUT SOLANA PAY"
-      ]
+      "buttons": ["Get Started", "LEARN MORE ABOUT SOLANA PAY"]
     },
     "stats": [
       {
@@ -8822,17 +8777,12 @@
       "eyebrow": "ANCHOR FRAMEWORK",
       "headline": "Build the future together",
       "body": "<p>Solana’s blockchain enables the core building blocks for the future of commerce. If you’re ready to build the next generation of payments, loyalty and offers solutions, we want to hear from you.</p>",
-      "buttons": [
-        "Learn about turnkey solutions"
-      ]
+      "buttons": ["Learn about turnkey solutions"]
     },
     "communityPanel": {
       "heading": "Join the Community",
       "body": "",
-      "listItems": [
-        "Solana Discord",
-        "Solana Forums"
-      ]
+      "listItems": ["Solana Discord", "Solana Forums"]
     }
   },
   "pyusd": {
@@ -8844,9 +8794,7 @@
       "eyebrow": "Payments",
       "headline": "PayPal USD on Solana. Fast. Minimal Fees. Trusted.",
       "body": "<p>Issued by Paxos Trust Company, LLC, PayPal USD (or PYUSD) is 100% backed by high-quality liquid assets and supported by one of the largest payment companies in the world.</p>",
-      "buttons": [
-        "Read the Whitepaper"
-      ]
+      "buttons": ["Read the Whitepaper"]
     },
     "primaryCardDeck": {
       "cards": [
@@ -8965,9 +8913,7 @@
       "eyebrow": "",
       "headline": "Mint, sell, and trade NFTs at scale.",
       "body": "<p>Solana's high throughput and low fees make it a perfect fit for NFTs of all shapes and sizes.</p>",
-      "buttons": [
-        "Get Started"
-      ]
+      "buttons": ["Get Started"]
     },
     "stats": [
       {
@@ -9049,9 +8995,7 @@
       "eyebrow": "",
       "headline": "Solana Ecosystem",
       "body": "<p>Take a peek at the explosive NFT ecosystem on Solana. Find marketplaces, DAOs, artist collectives, fractionalization tools, and more.</p>",
-      "buttons": [
-        "Find out more"
-      ]
+      "buttons": ["Find out more"]
     },
     "featureHighlight": {
       "eyebrow": "",
@@ -9079,9 +9023,7 @@
           "buttonLabel": "Visit Site"
         }
       ],
-      "buttons": [
-        "Explore Marketplaces"
-      ]
+      "buttons": ["Explore Marketplaces"]
     },
     "communityGallery": {
       "cards": [
@@ -9160,16 +9102,12 @@
     "switchback": {
       "headline": "Discover Tools That Inspire",
       "body": "<p>Discover resources, tutorials, testimonials, and more for the boundary-breaking artist in you.</p>",
-      "buttons": [
-        "Get started"
-      ]
+      "buttons": ["Get started"]
     },
     "mintingPanel": {
       "heading": "Minting made simple",
       "body": "Minting your digital artwork on Solana is the best way to tap into new collector and fan audiences, marketplaces, and avenues to monetize and own your work. On Solana, artists can focus on their creative process rather than be distracted by complex technical instructions or burdened by high minting costs.",
-      "buttons": [
-        "start minting"
-      ]
+      "buttons": ["start minting"]
     },
     "whySolana": {
       "eyebrow": "why solana?",
@@ -9185,18 +9123,12 @@
         "The Solana protocol unlocks a fast, secure, scalable, and user-friendly future — a future that's only possible on Solana. Explore resources, connect to the ecosystem, and get creating.",
         "Solana is home to a global community of builders, innovators, and creatives. Check out the channels and platforms for staying connected with fellow forward-thinkers."
       ],
-      "ctaLabels": [
-        "learn more",
-        "Learn more"
-      ]
+      "ctaLabels": ["learn more", "Learn more"]
     },
     "contactPanel": {
       "heading": "Start a conversation",
       "body": "Get in touch directly with the Solana team or explore case studies below.",
-      "buttons": [
-        "Get in touch",
-        "Explore case studies"
-      ]
+      "buttons": ["Get in touch", "Explore case studies"]
     }
   },
   "developers-gaming": {
@@ -9208,43 +9140,30 @@
       "eyebrow": "gaming",
       "headline": "Web3 games. Web2 speeds.",
       "body": "<p>Build the games of the future at the speed of the internet. Solana’s high throughput and low fees make it a perfect fit for your masterpiece.</p>",
-      "buttons": [
-        "Start Building",
-        "Reach out"
-      ]
+      "buttons": ["Start Building", "Reach out"]
     },
     "conversionPanels": {
       "gamesKit": {
         "heading": "Solana Games Kit",
         "body": "A collection of such tools and services being developed in the Solana ecosystem to empower game developers and accelerate the development of amazing web3 games on Solana.",
-        "listItems": [
-          "Check it out"
-        ]
+        "listItems": ["Check it out"]
       },
       "funding": {
         "heading": "Fund the development of your game",
         "body": "Take your first steps towards blockchain gaming with these Game Investment Funds",
-        "buttons": [
-          "Start Building",
-          "Learn more"
-        ]
+        "buttons": ["Start Building", "Learn more"]
       },
       "community": {
         "heading": "Join the Community",
         "body": "",
-        "listItems": [
-          "Solana Discord",
-          "Solana Forums"
-        ]
+        "listItems": ["Solana Discord", "Solana Forums"]
       }
     },
     "featureHighlight": {
       "eyebrow": "why solana",
       "headline": "Go bigger, faster, smarter.",
       "body": "",
-      "buttons": [
-        "Start Building"
-      ],
+      "buttons": ["Start Building"],
       "cards": [
         {
           "feature": "A single state, by design",
@@ -9268,9 +9187,7 @@
       "eyebrow": "SOLANA IN ACTION",
       "headline": "Super fast. Super cheap. Super seamless.",
       "body": "<p>Solana’s blazing-fast speed and ultra-low fees are built to scale, so the ecosystem grows without sacrificing censorship resistance or security. It’s so fast, your players will definitely notice. See how Mini Royale: Nations uses the blockchain to create a unique open-economy multiplayer shooter.</p>",
-      "buttons": [
-        "Play Game"
-      ]
+      "buttons": ["Play Game"]
     },
     "heading": {
       "eyebrow": "Solana games",
@@ -9484,22 +9401,13 @@
       ]
     },
     "ethereumTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
-          "cells": [
-            "`address`",
-            "An Account's address"
-          ]
+          "cells": ["`address`", "An Account's address"]
         },
         {
-          "cells": [
-            "`balance`",
-            "The amount of ETH (in wei) an address owns."
-          ]
+          "cells": ["`balance`", "The amount of ETH (in wei) an address owns."]
         },
         {
           "cells": [
@@ -9508,10 +9416,7 @@
           ]
         },
         {
-          "cells": [
-            "`code hash`",
-            "The code of an account on the EVM."
-          ]
+          "cells": ["`code hash`", "The code of an account on the EVM."]
         },
         {
           "cells": [
@@ -9541,10 +9446,7 @@
       ]
     },
     "solanaTable": {
-      "headers": [
-        "Field",
-        "Description"
-      ],
+      "headers": ["Field", "Description"],
       "rows": [
         {
           "cells": [
@@ -9553,10 +9455,7 @@
           ]
         },
         {
-          "cells": [
-            "`owner`",
-            "The program owner of this account."
-          ]
+          "cells": ["`owner`", "The program owner of this account."]
         },
         {
           "cells": [
@@ -9565,10 +9464,7 @@
           ]
         },
         {
-          "cells": [
-            "`data`",
-            "The raw data byte array stored by this account."
-          ]
+          "cells": ["`data`", "The raw data byte array stored by this account."]
         },
         {
           "cells": [
@@ -9599,46 +9495,25 @@
       ]
     },
     "comparisonTable": {
-      "headers": [
-        "Ethereum's Account",
-        "Solana's Account"
-      ],
+      "headers": ["Ethereum's Account", "Solana's Account"],
       "rows": [
         {
-          "cells": [
-            "`Account`",
-            "`owner`"
-          ]
+          "cells": ["`Account`", "`owner`"]
         },
         {
-          "cells": [
-            "`balance`",
-            "`lamports`"
-          ]
+          "cells": ["`balance`", "`lamports`"]
         },
         {
-          "cells": [
-            "`nonce`",
-            "[no equivalent]"
-          ]
+          "cells": ["`nonce`", "[no equivalent]"]
         },
         {
-          "cells": [
-            "`code hash`",
-            "`executable && data`"
-          ]
+          "cells": ["`code hash`", "`executable && data`"]
         },
         {
-          "cells": [
-            "`storage hash`",
-            "`data`"
-          ]
+          "cells": ["`storage hash`", "`data`"]
         },
         {
-          "cells": [
-            "[no equivalent]",
-            "`rent_epoch`"
-          ]
+          "cells": ["[no equivalent]", "`rent_epoch`"]
         }
       ]
     },
@@ -9780,118 +9655,64 @@
     "intro": "<p>Ethereum and Solana are unique blockchains that have multiple diverse validator clients for validating transactions. Having various validator clients helps prevent network disruptions in case a specific client encounters issues. In this chapter, we will introduce validator clients in the Ethereum and Solana ecosystems and discuss the types of nodes that exist.</p>",
     "typesOfClients": "<h2><strong>Types of validator clients</strong></h2><p>As Ethereum transitioned from PoW (Proof of Work) to PoS (Proof of Stake), it adopted two types of validator clients: Execution Layer (EL) and Consensus Layer (CL) clients. Execution clients are responsible for receiving new transactions broadcasted on the network, executing them on the EVM, and maintaining the current state and database of all Ethereum data. Consensus clients, on the other hand, implement the consensus algorithm of PoS and achieve consensus on the network based on verified data from execution clients. These two types of clients serve different roles, which is why Ethereum validator nodes typically run both execution and consensus clients. In contrast, Solana combines both functionalities in a single client.</p><p>Here is the list of execution clients for Ethereum:</p>",
     "executionClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Geth",
-            "Golang"
-          ]
+          "cells": ["Geth", "Golang"]
         },
         {
-          "cells": [
-            "Besu",
-            "Java"
-          ]
+          "cells": ["Besu", "Java"]
         },
         {
-          "cells": [
-            "Nethermind",
-            "C# .NET"
-          ]
+          "cells": ["Nethermind", "C# .NET"]
         },
         {
-          "cells": [
-            "Erigon",
-            "Go"
-          ]
+          "cells": ["Erigon", "Go"]
         },
         {
-          "cells": [
-            "Reth",
-            "Rust"
-          ]
+          "cells": ["Reth", "Rust"]
         }
       ]
     },
     "consensusClientsIntro": "<p>And here is the list of consensus clients for Ethereum:</p>",
     "consensusClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Lighthouse",
-            "Rust"
-          ]
+          "cells": ["Lighthouse", "Rust"]
         },
         {
-          "cells": [
-            "Lodestar",
-            "TypeScript"
-          ]
+          "cells": ["Lodestar", "TypeScript"]
         },
         {
-          "cells": [
-            "Nimbus",
-            "Nim"
-          ]
+          "cells": ["Nimbus", "Nim"]
         },
         {
-          "cells": [
-            "Prysm",
-            "Go"
-          ]
+          "cells": ["Prysm", "Go"]
         },
         {
-          "cells": [
-            "Teku",
-            "Java"
-          ]
+          "cells": ["Teku", "Java"]
         }
       ]
     },
     "solanaClientsIntro": "<p>Now, let's take a look at Solana's validator clients list:</p>",
     "solanaClientsTable": {
-      "headers": [
-        "Client",
-        "Language"
-      ],
+      "headers": ["Client", "Language"],
       "rows": [
         {
-          "cells": [
-            "Solana Labs",
-            "Rust"
-          ]
+          "cells": ["Solana Labs", "Rust"]
         },
         {
-          "cells": [
-            "Jito-Solana",
-            "Rust"
-          ]
+          "cells": ["Jito-Solana", "Rust"]
         },
         {
-          "cells": [
-            "Firedancer",
-            "C++"
-          ]
+          "cells": ["Firedancer", "C++"]
         },
         {
-          "cells": [
-            "sig",
-            "Zig"
-          ]
+          "cells": ["sig", "Zig"]
         },
         {
-          "cells": [
-            "Agave",
-            "Rust"
-          ]
+          "cells": ["Agave", "Rust"]
         }
       ]
     },
@@ -9901,33 +9722,20 @@
       "sections": [
         {
           "title": "Node storing all data and participating in consensus",
-          "items": [
-            "Ethereum: Archive Node",
-            "Solana: [n/a]"
-          ]
+          "items": ["Ethereum: Archive Node", "Solana: [n/a]"]
         },
         {
           "title": "Node storing some data and participating in consensus",
-          "items": [
-            "Ethereum: Full Node",
-            "Solana: Consensus Node"
-          ]
+          "items": ["Ethereum: Full Node", "Solana: Consensus Node"]
         },
         {
           "title": "Node storing some data and not participating in consensus",
-          "items": [
-            "Ethereum: Light Node",
-            "Solana: RPC Node"
-          ]
+          "items": ["Ethereum: Light Node", "Solana: RPC Node"]
         }
       ]
     },
     "nodeComparisonTable": {
-      "headers": [
-        "Node Type",
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Node Type", "Ethereum", "Solana"],
       "rows": [
         {
           "cells": [
@@ -10025,16 +9833,10 @@
     "solanasConsensusHeading": "<h3><strong>Solana's consensus</strong></h3>",
     "solanasConsensusBody": "<p>What are the corresponding technological components in Solana for each of Ethereum's consensus algorithms? The answer lies in Tower BFT, which supports PoS.</p><p>First, let's understand BFT and PBFT. BFT is a method for achieving reliable consensus among nodes in a distributed system, stemming from the 'Byzantine Generals Problem.' It ensures the system operates correctly even if some nodes are malicious or unreliable. PBFT is a practical implementation of BFT that guarantees system finality and consistency by securing agreement on all transactions among all nodes.</p><p>Tower BFT adopts a variant of PBFT, with one fundamental difference: Proof of History (PoH) acts as a global clock before consensus. In Solana's implementation, PoH is used as the network clock, arranging the order of blocks, transactions, and data.</p><p>Ethereum often inefficiently updates its entire network state for specific transactions, and transactions may not be processed sequentially. In contrast, Solana utilizes PoH (Proof of History) to support PoS. To determine the cryptographic time between two events, a series of computational steps are required. For example, consider two photos: one of an apple and another of the photo being taken. We can infer that the photo of the apple was taken first. Solana tracks their sequence by adding timestamps to data, ensuring no mix-up in its structures.</p><p>Using PoH, Tower BFT effectively determines the order of blocks, transactions, and data through timestamp verification. Therefore, validators can conclusively decide on forks, opting for the chain most trusted by votes. Ethereum lacks a timestamp concept like PoH for overall state synchronization, forcing validators to calculate from previous hashes to select a fork. Conversely, Solana's Tower BFT, based on PoH, effortlessly achieves consensus without needing full block verification.</p><p>Therefore, the comparison can be summarized as follows:</p>",
     "comparisonTable": {
-      "headers": [
-        "Ethereum",
-        "Solana"
-      ],
+      "headers": ["Ethereum", "Solana"],
       "rows": [
         {
-          "cells": [
-            "Proof of Work » Proof of Stake",
-            "Proof of Stake"
-          ]
+          "cells": ["Proof of Work » Proof of Stake", "Proof of Stake"]
         },
         {
           "cells": [
@@ -10043,10 +9845,7 @@
           ]
         },
         {
-          "cells": [
-            "LMD-GHOST Fork Choice Rule",
-            "Tower BFT"
-          ]
+          "cells": ["LMD-GHOST Fork Choice Rule", "Tower BFT"]
         }
       ]
     },
@@ -10207,11 +10006,7 @@
       "eyebrow": "",
       "headline": "Solana Network Research and Reports",
       "body": "<p>Solana is an open-source, community-run network. The Solana Foundation, As part of its mission dedicated to supporting the decentralization, security, and health of the network, regularly conducts and commissions research on the network, its impact, and usage.</p>",
-      "buttons": [
-        "Validator Health",
-        "Energy Impact",
-        "Network Performance"
-      ]
+      "buttons": ["Validator Health", "Energy Impact", "Network Performance"]
     },
     "sections": {
       "validator": {
@@ -10379,10 +10174,7 @@
     "conversionPanel": {
       "heading": "It's time to get started",
       "body": "Have questions? Reach out to the Solana Foundation's product support team, or dig into developer courses and materials.",
-      "buttons": [
-        "Reach Out",
-        "See Developer Materials"
-      ]
+      "buttons": ["Reach Out", "See Developer Materials"]
     }
   },
   "community-report-2024-newsletter-sign-up": {
@@ -10891,9 +10683,7 @@
         },
         "withdraw": {
           "title": "Withdraw / Redeem",
-          "items": [
-            "Reverse order: burn shares → transfer underlying out."
-          ]
+          "items": ["Reverse order: burn shares → transfer underlying out."]
         },
         "stateUpdate": "State Update inside the program (vault_state.total_assets += amount)",
         "preview": "Because every account touched is explicit in the Tx, wallets can simulate side effects and show accurate previews to users at signing time."
@@ -10909,11 +10699,7 @@
         "conceptualMap": "1. conceptual map"
       },
       "conceptualMapTable": {
-        "headers": [
-          "Piece",
-          "链上对象",
-          "Purpose"
-        ],
+        "headers": ["Piece", "链上对象", "Purpose"],
         "rows": [
           {
             "label": "Underlying Mint",


### PR DESCRIPTION
## Problem

The Lingo translation update (#1823) committed `packages/i18n/messages/web/*/common.json` files that don't satisfy the repo's Prettier config. This turned the **Format** and **Lint @workspace/i18n** checks red on `main`, so every branch cut from `main` inherits failing CI.

## Changes

- `prettier --write` on the 18 affected `common.json` files. Formatting-only (short arrays collapsed to single lines) — no translation content changes.

Unblocks CI on main and all open PRs branched from it.