### PR TITLE
Add Breakpoint invitation letter FAQ

### DIFF
--- a/apps/breakpoint/src/content/faq-page.ts
+++ b/apps/breakpoint/src/content/faq-page.ts
@@ -143,6 +143,13 @@ export const faqPageSections = [
           "Entry requirements depend on your passport and travel plans. Review the official UK visa checker before booking travel.",
       },
       {
+        id: "travel-invitation-letter",
+        question: "How do I request an invitation letter?",
+        answer: "Please email",
+        answerHref: "mailto:breakpoint@solana.org",
+        answerLinkLabel: "breakpoint@solana.org",
+      },
+      {
         id: "travel-venue",
         question: "How do I get to Olympia Convention Centre?",
         answer:


### PR DESCRIPTION
## Summary
- add a travel FAQ for requesting an invitation letter
- link breakpoint@solana.org with a mailto link

## Validation
- pnpm -w exec prettier --ignore-path .prettierignore --check apps/breakpoint/src/content/faq-page.ts
- git diff --check
- pnpm --filter solana-com-breakpoint check-types *(fails: existing unresolved @solana-foundation/fab-menu module in src/components/FabMenu.tsx)*