### PR TITLE
feat(breakpoint): add language selector to navigation

### DIFF
--- a/apps/breakpoint/next.config.ts
+++ b/apps/breakpoint/next.config.ts
@@ -30,7 +30,30 @@ const nextConfig: NextConfig = {
   },
   webpack(config) {
     config.module.rules.push({
-      test: /\.svg$/,
+      test: /\.inline\.svg$/,
+      use: {
+        loader: "@svgr/webpack",
+        options: {
+          svgoConfig: {
+            plugins: [
+              {
+                name: "preset-default",
+                params: {
+                  overrides: {
+                    removeViewBox: false,
+                    removeUselessStrokeAndFill: false,
+                    cleanupIds: false,
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    config.module.rules.push({
+      test: /(?<!inline)\.svg$/,
       type: "asset",
     });
 

--- a/apps/breakpoint/package.json
+++ b/apps/breakpoint/package.json
@@ -28,6 +28,7 @@
     "rtl-detect": "^1.1.2"
   },
   "devDependencies": {
+    "@svgr/webpack": "^8.1.0",
     "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.3.2",

--- a/apps/breakpoint/src/components/Navigation.tsx
+++ b/apps/breakpoint/src/components/Navigation.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import Script from "next/script";
+import { LanguageSelector } from "@solana-com/ui-chrome";
 import { useTranslations } from "@workspace/i18n/client";
 import { Link, usePathname } from "@workspace/i18n/routing";
 import ArrowUpRightIcon from "@/components/ArrowUpRightIcon";
@@ -214,10 +215,15 @@ export default function Navigation({
     };
 
     const onPointerDown = (event: PointerEvent) => {
+      const target = event.target;
+      const isLanguageMenu =
+        target instanceof Element && target.closest('[role="menu"]');
+
       if (
         navRef.current &&
-        event.target instanceof Node &&
-        !navRef.current.contains(event.target)
+        target instanceof Node &&
+        !navRef.current.contains(target) &&
+        !isLanguageMenu
       ) {
         setMenuOpen(false);
       }
@@ -434,6 +440,8 @@ export default function Navigation({
                 </div>
               );
             })}
+            <div className="relative h-0 w-full before:absolute before:inset-x-0 before:top-0 before:h-px before:bg-neutral-700" />
+            <LanguageSelector className="type-button h-[26px] !text-white hover:!text-purple focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-4 focus-visible:outline-white [&>span]:text-button [&>span]:font-bold" />
           </div>
         )}
       </nav>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2
     devDependencies:
+      "@svgr/webpack":
+        specifier: ^8.1.0
+        version: 8.1.0(typescript@5.8.3)
       "@tailwindcss/postcss":
         specifier: ^4.2.4
         version: 4.2.4


### PR DESCRIPTION
### Problem

The Breakpoint site supports localized routes and translated message catalogs, but its navigation menu does not provide a way to switch languages.

### Summary of Changes

- Add the shared `LanguageSelector` to the Breakpoint navigation menu, styled with Breakpoint design tokens.
- Keep the menu open while interacting with the selector portal so locale links remain clickable.
- Configure Breakpoint to compile the shared chrome `.inline.svg` icons consistently with the other monorepo apps.

No security-sensitive runtime behavior is introduced.

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] No new user or external-service input paths or unsanitized HTML are introduced.
- [ ] New or updated dependencies are justified below, and `pnpm audit` passes with no High/Critical advisories.
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

New dependency declaration: `@svgr/webpack` is added to the Breakpoint workspace so it can compile the existing shared chrome inline SVGs. It reuses the version already present in the lockfile and used by the web, docs, media, templates, and accelerate apps; no new package version is resolved. `pnpm audit --audit-level high` still reports four existing high advisories, including the existing transitive SVGO advisory.

Threat-model note: n/a.

### Validation

- `pnpm --filter solana-com-breakpoint lint`
- `pnpm --filter solana-com-breakpoint check-types`
- `pnpm --filter solana-com-breakpoint test` (28 tests)
- `pnpm --filter solana-com-breakpoint build`
- Browser-verified at 390×844 and 1440×900; all 19 configured languages render and English → French navigates `/breakpoint/travel` to `/fr/breakpoint/travel` without runtime errors.