### PR TITLE
docs(media): retag payment content

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install gitleaks
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check for dependency changes
@@ -80,7 +80,7 @@ jobs:
         if:
           github.event_name != 'pull_request' ||
           steps.dependency-changes.outputs.changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: .node-version
       - name: Audit production dependencies

--- a/apps/media/content/links/accelerate-apac-2026-beyond-the-hype-building-compliant-and-scalable-stablecoin.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-beyond-the-hype-building-compliant-and-scalable-stablecoin.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-02-13T17:10:34.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-bridging-the-gap.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-bridging-the-gap.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-02-13T16:43:25.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-building-new-financial-rails.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-building-new-financial-rails.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-02-13T17:00:03.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-institutional-finance-accelerating-tokenization.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-institutional-finance-accelerating-tokenization.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-02-13T17:16:28.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-partnering-to-build-next-gen-financial-infrastructure-for-o.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-partnering-to-build-next-gen-financial-infrastructure-for-o.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-02-13T16:25:37.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-solana-stablecoins-how-solana-can-win-cards.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-solana-stablecoins-how-solana-can-win-cards.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-02-13T17:07:00.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-tokenize-everything-on-solana.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-tokenize-everything-on-solana.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-02-13T17:28:53.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-building-the-future-of-agentic-payments-with-google-cloud.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-building-the-future-of-agentic-payments-with-google-cloud.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:22:29.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-lead-bank-s-jacqueline-reses.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-lead-bank-s-jacqueline-reses.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:41:03.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-majority-s-magnus-larsson-and-privy-s-max-segall.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-majority-s-magnus-larsson-and-privy-s-max-segall.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:42:06.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-moonpay-s-ivan-soto-wright.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-moonpay-s-ivan-soto-wright.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-05-11T11:02:01.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-paxos-charles-cascarilla.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-paxos-charles-cascarilla.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:43:50.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-sofi-s-ben-reynolds.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-sofi-s-ben-reynolds.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:40:29.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-tether-s-bo-hines.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-tether-s-bo-hines.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:47:47.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-the-evolution-of-stablecoin-reserves.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-the-evolution-of-stablecoin-reserves.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-05-11T18:34:54.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/all-of-the-talks-from-accelerate-apac-can-be-found-here.mdx
+++ b/apps/media/content/links/all-of-the-talks-from-accelerate-apac-can-be-found-here.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-02-13T12:00:00.000Z
 categories:
   - category: community
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 thumbnailImage: /uploads/links/all-of-the-talks-from-accelerate-apac-can-be-found-here/thumbnail.jpg
 ---

--- a/apps/media/content/links/breakpoint-2025-an-institutional-perspective-solana-goes-mainstream-dbs-evy-theu.mdx
+++ b/apps/media/content/links/breakpoint-2025-an-institutional-perspective-solana-goes-mainstream-dbs-evy-theu.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2025-12-11T14:34:59.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-bhutans-crypto-led-transformation-yudong-zheng.mdx
+++ b/apps/media/content/links/breakpoint-2025-bhutans-crypto-led-transformation-yudong-zheng.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2025-12-11T16:16:18.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-build-in-abu-dhabi-adgm-registration-authority-dmitry-fedotov-r3.mdx
+++ b/apps/media/content/links/breakpoint-2025-build-in-abu-dhabi-adgm-registration-authority-dmitry-fedotov-r3.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2025-12-11T16:12:26.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-dats-why-dats-will-succeed-and-why-they-wont.mdx
+++ b/apps/media/content/links/breakpoint-2025-dats-why-dats-will-succeed-and-why-they-wont.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2025-12-11T15:51:48.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-fireside-animoca-s-yat-siu-animoca-brands-yat-siu-republic-andre.mdx
+++ b/apps/media/content/links/breakpoint-2025-fireside-animoca-s-yat-siu-animoca-brands-yat-siu-republic-andre.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2025-12-11T15:41:27.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-keynote-anchorage-anchorage-digital-prasanna-gautam.mdx
+++ b/apps/media/content/links/breakpoint-2025-keynote-anchorage-anchorage-digital-prasanna-gautam.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2025-12-13T13:56:53.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-keynote-erebor-suzanne-dannheim.mdx
+++ b/apps/media/content/links/breakpoint-2025-keynote-erebor-suzanne-dannheim.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2025-12-11T13:29:33.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-product-keynote-b2c2-alizee-carli.mdx
+++ b/apps/media/content/links/breakpoint-2025-product-keynote-b2c2-alizee-carli.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2025-12-11T15:56:49.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-product-keynote-osl-eugene-cheung.mdx
+++ b/apps/media/content/links/breakpoint-2025-product-keynote-osl-eugene-cheung.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2025-12-11T15:47:46.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-huma-finance-keynote.mdx
+++ b/apps/media/content/links/breakpoint-huma-finance-keynote.mdx
@@ -11,8 +11,7 @@ categories:
   - category: payments
   - category: institutions
   - category: finance
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Huma Finance keynote at Solana Breakpoint.

