### PR TITLE
content(media): add Produced by Solana provenance tag

### DIFF
--- a/apps/media/content/links/accelerate-apac-2026-beyond-the-hype-building-compliant-and-scalable-stablecoin.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-beyond-the-hype-building-compliant-and-scalable-stablecoin.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-02-13T17:10:34.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-bridging-the-gap.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-bridging-the-gap.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-02-13T16:43:25.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-building-new-financial-rails.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-building-new-financial-rails.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-02-13T17:00:03.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-institutional-finance-accelerating-tokenization.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-institutional-finance-accelerating-tokenization.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-02-13T17:16:28.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-partnering-to-build-next-gen-financial-infrastructure-for-o.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-partnering-to-build-next-gen-financial-infrastructure-for-o.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-02-13T16:25:37.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-solana-stablecoins-how-solana-can-win-cards.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-solana-stablecoins-how-solana-can-win-cards.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-02-13T17:07:00.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-apac-2026-tokenize-everything-on-solana.mdx
+++ b/apps/media/content/links/accelerate-apac-2026-tokenize-everything-on-solana.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-02-13T17:28:53.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-building-the-future-of-agentic-payments-with-google-cloud.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-building-the-future-of-agentic-payments-with-google-cloud.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:22:29.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-lead-bank-s-jacqueline-reses.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-lead-bank-s-jacqueline-reses.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:41:03.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-majority-s-magnus-larsson-and-privy-s-max-segall.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-majority-s-magnus-larsson-and-privy-s-max-segall.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:42:06.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-moonpay-s-ivan-soto-wright.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-moonpay-s-ivan-soto-wright.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-05-11T11:02:01.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-paxos-charles-cascarilla.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-paxos-charles-cascarilla.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:43:50.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-sofi-s-ben-reynolds.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-sofi-s-ben-reynolds.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:40:29.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-tether-s-bo-hines.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-tether-s-bo-hines.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-05-11T12:47:47.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/accelerate-usa-2026-the-evolution-of-stablecoin-reserves.mdx
+++ b/apps/media/content/links/accelerate-usa-2026-the-evolution-of-stablecoin-reserves.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-05-11T18:34:54.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/all-of-the-talks-from-accelerate-apac-can-be-found-here.mdx
+++ b/apps/media/content/links/all-of-the-talks-from-accelerate-apac-can-be-found-here.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-02-13T12:00:00.000Z
 categories:
   - category: community
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 thumbnailImage: /uploads/links/all-of-the-talks-from-accelerate-apac-can-be-found-here/thumbnail.jpg
 ---

--- a/apps/media/content/links/breakpoint-2025-an-institutional-perspective-solana-goes-mainstream-dbs-evy-theu.mdx
+++ b/apps/media/content/links/breakpoint-2025-an-institutional-perspective-solana-goes-mainstream-dbs-evy-theu.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2025-12-11T14:34:59.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-build-in-abu-dhabi-adgm-registration-authority-dmitry-fedotov-r3.mdx
+++ b/apps/media/content/links/breakpoint-2025-build-in-abu-dhabi-adgm-registration-authority-dmitry-fedotov-r3.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2025-12-11T16:12:26.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-dats-why-dats-will-succeed-and-why-they-wont.mdx
+++ b/apps/media/content/links/breakpoint-2025-dats-why-dats-will-succeed-and-why-they-wont.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2025-12-11T15:51:48.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-fireside-animoca-s-yat-siu-animoca-brands-yat-siu-republic-andre.mdx
+++ b/apps/media/content/links/breakpoint-2025-fireside-animoca-s-yat-siu-animoca-brands-yat-siu-republic-andre.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2025-12-11T15:41:27.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-keynote-anchorage-anchorage-digital-prasanna-gautam.mdx
+++ b/apps/media/content/links/breakpoint-2025-keynote-anchorage-anchorage-digital-prasanna-gautam.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2025-12-13T13:56:53.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-keynote-erebor-suzanne-dannheim.mdx
+++ b/apps/media/content/links/breakpoint-2025-keynote-erebor-suzanne-dannheim.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2025-12-11T13:29:33.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-product-keynote-b2c2-alizee-carli.mdx
+++ b/apps/media/content/links/breakpoint-2025-product-keynote-b2c2-alizee-carli.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2025-12-11T15:56:49.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-2025-product-keynote-osl-eugene-cheung.mdx
+++ b/apps/media/content/links/breakpoint-2025-product-keynote-osl-eugene-cheung.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2025-12-11T15:47:46.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/breakpoint-huma-finance-keynote.mdx
+++ b/apps/media/content/links/breakpoint-huma-finance-keynote.mdx
@@ -11,7 +11,8 @@ categories:
   - category: payments
   - category: institutions
   - category: finance
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Huma Finance keynote at Solana Breakpoint.

