### PR TITLE
fix(docs): redirect old /docs/tokens/spl-token-basics URL

### DIFF
--- a/apps/web/rewrites-redirects.ts
+++ b/apps/web/rewrites-redirects.ts
@@ -252,6 +252,12 @@ const movedDocsRedirects: RedirectInput[] = withMdVariants([
     destination: "/docs/references/clusters",
   },
   {
+    // Page was renamed during the tokens docs restructure; old URL is
+    // still indexed/bookmarked and 404s without this redirect.
+    source: "/docs/tokens/spl-token-basics",
+    destination: "/docs/tokens/quickstart",
+  },
+  {
     source: "/docs/clients/javascript",
     destination: "/docs/clients/official/javascript",
   },


### PR DESCRIPTION
## Summary

`/docs/tokens/spl-token-basics` currently 404s in production. The tokens docs section was restructured and this page was renamed to `/docs/tokens/quickstart` ("Quickstart: create a token with the CLI" — same content: create mint → create token account → mint → transfer via the `spl-token` CLI), but no redirect was added for the old URL. Anyone with an old bookmark, external link, or a search-engine-indexed result for the old slug hits a dead end.

**Edit:** reworked per Greptile's review — moved the redirect from `apps/docs/next.config.ts` (which had no `redirects()` at all before this PR) into `apps/web/rewrites-redirects.ts`, the file that actually owns `/docs/*` redirects (confirmed: it's what makes e.g. `/es/docs/install` work). It's added to the existing `movedDocsRedirects` array, which is wrapped in `withMdVariants` + `withLocaleRedirects`, so this now also fixes the `.md` variant Greptile flagged *and* all 19 locale-prefixed variants (e.g. `/es/docs/tokens/spl-token-basics`, previously still 404), which the original version missed entirely.

- Confirmed live 404 (bare, `.md`, and locale-prefixed): all 404 before this change
- Confirmed `quickstart.mdx` is the semantic successor page (same spl-token CLI walkthrough)
- Confirmed no existing `source: "/docs/tokens/spl-token-basics"` entry that this would duplicate

## Test plan

- [x] Verified `quickstart.mdx` is the semantic successor page
- [x] Verified no other current docs content references the old slug
- [ ] Vercel preview: `/docs/tokens/spl-token-basics`, `/es/docs/tokens/spl-token-basics`, `/docs/tokens/spl-token-basics.md` all resolve 301 → the corresponding `quickstart` URL