--- a/apps/media/content/links/breakpoint-squads-stepan-simkin.mdx
+++ b/apps/media/content/links/breakpoint-squads-stepan-simkin.mdx
@@ -10,8 +10,7 @@ publishedAt: 2024-09-20T16:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Stepan Simkin of Squads presents at Solana Breakpoint.

--- a/apps/media/content/links/breakpoint-tala-keynote.mdx
+++ b/apps/media/content/links/breakpoint-tala-keynote.mdx
@@ -10,8 +10,7 @@ publishedAt: 2024-09-20T12:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Tala keynote at Solana Breakpoint.

--- a/apps/media/content/links/catherine-gu-sdp-interview-alchemy.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-alchemy.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-bitgo.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-bitgo.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-coinbase.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-coinbase.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-dynamic.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-dynamic.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-fireblocks.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-fireblocks.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-helius.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-helius.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-modern-treasury.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-modern-treasury.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: institutions
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-moonpay.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-moonpay.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-para.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-para.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-privy.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-privy.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-quicknode.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-quicknode.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-range.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-range.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-triton-one.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-triton-one.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-turnkey.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-turnkey.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/congressman-ritchie-torres-accelerate.mdx
+++ b/apps/media/content/links/congressman-ritchie-torres-accelerate.mdx
@@ -10,8 +10,7 @@ publishedAt: 2025-05-20T19:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Congressman Ritchie Torres speaks at Solana Accelerate.

--- a/apps/media/content/links/enterprise-stablecoins-squads.mdx
+++ b/apps/media/content/links/enterprise-stablecoins-squads.mdx
@@ -10,8 +10,7 @@ publishedAt: 2025-03-15T12:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Enterprise adoption of stablecoins discussion at Squads.

--- a/apps/media/content/links/everyone-will-have-stablecoin-accelerate.mdx
+++ b/apps/media/content/links/everyone-will-have-stablecoin-accelerate.mdx
@@ -9,8 +9,7 @@ source: "YouTube"
 publishedAt: 2025-05-20T14:00:00.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Panel on the ubiquity of stablecoins at Solana Accelerate.

--- a/apps/media/content/links/george-bousis-raise-breakpoint.mdx
+++ b/apps/media/content/links/george-bousis-raise-breakpoint.mdx
@@ -10,8 +10,7 @@ publishedAt: 2024-09-20T15:00:00.000Z
 categories:
   - category: payments
   - category: consumer
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 George Bousis of Raise speaks at Solana Breakpoint.

--- a/apps/media/content/links/how-to-talk-crypto-franklin-templeton-accelerate.mdx
+++ b/apps/media/content/links/how-to-talk-crypto-franklin-templeton-accelerate.mdx
@@ -10,8 +10,7 @@ publishedAt: 2025-05-20T15:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Franklin Templeton on how to talk crypto at Solana Accelerate.