--- a/apps/media/content/links/breakpoint-squads-stepan-simkin.mdx
+++ b/apps/media/content/links/breakpoint-squads-stepan-simkin.mdx
@@ -10,7 +10,8 @@ publishedAt: 2024-09-20T16:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Stepan Simkin of Squads presents at Solana Breakpoint.

--- a/apps/media/content/links/breakpoint-tala-keynote.mdx
+++ b/apps/media/content/links/breakpoint-tala-keynote.mdx
@@ -10,7 +10,8 @@ publishedAt: 2024-09-20T12:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Tala keynote at Solana Breakpoint.

--- a/apps/media/content/links/catherine-gu-sdp-interview-alchemy.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-alchemy.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-bitgo.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-bitgo.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-coinbase.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-coinbase.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-dynamic.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-dynamic.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-fireblocks.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-fireblocks.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-helius.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-helius.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-modern-treasury.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-modern-treasury.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: institutions
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-moonpay.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-moonpay.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-para.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-para.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-privy.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-privy.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-quicknode.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-quicknode.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-range.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-range.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-triton-one.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-triton-one.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/catherine-gu-sdp-interview-turnkey.mdx
+++ b/apps/media/content/links/catherine-gu-sdp-interview-turnkey.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-03-20T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/congressman-ritchie-torres-accelerate.mdx
+++ b/apps/media/content/links/congressman-ritchie-torres-accelerate.mdx
@@ -10,7 +10,8 @@ publishedAt: 2025-05-20T19:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Congressman Ritchie Torres speaks at Solana Accelerate.

--- a/apps/media/content/links/enterprise-stablecoins-squads.mdx
+++ b/apps/media/content/links/enterprise-stablecoins-squads.mdx
@@ -10,7 +10,8 @@ publishedAt: 2025-03-15T12:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Enterprise adoption of stablecoins discussion at Squads.

--- a/apps/media/content/links/everyone-will-have-stablecoin-accelerate.mdx
+++ b/apps/media/content/links/everyone-will-have-stablecoin-accelerate.mdx
@@ -9,7 +9,8 @@ source: "YouTube"
 publishedAt: 2025-05-20T14:00:00.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Panel on the ubiquity of stablecoins at Solana Accelerate.

--- a/apps/media/content/links/george-bousis-raise-breakpoint.mdx
+++ b/apps/media/content/links/george-bousis-raise-breakpoint.mdx
@@ -10,7 +10,8 @@ publishedAt: 2024-09-20T15:00:00.000Z
 categories:
   - category: payments
   - category: consumer
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 George Bousis of Raise speaks at Solana Breakpoint.

--- a/apps/media/content/links/how-to-talk-crypto-franklin-templeton-accelerate.mdx
+++ b/apps/media/content/links/how-to-talk-crypto-franklin-templeton-accelerate.mdx
@@ -10,7 +10,8 @@ publishedAt: 2025-05-20T15:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Franklin Templeton on how to talk crypto at Solana Accelerate.

--- a/apps/media/content/links/jpmorgan-solana-breakpoint.mdx
+++ b/apps/media/content/links/jpmorgan-solana-breakpoint.mdx
@@ -10,7 +10,8 @@ publishedAt: 2024-09-20T14:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 JPMorgan presents at Solana Breakpoint.

--- a/apps/media/content/links/paxos-chad-cascarilla-breakpoint.mdx
+++ b/apps/media/content/links/paxos-chad-cascarilla-breakpoint.mdx
@@ -10,7 +10,8 @@ publishedAt: 2024-09-20T19:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Chad Cascarilla of Paxos presents at Solana Breakpoint.

--- a/apps/media/content/links/payfi-at-scale-worldpay-accelerate.mdx
+++ b/apps/media/content/links/payfi-at-scale-worldpay-accelerate.mdx
@@ -10,7 +10,8 @@ publishedAt: 2025-05-20T17:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Ahmed Zifzaf of Worldpay on PayFi at scale at Solana Accelerate.

