### PR TITLE
fix(i18n): default proxied apps to English

### DIFF
--- a/packages/i18n/src/middleware.test.ts
+++ b/packages/i18n/src/middleware.test.ts
@@ -1,11 +1,12 @@
+import { NextRequest } from "next/server";
 import { describe, expect, it } from "vitest";
 import {
   SHARED_LOCALE_COOKIE,
-  buildSharedLocaleCookie,
+  createMiddleware,
   getFixedProxiedLocation,
   getLocaleFromPathname,
-  getLocaleRedirectPath,
-  getPreferredLocaleCookie,
+  routing,
+  routingWithoutDetection,
 } from "./middleware";
 import { getAlternates } from "./alternates";
 
@@ -16,30 +17,67 @@ describe("@workspace/i18n middleware", () => {
     expect(getLocaleFromPathname("/docs")).toBeNull();
   });
 
-  it("accepts only supported shared locale cookie values", () => {
-    expect(getPreferredLocaleCookie("es")).toBe("es");
-    expect(getPreferredLocaleCookie("sv")).toBeNull();
-    expect(getPreferredLocaleCookie(null)).toBeNull();
+  it("uses the shared locale cookie when locale detection is enabled", async () => {
+    const handleI18nRouting = createMiddleware(routing);
+    const request = new NextRequest("https://solana.com/breakpoint", {
+      headers: { cookie: `${SHARED_LOCALE_COOKIE}=uk` },
+    });
+
+    const response = await handleI18nRouting(request);
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(
+      "https://solana.com/uk/breakpoint",
+    );
   });
 
-  it("builds localized redirect paths for non-default locales", () => {
-    expect(getLocaleRedirectPath("/", "es")).toBe("/es");
-    expect(getLocaleRedirectPath("/docs/payments", "es")).toBe(
-      "/es/docs/payments",
-    );
-    expect(getLocaleRedirectPath("/docs/payments", "en")).toBe(
-      "/docs/payments",
+  it("defaults unprefixed sub-app routes to English", async () => {
+    const handleI18nRouting = createMiddleware(routingWithoutDetection);
+    const request = new NextRequest("https://solana.com/breakpoint", {
+      headers: {
+        "accept-language": "uk,en;q=0.5",
+        cookie: `${SHARED_LOCALE_COOKIE}=uk; NEXT_LOCALE=uk`,
+      },
+    });
+
+    const response = await handleI18nRouting(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    expect(response.headers.get("x-middleware-rewrite")).toContain(
+      "/en/breakpoint",
     );
   });
 
-  it("serializes the shared locale cookie", () => {
-    expect(buildSharedLocaleCookie("es")).toContain(
-      `${SHARED_LOCALE_COOKIE}=es`,
+  it("keeps explicit non-English sub-app routes localized", async () => {
+    const handleI18nRouting = createMiddleware(routingWithoutDetection);
+    const request = new NextRequest("https://solana.com/uk/breakpoint");
+
+    const response = await handleI18nRouting(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+  });
+
+  it("does not let a proxied sub-app overwrite the shared locale cookie", async () => {
+    const handleI18nRouting = createMiddleware(routingWithoutDetection, {
+      preserveProxiedLocaleCookie: true,
+    });
+    const request = new NextRequest(
+      "https://solana-com-breakpoint.vercel.app/uk/breakpoint",
+      {
+        headers: {
+          cookie: `${SHARED_LOCALE_COOKIE}=en`,
+          host: "solana-com-breakpoint.vercel.app",
+          "x-forwarded-host": "solana.com",
+          "x-forwarded-proto": "https",
+        },
+      },
     );
-    expect(buildSharedLocaleCookie("es")).toContain("Path=/");
-    expect(buildSharedLocaleCookie("es")).toContain("Max-Age=31536000");
-    expect(buildSharedLocaleCookie("es")).toContain("Expires=");
-    expect(buildSharedLocaleCookie("es")).toContain("SameSite=Lax");
+
+    const response = await handleI18nRouting(request);
+
+    expect(response.headers.get("set-cookie")).toBeNull();
   });
 
   it("normalizes canonical and hreflang alternate paths", () => {

--- a/packages/i18n/src/middleware.ts
+++ b/packages/i18n/src/middleware.ts
@@ -1,13 +1,17 @@
 import createNextIntlMiddleware from "next-intl/middleware";
-import { defineRouting } from "next-intl/routing";
-import { NextResponse, type NextRequest } from "next/server";
-import { locales, defaultLocale } from "./config";
-import { getLocaleFromPathname } from "./pathname";
+import type { NextRequest } from "next/server";
+import {
+  routing,
+  routingWithoutDetection,
+  SHARED_LOCALE_COOKIE,
+} from "./routing-config";
 
 export { getLocaleFromPathname } from "./pathname";
-
-export const SHARED_LOCALE_COOKIE = "SOLANA_LOCALE";
-const SHARED_LOCALE_COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+export {
+  routing,
+  routingWithoutDetection,
+  SHARED_LOCALE_COOKIE,
+} from "./routing-config";
 
 interface CreateMiddlewareOptions {
   /**
@@ -17,53 +21,6 @@ interface CreateMiddlewareOptions {
    * @default false
    */
   preserveProxiedLocaleCookie?: boolean;
-}
-
-/**
- * Routing configuration with locale detection enabled.
- * Use this for the main app that should detect browser language.
- */
-export const routing = defineRouting({
-  locales,
-  defaultLocale,
-  localePrefix: "as-needed",
-  localeDetection: true,
-});
-
-/**
- * Routing configuration with locale detection disabled.
- * Use this for sub-apps that are accessed via rewrites to prevent
- * redirect loops to the internal Vercel URL.
- */
-export const routingWithoutDetection = defineRouting({
-  locales,
-  defaultLocale,
-  localePrefix: "as-needed",
-  localeDetection: false,
-});
-
-export function getPreferredLocaleCookie(value?: string | null) {
-  return value && locales.includes(value) ? value : null;
-}
-
-export function getLocaleRedirectPath(pathname: string, locale: string) {
-  if (locale === defaultLocale) {
-    return pathname;
-  }
-
-  return pathname === "/" ? `/${locale}` : `/${locale}${pathname}`;
-}
-
-export function buildSharedLocaleCookie(locale: string) {
-  const expires = new Date(Date.now() + SHARED_LOCALE_COOKIE_MAX_AGE * 1000);
-
-  return [
-    `${SHARED_LOCALE_COOKIE}=${encodeURIComponent(locale)}`,
-    "Path=/",
-    `Max-Age=${SHARED_LOCALE_COOKIE_MAX_AGE}`,
-    `Expires=${expires.toUTCString()}`,
-    "SameSite=Lax",
-  ].join("; ");
 }
 
 export function getEffectiveOrigin(req: NextRequest) {
@@ -112,31 +69,16 @@ export function getFixedProxiedLocation({
   }
 }
 
-function getResponseLocale(req: NextRequest, response: Response) {
-  const localeFromRequestPath = getLocaleFromPathname(req.nextUrl.pathname);
-  if (localeFromRequestPath) {
-    return localeFromRequestPath;
-  }
-
-  const location = response.headers.get("location");
-  if (!location) {
-    return null;
-  }
-
-  const redirectPathname = new URL(location, getEffectiveOrigin(req)).pathname;
-  return getLocaleFromPathname(redirectPathname);
-}
-
 /**
  * Creates an i18n middleware that wraps next-intl's middleware with additional
  * functionality to handle multi-app deployments on the same domain.
  *
  * When multiple apps are served via rewrites on the same domain (e.g., main site,
- * docs, media), each app's middleware would normally set the NEXT_LOCALE cookie,
+ * docs, media), each app's middleware would normally set the locale cookie,
  * potentially overwriting each other. This wrapper prevents that by:
  *
  * 1. Detecting when a request comes through a proxy (via x-forwarded-host header)
- * 2. Stripping the NEXT_LOCALE Set-Cookie header from the response
+ * 2. Stripping the locale Set-Cookie header from the response
  * 3. Fixing redirect URLs to use the original host instead of the proxy target
  *
  * @param routingConfig - Use `routing` or `routingWithoutDetection` from this module
@@ -149,35 +91,7 @@ export function createMiddleware<
   const handleI18nRouting = createNextIntlMiddleware(routingConfig);
 
   return async function middleware(req: NextRequest) {
-    const pathname = req.nextUrl.pathname;
-    const localeFromPath = getLocaleFromPathname(pathname);
-    const preferredLocale = getPreferredLocaleCookie(
-      req.cookies.get(SHARED_LOCALE_COOKIE)?.value,
-    );
-
-    if (
-      !localeFromPath &&
-      preferredLocale &&
-      preferredLocale !== defaultLocale
-    ) {
-      const redirectUrl = getEffectiveOrigin(req);
-      redirectUrl.pathname = getLocaleRedirectPath(pathname, preferredLocale);
-      const redirectResponse = NextResponse.redirect(redirectUrl, 307);
-      redirectResponse.headers.append(
-        "set-cookie",
-        buildSharedLocaleCookie(preferredLocale),
-      );
-      return redirectResponse;
-    }
-
     const response = await handleI18nRouting(req);
-    const responseLocale = getResponseLocale(req, response);
-    if (responseLocale) {
-      response.headers.append(
-        "set-cookie",
-        buildSharedLocaleCookie(responseLocale),
-      );
-    }
 
     // Check if request came through a proxy (e.g., rewrite from another Vercel app)
     const forwardedHost = req.headers.get("x-forwarded-host");
@@ -191,7 +105,7 @@ export function createMiddleware<
 
     // When proxied, we need to:
     // 1. Fix redirect URLs to use the original host
-    // 2. Remove NEXT_LOCALE cookie to prevent overwriting the main app's cookie
+    // 2. Remove locale cookie to prevent overwriting the main app's cookie
     const location = response.headers.get("location");
     const setCookie = response.headers.get("set-cookie");
 
@@ -217,13 +131,18 @@ export function createMiddleware<
       fixedResponse.headers.set("location", fixedLocation);
     }
 
-    // Remove NEXT_LOCALE cookie from response to prevent overwriting the main app's cookie
+    // Remove the locale cookie from the response to prevent overwriting the
+    // main app's cookie. NEXT_LOCALE is also removed during migration from the
+    // previous next-intl default.
     if (setCookie) {
-      // Handle both single cookies and multiple cookies (separated by ", ")
-      // Note: Cookies can contain commas in values, but NEXT_LOCALE is a simple string
+      const localeCookieNames = [SHARED_LOCALE_COOKIE, "NEXT_LOCALE"];
       const cookies = setCookie
-        .split(/,(?=\s*NEXT_LOCALE=|[^;]*?=)/)
-        .filter((cookie) => !cookie.trim().startsWith("NEXT_LOCALE="));
+        .split(/,(?=\s*[^;,=]+=[^;,]*)/)
+        .filter((cookie) =>
+          localeCookieNames.every(
+            (name) => !cookie.trim().startsWith(`${name}=`),
+          ),
+        );
 
       if (cookies.length > 0) {
         fixedResponse.headers.set("set-cookie", cookies.join(", "));

--- a/packages/i18n/src/routing-config.ts
+++ b/packages/i18n/src/routing-config.ts
@@ -1,0 +1,35 @@
+import { defineRouting } from "next-intl/routing";
+import { defaultLocale, locales } from "./config";
+
+export const SHARED_LOCALE_COOKIE = "SOLANA_LOCALE";
+
+const localeCookie = {
+  name: SHARED_LOCALE_COOKIE,
+  maxAge: 60 * 60 * 24 * 365,
+  path: "/",
+  sameSite: "lax" as const,
+};
+
+/**
+ * Main-app routing. Browser and cookie detection are enabled so an explicit
+ * locale choice can carry across the marketing site.
+ */
+export const routing = defineRouting({
+  locales,
+  defaultLocale,
+  localePrefix: "as-needed",
+  localeDetection: true,
+  localeCookie,
+});
+
+/**
+ * Routing for apps served through cross-app rewrites. Unprefixed URLs always
+ * use the default locale; only an explicit locale prefix changes the locale.
+ */
+export const routingWithoutDetection = defineRouting({
+  locales,
+  defaultLocale,
+  localePrefix: "as-needed",
+  localeDetection: false,
+  localeCookie,
+});

--- a/packages/i18n/src/routing.ts
+++ b/packages/i18n/src/routing.ts
@@ -1,15 +1,8 @@
 import { createNavigation } from "next-intl/navigation";
-import { defineRouting } from "next-intl/routing";
-import { locales, defaultLocale } from "./config";
+import { routing } from "./routing-config";
 
 export { getAlternates } from "./alternates";
-
-export const routing = defineRouting({
-  locales,
-  defaultLocale,
-  localePrefix: "as-needed",
-  localeDetection: true,
-});
+export { routing } from "./routing-config";
 
 export const { Link, redirect, usePathname, useRouter } =
   createNavigation(routing);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,8 +10,8 @@ catalogs:
       specifier: 15.5.21
       version: 15.5.21
     next-intl:
-      specifier: 4.13.0
-      version: 4.13.0
+      specifier: 4.13.4
+      version: 4.13.4
     react:
       specifier: 19.2.6
       version: 19.2.6
@@ -114,7 +114,7 @@ importers:
         version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -208,7 +208,7 @@ importers:
         version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -374,7 +374,7 @@ importers:
         version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-seo:
         specifier: ^6.6.0
         version: 6.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -561,7 +561,7 @@ importers:
         version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -715,7 +715,7 @@ importers:
         version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       nuqs:
         specifier: ^2.4.3
         version: 2.7.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6)
@@ -926,7 +926,7 @@ importers:
         version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -1240,7 +1240,7 @@ importers:
         version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -1393,7 +1393,7 @@ importers:
         version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -12798,10 +12798,10 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  icu-minify@4.13.0:
+  icu-minify@4.13.4:
     resolution:
       {
-        integrity: sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==,
+        integrity: sha512-yK6HyPLGlQjqm8fTKtnBpM77z7vl7JdDBN2EXLvmgAu/b7XaOHWZb73M3ISl9ahBTehBv7RYeqqWSHfk1v2YcA==,
       }
 
   idb-keyval@6.2.2:
@@ -14593,16 +14593,16 @@ packages:
       }
     engines: { node: ">= 0.4.0" }
 
-  next-intl-swc-plugin-extractor@4.13.0:
+  next-intl-swc-plugin-extractor@4.13.4:
     resolution:
       {
-        integrity: sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==,
+        integrity: sha512-uN1+NMUYbG6YkO3q+rjc2bvAPX9nQ23owemvHJAyW0pRbQjVDwvNhmrV5qaak0oQc/9okbK17KLT49AoMGhVEQ==,
       }
 
-  next-intl@4.13.0:
+  next-intl@4.13.4:
     resolution:
       {
-        integrity: sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==,
+        integrity: sha512-jhPAT0u0lahIK6E4gVdZAehugWCosBhLG8sV7xMzgSVoJpxHObP+Fiu+z2FfkEW0XPPtr7uEXoUlLEfhxhNMTg==,
       }
     peerDependencies:
       next: ^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -18069,10 +18069,10 @@ packages:
       "@types/react":
         optional: true
 
-  use-intl@4.13.0:
+  use-intl@4.13.4:
     resolution:
       {
-        integrity: sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==,
+        integrity: sha512-wRhU5zyPNgu845++EJ8ckQsi89b22QUop7NlGxNXpsnKSwEJr7WErAkdAYeVQgFTmDWsa8e2NI1e14XbWz9Ecw==,
       }
     peerDependencies:
       react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0
@@ -26917,7 +26917,7 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icu-minify@4.13.0:
+  icu-minify@4.13.4:
     dependencies:
       "@formatjs/icu-messageformat-parser": 3.5.11
 
@@ -28141,20 +28141,20 @@ snapshots:
 
   netmask@2.0.2: {}
 
-  next-intl-swc-plugin-extractor@4.13.0: {}
+  next-intl-swc-plugin-extractor@4.13.4: {}
 
-  next-intl@4.13.0(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
+  next-intl@4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
     dependencies:
       "@formatjs/intl-localematcher": 0.8.10
       "@parcel/watcher": 2.5.1
       "@swc/core": 1.15.41(@swc/helpers@0.5.17)
-      icu-minify: 4.13.0
+      icu-minify: 4.13.4
       negotiator: 1.0.0
       next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
-      next-intl-swc-plugin-extractor: 4.13.0
+      next-intl-swc-plugin-extractor: 4.13.4
       po-parser: 2.1.1
       react: 19.2.6
-      use-intl: 4.13.0(react@19.2.6)
+      use-intl: 4.13.4(react@19.2.6)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -30582,11 +30582,11 @@ snapshots:
     optionalDependencies:
       "@types/react": 19.1.12
 
-  use-intl@4.13.0(react@19.2.6):
+  use-intl@4.13.4(react@19.2.6):
     dependencies:
       "@formatjs/fast-memoize": 3.1.6
       "@schummar/icu-type-parser": 1.21.5
-      icu-minify: 4.13.0
+      icu-minify: 4.13.4
       intl-messageformat: 11.2.8
       react: 19.2.6
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,7 +8,7 @@ verifyDepsBeforeRun: false
 
 catalog:
   next: 15.5.21
-  next-intl: 4.13.0
+  next-intl: 4.13.4
   react: 19.2.6
   react-dom: 19.2.6
   vitest: 4.1.8


### PR DESCRIPTION
### Problem

Opening an unprefixed proxied-app URL such as `/breakpoint` could unexpectedly redirect to a non-English locale. Production probing confirmed that `Accept-Language: uk` and `NEXT_LOCALE=uk` were ignored as intended, but `SOLANA_LOCALE=uk` caused a `307` redirect to `/uk/breakpoint`.

The shared middleware configured `localeDetection: false` for proxied apps, then bypassed that setting with custom `SOLANA_LOCALE` redirect and cookie-sync logic. This contradicted the next-intl URL-only behavior and recreated the random-language class of bugs addressed by earlier middleware changes.

### Summary of Changes

- centralize routing configuration so middleware and navigation use the same locale-cookie settings
- let next-intl own `SOLANA_LOCALE` through its supported `localeCookie` configuration
- remove custom shared-cookie redirect and response-sync logic
- preserve locale detection for the main marketing app
- make unprefixed proxied-app routes default to English while preserving explicit localized routes such as `/uk/breakpoint`
- continue preventing proxied sub-app responses from overwriting the shared locale cookie
- update next-intl from 4.13.0 to 4.13.4; 4.13.3 includes the upstream fix that limits locale-cookie updates to document requests rather than background router requests
- add regression coverage for detected routes, URL-only routes, explicit locale prefixes, and proxied cookie preservation

Official references:
- https://next-intl.dev/docs/routing/configuration#locale-detection
- https://github.com/amannn/next-intl/releases/tag/v4.13.4
- https://github.com/amannn/next-intl/pull/2355

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] No new user or external-service input paths are introduced.
- [ ] `pnpm audit --audit-level high` is clean. It still reports the repositories four existing High advisories; none are introduced through next-intl.
- [x] No new silent error paths are introduced.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is included below, and a second reviewer has been requested.

Updated dependency: `next-intl` 4.13.0 → 4.13.4, a patch update containing locale-cookie correctness fixes relevant to this routing flow.

Threat-model note: n/a.

### Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @workspace/i18n lint`
- `pnpm --filter @workspace/i18n check-types`
- `pnpm --filter @workspace/i18n test` (20 tests)
- `pnpm --filter solana-com-breakpoint lint`
- `pnpm --filter solana-com-breakpoint test` (28 tests)
- `pnpm --filter solana-com-breakpoint build`
- web test suite (206 passed, 18 skipped)
- Turbo type checks for web, docs, media, templates, Accelerate, Breakpoint, and shared dependencies (14 tasks)
- local HTTP regression probe: `/breakpoint` with `SOLANA_LOCALE=uk` renders `data-locale="en"`; `/uk/breakpoint` renders `data-locale="uk"`