### PR TITLE
feat(x402): add ByKaranteli to the x402 ecosystem projects

### DIFF
--- a/apps/web/src/data/solutions/x402.ts
+++ b/apps/web/src/data/solutions/x402.ts
@@ -23,6 +23,10 @@ export const PRODUCTS = [
     key: "cdp",
     href: "https://docs.cdp.coinbase.com/embedded-wallets/welcome",
   },
+  {
+    key: "bykaranteli",
+    href: "https://bykaranteli.com/developers",
+  },
 ];
 
 export const TOOLS = [

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -7045,6 +7045,10 @@
       "cdp": {
         "title": "CDP Wallet",
         "description": "Embedded wallet solution built by the Coinbase Development Platform"
+      },
+      "bykaranteli": {
+        "title": "ByKaranteli",
+        "description": "Crypto derivatives data sold per call over x402: multi-exchange liquidation maps, options flow and order-flow toxicity, settled in USDC on Solana"
       }
     },
     "tools": {


### PR DESCRIPTION
### Problem

The ecosystem section on `/x402` is a hardcoded array in `apps/web/src/data/solutions/x402.ts` with no submission path, so an x402 service running on Solana has no way to be represented there. Today the six entries are protocol-level infrastructure (x402.org, Corbits, PayAI, x402scan, T54, CDP Wallet) and there is no example of an actual paid resource selling data over the protocol on Solana.

### Summary of Changes

Adds one entry, ByKaranteli, to `PRODUCTS` plus the matching English `title` / `description` under `x402.ecoProjects` in `packages/i18n/messages/web/en/common.json`, since `products.v2.tsx` resolves the entry `key` through `t(...)` and would throw on a missing key. English only; the Lingo action propagates the other locales.

ByKaranteli sells crypto derivatives market structure per call over x402: multi-exchange liquidation maps and raw liquidation events, funding and open-interest history, Deribit options tape and options open interest, DVOL, CFTC COT positioning, Coinbase premium, execution-slippage ladders, perp listing history and VPIN order-flow toxicity. **13 paid endpoints priced $0.002 to $0.010 USDC**, settled on Solana mainnet through the **Coinbase CDP facilitator** (Base mainnet is also accepted at the same price). No account, no API key. Live surfaces:

- Free catalog: https://bykaranteli.com/api/x402
- OpenAPI: https://bykaranteli.com/openapi.json
- Developer docs (the `href` used here): https://bykaranteli.com/developers
- Paid endpoints return an x402 v2 `402` challenge with Solana USDC in `accepts`

**Correction (2026-08-09):** an earlier revision of this description said "$0.002 to $0.005 ... through the PayAI facilitator". Both were true when the PR was opened and are now stale: the catalog grew from 3 to 13 endpoints and settlement moved to the Coinbase CDP facilitator. The diff itself did not carry a price, a count or a facilitator name, so no code change was needed; only this description was wrong.

Being straightforward about fit: we are a merchant on x402, not infrastructure for it, so if this section is deliberately reserved for protocol-level projects please close this and treat it as a data point that sellers would like a route onto the page. A separate PR is open at `solana-foundation/pay-skills` for the registry side.

Fixes #

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none": -->

none

<!-- Threat-model note for Critical changes, or "n/a": -->

n/a. Content-only change: one entry in a static array and one English message key. No code paths, no dependencies, no runtime behaviour changed.
