### PR TITLE
fix(ci): unblock dependency audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Install gitleaks
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check for dependency changes
@@ -80,7 +80,7 @@ jobs:
         if:
           github.event_name != 'pull_request' ||
           steps.dependency-changes.outputs.changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version-file: .node-version
       - name: Audit production dependencies

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14464,18 +14464,18 @@ packages:
         integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==,
       }
 
-  nanoid@3.3.12:
+  nanoid@3.3.17:
     resolution:
       {
-        integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==,
+        integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
 
-  nanoid@5.1.6:
+  nanoid@5.1.16:
     resolution:
       {
-        integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==,
+        integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==,
       }
     engines: { node: ^18 || >=20 }
     hasBin: true
@@ -18696,7 +18696,7 @@ snapshots:
   "@ai-sdk/provider-utils@2.2.8(zod@4.4.3)":
     dependencies:
       "@ai-sdk/provider": 1.1.3
-      nanoid: 3.3.12
+      nanoid: 3.3.17
       secure-json-parse: 2.7.0
       zod: 4.4.3
 
@@ -23773,7 +23773,7 @@ snapshots:
   "@toeverything/y-indexeddb@0.10.0-canary.9(yjs@13.6.29)":
     dependencies:
       idb: 7.1.1
-      nanoid: 5.1.6
+      nanoid: 5.1.16
       y-provider: 0.10.0-canary.9(yjs@13.6.29)
       yjs: 13.6.29
 
@@ -27963,9 +27963,9 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.17: {}
 
-  nanoid@5.1.6: {}
+  nanoid@5.1.16: {}
 
   natural-compare@1.4.0: {}
 
@@ -28688,7 +28688,7 @@ snapshots:
 
   postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,14 @@ overrides:
   # Package-level overrides are not inherited by pnpm consumers.
   "thrift@0.23.0>uuid": 11.1.1
 
+auditConfig:
+  ignoreGhsas:
+    # image-size has not published the >=2.0.3 patched release yet. Fumadocs
+    # only uses it for trusted, repository-owned assets; remove these ignores
+    # as soon as the patched release is available.
+    - GHSA-5p2g-fcmc-qvqq
+    - GHSA-w3rx-r6r6-pgpr
+
 allowBuilds:
   "@parcel/watcher": true
   "@sentry/cli": true


### PR DESCRIPTION
### Problem

The pnpm dependency audit failed after new High-severity advisories were published for transitive `nanoid` and `image-size` releases. The security workflow also warned that checkout and setup-node still targeted the deprecated Node.js 20 action runtime.

### Summary of Changes

- Update the locked `nanoid` 3.x and 5.x releases to patched versions within their existing compatible ranges.
- Temporarily ignore the two `image-size` advisories because the declared patched release (`>=2.0.3`) is not yet published and compatible Fumadocs 15.x releases still depend on `^2.0.2`.
- Document that the ignores must be removed once the patched package is available.
- Move checkout and setup-node to their Node.js 24-backed v5 actions.

---

### Change classification (SDLC §2)

- [x] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] No new user or external-service input handling is introduced.
- [x] Updated dependencies are justified below, and the CI `pnpm audit` command passes.
- [x] No production error-handling path is changed.
- [x] The trust-boundary note for this Critical CI security-gate change is included below.

New dependencies: none. Transitive `nanoid` is updated from 3.3.12 to 3.3.17 and from 5.1.6 to 5.1.16 to pick up the published security fixes.

Threat-model note: the temporary exceptions cover denial-of-service parsing flaws in `image-size`, reached through Fumadocs while processing trusted, repository-owned documentation assets. A malicious committed asset could hang a docs build; no untrusted runtime upload path is introduced. All other High/Critical advisories remain enforced, and both exceptions are documented for removal as soon as `image-size@2.0.3` or newer is published.

### Validation

- `pnpm audit --audit-level high --prod`
- Prettier check for the changed workflow/workspace YAML
- `git diff --check`