### PR TITLE
fix(docs): redirect /docs/programs section root (404)

### DIFF
--- a/apps/web/rewrites-redirects.ts
+++ b/apps/web/rewrites-redirects.ts
@@ -252,6 +252,12 @@ const movedDocsRedirects: RedirectInput[] = withMdVariants([
     destination: "/docs/references/clusters",
   },
   {
+    // "Developing Programs" section has no index.mdx, same as /docs/references
+    // above; redirect the bare section root to its first page.
+    source: "/docs/programs",
+    destination: "/docs/programs/rust",
+  },
+  {
     source: "/docs/clients/javascript",
     destination: "/docs/clients/official/javascript",
   },


### PR DESCRIPTION
## Summary

`/docs/programs` — the "Developing Programs" section root — 404s in production and has no route or redirect at all. Verified:

```
curl -o /dev/null -w '%{http_code}' https://solana.com/docs/programs
404
```

Root cause: `apps/docs/content/docs/en/programs/` has no `index.mdx` (unlike sibling sections like `core`, `tokens`, `frontend`). `/docs/references` has the exact same situation and is already fixed by redirecting the bare section root to its first child page (`/docs/references/clusters`). This PR applies the identical pattern: redirect `/docs/programs` → `/docs/programs/rust`, the first page in `programs/meta.json`.

Added the entry to `movedDocsRedirects`, which is wrapped in `withMdVariants` and spread into `withLocaleRedirects` — so it picks up the raw-markdown `.md` variant and all locale-prefixed variants (`/es/docs/programs`, etc.) for free, same as every other entry in that array.

I audited all 197 unique redirect destinations in this file against production and found a few other stale ones, but #1807 (already open, approved) covers those — this PR is scoped to the one gap it doesn't touch.

## Test plan

- [x] Confirmed live 404 before the fix
- [x] Confirmed `/docs/programs/rust` (redirect target) returns 200, including its `.md` variant
- [x] Confirmed no existing `source: "/docs/programs"` entry that this would shadow or duplicate
- [ ] Vercel preview: `/docs/programs`, `/es/docs/programs`, `/docs/programs.md` all resolve 200 after redirect