### PR TITLE
docs: add Haskell SDK to community clients

### DIFF
--- a/apps/docs/content/docs/en/clients/community/haskell.mdx
+++ b/apps/docs/content/docs/en/clients/community/haskell.mdx
@@ -1,0 +1,109 @@
+---
+title: Haskell SDK
+description:
+  Learn how to interact with Solana using the Haskell SDK (solana-haskell-sdk).
+h1: Haskell SDK for Solana
+---
+
+## Solana Haskell SDK
+
+[`solana-haskell-sdk`](https://github.com/mariusgeorgescu/solana-haskell-sdk)
+
+- Build, sign, and submit transactions from Haskell, including sponsored fees
+  (an explicit fee payer with automatic signature ordering), durable nonces,
+  and priority fees.
+- Clients for the native programs (System, Stake, Vote, Address Lookup Table,
+  BPF Loader, Compute Budget, Secp256k1), SPL Token and Associated Token
+  Account, and Metaplex Token Metadata.
+- Versioned (v0) transactions with address lookup tables, plus decoders for
+  on-chain account state: token accounts, mints, lookup tables, stake and
+  nonce accounts, and metadata.
+- A [Solana JSON RPC API](/docs/rpc) client and PubSub (WebSocket)
+  subscriptions with push-based transaction confirmation.
+- Serialization is verified byte-for-byte against the official Rust crates by
+  golden-vector tests.
+- Available on
+  [Hackage](https://hackage.haskell.org/package/solana-haskell-sdk), with full
+  API documentation on the package page.
+
+## Installation
+
+Add `solana-haskell-sdk` to your project's `build-depends`, or install it
+directly from [Hackage](https://hackage.haskell.org/package/solana-haskell-sdk):
+
+```bash
+cabal update
+cabal install --lib solana-haskell-sdk
+```
+
+## Transfer SOL
+
+The examples use `GHC2021` (the package's `default-language`). This program
+generates a keypair, funds it with an airdrop on a local validator, and
+transfers 1 SOL:
+
+```haskell
+{-# LANGUAGE OverloadedStrings #-}
+
+module Main where
+
+import Control.Monad (void)
+import Control.Monad.IO.Class (liftIO)
+import Network.Solana.Core.Crypto
+import Network.Solana.NativePrograms.SystemProgram qualified as SystemProgram
+import Network.Solana.RPC.HTTP.Transaction
+import Network.Solana.SolanaWeb3
+import Network.Web3.Provider
+
+main :: IO ()
+main = do
+  -- Generate keypairs for fee payer (sender)
+  (myPublicKey, myPrivateKey) <- createSolanaKeyPair
+
+  -- Create Connection, local validator in this example
+  result <- runWeb3' (HttpProvider "http://127.0.0.1:8899") $ do
+    -- Fund fee payer
+    void $ requestAirdrop myPublicKey 10_000_000_000
+    wait 15 -- Wait 15 seconds be sure the tx was confirmed
+
+    -- Define recipient's address from a base58-encoded string
+    let recipient = "A988FuUtUVk8jMUuVc1ccaoTA3VS9CB4dkEf9XUAUqV4"
+
+    -- Check balance
+    printBalances [myPublicKey, recipient]
+
+    -- Create a new transaction.
+    txId <-
+      newTransaction
+        [myPrivateKey] -- Signing keys (with all required signers)
+        -- List of instructions
+        [ SystemProgram.transfer
+            myPublicKey -- sender address
+            recipient -- recipient address
+            1_000_000_000 -- amount to transfer 1 SOL
+        ]
+    liftIO $ putStrLn ("Transaction sent: " <> show txId)
+
+    void $ confirmTransaction txId
+    -- Check balance
+    printBalances [myPublicKey, recipient]
+
+  either (\e -> putStrLn ("RPC error: " <> show e)) pure result
+```
+
+## Push-based confirmation over WebSocket
+
+The SDK speaks Solana's PubSub protocol without depending on a WebSocket
+library — you supply the connection (for example with the
+[`websockets`](https://hackage.haskell.org/package/websockets) package), and
+`awaitSignature` waits for the confirmation to be pushed instead of polling:
+
+```haskell
+import Network.Solana.RPC.WebSocket
+import Network.WebSockets qualified as WS
+
+WS.runClient "127.0.0.1" 8900 "/" $ \conn -> do
+  let transport = WsTransport (WS.sendTextData conn) (WS.receiveData conn)
+  result <- awaitSignature transport (RequestId 1) (Just "confirmed") 30 signature
+  print result -- Right <slot>, or Left with the on-chain or protocol error
+```

--- a/apps/docs/content/docs/en/clients/community/meta.json
+++ b/apps/docs/content/docs/en/clients/community/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Python, Java, Go & More",
-  "pages": ["python", "java", "go", "game-sdks"],
+  "pages": ["python", "java", "go", "haskell", "game-sdks"],
   "defaultOpen": false
 }

--- a/apps/docs/content/docs/en/clients/index.mdx
+++ b/apps/docs/content/docs/en/clients/index.mdx
@@ -23,6 +23,10 @@ hideTableOfContents: true
   <Card title="Go" href="/docs/clients/community/go">
     solana-go for Go clients and services.
   </Card>
+  <Card title="Haskell" href="/docs/clients/community/haskell">
+    solana-haskell-sdk for building, signing, and sending transactions from
+    Haskell.
+  </Card>
   <Card title="Game SDKs" href="/docs/clients/community/game-sdks">
     Unity, Godot, Unreal, and other game engine integrations.
   </Card>


### PR DESCRIPTION
### Problem

The community client SDKs page (`/docs/clients`) lists Python, Java, Go, and
game-engine SDKs, but has no entry for Haskell. Haskell developers building on
Solana have no discoverable starting point on solana.com.

### Summary of Changes

Adds the Haskell SDK to the community clients docs, in the same format as the
existing Python/Java/Go entries:

- `apps/docs/content/docs/en/clients/community/haskell.mdx` — new community
  client page for
  [solana-haskell-sdk](https://github.com/mariusgeorgescu/solana-haskell-sdk),
  published on [Hackage](https://hackage.haskell.org/package/solana-haskell-sdk)
  (v1.2.0.0) with full API documentation. CI is green; the package has 352
  unit tests, serialization verified byte-for-byte against the official Rust
  crates via golden-vector tests, and a local-validator integration suite
  covering transfers, SPL tokens, durable nonces, address lookup tables with
  v0 transactions, and WebSocket confirmation.
- `apps/docs/content/docs/en/clients/community/meta.json` — registers the new
  `haskell` page in the community clients section nav.
- `apps/docs/content/docs/en/clients/index.mdx` — adds a Haskell card to the
  clients index, placed after Go and before Game SDKs.

Docs-only change; no code, dependencies, or configuration touched.

Fixes # N/A

---

### Change classification (SDLC §2)

- [x] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser). — N/A, no secrets involved; content-only MDX/JSON changes.
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input. — N/A,
      no user input or HTML rendering introduced.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories). — No new or updated
      dependencies.
- [x] Errors are handled explicitly — no silent failures on production
      paths. — N/A, static documentation content only.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested. — N/A, not a
      Critical change.

<!-- New dependencies (name + why), or "none": -->

none

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a": -->

n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