--- a/apps/media/content/links/quest-digital-dollar-accelerate.mdx
+++ b/apps/media/content/links/quest-digital-dollar-accelerate.mdx
@@ -9,7 +9,8 @@ source: "YouTube"
 publishedAt: 2025-05-20T16:00:00.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 The quest for a digital dollar discussed at Solana Accelerate.

--- a/apps/media/content/links/senator-gillibrand-solana-accelerate.mdx
+++ b/apps/media/content/links/senator-gillibrand-solana-accelerate.mdx
@@ -10,7 +10,8 @@ publishedAt: 2025-05-20T12:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Senator Kirsten Gillibrand speaks at Solana Accelerate.

--- a/apps/media/content/links/senators-scott-hagerty-congressman-hill-accelerate.mdx
+++ b/apps/media/content/links/senators-scott-hagerty-congressman-hill-accelerate.mdx
@@ -10,7 +10,8 @@ publishedAt: 2025-05-20T18:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Senators Scott, Hagerty, and Congressman Hill at Solana Accelerate.

--- a/apps/media/content/links/singapore-gulf-bank-breakpoint.mdx
+++ b/apps/media/content/links/singapore-gulf-bank-breakpoint.mdx
@@ -10,7 +10,8 @@ publishedAt: 2024-09-20T18:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Singapore Gulf Bank presents at Solana Breakpoint.

--- a/apps/media/content/links/solana-developer-platform-infrastructure-partner-interviews.mdx
+++ b/apps/media/content/links/solana-developer-platform-infrastructure-partner-interviews.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2026-04-17T12:00:00.000Z
 categories:
   - category: developers
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 thumbnailImage: /uploads/links/solana-developer-platform-infrastructure-partner-interviews/thumbnail.jpg
 ---

--- a/apps/media/content/links/solana-money-summit-agentic-commerce.mdx
+++ b/apps/media/content/links/solana-money-summit-agentic-commerce.mdx
@@ -10,7 +10,8 @@ publishedAt: 2025-06-15T12:00:00.000Z
 categories:
   - category: payments
   - category: developers
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Solana Money Summit session on agentic commerce.

--- a/apps/media/content/links/solana-money-summit-huma-finance.mdx
+++ b/apps/media/content/links/solana-money-summit-huma-finance.mdx
@@ -10,7 +10,8 @@ publishedAt: 2025-06-15T15:00:00.000Z
 categories:
   - category: payments
   - category: defi
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Huma Finance presents at Solana Money Summit.

--- a/apps/media/content/links/solana-money-summit-solstice-agora.mdx
+++ b/apps/media/content/links/solana-money-summit-solstice-agora.mdx
@@ -9,7 +9,8 @@ source: "YouTube"
 publishedAt: 2025-06-15T14:00:00.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Solana Money Summit session with Solstice and Agora.

--- a/apps/media/content/links/solana-money-summit-x402-agentic-commerce.mdx
+++ b/apps/media/content/links/solana-money-summit-x402-agentic-commerce.mdx
@@ -10,7 +10,8 @@ publishedAt: 2025-06-15T13:00:00.000Z
 categories:
   - category: payments
   - category: developers
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Solana Money Summit session on x402 and agentic commerce.

--- a/apps/media/content/links/solana-money-summit-zynta.mdx
+++ b/apps/media/content/links/solana-money-summit-zynta.mdx
@@ -9,7 +9,8 @@ source: "YouTube"
 publishedAt: 2025-06-15T16:00:00.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Zynta presents at Solana Money Summit.

--- a/apps/media/content/links/solana-payments-webinar-payments-on-solana.mdx
+++ b/apps/media/content/links/solana-payments-webinar-payments-on-solana.mdx
@@ -8,7 +8,8 @@ source: "YouTube"
 publishedAt: 2025-10-27T12:00:00.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/solana-stories-raise.mdx
+++ b/apps/media/content/links/solana-stories-raise.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-01-15T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/solana-stories-reap.mdx
+++ b/apps/media/content/links/solana-stories-reap.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-01-15T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/solana-stories-worldpay.mdx
+++ b/apps/media/content/links/solana-stories-worldpay.mdx
@@ -9,7 +9,8 @@ publishedAt: 2026-01-15T12:00:00.000Z
 categories:
   - category: ecosystem
 tags:
-  - tag: payments-org
+  - tag: payments
+  - tag: produced-by-solana
 featured: false
 ---
 

