### PR TITLE
feat(templates): align templates showcase with current site design

### DIFF
--- a/apps/templates/src/app/developers/templates/[id]/page.tsx
+++ b/apps/templates/src/app/developers/templates/[id]/page.tsx
@@ -64,10 +64,10 @@ export default async function TemplateDetailPage({
   const templates = await fetchTemplatesFromGitHub();
 
   return (
-    <div className="relative min-h-screen bg-gradient-to-br from-purple-500/5 via-background via-50% to-emerald-400/8">
+    <div className="relative min-h-screen bg-nd-inverse text-nd-high-em-text">
       <BackgroundShapes />
-      <div className="absolute inset-0 bg-gradient-to-t from-transparent via-cyan-400/3 to-transparent pointer-events-none"></div>
-      <div className="absolute inset-0 bg-gradient-to-bl from-pink-400/3 via-transparent to-transparent pointer-events-none"></div>
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.08),transparent_55%)] pointer-events-none"></div>
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_right,rgba(85,233,171,0.06),transparent_55%)] pointer-events-none"></div>
       <AppProviders>
         <TemplatesProviderWrapper>
           <div className="relative z-10 container mx-auto px-4 py-8">

--- a/apps/templates/src/app/developers/templates/[id]/page.tsx
+++ b/apps/templates/src/app/developers/templates/[id]/page.tsx
@@ -66,11 +66,9 @@ export default async function TemplateDetailPage({
   return (
     <div className="relative min-h-screen bg-nd-inverse text-nd-high-em-text">
       <BackgroundShapes />
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.08),transparent_55%)] pointer-events-none"></div>
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_right,rgba(85,233,171,0.06),transparent_55%)] pointer-events-none"></div>
       <AppProviders>
         <TemplatesProviderWrapper>
-          <div className="relative z-10 container mx-auto px-4 py-8">
+          <div className="relative z-10">
             <TemplatesUiLayoutDetail
               name={id}
               source={templates.find((t) => t.name === id)?.source.id || ""}

--- a/apps/templates/src/app/developers/templates/page.tsx
+++ b/apps/templates/src/app/developers/templates/page.tsx
@@ -4,6 +4,7 @@ import { getTranslations } from "next-intl/server";
 import { AppHero } from "@/components/app-hero";
 import { BackgroundShapes } from "@/components/background-shapes";
 import { TemplatesUiLayoutList } from "@/components/templates/templates-ui-layout-list";
+import { TemplatesUiHeroVisual } from "@/components/templates/templates-ui-hero-visual";
 import { fetchTemplatesFromGitHub } from "@/lib/fetch-templates";
 import { AppProviders } from "@/components/app-providers";
 import { TemplatesProviderWrapper } from "@/components/providers/templates-provider-wrapper";
@@ -42,13 +43,13 @@ export default async function TemplatesPage() {
   return (
     <div className="relative min-h-screen bg-nd-inverse text-nd-high-em-text">
       <BackgroundShapes />
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.08),transparent_55%)] pointer-events-none"></div>
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_right,rgba(85,233,171,0.06),transparent_55%)] pointer-events-none"></div>
       <AppProviders>
         <TemplatesProviderWrapper>
           <Suspense>
-            <div className="relative z-10 container mx-auto px-4 py-8">
-              <AppHero title={t("title")} subtitle={t("subtitle")} />
+            <div className="relative z-10">
+              <AppHero title={t("title")} subtitle={t("subtitle")}>
+                <TemplatesUiHeroVisual templates={templates.slice(0, 3)} />
+              </AppHero>
               <TemplatesUiLayoutList templates={templates} />
             </div>
           </Suspense>

--- a/apps/templates/src/app/developers/templates/page.tsx
+++ b/apps/templates/src/app/developers/templates/page.tsx
@@ -39,9 +39,9 @@ export default async function TemplatesPage() {
   const t = await getTranslations("templates");
 
   return (
-    <div className="relative min-h-screen bg-gradient-to-br from-purple-500/5 via-background via-50% to-emerald-400/8">
-      <div className="absolute inset-0 bg-gradient-to-t from-transparent via-cyan-400/3 to-transparent pointer-events-none"></div>
-      <div className="absolute inset-0 bg-gradient-to-bl from-pink-400/3 via-transparent to-transparent pointer-events-none"></div>
+    <div className="relative min-h-screen bg-nd-inverse text-nd-high-em-text">
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.08),transparent_55%)] pointer-events-none"></div>
+      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_right,rgba(85,233,171,0.06),transparent_55%)] pointer-events-none"></div>
       <AppProviders>
         <TemplatesProviderWrapper>
           <Suspense>

--- a/apps/templates/src/app/developers/templates/page.tsx
+++ b/apps/templates/src/app/developers/templates/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import type { Metadata } from "next";
 import { getTranslations } from "next-intl/server";
 import { AppHero } from "@/components/app-hero";
+import { BackgroundShapes } from "@/components/background-shapes";
 import { TemplatesUiLayoutList } from "@/components/templates/templates-ui-layout-list";
 import { fetchTemplatesFromGitHub } from "@/lib/fetch-templates";
 import { AppProviders } from "@/components/app-providers";
@@ -40,6 +41,7 @@ export default async function TemplatesPage() {
 
   return (
     <div className="relative min-h-screen bg-nd-inverse text-nd-high-em-text">
+      <BackgroundShapes />
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.08),transparent_55%)] pointer-events-none"></div>
       <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_right,rgba(85,233,171,0.06),transparent_55%)] pointer-events-none"></div>
       <AppProviders>

--- a/apps/templates/src/app/globals.css
+++ b/apps/templates/src/app/globals.css
@@ -4,25 +4,25 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 0%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 0%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 100%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 0 0% 8%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 8%;
+    --muted-foreground: 0 0% 67%;
+    --accent: 0 0% 8%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 15%;
+    --input: 0 0% 15%;
+    --ring: 0 0% 90%;
     --radius: 0.5rem;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
@@ -32,25 +32,25 @@
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
+    --background: 0 0% 0%;
+    --foreground: 0 0% 98%;
+    --card: 0 0% 0%;
+    --card-foreground: 0 0% 98%;
+    --popover: 0 0% 0%;
+    --popover-foreground: 0 0% 98%;
+    --primary: 0 0% 100%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 0 0% 8%;
+    --secondary-foreground: 0 0% 98%;
+    --muted: 0 0% 8%;
+    --muted-foreground: 0 0% 67%;
+    --accent: 0 0% 8%;
+    --accent-foreground: 0 0% 98%;
+    --destructive: 0 72% 51%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 0 0% 15%;
+    --input: 0 0% 15%;
+    --ring: 0 0% 90%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
@@ -426,4 +426,80 @@ body {
   -moz-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   scroll-behavior: smooth;
+}
+
+/* Shared nd (new design) typography scale, matching apps/web and apps/docs */
+.nd-heading-2xl {
+  @apply my-0 font-brand font-medium text-[40px] md:text-[56px] xl:text-[88px] leading-[1.1] md:leading-[1.0] xl:leading-[1.0] tracking-[-1.2px] md:tracking-[-1.68px] xl:tracking-[-2.64px];
+}
+
+.nd-heading-xl {
+  @apply my-0 font-brand font-medium text-[40px] md:text-[48px] xl:text-[80px] leading-[1.1] md:leading-[1.083] xl:leading-[1.0];
+}
+
+.nd-heading-l {
+  @apply my-0 font-brand font-medium text-[32px] md:text-[40px] xl:text-[64px] leading-[1.25] md:leading-[1.1] xl:leading-[1.125] tracking-[-1.28px] md:tracking-[-1.6px] xl:tracking-[-2.56px];
+}
+
+.nd-heading-l-a {
+  @apply my-0 font-brand font-medium text-[28px] md:text-[40px] xl:text-[48px] leading-[1.28] md:leading-[1.3] xl:leading-[1.083] tracking-[-0.84px] md:tracking-[-1.2px] xl:tracking-[-1.44px];
+}
+
+.nd-heading-m {
+  @apply my-0 font-brand font-medium text-[18px] md:text-[32px] xl:text-[36px] leading-[1.333] md:leading-[1.25] xl:leading-[1.222] tracking-[-0.54px] md:tracking-[-0.96px] xl:tracking-[-1.08px];
+}
+
+.nd-heading-s {
+  @apply my-0 font-brand font-medium text-[16px] md:text-[24px] xl:text-[24px] leading-[1.5] md:leading-[1.333] xl:leading-[1.333] tracking-[-0.32px] md:tracking-[-0.48px] xl:tracking-[-0.48px];
+}
+
+.nd-heading-xs {
+  @apply my-0 font-brand font-medium text-[16px] md:text-[18px] xl:text-[22px] leading-[1.5] md:leading-[1.333] xl:leading-[1.273];
+}
+
+.nd-body-2xl {
+  @apply my-0 text-[20px] md:text-[32px] xl:text-[32px] leading-[1.4] md:leading-[1.25] xl:leading-[1.25];
+}
+
+.nd-body-xl {
+  @apply my-0 text-[18px] md:text-[24px] leading-[1.33] tracking-[-0.36px] md:tracking-[-0.48px] xl:tracking-[-0.48px];
+}
+
+.nd-body-l {
+  @apply my-0 text-[16px] md:text-[18px] xl:text-[20px] leading-[1.375] md:leading-[1.33] xl:leading-[1.5] tracking-[-0.16px] md:tracking-[-0.18px] xl:tracking-[-0.2px];
+}
+
+.nd-body-m {
+  @apply my-0 text-[16px] md:text-[18px] xl:text-[18px] leading-[1.25] md:leading-[1.44] xl:leading-[1.33] tracking-[-0.16px] md:tracking-[-0.18px] xl:tracking-[-0.18px];
+}
+
+.nd-body-s {
+  @apply my-0 text-[14px] md:text-[16px] leading-[1.42] md:leading-[1.5] tracking-[-0.14px] md:tracking-[-0.16px];
+}
+
+.nd-body-xs {
+  @apply my-0 text-[12px] md:text-[14px] xl:text-[14px] leading-[1.33] md:leading-[1.43] xl:leading-[1.43];
+}
+
+/* Thin, subtle scrollbar used by sticky filter and search panels */
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.2);
+  border-radius: 9999px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.35);
 }

