### PR TITLE
fix: align sub-navigation with global header

### DIFF
--- a/apps/docs/src/app/components/docs-layout.tsx
+++ b/apps/docs/src/app/components/docs-layout.tsx
@@ -81,7 +81,7 @@ function CustomSidebar() {
     <>
       <CollapsibleSidebar
         className="md:bg-transparent text-base data-[collapsed=true]:pointer-events-none"
-        style={{ maxHeight: "calc(100vh - 65px)" }}
+        style={{ maxHeight: "calc(100vh - var(--fd-nav-height))" }}
       >
         <SidebarViewport>
           <div className="mt-1">

--- a/apps/docs/src/app/globals.css
+++ b/apps/docs/src/app/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 .fumadocs {
-  --fd-nav-height: 65px;
+  --fd-nav-height: 56px;
   --fd-muted-foreground: 225.88deg 7.42% 55.1%;
   --background: 0deg 0% 100%;
   --foreground: 255deg 14.71% 21%;

--- a/apps/docs/src/components/learn/mobile-chapter-navigation.tsx
+++ b/apps/docs/src/components/learn/mobile-chapter-navigation.tsx
@@ -26,7 +26,7 @@ export default function MobileChapterNavigation({
   translations,
 }: MobileChapterNavigationProps) {
   return (
-    <div className="xl:hidden sticky top-16 z-50 -mx-4 px-4 pb-8 bg-[rgb(18_18_18_/_95%)] backdrop-blur-md">
+    <div className="xl:hidden sticky top-14 z-50 -mx-4 px-4 pb-8 bg-[rgb(18_18_18_/_95%)] backdrop-blur-md">
       <details className="rounded-lg relative">
         <summary
           className="px-4 py-3 cursor-pointer flex items-center justify-between text-white hover:bg-zinc-800 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:ring-offset-black"

--- a/apps/media/components/news/news-masthead.tsx
+++ b/apps/media/components/news/news-masthead.tsx
@@ -79,12 +79,12 @@ export function NewsMasthead({
 
       {/*
         Sticky section nav. Sticks directly beneath the global site header
-        (sticky top-0, ~65px mobile / ~71px desktop) so verticals stay reachable
+        (sticky top-0, 56px) so verticals stay reachable
         while scrolling. z-40 keeps it below the global header's z-50.
       */}
       <nav
         aria-label={t("navLabel")}
-        className="sticky top-[65px] lg:top-[71px] z-40 border-y border-border bg-background/85 backdrop-blur-md"
+        className="sticky top-14 z-40 border-y border-border bg-background/85 backdrop-blur-md"
       >
         <div className="max-w-6xl mx-auto w-full px-4 md:px-6 lg:px-0">
           <ul className="flex flex-nowrap gap-x-6 overflow-x-auto overflow-y-hidden whitespace-nowrap md:flex-wrap md:whitespace-normal">

--- a/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
+++ b/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
@@ -472,7 +472,7 @@ export function SolanaDataDashboard() {
 
         <nav
           aria-label={t("controls.ariaLabel")}
-          className="sticky top-[65px] lg:top-[71px] z-40 mt-8 -mx-4 md:-mx-8 xl:-mx-10 bg-nd-inverse/90 backdrop-blur-md border-y border-nd-border-light"
+          className="sticky top-14 z-40 mt-8 -mx-4 md:-mx-8 xl:-mx-10 bg-nd-inverse/90 backdrop-blur-md border-y border-nd-border-light"
         >
           <DashboardControls
             activeTab={activeTab}

--- a/apps/web/src/components/skills/SkillsGrid.tsx
+++ b/apps/web/src/components/skills/SkillsGrid.tsx
@@ -92,7 +92,7 @@ export function SkillsGrid({
 
   return (
     <div className="flex flex-col">
-      <div className="sticky top-[57px] xl:top-[65px] z-40 bg-black/80 backdrop-blur-md border-b border-white/10">
+      <div className="sticky top-14 z-40 bg-black/80 backdrop-blur-md border-b border-white/10">
         <div className="max-w-[1440px] mx-auto px-[20px] md:px-[32px] xl:px-[40px] w-full py-3">
           <div className="flex flex-wrap items-center gap-2">
             <div className="relative group/search">


### PR DESCRIPTION
## Summary
- align sticky web and media sub-navigation with the shared 56px global header
- update the docs navigation height token and mobile chapter navigation
- remove the docs sidebar’s duplicated header-height value

## Validation
- pnpm --filter solana-com lint
- pnpm --filter solana-com-media lint
- pnpm --filter solana-docs lint
- Playwright: verified `/news` sticky alignment at 375, 640, 768, 1024, 1280, and 1536px; measured 0px gap at each width