### PR TITLE
docs: add missing rpcAirdrop plugin to account-types example

### DIFF
--- a/apps/docs/content/docs/en/core/accounts/account-types.mdx
+++ b/apps/docs/content/docs/en/core/accounts/account-types.mdx
@@ -421,7 +421,7 @@ the account. The `owner` field is `11111111111111111111111111111111` (the
 
 ```ts !! title="Kit"
 import { createClient, generateKeyPairSigner, lamports } from "@solana/kit";
-import { solanaRpc } from "@solana/kit-plugin-rpc";
+import { solanaRpc, rpcAirdrop } from "@solana/kit-plugin-rpc";
 import { generatedPayer } from "@solana/kit-plugin-signer";
 
 const client = await createClient()
@@ -431,7 +431,8 @@ const client = await createClient()
       rpcUrl: "http://localhost:8899",
       rpcSubscriptionsUrl: "ws://localhost:8900"
     })
-  );
+  )
+  .use(rpcAirdrop());
 
 // Generate a new keypair
 const keypair = await generateKeyPairSigner();

--- a/apps/media/content/posts/solana-changelog-august-6-2026.mdx
+++ b/apps/media/content/posts/solana-changelog-august-6-2026.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Solana Changelog: August 6, 2026"
+title: 'Solana Changelog: August 6, 2026'
 status: published
 heroImage: /uploads/posts/solana-changelog-august-6-2026/heroImage.png
 description: >-
@@ -14,97 +14,114 @@ tags:
   - tag: newsletter
   - tag: technology
 ---
-
 ## **Releases**
 
 **Notable feature gates**
 
-- Lowering slot times from 400ms to 350ms - [Devnet](https://explorer.solana.com/address/iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ?cluster=devnet), [Testnet](https://explorer.solana.com/address/iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ?cluster=testnet)
+* Lowering slot times from 400ms to 350ms - [Devnet](https://explorer.solana.com/address/iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ?cluster=devnet), [Testnet](https://explorer.solana.com/address/iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ?cluster=testnet)
 
 Upcoming feature gates [here](https://github.com/anza-xyz/agave/wiki/Feature-Gate-Tracker-Schedule).
 
 **New versions**
 
-- Agave [v4.3.0-alpha.3](https://github.com/anza-xyz/agave/releases/tag/v4.3.0-alpha.3), [v4.2.0-rc.1](https://github.com/anza-xyz/agave/releases/tag/v4.2.0-rc.1)
-- Firedancer [Mainnet v1.1.3](https://github.com/firedancer-io/firedancer/releases/tag/v1.1.3)
-- Frankendancer [Mainnet v0.1007.40100](https://github.com/firedancer-io/firedancer/releases/tag/v0.1007.40100), [Testnet v0.1104.40200](https://github.com/firedancer-io/firedancer/releases/tag/v0.1104.40200)
-- solana-signature [v3.5.1](https://github.com/anza-xyz/solana-sdk/releases/tag/signature%40v3.5.1)
-- Wallet Standard [v1.1.6](https://github.com/anza-xyz/wallet-standard/releases/tag/%40solana/wallet-standard%401.1.6)
-- Stake Program [Rust SDK v4.4.0](https://github.com/solana-program/stake/releases/tag/interface%40v4.4.0)
-- Token 2022 Program [JS SDK v0.14.1](https://github.com/solana-program/token-2022/releases/tag/js%40v0.14.1)
-- ZK Elgamal Proof Program [WASM JS SDK v0.5.1](https://github.com/solana-program/zk-elgamal-proof/releases/tag/zk-sdk-wasm-js%40v0.5.1)
-- Subscriptions Program [Typescript SDK v0.5.0-beta.1](https://github.com/solana-foundation/subscriptions/releases/tag/ts-client-v0.5.0-beta.1), [Rust SDK v0.5.0-beta.1](https://github.com/solana-foundation/subscriptions/releases/tag/rust-client-v0.5.0-beta.1)
-- LiteSVM [v0.15.2](https://github.com/LiteSVM/litesvm/releases/tag/v0.15.2)
-- Surfpool [v1.5.0](https://github.com/solana-foundation/surfpool/releases/tag/v1.5.0)
+* Agave [v4.3.0-alpha.3](https://github.com/anza-xyz/agave/releases/tag/v4.3.0-alpha.3), [v4.2.0-rc.1](https://github.com/anza-xyz/agave/releases/tag/v4.2.0-rc.1)
+* Firedancer [Mainnet v1.1.3](https://github.com/firedancer-io/firedancer/releases/tag/v1.1.3)
+* Frankendancer [Mainnet v0.1007.40100](https://github.com/firedancer-io/firedancer/releases/tag/v0.1007.40100), [Testnet v0.1104.40200](https://github.com/firedancer-io/firedancer/releases/tag/v0.1104.40200)
+* solana-signature [v3.5.1](https://github.com/anza-xyz/solana-sdk/releases/tag/signature%40v3.5.1)
+* Wallet Standard [v1.1.6](https://github.com/anza-xyz/wallet-standard/releases/tag/%40solana/wallet-standard%401.1.6)
+* Stake Program [Rust SDK v4.4.0](https://github.com/solana-program/stake/releases/tag/interface%40v4.4.0)
+* Token 2022 Program [JS SDK v0.14.1](https://github.com/solana-program/token-2022/releases/tag/js%40v0.14.1)
+* ZK Elgamal Proof Program [WASM JS SDK v0.5.1](https://github.com/solana-program/zk-elgamal-proof/releases/tag/zk-sdk-wasm-js%40v0.5.1)
+* Subscriptions Program [Typescript SDK v0.5.0-beta.1](https://github.com/solana-foundation/subscriptions/releases/tag/ts-client-v0.5.0-beta.1), [Rust SDK v0.5.0-beta.1](https://github.com/solana-foundation/subscriptions/releases/tag/rust-client-v0.5.0-beta.1)
+* LiteSVM [v0.15.2](https://github.com/LiteSVM/litesvm/releases/tag/v0.15.2)
+* Surfpool [v1.5.0](https://github.com/solana-foundation/surfpool/releases/tag/v1.5.0)
 
 ## **Ecosystem work**
 
 **SIMDs**
 
-- A proposal to [set the right account data size when modifying a Solana program](https://github.com/solana-foundation/solana-improvement-documents/pull/433) has been accepted\
+* A proposal to [set the right account data size when modifying a Solana program](https://github.com/solana-foundation/solana-improvement-documents/pull/433) has been accepted\
   \
   **What this means (WTM)** - Modifying an existing program requires manually extending the program size before loading in the new update. This proposal makes extending that space automatic. 
 
-- A discussion on [prohibiting a self-withdrawal from a Vote account](https://github.com/solana-foundation/solana-improvement-documents/discussions/594) was created\
+
+* A discussion on [prohibiting a self-withdrawal from a Vote account](https://github.com/solana-foundation/solana-improvement-documents/discussions/594) was created\
   \
   **WTM** - This is a footgun within the existing Vote program. It allows the Vote account to withdraw SOL from itself and send it back to itself. The runtime treats this as a close account operation so the data in the Vote account is erased. 
 
+
+
 **Validator clients (Agave, Firedancer, Mithril)**
 
-- Additional [conformance](https://github.com/anza-xyz/agave/issues/12378) work was done on Agave, specifically for [instructions](https://github.com/anza-xyz/agave/pull/14264), [VM syscalls](https://github.com/anza-xyz/agave/pull/14236), [VM serialization](https://github.com/anza-xyz/agave/pull/14198), and [VM transaction running\
+* Additional [conformance](https://github.com/anza-xyz/agave/issues/12378) work was done on Agave, specifically for [instructions](https://github.com/anza-xyz/agave/pull/14264), [VM syscalls](https://github.com/anza-xyz/agave/pull/14236), [VM serialization](https://github.com/anza-xyz/agave/pull/14198), and [VM transaction running\
   \
   ](https://github.com/anza-xyz/agave/pull/14305)**WTM** - Fuzz testing is a form of programmatic testing that generates possible inputs to a system in order to find bugs. On Solana, not only should valid cases be the same for any validator client, but errors should also be the same bar for bar. Conformance allows for fuzz testing multiple validator client implementations in any language and from any version.  
 
-- Agave is [deprecating SysvarSerialize](https://github.com/anza-xyz/agave/issues/10672) on the solana-account crate\
+
+* Agave is [deprecating SysvarSerialize](https://github.com/anza-xyz/agave/issues/10672) on the solana-account crate\
   \
   **WTM** - Several pieces of the Agave code use a trait called SysvarSerialize, when a more generic method of serializing Sysvar accounts will do. This issue tracks the effort to remove this trait and its use all over the Agave stack. 
 
-- Agave is rethinking its [program reloading methodology](https://github.com/anza-xyz/agave/pull/14296) during transaction processing\
+
+* Agave is rethinking its [program reloading methodology](https://github.com/anza-xyz/agave/pull/14296) during transaction processing\
   \
   **WTM** - When instructions are executed in the runtime, a program cache is created before execution. All the programs among the instruction accounts are deserialized and loaded into memory. This is generally a problem because there’s a chance that the execution will fail and the program won’t get used, or that the program is only added in the instruction but not used at all. This change proposes a more incremental strategy where programs are loaded on an as-need basis. 
 
-- Leader [Turbine broadcasting caching and routing table rebuild](https://github.com/anza-xyz/agave/pull/14321) was improved on Agave\
+
+* Leader [Turbine broadcasting caching and routing table rebuild](https://github.com/anza-xyz/agave/pull/14321) was improved on Agave\
   \
   **WTM** - Leaders create blocks from transactions sent to them by the network and are responsible for breaking them up and sending them to validators as shreds. Solana does this through a system called Turbine, which breaks down from whom they get the shreds for the block and how the shreds are distributed across the network. This change allows a leader to more efficiently know who the peers in the network are and update its cache of that information more effectively.
 
-- Firedancer is [implementing snapshot creation\
+
+* Firedancer is [implementing snapshot creation\
   \
   ](https://github.com/firedancer-io/firedancer/pull/10609)**WTM** - Validators may create snapshots to make it easier to rebuild a starting point from which they can start participating in consensus and processing transactions. Firedancer did not produce snapshots before this change. It and Frankendancer used the embedded Agave validator to produce them. 
-- Firdancer will support [QUIC datagrams\
+* Firdancer will support [QUIC datagrams\
   \
   ](https://github.com/firedancer-io/firedancer/pull/10677)**WTM** - Both Agave and Firedancer now will be using QUIC datagrams instead of QUIC streams in order to send Alpenglow messages. This allows for more performance and does away with the overhead required by setting up QUIC stream connections. 
 
-- Mithril is [keeping updated on Agave’s conformance suite\
+
+* Mithril is [keeping updated on Agave’s conformance suite\
   \
   ](https://github.com/Overclock-Validator/mithril/pull/258)**WTM** - Mithril is a new validator implementation that will soon participate in consensus written in Go. The conformance suite allows for fuzz testing across multiple client implementations. Having this suite on Mithril’s side will allow it to keep up with Agave more closely moving forward.
 
+
+
 **RPC 2.0**
 
-- Superbank is [adding a request filter](https://github.com/solana-rpc/superbank/pull/64) for suspicious requests\
+* Superbank is [adding a request filter](https://github.com/solana-rpc/superbank/pull/64) for suspicious requests\
   \
   **WTM** - When creating a service that does data streaming, it’s possible to have spam requests that only add unnecessary load onto the system. This change allows Superbank to block those requests at the parameter level. 
 
+
+
 **Solana language clients (Web3.js, Solana Kit, Kit plugins, Solana SDK, Codama, Solana Go)**
 
-- Kit will add new react hooks, including [useAirdrop](https://github.com/anza-xyz/kit/pull/1879), [usePayer, useIdentity](https://github.com/anza-xyz/kit/pull/1876), [usePlanTransaction, usePlanTransactions, useSendTransaction, and useSendTransactions\
+* Kit will add new react hooks, including [useAirdrop](https://github.com/anza-xyz/kit/pull/1879), [usePayer, useIdentity](https://github.com/anza-xyz/kit/pull/1876), [usePlanTransaction, usePlanTransactions, useSendTransaction, and useSendTransactions\
   \
   ](https://github.com/anza-xyz/kit/pull/1869)**WTM** - These hooks allow React applications to more closely use these primitives and change application components based on state changes. 
 
+
+
 **Solana Program Library (SPL) and Core BPF**
 
-- The under-development ed25519-programmatic-signer program [added a nonce program implementation](https://github.com/solana-program/ed25519-programmatic-signer/pull/12) as their replacement for durable nonces\
+* The under-development ed25519-programmatic-signer program [added a nonce program implementation](https://github.com/solana-program/ed25519-programmatic-signer/pull/12) as their replacement for durable nonces\
   \
   **WTM** - This change is the SPL successor to the durable nonces implementation that currently lives onchain. This is now very similar to how [Vector](https://github.com/blueshift-gg/vector) from @blueshift works. 
 
+
+
 **Solana program frameworks (Anchor, Pinocchio, Steel, Quasar)**
 
-- Anchor will [support multisig authorities on its SPL token interface\
+* Anchor will [support multisig authorities on its SPL token interface\
   \
   ](https://github.com/otter-sec/anchor/pull/4870)**WTM** - It was always possible to assign a multisig address as the authority on an SPL token. This allows Anchor to give SPL tokens created by an Anchor program more flexibility in supporting this functionality. 
 
+
+
 **Testing frameworks (mollusk, litesvm, surfpool)**
 
-- Surfpool added a [stop command to their daemon service\
+* Surfpool added a [stop command to their daemon service\
   \
   ](https://github.com/solana-foundation/surfpool/pull/700)**WTM** - Usually, a user would need to type Ctrl+C in order to stop a running Surfpool instance. When running Surfpool in detached mode, you can now run an additional command that stops the service. It’s a standard interface in daemon services.
 
@@ -112,19 +129,19 @@ Upcoming feature gates [here](https://github.com/anza-xyz/agave/wiki/Feature-Gat
 
 Research posts, calls for talks, service releases, and developer resources rounded out the week. Several updates focused on fees, Alpenglow, Explorer improvements, and lower-level program performance work.
 
-- With the validator governance vote for resource fees ongoing, [@temporal](https://x.com/temporal_xyz/status/2085111376754962462?s=20) and @cavemanloveryboy published research on the new fee proposal, including [Cavey’s defense post](http://cavey.xyz/defense).
-- Calls for talks for Scale or Die are ongoing, with details in [Jacob Creech’s post](https://x.com/jacobvcreech/status/2084738370794627119?s=20).
-- [@dev_jodee shared usage and progress updates](https://x.com/dev_jodee/status/2084396256982352143?s=46) on the Subscriptions Program.
-- [@Solplay_jonas shared improvements](https://x.com/solplay_jonas/status/2084596572055019992?s=46) to Explorer.
-- Helius released a [filtering API for the Laserstream service](https://x.com/helius/status/2084388973867339883?s=46).
-- Jump Firedancer released a [Falcon signature verification implementation](https://x.com/jump_firedancer/status/2084293570740052023).
-- [@OkohEbina created a tool](https://x.com/OkohEbina/status/2083268775848112588?s=20) for diving deep into a Solana program’s sBPF assembly.
-- [@Subhdotsol shared guidance](https://x.com/Subhdotsol/status/2083912682034606573?s=20) on optimizing Solana programs by understanding the underlying assembly that runs on the validator as it is processed and replayed.
-- [@OkohEbina published a Devs at a Bar podcast](https://x.com/OkohEbina/status/2083507793957355637?s=20) with @cavemanloverboy.
-- Anza opened the [Alpenglow bug bounty](https://x.com/anza_xyz/status/2085033476575949111?s=20).
-- [@vyralabshq wrote about running a small validator](https://x.com/vyralabshq/status/2083184075813302589?s=46&t=Lpw8gmtR7Ax_A2A4o_APgQ) with relatively lower stake.
-- Anza shared a [post-quantum improvement to Alpenglow](https://x.com/anza_xyz/status/2082848421745160196?s=46).
+* With the validator governance vote for resource fees ongoing, [@temporal](https://x.com/temporal_xyz/status/2085111376754962462?s=20) and @cavemanloveryboy published research on the new fee proposal, including [Cavey’s defense post](http://cavey.xyz/defense).
+* Calls for talks for Scale or Die are ongoing, with details in [Jacob Creech’s post](https://x.com/jacobvcreech/status/2084738370794627119?s=20).
+* [@dev\_jodee shared usage and progress updates](https://x.com/dev_jodee/status/2084396256982352143?s=46) on the Subscriptions Program.
+* [@Solplay\_jonas shared improvements](https://x.com/solplay_jonas/status/2084596572055019992?s=46) to Explorer.
+* Helius released a [filtering API for the Laserstream service](https://x.com/helius/status/2084388973867339883?s=46).
+* Jump Firedancer released a [Falcon signature verification implementation](https://x.com/jump_firedancer/status/2084293570740052023).
+* [@OkohEbina created a tool](https://x.com/OkohEbina/status/2083268775848112588?s=20) for diving deep into a Solana program’s sBPF assembly.
+* [@Subhdotsol shared guidance](https://x.com/Subhdotsol/status/2083912682034606573?s=20) on optimizing Solana programs by understanding the underlying assembly that runs on the validator as it is processed and replayed.
+* [@OkohEbina published a Devs at a Bar podcast](https://x.com/OkohEbina/status/2083507793957355637?s=20) with @cavemanloverboy.
+* Anza opened the [Alpenglow bug bounty](https://x.com/anza_xyz/status/2085033476575949111?s=20).
+* [@vyralabshq wrote about running a small validator](https://x.com/vyralabshq/status/2083184075813302589?s=46\&t=Lpw8gmtR7Ax_A2A4o_APgQ) with relatively lower stake.
+* Anza shared a [post-quantum improvement to Alpenglow](https://x.com/anza_xyz/status/2082848421745160196?s=46).
 
 ## Follow along
 
-For weekly Solana engineering updates, follow [@solana_devs](https://x.com/solana_devs). You can also read [last week’s issue](https://x.com/solana_devs/status/2082808192434905316).
+For weekly Solana engineering updates, follow [@solana\_devs](https://x.com/solana_devs). You can also read [last week’s issue](https://x.com/solana_devs/status/2082808192434905316).

--- a/apps/media/content/posts/solana-changelog-august-6-2026.mdx
+++ b/apps/media/content/posts/solana-changelog-august-6-2026.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Solana Changelog: August 6, 2026'
+title: "Solana Changelog: August 6, 2026"
 status: published
 heroImage: /uploads/posts/solana-changelog-august-6-2026/heroImage.png
 description: >-
@@ -14,114 +14,97 @@ tags:
   - tag: newsletter
   - tag: technology
 ---
+
 ## **Releases**
 
 **Notable feature gates**
 
-* Lowering slot times from 400ms to 350ms - [Devnet](https://explorer.solana.com/address/iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ?cluster=devnet), [Testnet](https://explorer.solana.com/address/iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ?cluster=testnet)
+- Lowering slot times from 400ms to 350ms - [Devnet](https://explorer.solana.com/address/iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ?cluster=devnet), [Testnet](https://explorer.solana.com/address/iBRL5RuWhw4yqaAZu96RUULHckHTZAoe2b77qaV38JZ?cluster=testnet)
 
 Upcoming feature gates [here](https://github.com/anza-xyz/agave/wiki/Feature-Gate-Tracker-Schedule).
 
 **New versions**
 
-* Agave [v4.3.0-alpha.3](https://github.com/anza-xyz/agave/releases/tag/v4.3.0-alpha.3), [v4.2.0-rc.1](https://github.com/anza-xyz/agave/releases/tag/v4.2.0-rc.1)
-* Firedancer [Mainnet v1.1.3](https://github.com/firedancer-io/firedancer/releases/tag/v1.1.3)
-* Frankendancer [Mainnet v0.1007.40100](https://github.com/firedancer-io/firedancer/releases/tag/v0.1007.40100), [Testnet v0.1104.40200](https://github.com/firedancer-io/firedancer/releases/tag/v0.1104.40200)
-* solana-signature [v3.5.1](https://github.com/anza-xyz/solana-sdk/releases/tag/signature%40v3.5.1)
-* Wallet Standard [v1.1.6](https://github.com/anza-xyz/wallet-standard/releases/tag/%40solana/wallet-standard%401.1.6)
-* Stake Program [Rust SDK v4.4.0](https://github.com/solana-program/stake/releases/tag/interface%40v4.4.0)
-* Token 2022 Program [JS SDK v0.14.1](https://github.com/solana-program/token-2022/releases/tag/js%40v0.14.1)
-* ZK Elgamal Proof Program [WASM JS SDK v0.5.1](https://github.com/solana-program/zk-elgamal-proof/releases/tag/zk-sdk-wasm-js%40v0.5.1)
-* Subscriptions Program [Typescript SDK v0.5.0-beta.1](https://github.com/solana-foundation/subscriptions/releases/tag/ts-client-v0.5.0-beta.1), [Rust SDK v0.5.0-beta.1](https://github.com/solana-foundation/subscriptions/releases/tag/rust-client-v0.5.0-beta.1)
-* LiteSVM [v0.15.2](https://github.com/LiteSVM/litesvm/releases/tag/v0.15.2)
-* Surfpool [v1.5.0](https://github.com/solana-foundation/surfpool/releases/tag/v1.5.0)
+- Agave [v4.3.0-alpha.3](https://github.com/anza-xyz/agave/releases/tag/v4.3.0-alpha.3), [v4.2.0-rc.1](https://github.com/anza-xyz/agave/releases/tag/v4.2.0-rc.1)
+- Firedancer [Mainnet v1.1.3](https://github.com/firedancer-io/firedancer/releases/tag/v1.1.3)
+- Frankendancer [Mainnet v0.1007.40100](https://github.com/firedancer-io/firedancer/releases/tag/v0.1007.40100), [Testnet v0.1104.40200](https://github.com/firedancer-io/firedancer/releases/tag/v0.1104.40200)
+- solana-signature [v3.5.1](https://github.com/anza-xyz/solana-sdk/releases/tag/signature%40v3.5.1)
+- Wallet Standard [v1.1.6](https://github.com/anza-xyz/wallet-standard/releases/tag/%40solana/wallet-standard%401.1.6)
+- Stake Program [Rust SDK v4.4.0](https://github.com/solana-program/stake/releases/tag/interface%40v4.4.0)
+- Token 2022 Program [JS SDK v0.14.1](https://github.com/solana-program/token-2022/releases/tag/js%40v0.14.1)
+- ZK Elgamal Proof Program [WASM JS SDK v0.5.1](https://github.com/solana-program/zk-elgamal-proof/releases/tag/zk-sdk-wasm-js%40v0.5.1)
+- Subscriptions Program [Typescript SDK v0.5.0-beta.1](https://github.com/solana-foundation/subscriptions/releases/tag/ts-client-v0.5.0-beta.1), [Rust SDK v0.5.0-beta.1](https://github.com/solana-foundation/subscriptions/releases/tag/rust-client-v0.5.0-beta.1)
+- LiteSVM [v0.15.2](https://github.com/LiteSVM/litesvm/releases/tag/v0.15.2)
+- Surfpool [v1.5.0](https://github.com/solana-foundation/surfpool/releases/tag/v1.5.0)
 
 ## **Ecosystem work**
 
 **SIMDs**
 
-* A proposal to [set the right account data size when modifying a Solana program](https://github.com/solana-foundation/solana-improvement-documents/pull/433) has been accepted\
+- A proposal to [set the right account data size when modifying a Solana program](https://github.com/solana-foundation/solana-improvement-documents/pull/433) has been accepted\
   \
   **What this means (WTM)** - Modifying an existing program requires manually extending the program size before loading in the new update. This proposal makes extending that space automatic. 
 
-
-* A discussion on [prohibiting a self-withdrawal from a Vote account](https://github.com/solana-foundation/solana-improvement-documents/discussions/594) was created\
+- A discussion on [prohibiting a self-withdrawal from a Vote account](https://github.com/solana-foundation/solana-improvement-documents/discussions/594) was created\
   \
   **WTM** - This is a footgun within the existing Vote program. It allows the Vote account to withdraw SOL from itself and send it back to itself. The runtime treats this as a close account operation so the data in the Vote account is erased. 
 
-
-
 **Validator clients (Agave, Firedancer, Mithril)**
 
-* Additional [conformance](https://github.com/anza-xyz/agave/issues/12378) work was done on Agave, specifically for [instructions](https://github.com/anza-xyz/agave/pull/14264), [VM syscalls](https://github.com/anza-xyz/agave/pull/14236), [VM serialization](https://github.com/anza-xyz/agave/pull/14198), and [VM transaction running\
+- Additional [conformance](https://github.com/anza-xyz/agave/issues/12378) work was done on Agave, specifically for [instructions](https://github.com/anza-xyz/agave/pull/14264), [VM syscalls](https://github.com/anza-xyz/agave/pull/14236), [VM serialization](https://github.com/anza-xyz/agave/pull/14198), and [VM transaction running\
   \
   ](https://github.com/anza-xyz/agave/pull/14305)**WTM** - Fuzz testing is a form of programmatic testing that generates possible inputs to a system in order to find bugs. On Solana, not only should valid cases be the same for any validator client, but errors should also be the same bar for bar. Conformance allows for fuzz testing multiple validator client implementations in any language and from any version.  
 
-
-* Agave is [deprecating SysvarSerialize](https://github.com/anza-xyz/agave/issues/10672) on the solana-account crate\
+- Agave is [deprecating SysvarSerialize](https://github.com/anza-xyz/agave/issues/10672) on the solana-account crate\
   \
   **WTM** - Several pieces of the Agave code use a trait called SysvarSerialize, when a more generic method of serializing Sysvar accounts will do. This issue tracks the effort to remove this trait and its use all over the Agave stack. 
 
-
-* Agave is rethinking its [program reloading methodology](https://github.com/anza-xyz/agave/pull/14296) during transaction processing\
+- Agave is rethinking its [program reloading methodology](https://github.com/anza-xyz/agave/pull/14296) during transaction processing\
   \
   **WTM** - When instructions are executed in the runtime, a program cache is created before execution. All the programs among the instruction accounts are deserialized and loaded into memory. This is generally a problem because there’s a chance that the execution will fail and the program won’t get used, or that the program is only added in the instruction but not used at all. This change proposes a more incremental strategy where programs are loaded on an as-need basis. 
 
-
-* Leader [Turbine broadcasting caching and routing table rebuild](https://github.com/anza-xyz/agave/pull/14321) was improved on Agave\
+- Leader [Turbine broadcasting caching and routing table rebuild](https://github.com/anza-xyz/agave/pull/14321) was improved on Agave\
   \
   **WTM** - Leaders create blocks from transactions sent to them by the network and are responsible for breaking them up and sending them to validators as shreds. Solana does this through a system called Turbine, which breaks down from whom they get the shreds for the block and how the shreds are distributed across the network. This change allows a leader to more efficiently know who the peers in the network are and update its cache of that information more effectively.
 
-
-* Firedancer is [implementing snapshot creation\
+- Firedancer is [implementing snapshot creation\
   \
   ](https://github.com/firedancer-io/firedancer/pull/10609)**WTM** - Validators may create snapshots to make it easier to rebuild a starting point from which they can start participating in consensus and processing transactions. Firedancer did not produce snapshots before this change. It and Frankendancer used the embedded Agave validator to produce them. 
-* Firdancer will support [QUIC datagrams\
+- Firdancer will support [QUIC datagrams\
   \
   ](https://github.com/firedancer-io/firedancer/pull/10677)**WTM** - Both Agave and Firedancer now will be using QUIC datagrams instead of QUIC streams in order to send Alpenglow messages. This allows for more performance and does away with the overhead required by setting up QUIC stream connections. 
 
-
-* Mithril is [keeping updated on Agave’s conformance suite\
+- Mithril is [keeping updated on Agave’s conformance suite\
   \
   ](https://github.com/Overclock-Validator/mithril/pull/258)**WTM** - Mithril is a new validator implementation that will soon participate in consensus written in Go. The conformance suite allows for fuzz testing across multiple client implementations. Having this suite on Mithril’s side will allow it to keep up with Agave more closely moving forward.
 
-
-
 **RPC 2.0**
 
-* Superbank is [adding a request filter](https://github.com/solana-rpc/superbank/pull/64) for suspicious requests\
+- Superbank is [adding a request filter](https://github.com/solana-rpc/superbank/pull/64) for suspicious requests\
   \
   **WTM** - When creating a service that does data streaming, it’s possible to have spam requests that only add unnecessary load onto the system. This change allows Superbank to block those requests at the parameter level. 
 
-
-
 **Solana language clients (Web3.js, Solana Kit, Kit plugins, Solana SDK, Codama, Solana Go)**
 
-* Kit will add new react hooks, including [useAirdrop](https://github.com/anza-xyz/kit/pull/1879), [usePayer, useIdentity](https://github.com/anza-xyz/kit/pull/1876), [usePlanTransaction, usePlanTransactions, useSendTransaction, and useSendTransactions\
+- Kit will add new react hooks, including [useAirdrop](https://github.com/anza-xyz/kit/pull/1879), [usePayer, useIdentity](https://github.com/anza-xyz/kit/pull/1876), [usePlanTransaction, usePlanTransactions, useSendTransaction, and useSendTransactions\
   \
   ](https://github.com/anza-xyz/kit/pull/1869)**WTM** - These hooks allow React applications to more closely use these primitives and change application components based on state changes. 
 
-
-
 **Solana Program Library (SPL) and Core BPF**
 
-* The under-development ed25519-programmatic-signer program [added a nonce program implementation](https://github.com/solana-program/ed25519-programmatic-signer/pull/12) as their replacement for durable nonces\
+- The under-development ed25519-programmatic-signer program [added a nonce program implementation](https://github.com/solana-program/ed25519-programmatic-signer/pull/12) as their replacement for durable nonces\
   \
   **WTM** - This change is the SPL successor to the durable nonces implementation that currently lives onchain. This is now very similar to how [Vector](https://github.com/blueshift-gg/vector) from @blueshift works. 
 
-
-
 **Solana program frameworks (Anchor, Pinocchio, Steel, Quasar)**
 
-* Anchor will [support multisig authorities on its SPL token interface\
+- Anchor will [support multisig authorities on its SPL token interface\
   \
   ](https://github.com/otter-sec/anchor/pull/4870)**WTM** - It was always possible to assign a multisig address as the authority on an SPL token. This allows Anchor to give SPL tokens created by an Anchor program more flexibility in supporting this functionality. 
 
-
-
 **Testing frameworks (mollusk, litesvm, surfpool)**
 
-* Surfpool added a [stop command to their daemon service\
+- Surfpool added a [stop command to their daemon service\
   \
   ](https://github.com/solana-foundation/surfpool/pull/700)**WTM** - Usually, a user would need to type Ctrl+C in order to stop a running Surfpool instance. When running Surfpool in detached mode, you can now run an additional command that stops the service. It’s a standard interface in daemon services.
 
@@ -129,19 +112,19 @@ Upcoming feature gates [here](https://github.com/anza-xyz/agave/wiki/Feature-Gat
 
 Research posts, calls for talks, service releases, and developer resources rounded out the week. Several updates focused on fees, Alpenglow, Explorer improvements, and lower-level program performance work.
 
-* With the validator governance vote for resource fees ongoing, [@temporal](https://x.com/temporal_xyz/status/2085111376754962462?s=20) and @cavemanloveryboy published research on the new fee proposal, including [Cavey’s defense post](http://cavey.xyz/defense).
-* Calls for talks for Scale or Die are ongoing, with details in [Jacob Creech’s post](https://x.com/jacobvcreech/status/2084738370794627119?s=20).
-* [@dev\_jodee shared usage and progress updates](https://x.com/dev_jodee/status/2084396256982352143?s=46) on the Subscriptions Program.
-* [@Solplay\_jonas shared improvements](https://x.com/solplay_jonas/status/2084596572055019992?s=46) to Explorer.
-* Helius released a [filtering API for the Laserstream service](https://x.com/helius/status/2084388973867339883?s=46).
-* Jump Firedancer released a [Falcon signature verification implementation](https://x.com/jump_firedancer/status/2084293570740052023).
-* [@OkohEbina created a tool](https://x.com/OkohEbina/status/2083268775848112588?s=20) for diving deep into a Solana program’s sBPF assembly.
-* [@Subhdotsol shared guidance](https://x.com/Subhdotsol/status/2083912682034606573?s=20) on optimizing Solana programs by understanding the underlying assembly that runs on the validator as it is processed and replayed.
-* [@OkohEbina published a Devs at a Bar podcast](https://x.com/OkohEbina/status/2083507793957355637?s=20) with @cavemanloverboy.
-* Anza opened the [Alpenglow bug bounty](https://x.com/anza_xyz/status/2085033476575949111?s=20).
-* [@vyralabshq wrote about running a small validator](https://x.com/vyralabshq/status/2083184075813302589?s=46\&t=Lpw8gmtR7Ax_A2A4o_APgQ) with relatively lower stake.
-* Anza shared a [post-quantum improvement to Alpenglow](https://x.com/anza_xyz/status/2082848421745160196?s=46).
+- With the validator governance vote for resource fees ongoing, [@temporal](https://x.com/temporal_xyz/status/2085111376754962462?s=20) and @cavemanloveryboy published research on the new fee proposal, including [Cavey’s defense post](http://cavey.xyz/defense).
+- Calls for talks for Scale or Die are ongoing, with details in [Jacob Creech’s post](https://x.com/jacobvcreech/status/2084738370794627119?s=20).
+- [@dev_jodee shared usage and progress updates](https://x.com/dev_jodee/status/2084396256982352143?s=46) on the Subscriptions Program.
+- [@Solplay_jonas shared improvements](https://x.com/solplay_jonas/status/2084596572055019992?s=46) to Explorer.
+- Helius released a [filtering API for the Laserstream service](https://x.com/helius/status/2084388973867339883?s=46).
+- Jump Firedancer released a [Falcon signature verification implementation](https://x.com/jump_firedancer/status/2084293570740052023).
+- [@OkohEbina created a tool](https://x.com/OkohEbina/status/2083268775848112588?s=20) for diving deep into a Solana program’s sBPF assembly.
+- [@Subhdotsol shared guidance](https://x.com/Subhdotsol/status/2083912682034606573?s=20) on optimizing Solana programs by understanding the underlying assembly that runs on the validator as it is processed and replayed.
+- [@OkohEbina published a Devs at a Bar podcast](https://x.com/OkohEbina/status/2083507793957355637?s=20) with @cavemanloverboy.
+- Anza opened the [Alpenglow bug bounty](https://x.com/anza_xyz/status/2085033476575949111?s=20).
+- [@vyralabshq wrote about running a small validator](https://x.com/vyralabshq/status/2083184075813302589?s=46&t=Lpw8gmtR7Ax_A2A4o_APgQ) with relatively lower stake.
+- Anza shared a [post-quantum improvement to Alpenglow](https://x.com/anza_xyz/status/2082848421745160196?s=46).
 
 ## Follow along
 
-For weekly Solana engineering updates, follow [@solana\_devs](https://x.com/solana_devs). You can also read [last week’s issue](https://x.com/solana_devs/status/2082808192434905316).
+For weekly Solana engineering updates, follow [@solana_devs](https://x.com/solana_devs). You can also read [last week’s issue](https://x.com/solana_devs/status/2082808192434905316).


### PR DESCRIPTION
## Problem

The Kit example in `core/accounts/account-types.mdx` calls `client.airdrop()` on a client built from `solanaRpc` alone:

```
TS2339: Property 'airdrop' does not exist on type 'Client<...>'
```

`rpcAirdrop` is bundled only into `solanaDevnetRpc` and `solanaLocalRpc` — never plain `solanaRpc` — so the block could not compile as written.

## Changes

Installs `rpcAirdrop()` explicitly, matching the pattern already used by the mint example earlier on the same page.

## Verification

Extracted the block to a `.ts` file and ran `tsc --strict` against the workspace's installed Kit versions — exit 0, was `TS2339`. `pnpm lint --filter solana-docs` passes.

## Notes

Found while auditing DEV-834. That ticket proposed converting read-only examples off `generatedPayer()` to `solanaRpcConnection`; we opted to keep `solanaRpc` as the house idiom, so this PR carries only the compile fix.

Nothing checks these blocks today — `packages/docs-examples` only covers code transcluded via `file=...`, which is almost entirely `content/cookbook`. The 596 inline `ts` fences in `docs/en` are unchecked, which is why this shipped green. Filed as DEV-843.

Refs DEV-834