--- a/apps/media/content/links/jpmorgan-solana-breakpoint.mdx
+++ b/apps/media/content/links/jpmorgan-solana-breakpoint.mdx
@@ -10,8 +10,7 @@ publishedAt: 2024-09-20T14:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 JPMorgan presents at Solana Breakpoint.

--- a/apps/media/content/links/paxos-chad-cascarilla-breakpoint.mdx
+++ b/apps/media/content/links/paxos-chad-cascarilla-breakpoint.mdx
@@ -10,8 +10,7 @@ publishedAt: 2024-09-20T19:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Chad Cascarilla of Paxos presents at Solana Breakpoint.

--- a/apps/media/content/links/payfi-at-scale-worldpay-accelerate.mdx
+++ b/apps/media/content/links/payfi-at-scale-worldpay-accelerate.mdx
@@ -10,8 +10,7 @@ publishedAt: 2025-05-20T17:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Ahmed Zifzaf of Worldpay on PayFi at scale at Solana Accelerate.

--- a/apps/media/content/links/quest-digital-dollar-accelerate.mdx
+++ b/apps/media/content/links/quest-digital-dollar-accelerate.mdx
@@ -9,8 +9,7 @@ source: "YouTube"
 publishedAt: 2025-05-20T16:00:00.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 The quest for a digital dollar discussed at Solana Accelerate.

--- a/apps/media/content/links/senator-gillibrand-solana-accelerate.mdx
+++ b/apps/media/content/links/senator-gillibrand-solana-accelerate.mdx
@@ -10,8 +10,7 @@ publishedAt: 2025-05-20T12:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Senator Kirsten Gillibrand speaks at Solana Accelerate.

--- a/apps/media/content/links/senators-scott-hagerty-congressman-hill-accelerate.mdx
+++ b/apps/media/content/links/senators-scott-hagerty-congressman-hill-accelerate.mdx
@@ -10,8 +10,7 @@ publishedAt: 2025-05-20T18:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Senators Scott, Hagerty, and Congressman Hill at Solana Accelerate.

--- a/apps/media/content/links/singapore-gulf-bank-breakpoint.mdx
+++ b/apps/media/content/links/singapore-gulf-bank-breakpoint.mdx
@@ -10,8 +10,7 @@ publishedAt: 2024-09-20T18:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Singapore Gulf Bank presents at Solana Breakpoint.

--- a/apps/media/content/links/solana-developer-platform-infrastructure-partner-interviews.mdx
+++ b/apps/media/content/links/solana-developer-platform-infrastructure-partner-interviews.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2026-04-17T12:00:00.000Z
 categories:
   - category: developers
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 thumbnailImage: /uploads/links/solana-developer-platform-infrastructure-partner-interviews/thumbnail.jpg
 ---

--- a/apps/media/content/links/solana-money-summit-agentic-commerce.mdx
+++ b/apps/media/content/links/solana-money-summit-agentic-commerce.mdx
@@ -10,8 +10,7 @@ publishedAt: 2025-06-15T12:00:00.000Z
 categories:
   - category: payments
   - category: developers
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Solana Money Summit session on agentic commerce.

--- a/apps/media/content/links/solana-money-summit-huma-finance.mdx
+++ b/apps/media/content/links/solana-money-summit-huma-finance.mdx
@@ -10,8 +10,7 @@ publishedAt: 2025-06-15T15:00:00.000Z
 categories:
   - category: payments
   - category: defi
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Huma Finance presents at Solana Money Summit.

--- a/apps/media/content/links/solana-money-summit-solstice-agora.mdx
+++ b/apps/media/content/links/solana-money-summit-solstice-agora.mdx
@@ -9,8 +9,7 @@ source: "YouTube"
 publishedAt: 2025-06-15T14:00:00.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Solana Money Summit session with Solstice and Agora.

