### PR TITLE
docs(commerce-kit): replace gill references with @solana/kit

### DIFF
--- a/apps/docs/content/docs/en/tools/commerce-kit/quickstart/installation.mdx
+++ b/apps/docs/content/docs/en/tools/commerce-kit/quickstart/installation.mdx
@@ -16,12 +16,12 @@ others.
 ## Common Peer Dependencies
 
 Solana Commerce Kit is built on top of the Solana Kit library, so it is
-compatible with Solana Kit, Gill, Solana Programs
+compatible with Solana Kit, Solana Programs
 [Clients](https://github.com/solana-program), and
 [Codama-generated JS Clients](https://github.com/codama-idl/renderers-js).
 
 ```bash
-pnpm add gill # or @solana/kit
+pnpm add @solana/kit
 pnpm add @solana-program/token # or @solana-program/target-program
 pnpm add @my-program/codama-js-client
 ```

--- a/apps/docs/content/docs/en/tools/commerce-kit/quickstart/payment-button.mdx
+++ b/apps/docs/content/docs/en/tools/commerce-kit/quickstart/payment-button.mdx
@@ -291,7 +291,7 @@ XSS attacks through URL injection.
 
 The component performs validation before rendering:
 
-1. **Wallet Validation** - Uses `isAddress()` from `gill` to validate the
+1. **Wallet Validation** - Uses `isAddress()` from `@solana/kit` to validate the
    merchant wallet address. If invalid, renders an error state instead of the
    payment UI.
 

--- a/apps/docs/content/docs/en/tools/commerce-kit/quickstart/payment-flows.mdx
+++ b/apps/docs/content/docs/en/tools/commerce-kit/quickstart/payment-flows.mdx
@@ -215,7 +215,7 @@ const tip = createTipRequest(
 ## Payment Verification Functions
 
 These functions interact with Solana to verify transactions and wait for
-confirmations. They require a Solana RPC client from the `gill` library.
+confirmations. They require a Solana RPC client from the `@solana/kit` library.
 
 ### `verifyPayment()`
 
@@ -224,7 +224,7 @@ amount, recipient, and token.
 
 ```typescript
 async function verifyPayment(
-  rpc: SolanaClient["rpc"],
+  rpc: Rpc<SolanaRpcApi>,
   signatureString: string,
   expectedAmount?: number,
   expectedRecipient?: string,
@@ -234,8 +234,8 @@ async function verifyPayment(
 
 #### Parameters
 
-- **`rpc`** (`SolanaClient['rpc']`, required) - RPC client from `gill`. Create
-  with `createSolanaClient(rpcUrl).rpc`.
+- **`rpc`** (`Rpc<SolanaRpcApi>`, required) - RPC client from `@solana/kit`.
+  Create with `createSolanaRpc(rpcUrl)`.
 
 - **`signatureString`** (`string`, required) - Transaction signature
   (base58-encoded) to verify.
@@ -305,14 +305,12 @@ The function performs these checks:
 
 ```typescript
 import { verifyPayment } from "@solana-commerce/headless";
-import { createSolanaClient } from "gill";
+import { createSolanaRpc } from "@solana/kit";
 
-const client = createSolanaClient({
-  urlOrMoniker: "mainnet"
-});
+const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 
 const result = await verifyPayment(
-  client.rpc,
+  rpc,
   "transaction-signature-here",
   50_000_000, // 0.05 SOL in lamports
   "merchant-wallet-address"
@@ -335,7 +333,7 @@ or times out.
 
 ```typescript
 async function waitForConfirmation(
-  rpc: SolanaClient["rpc"],
+  rpc: Rpc<SolanaRpcApi>,
   signatureStr: string,
   timeoutMs?: number
 ): Promise<boolean>;
@@ -343,7 +341,7 @@ async function waitForConfirmation(
 
 #### Parameters
 
-- **`rpc`** (`SolanaClient['rpc']`, required) - RPC client from `gill`.
+- **`rpc`** (`Rpc<SolanaRpcApi>`, required) - RPC client from `@solana/kit`.
 
 - **`signatureStr`** (`string`, required) - Transaction signature to wait for.
 
@@ -359,17 +357,15 @@ async function waitForConfirmation(
 
 ```typescript
 import { waitForConfirmation } from "@solana-commerce/headless";
-import { createSolanaClient } from "gill";
+import { createSolanaRpc } from "@solana/kit";
 
-const client = createSolanaClient({
-  urlOrMoniker: "mainnet"
-});
+const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 
 // After sending transaction
 const signature = await wallet.sendTransaction(transaction);
 
 // Wait for confirmation (30 second timeout)
-const confirmed = await waitForConfirmation(client.rpc, signature, 30000);
+const confirmed = await waitForConfirmation(rpc, signature, 30000);
 
 if (confirmed) {
   console.log("Transaction confirmed!");

--- a/apps/docs/content/docs/en/tools/commerce-kit/quickstart/solana-pay.mdx
+++ b/apps/docs/content/docs/en/tools/commerce-kit/quickstart/solana-pay.mdx
@@ -5,8 +5,8 @@ description: Generate Solana Pay URLs, QR codes, and payment transactions
 
 The `@solana-commerce/solana-pay` package provides complete
 [Solana Pay](https://solanapay.com) functionality for building payment
-experiences, compatible with [`gill`](https://www.gillsdk.com/) and
-[`@solana/kit`](https://github.com/anza-xyz/kit) libraries. It handles URL
+experiences, compatible with the
+[`@solana/kit`](https://github.com/anza-xyz/kit) library. It handles URL
 encoding/parsing, QR code generation with custom styling, and transaction
 construction for both SOL and SPL token transfers.
 
@@ -36,7 +36,7 @@ Used for simple payment requests (direct transfers):
 
 - **`recipient`** (`Address`, required) - The merchant's wallet address
   (base58-encoded public key) that will receive the payment. Can be a string or
-  `Address` type from `gill`.
+  `Address` type from `@solana/kit`.
 
 - **`amount`** (`bigint`, optional) - Payment amount in **lamports** (atomic
   units). For SOL, 1 SOL = 1,000,000,000 lamports (9 decimals). For SPL tokens,
@@ -104,7 +104,7 @@ The function performs several operations to construct a valid Solana Pay URL:
 
 ```typescript
 import { encodeURL } from "@solana-commerce/solana-pay";
-import { address } from "gill";
+import { address } from "@solana/kit";
 
 const url = encodeURL({
   recipient: address("merchantWalletAddress123..."),
@@ -121,7 +121,7 @@ console.log(url.toString());
 
 ```typescript
 import { encodeURL } from "@solana-commerce/solana-pay";
-import { address } from "gill";
+import { address } from "@solana/kit";
 
 const usdcMint = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
 
@@ -140,8 +140,7 @@ Use references to identify specific payments:
 
 ```typescript
 import { encodeURL } from "@solana-commerce/solana-pay";
-import { address } from "gill";
-import { Keypair } from "@solana/web3.js";
+import { address, generateKeyPairSigner } from "@solana/kit";
 
 // Generate unique reference for this order
 const orderReference = (await generateKeyPairSigner()).address;
@@ -278,7 +277,7 @@ logo size, logo background color, logo margin)._
 
 ```typescript
 import { createQR, encodeURL } from "@solana-commerce/solana-pay";
-import { address } from "gill";
+import { address } from "@solana/kit";
 
 async function generatePaymentQR() {
   const url = encodeURL({
@@ -306,7 +305,7 @@ async function generatePaymentQR() {
 
 ```typescript
 import { createStyledQRCode, encodeURL } from "@solana-commerce/solana-pay";
-import { address } from "gill";
+import { address } from "@solana/kit";
 
 async function createBrandedQR() {
   const url = encodeURL({
@@ -347,12 +346,12 @@ based on the `splToken` parameter, and constructs all necessary instructions.
 The function sets a blockhash lifetime for the transaction using the latest
 blockhash from the RPC client and returns a complete, unsigned transaction ready
 for signing and submission to the RPC (type
-`TransactionMessageWithBlockhashLifetime`, compatible with Solana Kit/Gill).
+`TransactionMessageWithBlockhashLifetime`, compatible with Solana Kit).
 
 #### Parameters
 
-- **`rpc`** (`Rpc<SolanaRpcApi>`) - Solana RPC client from `gill`. Create with
-  `createSolanaClient(rpcUrl).rpc`.
+- **`rpc`** (`Rpc<SolanaRpcApi>`) - Solana RPC client from `@solana/kit`. Create
+  with `createSolanaRpc(rpcUrl)`.
 
 - **`sender`** (`Address`) - The payer's wallet address. Must be a funded
   account that will sign the transaction.
@@ -388,10 +387,9 @@ Throws `CreateTransferError` with specific messages:
 
 ```typescript
 import { createTransfer } from "@solana-commerce/solana-pay";
-import { createSolanaClient } from "gill";
-import { address } from "gill";
+import { address, createSolanaRpc } from "@solana/kit";
 
-const rpc = createSolanaClient("https://api.mainnet-beta.solana.com").rpc;
+const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 
 // Build SOL transfer transaction
 const txMessage = await createTransfer(rpc, address("sender-wallet-address"), {
@@ -409,10 +407,9 @@ console.log("Transaction ready:", txMessage);
 
 ```typescript
 import { createTransfer } from "@solana-commerce/solana-pay";
-import { createSolanaClient } from "gill";
-import { address } from "gill";
+import { address, createSolanaRpc } from "@solana/kit";
 
-const rpc = createSolanaClient("https://api.mainnet-beta.solana.com").rpc;
+const rpc = createSolanaRpc("https://api.mainnet.solana.com");
 const usdcMint = address("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v");
 
 const txMessage = await createTransfer(rpc, address("sender-wallet"), {

--- a/apps/docs/content/docs/en/tools/commerce-kit/quickstart/wallet-connection.mdx
+++ b/apps/docs/content/docs/en/tools/commerce-kit/quickstart/wallet-connection.mdx
@@ -9,8 +9,7 @@ built on the
 manages wallet discovery, connection state, account management, and automatic
 reconnection. The package is designed to be framework-agnostic with React
 bindings included. It is tailored for seamless use in Solana Commerce Kit and is
-compatible with [@solana/kit](https://github.com/anza-xyz/kit) and
-[gill](https://www.gillsdk.com/).
+compatible with [@solana/kit](https://github.com/anza-xyz/kit).
 
 ![Wallet Connection](/assets/docs/tools/commerce-kit/connector.png)
 


### PR DESCRIPTION
## Problem

The Commerce Kit quickstart docs referenced `gill` throughout, presenting it as a co-equal option alongside `@solana/kit`. Every code example imported from `gill`, and two pages described types (`SolanaClient['rpc']`) that only exist in gill.

## Changes

Five files under `apps/docs/content/docs/en/tools/commerce-kit/quickstart/`:

- `address` / `isAddress` / `generateKeyPairSigner` now import from `@solana/kit`
- `createSolanaClient(url).rpc` -> `createSolanaRpc(url)`, which returns exactly the `Rpc<SolanaRpcApi>` these Commerce Kit functions declare
- `SolanaClient['rpc']` -> `Rpc<SolanaRpcApi>` in the `verifyPayment` / `waitForConfirmation` signatures
- Removed an unused legacy `import { Keypair } from "@solana/web3.js"` — the example actually calls `generateKeyPairSigner()`
- Example endpoints now use `https://api.mainnet.solana.com`
- Prose no longer lists gill as a compatible library

## Notes

- English only; other locales regenerate.
- `payment-button.mdx:327` still mentions `api.mainnet-beta.solana.com`, left deliberately — it documents Commerce Kit's own internal fallback endpoint, so changing it would misdescribe the library. Tracked in DEV-836.
- `createSolanaRpc` was chosen over a `createClient()` plugin chain because these examples are read-only; `solanaRpc` / `solanaMainnetRpc` are typed `<T extends ClientWithPayer>` and would require installing a signer plugin just to satisfy the constraint. Verified against `@solana/kit@7.0.0` and `@solana/kit-plugin-rpc@0.16.0`.

## Verification

`pnpm lint --filter solana-docs` passes (frontmatter guard, eslint, prettier).

Repo-wide `pnpm test` and `pnpm check-types` fail identically on `main` in this environment (node v26 vs the required 24.x), so they are unrelated to this change.

Closes DEV-823