--- a/apps/media/content/links/sphere-arnold-lee-breakpoint.mdx
+++ b/apps/media/content/links/sphere-arnold-lee-breakpoint.mdx
@@ -10,7 +10,8 @@ publishedAt: 2024-09-20T17:00:00.000Z
 categories:
   - category: payments
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Arnold Lee of Sphere presents at Solana Breakpoint.

--- a/apps/media/content/links/usdg-sergio-mello-walter-hessert-accelerate.mdx
+++ b/apps/media/content/links/usdg-sergio-mello-walter-hessert-accelerate.mdx
@@ -9,7 +9,8 @@ source: "YouTube"
 publishedAt: 2025-05-20T13:00:00.000Z
 categories:
   - category: payments
-tags: []
+tags:
+  - tag: produced-by-solana
 ---
 
 Sergio Mello and Walter Hessert discuss USDG at Solana Accelerate.

--- a/apps/media/content/links/webinar-corporate-treasuries-on-solana.mdx
+++ b/apps/media/content/links/webinar-corporate-treasuries-on-solana.mdx
@@ -11,6 +11,7 @@ categories:
   - category: finance
 tags:
   - tag: payments
+  - tag: produced-by-solana
   - tag: finance
   - tag: partner
 featured: false

--- a/apps/media/content/links/webinar-western-union.mdx
+++ b/apps/media/content/links/webinar-western-union.mdx
@@ -8,6 +8,7 @@ categories:
   - category: payments
   - category: consumer
   - category: institutions
-tags: []
+tags:
+  - tag: produced-by-solana
 featured: false
 ---

--- a/apps/media/content/posts/announcing-the-formation-of-the-solana-foundation.mdx
+++ b/apps/media/content/posts/announcing-the-formation-of-the-solana-foundation.mdx
@@ -11,6 +11,7 @@ heroImage: >-
 status: published
 author: solana-foundation
 tags:
+  - tag: produced-by-solana
   - tag: blockchain
   - tag: crypto
   - tag: finance

--- a/apps/media/content/posts/build-onchain-perps.mdx
+++ b/apps/media/content/posts/build-onchain-perps.mdx
@@ -10,6 +10,7 @@ publishedAt: 2026-06-01T17:00:00.000Z
 categories:
   - category: defi
 tags:
+  - tag: produced-by-solana
   - tag: defi
   - tag: trading
 ---

--- a/apps/media/content/posts/matrixdock-xaum-launch.mdx
+++ b/apps/media/content/posts/matrixdock-xaum-launch.mdx
@@ -14,6 +14,7 @@ categories:
   - category: defi
   - category: institutions
 tags:
+  - tag: produced-by-solana
   - tag: defi
   - tag: finance
   - tag: blockchain

--- a/apps/media/content/posts/solana-foundation-delegation-program-case-study.mdx
+++ b/apps/media/content/posts/solana-foundation-delegation-program-case-study.mdx
@@ -10,6 +10,7 @@ heroImage: /uploads/posts/sfdp-monitoring/solana-sfdp.webp
 status: published
 author: waddah-aldrobi
 tags:
+  - tag: produced-by-solana
   - tag: blockchain
   - tag: reports
   - tag: featured

--- a/apps/media/content/posts/solana-foundation-grants---wave-one.mdx
+++ b/apps/media/content/posts/solana-foundation-grants---wave-one.mdx
@@ -11,6 +11,7 @@ heroImage: >-
 status: published
 author: solana-foundation
 tags:
+  - tag: produced-by-solana
   - tag: announcements
   - tag: blockchain
   - tag: crypto

--- a/apps/media/content/tags/payments-org.mdx
+++ b/apps/media/content/tags/payments-org.mdx
@@ -1,3 +1,0 @@
----
-name: Payments.org
----

--- a/apps/media/content/tags/produced-by-solana.mdx
+++ b/apps/media/content/tags/produced-by-solana.mdx
@@ -1,0 +1,3 @@
+---
+name: Produced by Solana
+---


### PR DESCRIPTION
## Summary
- replace the `payments-org` taxonomy tag with `Produced by Solana`
- restore the prior provenance assignments across Media content
- preserve Payments relevance by adding the `payments` tag to the 17 former override videos
- exclude the Real Vision-hosted Breakpoint video and include the Solana-produced corporate treasury webinar

## Verification
- `pnpm --filter solana-com-media typecheck`
- audited the resulting payment-video set: 65 produced-by-Solana videos and 11 third-party videos

## Follow-up
This content migration is paired with the payments.org selector PR, which applies this tag only to Insights video Links.