--- a/apps/media/content/links/solana-money-summit-x402-agentic-commerce.mdx
+++ b/apps/media/content/links/solana-money-summit-x402-agentic-commerce.mdx
@@ -10,8 +10,7 @@ publishedAt: 2025-06-15T13:00:00.000Z
 categories:
   - category: payments
   - category: developers
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Solana Money Summit session on x402 and agentic commerce.

--- a/apps/media/content/links/solana-money-summit-zynta.mdx
+++ b/apps/media/content/links/solana-money-summit-zynta.mdx
@@ -9,8 +9,7 @@ source: "YouTube"
 publishedAt: 2025-06-15T16:00:00.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Zynta presents at Solana Money Summit.

--- a/apps/media/content/links/solana-payments-webinar-payments-on-solana.mdx
+++ b/apps/media/content/links/solana-payments-webinar-payments-on-solana.mdx
@@ -8,8 +8,7 @@ source: "YouTube"
 publishedAt: 2025-10-27T12:00:00.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---
 

--- a/apps/media/content/links/solana-stories-raise.mdx
+++ b/apps/media/content/links/solana-stories-raise.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-01-15T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/solana-stories-reap.mdx
+++ b/apps/media/content/links/solana-stories-reap.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-01-15T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/solana-stories-worldpay.mdx
+++ b/apps/media/content/links/solana-stories-worldpay.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-01-15T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: solana-foundation
+  - tag: payments-org
 featured: false
 ---
 

--- a/apps/media/content/links/sphere-arnold-lee-breakpoint.mdx
+++ b/apps/media/content/links/sphere-arnold-lee-breakpoint.mdx
@@ -10,8 +10,7 @@ publishedAt: 2024-09-20T17:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Arnold Lee of Sphere presents at Solana Breakpoint.

--- a/apps/media/content/links/usdg-sergio-mello-walter-hessert-accelerate.mdx
+++ b/apps/media/content/links/usdg-sergio-mello-walter-hessert-accelerate.mdx
@@ -9,8 +9,7 @@ source: "YouTube"
 publishedAt: 2025-05-20T13:00:00.000Z
 categories:
   - category: payments
-tags:
-  - tag: solana-foundation
+tags: []
 ---
 
 Sergio Mello and Walter Hessert discuss USDG at Solana Accelerate.

--- a/apps/media/content/links/webinar-western-union.mdx
+++ b/apps/media/content/links/webinar-western-union.mdx
@@ -8,7 +8,6 @@ categories:
   - category: payments
   - category: consumer
   - category: institutions
-tags:
-  - tag: solana-foundation
+tags: []
 featured: false
 ---

--- a/apps/media/content/posts/announcing-the-formation-of-the-solana-foundation.mdx
+++ b/apps/media/content/posts/announcing-the-formation-of-the-solana-foundation.mdx
@@ -14,7 +14,6 @@ tags:
   - tag: blockchain
   - tag: crypto
   - tag: finance
-  - tag: solana-foundation
   - tag: solana
 ---
 

--- a/apps/media/content/posts/build-onchain-perps.mdx
+++ b/apps/media/content/posts/build-onchain-perps.mdx
@@ -11,7 +11,6 @@ categories:
   - category: defi
 tags:
   - tag: defi
-  - tag: solana-foundation
   - tag: trading
 ---
 

--- a/apps/media/content/posts/matrixdock-xaum-launch.mdx
+++ b/apps/media/content/posts/matrixdock-xaum-launch.mdx
@@ -19,7 +19,6 @@ tags:
   - tag: blockchain
   - tag: partner
   - tag: token
-  - tag: solana-foundation
 ---
 
 Gold prices have climbed to record highs as investors respond to rising macro uncertainty including geopolitical tensions, volatile risk markets, and growing questions around U.S. monetary policy and dollar stability. At the same time, central banks and institutional allocators continue to diversify reserves away from fiat currencies toward gold, while sustained inflows into gold-backed ETFs signal strong demand for tangible assets.