--- a/apps/templates/src/components/app-hero.tsx
+++ b/apps/templates/src/components/app-hero.tsx
@@ -16,12 +16,12 @@ export function AppHero({
       <div className="text-center z-10">
         <div className="max-w-2xl">
           {typeof title === "string" ? (
-            <h1 className="text-3xl md:text-4xl font-bold">{title}</h1>
+            <h1 className="nd-heading-l text-nd-high-em-text">{title}</h1>
           ) : (
             title
           )}
           {typeof subtitle === "string" ? (
-            <p className="pt-2 md:pt-3 md:max-w-2xl mx-auto text-sm md:text-base text-neutral-400">
+            <p className="pt-2 md:pt-3 md:max-w-2xl mx-auto nd-body-m text-nd-mid-em-text">
               {subtitle}
             </p>
           ) : (

--- a/apps/templates/src/components/app-hero.tsx
+++ b/apps/templates/src/components/app-hero.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import { BackgroundShapes } from "./background-shapes";
 
 export function AppHero({
   children,
@@ -12,7 +11,6 @@ export function AppHero({
 }) {
   return (
     <div className="relative flex flex-col items-center justify-center py-8 md:py-16">
-      <BackgroundShapes />
       <div className="text-center z-10">
         <div className="max-w-2xl">
           {typeof title === "string" ? (

--- a/apps/templates/src/components/app-hero.tsx
+++ b/apps/templates/src/components/app-hero.tsx
@@ -9,25 +9,40 @@ export function AppHero({
   subtitle?: React.ReactNode;
   title?: React.ReactNode;
 }) {
+  const hasVisual = Boolean(children);
+
   return (
-    <div className="relative flex flex-col items-center justify-center py-8 md:py-16">
-      <div className="text-center z-10">
-        <div className="max-w-2xl">
-          {typeof title === "string" ? (
-            <h1 className="nd-heading-l text-nd-high-em-text">{title}</h1>
-          ) : (
-            title
-          )}
-          {typeof subtitle === "string" ? (
-            <p className="pt-2 md:pt-3 md:max-w-2xl mx-auto nd-body-m text-nd-mid-em-text">
-              {subtitle}
-            </p>
-          ) : (
-            subtitle
-          )}
-          {children}
+    <section className="relative mx-auto w-full max-w-[1440px] border-b border-white/[0.08] xl:border-x">
+      <div
+        className={
+          hasVisual
+            ? "grid min-h-[430px] xl:grid-cols-[minmax(0,1fr)_480px] xl:min-h-[560px]"
+            : "min-h-[360px]"
+        }
+      >
+        <div className="relative z-10 flex flex-col justify-end px-5 py-14 md:px-8 md:py-20 xl:px-12 xl:py-24">
+          <div className="max-w-[860px]">
+            {typeof title === "string" ? (
+              <h1 className="nd-heading-2xl text-nd-high-em-text">{title}</h1>
+            ) : (
+              title
+            )}
+            {typeof subtitle === "string" ? (
+              <p className="mt-5 max-w-[720px] nd-body-l text-nd-mid-em-text md:mt-6">
+                {subtitle}
+              </p>
+            ) : (
+              subtitle
+            )}
+          </div>
         </div>
+
+        {hasVisual ? (
+          <div className="relative hidden overflow-hidden border-l border-white/[0.08] xl:block">
+            {children}
+          </div>
+        ) : null}
       </div>
-    </div>
+    </section>
   );
 }

--- a/apps/templates/src/components/app-modal.tsx
+++ b/apps/templates/src/components/app-modal.tsx
@@ -30,11 +30,14 @@ export function AppModal({
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button variant="outline" className="w-full">
+        <Button
+          variant="outline"
+          className="w-full border-nd-border-prominent text-nd-high-em-text hover:bg-nd-border-prominent dark:bg-transparent dark:hover:bg-nd-border-prominent"
+        >
           {title}
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[800px] bg-zinc-950 border-white/5">
+      <DialogContent className="sm:max-w-[800px] bg-[#0D0C11] border-nd-border-light text-nd-high-em-text">
         <DialogHeader>
           {hideTitle ? (
             <VisuallyHidden>

--- a/apps/templates/src/components/app-modal.tsx
+++ b/apps/templates/src/components/app-modal.tsx
@@ -32,12 +32,12 @@ export function AppModal({
       <DialogTrigger asChild>
         <Button
           variant="outline"
-          className="w-full border-nd-border-prominent text-nd-high-em-text hover:bg-nd-border-prominent dark:bg-transparent dark:hover:bg-nd-border-prominent"
+          className="w-full rounded-none border-white bg-white text-black hover:bg-white/90 dark:bg-white dark:text-black dark:hover:bg-white/90"
         >
           {title}
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-[800px] bg-[#0D0C11] border-nd-border-light text-nd-high-em-text">
+      <DialogContent className="border-white/[0.12] bg-[#0C0C0E] text-nd-high-em-text sm:max-w-[800px] sm:rounded-none">
         <DialogHeader>
           {hideTitle ? (
             <VisuallyHidden>

--- a/apps/templates/src/components/background-shapes.tsx
+++ b/apps/templates/src/components/background-shapes.tsx
@@ -1,23 +1,17 @@
 import React from "react";
-import Image from "next/image";
 
+/**
+ * Soft brand glows used behind the templates hero.
+ * Matches the radial-glow treatment on newer nd-styled pages.
+ */
 export function BackgroundShapes() {
   return (
-    <div className="fixed top-0 left-0 w-screen h-screen -z-50 overflow-hidden pointer-events-none">
-      <Image
-        src={"/developers/templates/hero.webp"}
-        alt="Background decoration"
-        width={1000}
-        height={1000}
-        className="absolute top-0 -left-[550px] hidden md:block opacity-50"
-      />
-      <Image
-        src={"/developers/templates/hero.webp"}
-        alt="Background decoration"
-        width={1000}
-        height={1000}
-        className="absolute -top-44 -right-[550px] hidden md:block opacity-50"
-      />
+    <div
+      className="absolute inset-0 overflow-hidden pointer-events-none"
+      aria-hidden="true"
+    >
+      <div className="absolute top-0 -left-[550px] hidden md:block h-[620px] w-[620px] rounded-full bg-nd-highlight-lavendar/10 blur-[130px]" />
+      <div className="absolute -top-44 -right-[550px] hidden md:block h-[620px] w-[620px] rounded-full bg-nd-highlight-green/10 blur-[130px]" />
     </div>
   );
 }

--- a/apps/templates/src/components/background-shapes.tsx
+++ b/apps/templates/src/components/background-shapes.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
 /**
- * Soft brand glows used behind the templates hero.
+ * Full-page soft brand glows used behind the templates pages.
  * Matches the radial-glow treatment on newer nd-styled pages.
  */
 export function BackgroundShapes() {
@@ -10,8 +10,9 @@ export function BackgroundShapes() {
       className="absolute inset-0 overflow-hidden pointer-events-none"
       aria-hidden="true"
     >
-      <div className="absolute top-0 -left-[550px] hidden md:block h-[620px] w-[620px] rounded-full bg-nd-highlight-lavendar/10 blur-[130px]" />
-      <div className="absolute -top-44 -right-[550px] hidden md:block h-[620px] w-[620px] rounded-full bg-nd-highlight-green/10 blur-[130px]" />
+      <div className="absolute -top-44 -left-56 h-[640px] w-[640px] rounded-full bg-nd-highlight-lavendar/25 blur-[140px]" />
+      <div className="absolute top-16 -right-56 h-[600px] w-[600px] rounded-full bg-nd-highlight-blue/20 blur-[140px]" />
+      <div className="absolute -bottom-48 -right-40 h-[640px] w-[640px] rounded-full bg-nd-highlight-green/20 blur-[140px]" />
     </div>
   );
 }

--- a/apps/templates/src/components/background-shapes.tsx
+++ b/apps/templates/src/components/background-shapes.tsx
@@ -1,18 +1,25 @@
 import React from "react";
 
-/**
- * Full-page soft brand glows used behind the templates pages.
- * Matches the radial-glow treatment on newer nd-styled pages.
- */
 export function BackgroundShapes() {
   return (
     <div
       className="absolute inset-0 overflow-hidden pointer-events-none"
       aria-hidden="true"
     >
-      <div className="absolute -top-44 -left-56 h-[640px] w-[640px] rounded-full bg-nd-highlight-lavendar/25 blur-[140px]" />
-      <div className="absolute top-16 -right-56 h-[600px] w-[600px] rounded-full bg-nd-highlight-blue/20 blur-[140px]" />
-      <div className="absolute -bottom-48 -right-40 h-[640px] w-[640px] rounded-full bg-nd-highlight-green/20 blur-[140px]" />
+      <div className="absolute inset-x-0 top-0 h-[760px] bg-[radial-gradient(ellipse_at_14%_8%,rgba(202,159,245,0.22),transparent_42%),radial-gradient(ellipse_at_88%_18%,rgba(102,147,247,0.16),transparent_38%),radial-gradient(ellipse_at_58%_72%,rgba(85,233,171,0.09),transparent_35%)]" />
+      <div
+        className="absolute inset-x-0 top-0 h-[760px] opacity-40"
+        style={{
+          backgroundImage:
+            "linear-gradient(rgba(236,228,253,0.08) 1px, transparent 1px), linear-gradient(90deg, rgba(236,228,253,0.08) 1px, transparent 1px)",
+          backgroundSize: "64px 64px",
+          maskImage:
+            "radial-gradient(ellipse at 58% 34%, black 0%, transparent 72%)",
+          WebkitMaskImage:
+            "radial-gradient(ellipse at 58% 34%, black 0%, transparent 72%)",
+        }}
+      />
+      <div className="absolute inset-x-0 top-[360px] h-[520px] bg-gradient-to-b from-transparent via-black/75 to-black" />
     </div>
   );
 }

--- a/apps/templates/src/components/search/search-card.tsx
+++ b/apps/templates/src/components/search/search-card.tsx
@@ -3,7 +3,6 @@
 import React from "react";
 
 import type { TemplateRecord } from "../../types";
-import { useMemo } from "react";
 import Link from "next/link";
 import Image from "next/image";
 
@@ -26,8 +25,6 @@ const TECH_LOGOS = {
 export const SearchCard = React.memo<SearchCardProps>(
   ({ template, isActive = false, onCardClick, id }) => {
     const { name, description, tech, displayName } = template;
-
-    const randomRotation = useMemo(() => Math.floor(Math.random() * 360), []);
 
     const PlaceholderLogo = () => (
       <svg
@@ -70,26 +67,25 @@ export const SearchCard = React.memo<SearchCardProps>(
         onClick={onCardClick}
         id={id}
         className={`
-        block p-4 rounded-xl metallic-border transition duration-200 ease-in-out
+        block p-4 rounded-xl border transition duration-200 ease-in-out
         ${
           isActive
-            ? "bg-neutral-700 opacity-100 ring-2 ring-neutral-500"
-            : "bg-neutral-900 opacity-55 hover:opacity-100 hover:bg-neutral-800"
+            ? "bg-nd-border-prominent opacity-100 ring-1 ring-nd-border-hovered border-nd-border-hovered"
+            : "bg-white/[0.03] border-nd-border-light opacity-70 hover:opacity-100 hover:bg-white/[0.06] hover:border-nd-border-prominent"
         }
-        focus:outline-none focus:ring-2 focus:ring-neutral-500 focus:ring-offset-2 focus:ring-offset-neutral-900
+        focus:outline-none focus:ring-2 focus:ring-nd-highlight-lavendar/40
       `}
-        style={{ "--rotation": `${randomRotation}deg` } as React.CSSProperties}
       >
         <div className="flex items-start gap-3">
-          <div className="flex-shrink-0 text-neutral-400 mt-0.5">
+          <div className="flex-shrink-0 text-nd-mid-em-text mt-0.5">
             {renderLogo()}
           </div>
 
           <div className="flex-1 min-w-0">
-            <h3 className="text-neutral-100 font-medium text-sm truncate">
+            <h3 className="text-nd-high-em-text font-medium text-sm truncate">
               {displayName || name}
             </h3>
-            <p className="text-neutral-400 text-xs mt-1 line-clamp-2 leading-relaxed">
+            <p className="text-nd-mid-em-text text-xs mt-1 line-clamp-2 leading-relaxed">
               {description}
             </p>
           </div>

--- a/apps/templates/src/components/search/search-input.tsx
+++ b/apps/templates/src/components/search/search-input.tsx
@@ -19,7 +19,7 @@ export const SearchInput = React.memo<SearchInputProps>(
       <div className="">
         <div className="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
           <svg
-            className="h-5 w-5 text-neutral-400"
+            className="h-5 w-5 text-nd-mid-em-text"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -50,9 +50,9 @@ export const SearchInput = React.memo<SearchInputProps>(
           placeholder={t("filter.search_placeholder")}
           className="
           w-full pl-10 pr-4 py-3
-          bg-[#0d000e] border border-neutral-800 rounded-2xl
-          text-neutral-100 placeholder-neutral-400
-          focus:outline-none focus:ring-2 focus:ring-neutral-500 focus:border-transparent
+          bg-black border border-nd-border-prominent rounded-xl
+          text-nd-high-em-text placeholder:text-nd-mid-em-text/60
+          focus:outline-none focus:ring-2 focus:ring-nd-highlight-lavendar/30 focus:border-nd-border-hovered
           transition-colors duration-200
         "
         />

--- a/apps/templates/src/components/search/search-results.tsx
+++ b/apps/templates/src/components/search/search-results.tsx
@@ -33,19 +33,19 @@ export const SearchResults = React.memo<SearchResultsProps>(
         }
         className="
         absolute top-full left-0 right-0 mt-2 px-2 py-4
-        bg-[#0d000e] border border-purple-400/10 rounded-2xl shadow-xl
+        bg-[#0D0C11] border border-nd-border-light rounded-xl shadow-2xl
         max-h-96 overflow-y-auto z-50 custom-scrollbar
       "
       >
         {showEmptyState ? (
-          <div className="p-4 text-center text-neutral-400 text-sm">
+          <div className="p-4 text-center text-nd-mid-em-text text-sm">
             No templates found.
           </div>
         ) : (
           <div className="space-y-3">
             {isShowingFeatured && (
               <div className="px-3">
-                <h3 className="text-neutral-300 text-sm font-medium">
+                <h3 className="font-brand-mono text-[11px] leading-[1.42] font-bold uppercase tracking-wide text-nd-mid-em-text">
                   Featured Templates
                 </h3>
               </div>

--- a/apps/templates/src/components/templates/templates-ui-filter-header.tsx
+++ b/apps/templates/src/components/templates/templates-ui-filter-header.tsx
@@ -9,14 +9,14 @@ export function TemplatesUiFilterHeader() {
 
   return (
     <div className="flex justify-between items-center gap-2">
-      <span className="text-sm font-bold py-1.5 whitespace-nowrap">
+      <span className="font-brand-mono text-[11px] leading-[1.42] font-bold uppercase tracking-wide text-nd-high-em-text py-1.5 whitespace-nowrap">
         {t("filter.title")}
       </span>
       {isFiltered ? (
         <Button
           variant="ghost"
           onClick={() => clear()}
-          className="cursor-pointer h-auto py-1 px-2 text-xs flex-shrink-0 gap-1"
+          className="cursor-pointer h-auto py-1 px-2 text-xs flex-shrink-0 gap-1 text-nd-mid-em-text hover:text-nd-high-em-text"
         >
           <X className="h-1 w-2" />
           {t("filter.clear")}

--- a/apps/templates/src/components/templates/templates-ui-filter-header.tsx
+++ b/apps/templates/src/components/templates/templates-ui-filter-header.tsx
@@ -8,17 +8,17 @@ export function TemplatesUiFilterHeader() {
   const t = useTemplatesTranslations();
 
   return (
-    <div className="flex justify-between items-center gap-2">
-      <span className="font-brand-mono text-[11px] leading-[1.42] font-bold uppercase tracking-wide text-nd-high-em-text py-1.5 whitespace-nowrap">
+    <div className="flex items-center justify-between gap-3 border-b border-white/[0.08] pb-4">
+      <span className="whitespace-nowrap font-brand-mono text-[12px] font-medium uppercase tracking-[0.08em] text-nd-high-em-text">
         {t("filter.title")}
       </span>
       {isFiltered ? (
         <Button
           variant="ghost"
           onClick={() => clear()}
-          className="cursor-pointer h-auto py-1 px-2 text-xs flex-shrink-0 gap-1 text-nd-mid-em-text hover:text-nd-high-em-text"
+          className="h-auto flex-shrink-0 cursor-pointer gap-1 px-2 py-1 text-xs text-nd-mid-em-text hover:bg-white/[0.06] hover:text-nd-high-em-text"
         >
-          <X className="h-1 w-2" />
+          <X className="size-3" />
           {t("filter.clear")}
         </Button>
       ) : null}

--- a/apps/templates/src/components/templates/templates-ui-filter-keywords.tsx
+++ b/apps/templates/src/components/templates/templates-ui-filter-keywords.tsx
@@ -23,12 +23,12 @@ export function TemplatesUiFilterKeywords() {
     const isExpanded = expandedSections.includes(filter.id);
     return (
       <div
-        className="flex flex-col gap-2 border-b border-white/5 pb-4 last:border-b-0"
+        className="flex flex-col gap-2 border-b border-nd-border-light pb-4 last:border-b-0"
         key={filter.id}
       >
         <button
           onClick={() => toggleSection(filter.id)}
-          className="flex items-center justify-between text-sm font-bold py-1.5 hover:text-purple-400 transition-colors"
+          className="flex items-center justify-between font-brand-mono text-[11px] leading-[1.42] font-bold uppercase tracking-wide py-1.5 text-nd-high-em-text hover:text-nd-cta transition-colors"
         >
           <span>{filter.name}</span>
           <motion.div
@@ -53,13 +53,13 @@ export function TemplatesUiFilterKeywords() {
                   return (
                     <label
                       key={keyword.id}
-                      className="flex items-center gap-2 cursor-pointer hover:text-purple-400 transition-colors text-xs"
+                      className="flex items-center gap-2 cursor-pointer text-nd-mid-em-text hover:text-nd-high-em-text transition-colors text-xs"
                     >
                       <input
                         type="checkbox"
                         checked={isSelected}
                         onChange={() => toggleKeyword(keyword.id)}
-                        className="w-3.5 h-3.5 rounded border-white/10 bg-zinc-800/50 checked:bg-purple-500 checked:border-purple-500 cursor-pointer"
+                        className="w-3.5 h-3.5 rounded border-nd-border-prominent bg-white/5 checked:bg-nd-primary checked:border-nd-primary cursor-pointer"
                       />
                       <span>{keyword.name}</span>
                     </label>

--- a/apps/templates/src/components/templates/templates-ui-filter-keywords.tsx
+++ b/apps/templates/src/components/templates/templates-ui-filter-keywords.tsx
@@ -23,12 +23,13 @@ export function TemplatesUiFilterKeywords() {
     const isExpanded = expandedSections.includes(filter.id);
     return (
       <div
-        className="flex flex-col gap-2 border-b border-nd-border-light pb-4 last:border-b-0"
+        className="flex flex-col gap-2 border-b border-white/[0.08] pb-4 last:border-b-0 last:pb-0"
         key={filter.id}
       >
         <button
+          type="button"
           onClick={() => toggleSection(filter.id)}
-          className="flex items-center justify-between font-brand-mono text-[11px] leading-[1.42] font-bold uppercase tracking-wide py-1.5 text-nd-high-em-text hover:text-nd-cta transition-colors"
+          className="flex items-center justify-between py-1.5 font-brand-mono text-[11px] font-medium uppercase tracking-[0.08em] text-nd-high-em-text transition-colors hover:text-nd-mid-em-text"
         >
           <span>{filter.name}</span>
           <motion.div
@@ -47,19 +48,19 @@ export function TemplatesUiFilterKeywords() {
               transition={{ duration: 0.2 }}
               className="overflow-hidden"
             >
-              <div className="flex flex-col gap-1.5 pt-1">
+              <div className="flex flex-col gap-2 pt-1">
                 {filter.keywords.map((keyword) => {
                   const isSelected = selectedKeywords.includes(keyword.id);
                   return (
                     <label
                       key={keyword.id}
-                      className="flex items-center gap-2 cursor-pointer text-nd-mid-em-text hover:text-nd-high-em-text transition-colors text-xs"
+                      className="group flex cursor-pointer items-center gap-2.5 text-sm text-nd-mid-em-text transition-colors hover:text-nd-high-em-text"
                     >
                       <input
                         type="checkbox"
                         checked={isSelected}
                         onChange={() => toggleKeyword(keyword.id)}
-                        className="w-3.5 h-3.5 rounded border-nd-border-prominent bg-white/5 checked:bg-nd-primary checked:border-nd-primary cursor-pointer"
+                        className="size-3.5 cursor-pointer rounded-sm border-white/25 bg-white/[0.04] accent-white"
                       />
                       <span>{keyword.name}</span>
                     </label>

--- a/apps/templates/src/components/templates/templates-ui-filter-search.tsx
+++ b/apps/templates/src/components/templates/templates-ui-filter-search.tsx
@@ -34,6 +34,7 @@ export function TemplatesUiFilterSearch() {
         setLocalValue(e.target.value);
       }}
       placeholder={t("filter.search_placeholder")}
+      className="!bg-black/40 border-nd-border-prominent text-nd-high-em-text placeholder:text-nd-mid-em-text/60 focus-visible:border-nd-border-hovered focus-visible:ring-nd-highlight-lavendar/30 h-10 rounded-lg"
     />
   );
 }

--- a/apps/templates/src/components/templates/templates-ui-filter-search.tsx
+++ b/apps/templates/src/components/templates/templates-ui-filter-search.tsx
@@ -19,7 +19,6 @@ export function TemplatesUiFilterSearch() {
   useEffect(() => {
     const timer = setTimeout(() => {
       if (localValue !== filter) {
-        console.log("Updating filter to:", localValue);
         setFilter(localValue);
       }
     }, 300);
@@ -29,12 +28,10 @@ export function TemplatesUiFilterSearch() {
   return (
     <Input
       value={localValue}
-      onChange={(e) => {
-        console.log("Search input changed:", e.target.value);
-        setLocalValue(e.target.value);
-      }}
+      onChange={(e) => setLocalValue(e.target.value)}
+      aria-label={t("actions.search_label")}
       placeholder={t("filter.search_placeholder")}
-      className="!bg-black/40 border-nd-border-prominent text-nd-high-em-text placeholder:text-nd-mid-em-text/60 focus-visible:border-nd-border-hovered focus-visible:ring-nd-highlight-lavendar/30 h-10 rounded-lg"
+      className="h-11 rounded-none border-white/[0.16] !bg-white/[0.03] px-3 text-sm text-nd-high-em-text placeholder:text-nd-mid-em-text/60 focus-visible:border-white/30 focus-visible:ring-1 focus-visible:ring-white/20"
     />
   );
 }

--- a/apps/templates/src/components/templates/templates-ui-filter.tsx
+++ b/apps/templates/src/components/templates/templates-ui-filter.tsx
@@ -4,10 +4,9 @@ import { TemplatesUiFilterSearch } from "./templates-ui-filter-search";
 
 export function TemplatesUiFilter() {
   return (
-    <div className="relative overflow-hidden rounded-2xl">
-      {/* Gradient border effect */}
-      <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-purple-500/30 via-pink-500/20 to-blue-500/30 opacity-50" />
-      <div className="absolute inset-[1px] rounded-2xl bg-gradient-to-br from-zinc-900 to-zinc-950" />
+    <div className="relative overflow-hidden rounded-2xl border border-nd-border-light bg-[#0D0C11]">
+      {/* Soft brand glow */}
+      <div className="absolute inset-0 rounded-2xl bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.05),transparent_60%)] pointer-events-none" />
 
       <div className="relative flex flex-col gap-4 px-4 py-6">
         <TemplatesUiFilterHeader />

--- a/apps/templates/src/components/templates/templates-ui-filter.tsx
+++ b/apps/templates/src/components/templates/templates-ui-filter.tsx
@@ -4,15 +4,10 @@ import { TemplatesUiFilterSearch } from "./templates-ui-filter-search";
 
 export function TemplatesUiFilter() {
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-nd-border-light bg-[#0D0C11]">
-      {/* Soft brand glow */}
-      <div className="absolute inset-0 rounded-2xl bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.05),transparent_60%)] pointer-events-none" />
-
-      <div className="relative flex flex-col gap-4 px-4 py-6">
-        <TemplatesUiFilterHeader />
-        <TemplatesUiFilterSearch />
-        <TemplatesUiFilterKeywords />
-      </div>
+    <div className="flex flex-col gap-5">
+      <TemplatesUiFilterHeader />
+      <TemplatesUiFilterSearch />
+      <TemplatesUiFilterKeywords />
     </div>
   );
 }

--- a/apps/templates/src/components/templates/templates-ui-generate-command.tsx
+++ b/apps/templates/src/components/templates/templates-ui-generate-command.tsx
@@ -62,6 +62,7 @@ export function TemplatesUiGenerateCommand({
             key={item}
             variant="outline"
             onClick={() => setSelected(item)}
+            aria-pressed={item === selected}
             className={
               item === selected
                 ? "justify-start bg-nd-primary border-nd-primary text-nd-on-primary hover:bg-nd-primary-hovered dark:bg-nd-primary dark:hover:bg-nd-primary-hovered"
@@ -82,6 +83,7 @@ export function TemplatesUiGenerateCommand({
           size="icon"
           className="absolute top-2 right-2 text-nd-mid-em-text hover:text-nd-high-em-text"
           onClick={handleCopy}
+          aria-label={isCopied ? "Command copied" : "Copy command"}
         >
           {isCopied ? (
             <CheckIcon className="h-4 w-4" />

--- a/apps/templates/src/components/templates/templates-ui-generate-command.tsx
+++ b/apps/templates/src/components/templates/templates-ui-generate-command.tsx
@@ -64,8 +64,8 @@ export function TemplatesUiGenerateCommand({
             onClick={() => setSelected(item)}
             className={
               item === selected
-                ? "justify-start bg-purple-500/20 border-purple-500 text-purple-300 hover:bg-purple-500/30"
-                : "justify-start"
+                ? "justify-start bg-nd-primary border-nd-primary text-nd-on-primary hover:bg-nd-primary-hovered dark:bg-nd-primary dark:hover:bg-nd-primary-hovered"
+                : "justify-start border-nd-border-prominent text-nd-mid-em-text hover:bg-nd-border-prominent hover:text-nd-high-em-text dark:bg-transparent dark:hover:bg-nd-border-prominent"
             }
           >
             {item}
@@ -74,13 +74,13 @@ export function TemplatesUiGenerateCommand({
       </div>
       <div className="relative">
         <div
-          className="rounded-lg my-4 pr-12 overflow-x-auto max-w-full bg-zinc-900 [&>pre]:!bg-zinc-900 [&>pre]:!m-0 [&>pre]:!p-4 [&>pre]:!rounded-lg [&>pre]:overflow-x-auto [&>pre]:max-w-full [&>pre]:text-xs [&_code]:text-xs"
+          className="rounded-lg my-4 pr-12 overflow-x-auto max-w-full bg-black border border-nd-border-light [&>pre]:!bg-black [&>pre]:!m-0 [&>pre]:!p-4 [&>pre]:!rounded-lg [&>pre]:overflow-x-auto [&>pre]:max-w-full [&>pre]:text-xs [&_code]:text-xs"
           dangerouslySetInnerHTML={{ __html: highlightedHtml }}
         />
         <Button
           variant="ghost"
           size="icon"
-          className="absolute top-2 right-2"
+          className="absolute top-2 right-2 text-nd-mid-em-text hover:text-nd-high-em-text"
           onClick={handleCopy}
         >
           {isCopied ? (

--- a/apps/templates/src/components/templates/templates-ui-grid-item.tsx
+++ b/apps/templates/src/components/templates/templates-ui-grid-item.tsx
@@ -14,20 +14,21 @@ export function TemplatesUiGridItem({ template }: { template: Template }) {
   return (
     <MotionLink
       href={`/developers/templates/${template.name}`}
-      className="group relative overflow-hidden rounded-2xl bg-gradient-to-br from-zinc-900 to-zinc-950 p-6 block h-full flex flex-col"
+      className="group relative overflow-hidden rounded-2xl border border-nd-border-light bg-[#0D0C11] p-6 block h-full flex flex-col transition-colors hover:border-nd-border-hovered hover:bg-[#121016]"
       whileHover={{ scale: 1.02, y: -4 }}
       whileTap={{ scale: 0.98 }}
       transition={{ duration: 0.2, ease: "easeInOut" }}
       style={{ willChange: "transform" }}
     >
-      {/* Gradient border effect */}
-      <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-purple-500/20 via-pink-500/20 to-blue-500/20 opacity-0 transition-opacity group-hover:opacity-100" />
-      <div className="absolute inset-[1px] rounded-2xl bg-gradient-to-br from-zinc-900 to-zinc-950" />
+      {/* Hover glow */}
+      <div className="absolute inset-0 rounded-2xl bg-[radial-gradient(ellipse_at_top_right,rgba(202,159,245,0.08),transparent_60%)] opacity-0 transition-opacity group-hover:opacity-100 pointer-events-none" />
+      {/* Subtle top highlight */}
+      <div className="absolute inset-0 rounded-2xl bg-gradient-to-b from-white/[0.04] to-transparent pointer-events-none" />
 
       <div className="relative flex flex-col h-full">
         <div className="space-y-1.5 mb-4">
           <div className="flex justify-between items-start gap-2">
-            <h3 className="font-semibold text-base text-white line-clamp-1">
+            <h3 className="font-medium text-[17px] leading-[1.25] tracking-normal text-nd-high-em-text line-clamp-1">
               {template.displayName || template.name}
             </h3>
             <button
@@ -43,18 +44,18 @@ export function TemplatesUiGridItem({ template }: { template: Template }) {
               role="link"
               aria-label={t("actions.view_repo")}
               type="button"
-              className="text-xs flex items-center gap-1 hover:text-purple-400 transition-colors text-zinc-400 flex-shrink-0"
+              className="text-xs flex items-center gap-1 text-nd-mid-em-text hover:text-nd-high-em-text transition-colors flex-shrink-0"
             >
               <ExternalLinkIcon className="h-3.5 w-3.5" />
             </button>
           </div>
-          <p className="text-[11px] leading-relaxed text-zinc-400 line-clamp-2">
+          <p className="text-xs leading-relaxed text-nd-mid-em-text line-clamp-2">
             {template.description}
           </p>
         </div>
 
         <div
-          className="relative w-full overflow-hidden rounded-lg bg-white/5 backdrop-blur-sm mt-auto"
+          className="relative w-full overflow-hidden rounded-lg bg-white/[0.03] border border-nd-border-light mt-auto"
           style={{ aspectRatio: "1200/630" }}
         >
           <TemplatesUiImage template={template} />

--- a/apps/templates/src/components/templates/templates-ui-grid-item.tsx
+++ b/apps/templates/src/components/templates/templates-ui-grid-item.tsx
@@ -1,66 +1,70 @@
 "use client";
 
-import { Template, TemplatesUiImage } from "../../lib/templates";
+import type { Template } from "../../lib/types/templates";
+import { TemplatesUiImage } from "../../lib/templates/templates-ui-image";
 import { useTemplatesTranslations } from "../../lib/use-translations";
 import Link from "next/link";
 import { ArrowOutUpRightSquare as ExternalLinkIcon } from "@boxicons/react/ArrowOutUpRightSquare";
-import { motion } from "motion/react";
-
-const MotionLink = motion(Link);
+import { ArrowRight } from "@boxicons/react/ArrowRight";
+import { useTemplateFilters } from "../../lib/templates/use-template-filters";
 
 export function TemplatesUiGridItem({ template }: { template: Template }) {
   const t = useTemplatesTranslations();
+  const filters = useTemplateFilters({ template });
+  const keywords = filters.flatMap((filter) => filter.keywords).slice(0, 3);
+  const displayName = template.displayName || template.name;
 
   return (
-    <MotionLink
-      href={`/developers/templates/${template.name}`}
-      className="group relative overflow-hidden rounded-2xl border border-nd-border-light bg-[#0D0C11] p-6 block h-full flex flex-col transition-colors hover:border-nd-border-hovered hover:bg-[#121016]"
-      whileHover={{ scale: 1.02, y: -4 }}
-      whileTap={{ scale: 0.98 }}
-      transition={{ duration: 0.2, ease: "easeInOut" }}
-      style={{ willChange: "transform" }}
-    >
-      {/* Hover glow */}
-      <div className="absolute inset-0 rounded-2xl bg-[radial-gradient(ellipse_at_top_right,rgba(202,159,245,0.08),transparent_60%)] opacity-0 transition-opacity group-hover:opacity-100 pointer-events-none" />
-      {/* Subtle top highlight */}
-      <div className="absolute inset-0 rounded-2xl bg-gradient-to-b from-white/[0.04] to-transparent pointer-events-none" />
+    <article className="group relative min-w-0 bg-[#0C0C0E] transition-colors hover:bg-[#151518]">
+      <Link
+        href={`/developers/templates/${template.name}`}
+        className="flex h-full flex-col outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-white/70"
+      >
+        <div className="relative aspect-[16/10] overflow-hidden border-b border-white/[0.08] bg-white/[0.03]">
+          <TemplatesUiImage
+            template={template}
+            className="h-full w-full object-cover object-top transition-transform duration-500 ease-out group-hover:scale-[1.025]"
+            sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 360px"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-transparent opacity-60" />
+        </div>
 
-      <div className="relative flex flex-col h-full">
-        <div className="space-y-1.5 mb-4">
-          <div className="flex justify-between items-start gap-2">
-            <h3 className="font-medium text-[17px] leading-[1.25] tracking-normal text-nd-high-em-text line-clamp-1">
-              {template.displayName || template.name}
+        <div className="flex flex-1 flex-col p-5 xl:p-6">
+          {keywords.length ? (
+            <div className="mb-5 flex flex-wrap gap-1.5">
+              {keywords.map((keyword) => (
+                <span
+                  key={keyword.id}
+                  className="border border-white/[0.12] bg-white/[0.03] px-2 py-1 font-brand-mono text-[10px] font-medium uppercase tracking-[0.06em] text-nd-mid-em-text"
+                >
+                  {keyword.name}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          <div className="flex items-start justify-between gap-4">
+            <h3 className="nd-heading-xs line-clamp-2 text-nd-high-em-text">
+              {displayName}
             </h3>
-            <button
-              onClick={(e) => {
-                e.preventDefault();
-                return window.open(
-                  template.repoUrl,
-                  "_blank",
-                  "noopener,noreferrer",
-                );
-              }}
-              title={t("actions.view_repo")}
-              role="link"
-              aria-label={t("actions.view_repo")}
-              type="button"
-              className="text-xs flex items-center gap-1 text-nd-mid-em-text hover:text-nd-high-em-text transition-colors flex-shrink-0"
-            >
-              <ExternalLinkIcon className="h-3.5 w-3.5" />
-            </button>
+            <ArrowRight className="mt-1 size-4 shrink-0 text-nd-mid-em-text transition-transform duration-200 group-hover:translate-x-1 group-hover:text-white" />
           </div>
-          <p className="text-xs leading-relaxed text-nd-mid-em-text line-clamp-2">
+          <p className="mt-2 line-clamp-3 text-sm leading-5 text-nd-mid-em-text">
             {template.description}
           </p>
         </div>
+      </Link>
 
-        <div
-          className="relative w-full overflow-hidden rounded-lg bg-white/[0.03] border border-nd-border-light mt-auto"
-          style={{ aspectRatio: "1200/630" }}
-        >
-          <TemplatesUiImage template={template} />
-        </div>
-      </div>
-    </MotionLink>
+      <a
+        href={template.repoUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={t("actions.view_repo")}
+        aria-label={`${t("actions.view_repo")}: ${displayName}`}
+        className="absolute right-3 top-3 z-10 flex size-9 items-center justify-center rounded-full border border-white/[0.16] bg-black/70 text-nd-mid-em-text backdrop-blur-md transition-colors hover:border-white/30 hover:bg-black hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/70"
+      >
+        <ExternalLinkIcon className="size-4" />
+      </a>
+    </article>
   );
 }

--- a/apps/templates/src/components/templates/templates-ui-grid.tsx
+++ b/apps/templates/src/components/templates/templates-ui-grid.tsx
@@ -5,7 +5,7 @@ import { TemplatesUiGridItem } from "./templates-ui-grid-item";
 
 export function TemplatesUiGrid({ templates }: { templates: Template[] }) {
   return (
-    <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4 auto-rows-fr">
+    <div className="grid auto-rows-fr gap-px overflow-hidden border border-white/[0.08] bg-white/[0.08] md:grid-cols-2 xl:grid-cols-3">
       {templates.map((template) => (
         <TemplatesUiGridItem
           key={`${template.source.id}-${template.name}`}

--- a/apps/templates/src/components/templates/templates-ui-hero-visual.tsx
+++ b/apps/templates/src/components/templates/templates-ui-hero-visual.tsx
@@ -1,0 +1,64 @@
+import { TemplatesUiImage } from "../../lib/templates/templates-ui-image";
+import type { Template } from "../../lib/types/templates";
+
+export function TemplatesUiHeroVisual({
+  templates,
+}: {
+  templates: Template[];
+}) {
+  const [primaryTemplate, secondaryTemplate] = templates;
+
+  if (!primaryTemplate) return null;
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center p-10">
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_42%,rgba(202,159,245,0.14),transparent_48%)]" />
+
+      {secondaryTemplate ? (
+        <div className="absolute left-8 top-16 w-[72%] -rotate-3 border border-white/[0.08] bg-[#0C0C0E]/80 opacity-60 shadow-2xl">
+          <div className="flex h-8 items-center gap-1.5 border-b border-white/[0.08] px-3">
+            <span className="size-1.5 rounded-full bg-white/20" />
+            <span className="size-1.5 rounded-full bg-white/15" />
+            <span className="size-1.5 rounded-full bg-white/10" />
+          </div>
+          <div className="relative aspect-[1200/630] overflow-hidden">
+            <TemplatesUiImage
+              template={secondaryTemplate}
+              className="h-full w-full object-cover object-top"
+              sizes="340px"
+            />
+          </div>
+        </div>
+      ) : null}
+
+      <div className="relative ml-12 mt-16 w-full border border-white/[0.16] bg-[#0C0C0E] shadow-[0_32px_100px_rgba(0,0,0,0.65)]">
+        <div className="flex h-10 items-center justify-between border-b border-white/[0.08] px-4">
+          <div className="flex gap-1.5">
+            <span className="size-1.5 rounded-full bg-nd-highlight-lavendar/70" />
+            <span className="size-1.5 rounded-full bg-nd-highlight-blue/50" />
+            <span className="size-1.5 rounded-full bg-nd-highlight-green/60" />
+          </div>
+          <span className="h-px w-16 bg-white/10" />
+        </div>
+        <div className="relative aspect-[1200/630] overflow-hidden bg-white/[0.03]">
+          <TemplatesUiImage
+            template={primaryTemplate}
+            className="h-full w-full object-cover object-top"
+            sizes="390px"
+            priority
+          />
+          <div className="absolute inset-0 ring-1 ring-inset ring-white/[0.06]" />
+        </div>
+        <div className="grid grid-cols-[1fr_72px] border-t border-white/[0.08]">
+          <div className="space-y-2 px-4 py-4">
+            <div className="h-1.5 w-28 rounded-full bg-white/25" />
+            <div className="h-1.5 w-40 rounded-full bg-white/10" />
+          </div>
+          <div className="flex items-center justify-center border-l border-white/[0.08]">
+            <span className="size-7 rounded-full border border-white/20 bg-white/[0.06]" />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/templates/src/components/templates/templates-ui-layout-detail.tsx
+++ b/apps/templates/src/components/templates/templates-ui-layout-detail.tsx
@@ -1,12 +1,6 @@
 "use client";
 
 import Link from "next/link";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@workspace/ui";
 import { Button } from "@workspace/ui";
 import { AppHero } from "../app-hero";
 import { TemplatesUiImage } from "../../lib/templates";
@@ -44,65 +38,48 @@ export function TemplatesUiLayoutDetail({
   }
 
   return (
-    <div>
-      <div className="md:col-span-3 gap-4">
-        <div>
-          <div>
-            <div className="max-w-5xl mx-auto mb-4">
-              <Button
-                asChild
-                variant="ghost"
-                className="mb-4 px-2 text-nd-mid-em-text hover:text-nd-high-em-text hover:bg-nd-border-light"
-              >
-                <Link href="/developers/templates">← Back to templates</Link>
-              </Button>
-              <h1 className="nd-heading-l text-nd-high-em-text mb-6">
-                {template.displayName || template.name}
-              </h1>
-            </div>
-            <div className="relative overflow-hidden rounded-2xl border border-nd-border-light bg-black mb-4 max-w-5xl mx-auto">
-              {/* Soft brand glow */}
-              <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,rgba(202,159,245,0.06),transparent_60%)] pointer-events-none" />
-              <div className="absolute inset-0 bg-gradient-to-b from-white/[0.04] to-transparent pointer-events-none" />
+    <section className="mx-auto w-full max-w-[1440px] border-b border-white/[0.08] xl:border-x">
+      <header className="border-b border-white/[0.08] px-5 pb-14 pt-12 md:px-8 md:pb-20 md:pt-16 xl:px-12 xl:pb-24 xl:pt-20">
+        <Link
+          href="/developers/templates"
+          className="inline-flex items-center font-brand-mono text-[11px] font-medium uppercase tracking-[0.08em] text-nd-mid-em-text transition-colors hover:text-white"
+        >
+          ← Back to templates
+        </Link>
+        <h1 className="nd-heading-2xl mt-8 max-w-5xl text-nd-high-em-text">
+          {template.displayName || template.name}
+        </h1>
+        <p className="mt-5 max-w-2xl nd-body-l text-nd-mid-em-text md:mt-6">
+          {template.description}
+        </p>
+      </header>
 
-              <div className="relative w-full max-h-96 flex items-center justify-center">
-                <TemplatesUiImage template={template} />
-              </div>
-            </div>
-          </div>
-          <div className="grid grid-cols-2 md:grid-cols-5 gap-4 lg:gap-8 max-w-5xl mx-auto">
-            <div className="col-span-2">
-              <div className="hidden md:block md:sticky md:top-0 md:self-start">
-                <TemplatesUiSidebarDetail template={template} />
-              </div>
-              <div className="md:hidden ">
-                <Accordion type="single" collapsible className="w-full">
-                  <AccordionItem
-                    value="item-1"
-                    className="border-nd-border-light"
-                  >
-                    <AccordionTrigger className="text-nd-high-em-text hover:no-underline font-medium">
-                      Template details
-                    </AccordionTrigger>
-                    <AccordionContent>
-                      <TemplatesUiSidebarDetail template={template} />
-                    </AccordionContent>
-                  </AccordionItem>
-                </Accordion>
-              </div>
-            </div>
-            <div className="col-span-2 md:col-span-3 relative overflow-hidden rounded-2xl border border-nd-border-light bg-[#0D0C11]">
-              {/* Soft brand glow */}
-              <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.04),transparent_60%)] pointer-events-none" />
-              <div className="absolute inset-0 bg-gradient-to-b from-white/[0.03] to-transparent pointer-events-none" />
-
-              <div className={`relative ${PROSE_README_CLASSNAME}`}>
-                <div dangerouslySetInnerHTML={{ __html: template.readme }} />
-              </div>
-            </div>
+      <div className="border-b border-white/[0.08] p-3 md:p-8 xl:p-12">
+        <div className="relative overflow-hidden border border-white/[0.12] bg-black shadow-[0_32px_100px_rgba(0,0,0,0.45)]">
+          <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,rgba(202,159,245,0.08),transparent_60%)] pointer-events-none" />
+          <div className="relative flex w-full items-center justify-center">
+            <TemplatesUiImage
+              template={template}
+              className="h-auto w-full"
+              sizes="(max-width: 768px) 100vw, 1344px"
+              priority
+            />
           </div>
         </div>
       </div>
-    </div>
+
+      <div className="grid xl:grid-cols-[340px_minmax(0,1fr)]">
+        <aside className="border-b border-white/[0.08] p-5 md:p-8 xl:border-b-0 xl:border-r xl:p-10">
+          <div className="xl:sticky xl:top-20">
+            <TemplatesUiSidebarDetail template={template} />
+          </div>
+        </aside>
+        <article className="min-w-0 overflow-hidden p-5 md:p-8 xl:p-12">
+          <div className={PROSE_README_CLASSNAME}>
+            <div dangerouslySetInnerHTML={{ __html: template.readme }} />
+          </div>
+        </article>
+      </div>
+    </section>
   );
 }

--- a/apps/templates/src/components/templates/templates-ui-layout-detail.tsx
+++ b/apps/templates/src/components/templates/templates-ui-layout-detail.tsx
@@ -49,17 +49,21 @@ export function TemplatesUiLayoutDetail({
         <div>
           <div>
             <div className="max-w-5xl mx-auto mb-4">
-              <Button asChild variant="ghost" className="mb-4 px-2">
+              <Button
+                asChild
+                variant="ghost"
+                className="mb-4 px-2 text-nd-mid-em-text hover:text-nd-high-em-text hover:bg-nd-border-light"
+              >
                 <Link href="/developers/templates">← Back to templates</Link>
               </Button>
-              <h1 className="text-3xl font-bold mb-4">
+              <h1 className="nd-heading-l text-nd-high-em-text mb-6">
                 {template.displayName || template.name}
               </h1>
             </div>
-            <div className="relative overflow-hidden rounded-2xl mb-4 max-w-5xl mx-auto">
-              {/* Gradient border effect */}
-              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-purple-500/20 via-pink-500/20 to-blue-500/20" />
-              <div className="absolute inset-[1px] rounded-2xl bg-gradient-to-br from-zinc-900 to-zinc-950" />
+            <div className="relative overflow-hidden rounded-2xl border border-nd-border-light bg-black mb-4 max-w-5xl mx-auto">
+              {/* Soft brand glow */}
+              <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,rgba(202,159,245,0.06),transparent_60%)] pointer-events-none" />
+              <div className="absolute inset-0 bg-gradient-to-b from-white/[0.04] to-transparent pointer-events-none" />
 
               <div className="relative w-full max-h-96 flex items-center justify-center">
                 <TemplatesUiImage template={template} />
@@ -73,8 +77,13 @@ export function TemplatesUiLayoutDetail({
               </div>
               <div className="md:hidden ">
                 <Accordion type="single" collapsible className="w-full">
-                  <AccordionItem value="item-1">
-                    <AccordionTrigger>Template details</AccordionTrigger>
+                  <AccordionItem
+                    value="item-1"
+                    className="border-nd-border-light"
+                  >
+                    <AccordionTrigger className="text-nd-high-em-text hover:no-underline font-medium">
+                      Template details
+                    </AccordionTrigger>
                     <AccordionContent>
                       <TemplatesUiSidebarDetail template={template} />
                     </AccordionContent>
@@ -82,10 +91,10 @@ export function TemplatesUiLayoutDetail({
                 </Accordion>
               </div>
             </div>
-            <div className="col-span-2 md:col-span-3 relative overflow-hidden rounded-2xl">
-              {/* Gradient border effect */}
-              <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-purple-500/20 via-pink-500/20 to-blue-500/20" />
-              <div className="absolute inset-[1px] rounded-2xl bg-gradient-to-br from-zinc-900 to-zinc-950" />
+            <div className="col-span-2 md:col-span-3 relative overflow-hidden rounded-2xl border border-nd-border-light bg-[#0D0C11]">
+              {/* Soft brand glow */}
+              <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.04),transparent_60%)] pointer-events-none" />
+              <div className="absolute inset-0 bg-gradient-to-b from-white/[0.03] to-transparent pointer-events-none" />
 
               <div className={`relative ${PROSE_README_CLASSNAME}`}>
                 <div dangerouslySetInnerHTML={{ __html: template.readme }} />

--- a/apps/templates/src/components/templates/templates-ui-layout-list.tsx
+++ b/apps/templates/src/components/templates/templates-ui-layout-list.tsx
@@ -20,28 +20,32 @@ export function TemplatesUiLayoutList({
 
   return (
     <TemplatesProvider templates={templates}>
-      <div className="grid md:grid-cols-4 gap-4 lg:gap-8">
-        <aside className="md:col-span-1">
-          <div className="hidden md:block md:sticky md:top-20 md:max-h-[calc(100vh-6rem)] md:overflow-y-auto custom-scrollbar">
-            <TemplatesUiFilter />
+      <section className="mx-auto w-full max-w-[1440px] border-b border-white/[0.08] xl:border-x">
+        <div className="grid xl:grid-cols-[300px_minmax(0,1fr)]">
+          <aside className="border-b border-white/[0.08] xl:border-b-0 xl:border-r">
+            <div className="hidden px-8 py-10 xl:sticky xl:top-16 xl:block xl:max-h-[calc(100vh-4rem)] xl:overflow-y-auto custom-scrollbar">
+              <TemplatesUiFilter />
+            </div>
+            <div className="px-5 md:px-8 xl:hidden">
+              <Accordion type="single" collapsible className="w-full">
+                <AccordionItem value="item-1" className="border-0">
+                  <AccordionTrigger className="py-5 font-brand-mono text-[12px] font-medium uppercase tracking-[0.08em] text-nd-high-em-text hover:no-underline">
+                    {t("filter.mobile_accordion")}
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <div className="pb-6">
+                      <TemplatesUiFilter />
+                    </div>
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
+            </div>
+          </aside>
+          <div className="min-w-0 p-3 md:p-8 xl:p-10">
+            <TemplatesUiMain />
           </div>
-          <div className="md:hidden">
-            <Accordion type="single" collapsible className="w-full">
-              <AccordionItem value="item-1" className="border-nd-border-light">
-                <AccordionTrigger className="text-nd-high-em-text hover:no-underline font-medium">
-                  {t("filter.mobile_accordion")}
-                </AccordionTrigger>
-                <AccordionContent>
-                  <TemplatesUiFilter />
-                </AccordionContent>
-              </AccordionItem>
-            </Accordion>
-          </div>
-        </aside>
-        <main className="md:col-span-3">
-          <TemplatesUiMain />
-        </main>
-      </div>
+        </div>
+      </section>
     </TemplatesProvider>
   );
 }

--- a/apps/templates/src/components/templates/templates-ui-layout-list.tsx
+++ b/apps/templates/src/components/templates/templates-ui-layout-list.tsx
@@ -27,8 +27,8 @@ export function TemplatesUiLayoutList({
           </div>
           <div className="md:hidden">
             <Accordion type="single" collapsible className="w-full">
-              <AccordionItem value="item-1">
-                <AccordionTrigger>
+              <AccordionItem value="item-1" className="border-nd-border-light">
+                <AccordionTrigger className="text-nd-high-em-text hover:no-underline font-medium">
                   {t("filter.mobile_accordion")}
                 </AccordionTrigger>
                 <AccordionContent>

--- a/apps/templates/src/components/templates/templates-ui-main.tsx
+++ b/apps/templates/src/components/templates/templates-ui-main.tsx
@@ -10,9 +10,15 @@ export function TemplatesUiMain() {
   return templates.length ? (
     <TemplatesUiGrid templates={templates} />
   ) : (
-    <div className="flex flex-col items-center justify-center gap-8 border border-white/5 py-32 rounded-lg p-4 text-center">
-      <div className="font-bold text-lg">{t("empty_state.title")}</div>
-      <Button variant="outline" onClick={clear}>
+    <div className="flex flex-col items-center justify-center gap-8 border border-nd-border-light py-32 rounded-2xl p-4 text-center bg-[#0D0C11]">
+      <div className="nd-heading-s text-nd-high-em-text">
+        {t("empty_state.title")}
+      </div>
+      <Button
+        variant="outline"
+        onClick={clear}
+        className="border-nd-border-prominent text-nd-high-em-text hover:bg-nd-border-prominent dark:bg-transparent dark:hover:bg-nd-border-prominent"
+      >
         {t("empty_state.clear_filters")}
       </Button>
     </div>

--- a/apps/templates/src/components/templates/templates-ui-main.tsx
+++ b/apps/templates/src/components/templates/templates-ui-main.tsx
@@ -10,14 +10,14 @@ export function TemplatesUiMain() {
   return templates.length ? (
     <TemplatesUiGrid templates={templates} />
   ) : (
-    <div className="flex flex-col items-center justify-center gap-8 border border-nd-border-light py-32 rounded-2xl p-4 text-center bg-[#0D0C11]">
+    <div className="flex min-h-[420px] flex-col items-center justify-center gap-8 border border-white/[0.08] bg-[#0C0C0E] p-6 text-center">
       <div className="nd-heading-s text-nd-high-em-text">
         {t("empty_state.title")}
       </div>
       <Button
         variant="outline"
         onClick={clear}
-        className="border-nd-border-prominent text-nd-high-em-text hover:bg-nd-border-prominent dark:bg-transparent dark:hover:bg-nd-border-prominent"
+        className="rounded-none border-white/20 bg-white text-black hover:bg-white/90 dark:bg-white dark:text-black dark:hover:bg-white/90"
       >
         {t("empty_state.clear_filters")}
       </Button>

--- a/apps/templates/src/components/templates/templates-ui-sidebar-detail.tsx
+++ b/apps/templates/src/components/templates/templates-ui-sidebar-detail.tsx
@@ -13,70 +13,50 @@ export function TemplatesUiSidebarDetail({ template }: { template: Template }) {
   const filters: TemplateFilter[] = useTemplateFilters({ template });
 
   return (
-    <div className="flex flex-col gap-4">
-      <div className="relative overflow-hidden rounded-2xl border border-nd-border-light bg-[#0D0C11]">
-        {/* Soft brand glow */}
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.05),transparent_60%)] pointer-events-none" />
-        <div className="absolute inset-0 bg-gradient-to-b from-white/[0.04] to-transparent pointer-events-none" />
-
-        <div className="relative flex flex-col gap-4 px-4 py-6">
-          <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
-                <h3 className="text-[17px] font-medium leading-none text-nd-high-em-text">
-                  {template.displayName || template.name}
-                </h3>
-              </div>
-              <a
-                href={template.repoUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-nd-mid-em-text hover:text-nd-high-em-text transition-colors flex-shrink-0 flex items-center"
-                title="View on GitHub"
-              >
-                <Github className="h-4 w-4" />
-              </a>
-            </div>
-            <p className="text-sm text-nd-mid-em-text">
-              {template.description}
-            </p>
-          </div>
-          <div className="space-y-2">
-            <p className="flex justify-between gap-4 text-sm">
-              <strong className="font-medium text-nd-mid-em-text">
-                Author:
-              </strong>
-              <span className="text-nd-high-em-text text-right">
-                {sourceMap[template.source.name]?.name}
-              </span>
-            </p>
-            {filters.map((filters) => (
-              <div
-                key={filters.id}
-                className="flex justify-between gap-4 text-sm"
-              >
-                <strong className="font-medium text-nd-mid-em-text">
-                  {filters.name}:
-                </strong>
-                <span className="text-nd-high-em-text text-right">
-                  {filters.keywords.map((keyword) => keyword.name).join(", ")}
-                </span>
-              </div>
-            ))}
-          </div>
-          <AppModal title="Use This Template" hideTitle>
-            <div className="space-y-4  overflow-x-auto">
-              <p>
-                Generate a new Solana project using the{" "}
-                <strong>{template.displayName || template.name}</strong>{" "}
-                template.
-              </p>
-              <TemplatesUiGenerateCommand template={template} />
-              <p>Run the command above in your terminal to get started.</p>
-            </div>
-          </AppModal>
-        </div>
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between gap-4 border-b border-white/[0.08] pb-4">
+        <h2 className="font-brand-mono text-[12px] font-medium uppercase tracking-[0.08em] text-white">
+          Template details
+        </h2>
+        <a
+          href={template.repoUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 text-xs text-nd-mid-em-text transition-colors hover:text-white"
+          title="View on GitHub"
+        >
+          <Github className="size-4" />
+          GitHub
+        </a>
       </div>
+
+      <dl className="space-y-4">
+        <div className="flex justify-between gap-5 text-sm">
+          <dt className="text-nd-mid-em-text">Author</dt>
+          <dd className="text-right text-nd-high-em-text">
+            {sourceMap[template.source.name]?.name}
+          </dd>
+        </div>
+        {filters.map((filter) => (
+          <div key={filter.id} className="flex justify-between gap-5 text-sm">
+            <dt className="text-nd-mid-em-text">{filter.name}</dt>
+            <dd className="max-w-[170px] text-right text-nd-high-em-text">
+              {filter.keywords.map((keyword) => keyword.name).join(", ")}
+            </dd>
+          </div>
+        ))}
+      </dl>
+
+      <AppModal title="Use This Template" hideTitle>
+        <div className="space-y-4 overflow-x-auto">
+          <p>
+            Generate a new Solana project using the{" "}
+            <strong>{template.displayName || template.name}</strong> template.
+          </p>
+          <TemplatesUiGenerateCommand template={template} />
+          <p>Run the command above in your terminal to get started.</p>
+        </div>
+      </AppModal>
     </div>
   );
 }

--- a/apps/templates/src/components/templates/templates-ui-sidebar-detail.tsx
+++ b/apps/templates/src/components/templates/templates-ui-sidebar-detail.tsx
@@ -14,16 +14,16 @@ export function TemplatesUiSidebarDetail({ template }: { template: Template }) {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="relative overflow-hidden rounded-2xl">
-        {/* Gradient border effect */}
-        <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-purple-500/20 via-pink-500/20 to-blue-500/20" />
-        <div className="absolute inset-[1px] rounded-2xl bg-gradient-to-br from-zinc-900 to-zinc-950" />
+      <div className="relative overflow-hidden rounded-2xl border border-nd-border-light bg-[#0D0C11]">
+        {/* Soft brand glow */}
+        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(202,159,245,0.05),transparent_60%)] pointer-events-none" />
+        <div className="absolute inset-0 bg-gradient-to-b from-white/[0.04] to-transparent pointer-events-none" />
 
         <div className="relative flex flex-col gap-4 px-4 py-6">
           <div className="flex flex-col gap-2">
             <div className="flex items-center justify-between gap-2">
               <div className="flex items-center gap-2">
-                <h3 className="text-lg font-bold leading-none">
+                <h3 className="text-[17px] font-medium leading-none text-nd-high-em-text">
                   {template.displayName || template.name}
                 </h3>
               </div>
@@ -31,23 +31,34 @@ export function TemplatesUiSidebarDetail({ template }: { template: Template }) {
                 href={template.repoUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-zinc-400 hover:text-purple-400 transition-colors flex-shrink-0 flex items-center"
+                className="text-nd-mid-em-text hover:text-nd-high-em-text transition-colors flex-shrink-0 flex items-center"
                 title="View on GitHub"
               >
                 <Github className="h-4 w-4" />
               </a>
             </div>
-            <p className="text-sm text-neutral-500">{template.description}</p>
+            <p className="text-sm text-nd-mid-em-text">
+              {template.description}
+            </p>
           </div>
           <div className="space-y-2">
-            <p className="flex justify-between text-sm">
-              <strong>Author:</strong>
-              <span>{sourceMap[template.source.name]?.name}</span>
+            <p className="flex justify-between gap-4 text-sm">
+              <strong className="font-medium text-nd-mid-em-text">
+                Author:
+              </strong>
+              <span className="text-nd-high-em-text text-right">
+                {sourceMap[template.source.name]?.name}
+              </span>
             </p>
             {filters.map((filters) => (
-              <div key={filters.id} className="flex justify-between text-sm">
-                <strong>{filters.name}:</strong>
-                <span>
+              <div
+                key={filters.id}
+                className="flex justify-between gap-4 text-sm"
+              >
+                <strong className="font-medium text-nd-mid-em-text">
+                  {filters.name}:
+                </strong>
+                <span className="text-nd-high-em-text text-right">
                   {filters.keywords.map((keyword) => keyword.name).join(", ")}
                 </span>
               </div>

--- a/apps/templates/src/lib/prose-styles.ts
+++ b/apps/templates/src/lib/prose-styles.ts
@@ -3,4 +3,4 @@
  */
 
 export const PROSE_README_CLASSNAME =
-  "prose dark:prose-invert max-w-none p-6 backdrop-blur-md [&_pre]:!bg-zinc-900 [&_pre]:!p-0 [&_pre]:!rounded-lg [&_pre]:overflow-x-auto [&_pre]:!m-0 [&_pre]:!my-4 [&_pre]:text-base [&_pre]:!w-full [&_pre]:box-border [&_code]:text-base [&_pre_code]:!text-base [&_pre_code]:!bg-zinc-900 [&_pre_code]:!p-4 [&_pre_code]:!block [&_pre_code]:!w-full";
+  "prose dark:prose-invert max-w-none p-6 [&_pre]:!bg-black [&_pre]:!border [&_pre]:!border-nd-border-light [&_pre]:!p-0 [&_pre]:!rounded-lg [&_pre]:overflow-x-auto [&_pre]:!m-0 [&_pre]:!my-4 [&_pre]:text-base [&_pre]:!w-full [&_pre]:box-border [&_code]:text-base [&_pre_code]:!text-base [&_pre_code]:!bg-black [&_pre_code]:!p-4 [&_pre_code]:!block [&_pre_code]:!w-full";

--- a/apps/templates/src/lib/prose-styles.ts
+++ b/apps/templates/src/lib/prose-styles.ts
@@ -3,4 +3,4 @@
  */
 
 export const PROSE_README_CLASSNAME =
-  "prose dark:prose-invert max-w-none p-6 [&_pre]:!bg-black [&_pre]:!border [&_pre]:!border-nd-border-light [&_pre]:!p-0 [&_pre]:!rounded-lg [&_pre]:overflow-x-auto [&_pre]:!m-0 [&_pre]:!my-4 [&_pre]:text-base [&_pre]:!w-full [&_pre]:box-border [&_code]:text-base [&_pre_code]:!text-base [&_pre_code]:!bg-black [&_pre_code]:!p-4 [&_pre_code]:!block [&_pre_code]:!w-full";
+  "prose prose-invert min-w-0 max-w-none overflow-hidden prose-headings:font-brand prose-headings:font-medium prose-headings:tracking-tight prose-p:text-nd-mid-em-text prose-li:text-nd-mid-em-text prose-strong:text-white prose-a:text-white prose-a:underline-offset-4 [&_:not(pre)>code]:break-words [&_:not(pre)>code]:whitespace-normal [&_pre]:!my-6 [&_pre]:!w-full [&_pre]:max-w-full [&_pre]:overflow-x-auto [&_pre]:!rounded-none [&_pre]:!border [&_pre]:!border-white/[0.10] [&_pre]:!bg-black [&_pre]:!p-0 [&_pre]:box-border [&_pre_code]:!block [&_pre_code]:!w-full [&_pre_code]:!bg-black [&_pre_code]:!p-4 [&_pre_code]:!text-sm";

--- a/apps/templates/src/lib/templates/templates-ui-image.tsx
+++ b/apps/templates/src/lib/templates/templates-ui-image.tsx
@@ -12,11 +12,14 @@ export function TemplatesUiImage({
   const imageSrc = template.image
     ? `${GITHUB_RAW_BASE}/${template.image}`
     : null;
+  const { className, ...imageProps } = props;
 
   if (!imageSrc) {
     // Fallback placeholder
     return (
-      <div className="w-full aspect-[1200/630] bg-white/[0.02] flex items-center justify-center">
+      <div
+        className={`flex aspect-[1200/630] w-full items-center justify-center bg-white/[0.02] ${className ?? ""}`}
+      >
         <span className="font-brand-mono text-[11px] leading-[1.42] font-bold uppercase tracking-wide text-nd-mid-em-text/60">
           No preview available
         </span>
@@ -30,8 +33,8 @@ export function TemplatesUiImage({
       alt={`Preview of ${template.displayName || template.name}`}
       width={1200}
       height={630}
-      className="w-full h-auto"
-      {...props}
+      className={className ?? "h-auto w-full"}
+      {...imageProps}
     />
   );
 }

--- a/apps/templates/src/lib/templates/templates-ui-image.tsx
+++ b/apps/templates/src/lib/templates/templates-ui-image.tsx
@@ -16,8 +16,10 @@ export function TemplatesUiImage({
   if (!imageSrc) {
     // Fallback placeholder
     return (
-      <div className="w-full aspect-[1200/630] bg-gradient-to-br from-purple-900/20 to-pink-900/20 flex items-center justify-center">
-        <span className="text-neutral-500">No preview available</span>
+      <div className="w-full aspect-[1200/630] bg-white/[0.02] flex items-center justify-center">
+        <span className="font-brand-mono text-[11px] leading-[1.42] font-bold uppercase tracking-wide text-nd-mid-em-text/60">
+          No preview available
+        </span>
       </div>
     );
   }

--- a/apps/templates/tailwind.config.js
+++ b/apps/templates/tailwind.config.js
@@ -10,8 +10,31 @@ module.exports = {
     extend: {
       fontFamily: {
         brand: ["Diatype", "sans-serif"],
+        "brand-mono": ["DSemi", "monospace"],
       },
       colors: {
+        // New design system colors (shared with apps/web and apps/docs)
+        "nd-bg": "#000000",
+        "nd-cta": "#FFFFFF",
+        "nd-on-cta-high-em-text": "#000000",
+        "nd-on-cta-mid-em-text": "#000000A3",
+        "nd-high-em-text": "#FFFFFF",
+        "nd-mid-em-text": "#ABABBA",
+        "nd-mid-em-text-alpha": "#FFFFFFA3",
+        "nd-primary": "#FFFFFF",
+        "nd-primary-hovered": "#FFFFFFE5",
+        "nd-on-primary": "#000000",
+        "nd-inverse": "#000000",
+        "nd-on-inverse": "#FFFFFF",
+        "nd-border-light": "#ECE4FD1F",
+        "nd-border-prominent": "#ECE4FD33",
+        "nd-border-hovered": "#ECE4FD52",
+        "nd-highlight-lavendar": "#CA9FF5",
+        "nd-highlight-blue": "#6693F7",
+        "nd-highlight-gold": "#FFC526",
+        "nd-highlight-orange": "#F48252",
+        "nd-highlight-green": "#55E9AB",
+        "nd-highlight-lime": "#CFF15E",
         background: "hsl(var(--background))",
         foreground: "hsl(var(--foreground))",
         card: {


### PR DESCRIPTION
### Problem

The templates showcase (`/developers/templates`) still uses the legacy design language — zinc-900 gradient cards, purple/pink/blue gradient borders, and the default shadcn palette — while the rest of solana.com (home, data dashboard, component library) has moved to the current black-based "nd" design system with lavender-tinted borders, white CTAs, and the shared nd typography scale. The page sticks out from the rest of the site, especially the developer surfaces it is served alongside.


<img width="2600" height="1698" alt="image" src="https://github.com/user-attachments/assets/8de9e034-52f3-4d1a-ae06-c5bb4a571624" />


### Summary of Changes

Restyles the `apps/templates` app to match the current site design without changing any page layout:

- Added the shared `nd-*` design tokens (colors, borders, highlights, `brand-mono` font) to `tailwind.config.js` and the shared `.nd-heading-*` / `.nd-body-*` typography utilities to `globals.css`, matching `apps/web` and `apps/docs`.
- Swapped legacy purple/pink/blue gradients and zinc surfaces for black/`#0D0C11` panels with `nd-border-light` / `nd-border-prominent` borders, soft lavender/green radial glows, and white `nd-primary` accents.
- Restyled the hero (nd heading + muted body), filter panel, keyword checkboxes, template cards, empty state, detail layout, sidebar, generate-command PM switcher/code block, modal, and search input/results — layouts (grid columns, sticky sidebars, accordion, aspect ratios) untouched.
- Removed dead `metallic-border`/`--rotation` styling from search results and replaced the legacy `hero.webp` background shapes with CSS radial glows.
- Kept behavior identical: filtering/search/URL state, modals, and mobile accordion verified locally via Playwright; `lint`, `check-types`, `test`, and production `build` all pass.

Design references drawn from the last 6 months of site work: SDP landing page (#1261), Solana Data dashboard redesign (#1822), and the component-library consolidation (#1834).

### Change classification (SDLC §2)

- [x] **Standard** — production-facing, non-critical (visual-only change to an existing page)
- [ ] **Critical**
- [ ] **Low**

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] Input from users or external services is validated before use; the existing `dangerouslySetInnerHTML` README rendering is unchanged by this PR.
- [x] No new dependencies.
- [x] Errors are handled explicitly — no new failure paths introduced.

New dependencies: none.

Threat-model note: n/a