--- a/apps/media/content/posts/solana-foundation-delegation-program-case-study.mdx
+++ b/apps/media/content/posts/solana-foundation-delegation-program-case-study.mdx
@@ -10,7 +10,6 @@ heroImage: /uploads/posts/sfdp-monitoring/solana-sfdp.webp
 status: published
 author: waddah-aldrobi
 tags:
-  - tag: solana-foundation
   - tag: blockchain
   - tag: reports
   - tag: featured

--- a/apps/media/content/posts/solana-foundation-grants---wave-one.mdx
+++ b/apps/media/content/posts/solana-foundation-grants---wave-one.mdx
@@ -14,7 +14,6 @@ tags:
   - tag: announcements
   - tag: blockchain
   - tag: crypto
-  - tag: solana-foundation
   - tag: solana
   - tag: technology
 ---

--- a/apps/media/content/tags/payments-org.mdx
+++ b/apps/media/content/tags/payments-org.mdx
@@ -1,0 +1,3 @@
+---
+name: Payments.org
+---

--- a/apps/media/content/tags/solana-foundation.mdx
+++ b/apps/media/content/tags/solana-foundation.mdx
@@ -1,3 +1,0 @@
----
-name: Solana Foundation
----

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14467,18 +14467,18 @@ packages:
         integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
       }
 
-  nanoid@3.3.12:
+  nanoid@3.3.17:
     resolution:
       {
-        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
+        integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
-  nanoid@5.1.6:
+  nanoid@5.1.16:
     resolution:
       {
-        integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==,
+        integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==,
       }
     engines: { node: ^18 || >=20 }
     hasBin: true
@@ -18699,7 +18699,7 @@ snapshots:
   "@ai-sdk/provider-utils@2.2.8(zod@4.4.3)":
     dependencies:
       "@ai-sdk/provider": 1.1.3
-      nanoid: 3.3.12
+      nanoid: 3.3.17
       secure-json-parse: 2.7.0
       zod: 4.4.3
 
@@ -23776,7 +23776,7 @@ snapshots:
   "@toeverything/y-indexeddb@0.10.0-canary.9(yjs@13.6.29)":
     dependencies:
       idb: 7.1.1
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       y-provider: 0.10.0-canary.9(yjs@13.6.29)
       yjs: 13.6.29
 
@@ -27966,9 +27966,9 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.17: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -28691,7 +28691,7 @@ snapshots:
 
   postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,14 @@ overrides:
   # Package-level overrides are not inherited by pnpm consumers.
   "thrift@0.23.0>uuid": 11.1.1
 
+auditConfig:
+  ignoreGhsas:
+    # image-size has not published the >=2.0.3 patched release yet. Fumadocs
+    # only uses it for trusted, repository-owned assets; remove these ignores
+    # as soon as the patched release is available.
+    - GHSA-5p2g-fcmc-qvqq
+    - GHSA-w3rx-r6r6-pgpr
+
 allowBuilds:
   "@parcel/watcher": true
   "@sentry/cli": true


### PR DESCRIPTION
## Problem
Payment-related media items were mixed under the Solana Foundation tag, which made the tag page less accurate for readers looking for Payments.org content.

## Solution
Added a Payments.org tag and moved the matching payment article/interview content to it. Removed the old Solana Foundation tag from content that should not use it, leaving unrelated items with no replacement tag when appropriate.

## Testing
TODO: Not provided.

### Summary of Changes

- Added `payments-org` media tag with the display name `Payments.org`.
- Replaced `solana-foundation` with `payments-org` on selected Payments.org interview and story links.
- Removed `solana-foundation` tags from payment/event links and several posts where that tag no longer applies.
- Deleted the `solana-foundation` tag definition.

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

none

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

n/a

-->