### PR TITLE
Use FluxRPC brand amber for the RPC dashboard series color

### DIFF
--- a/apps/web/src/app/[locale]/data/data-config.ts
+++ b/apps/web/src/app/[locale]/data/data-config.ts
@@ -482,7 +482,7 @@ export const providerColors: Record<string, string> = {
   Chainstack: "#7B61FF",
   DeFiLlama: "#3B8CFF",
   Dune: "#F75F47",
-  FluxRPC: "#FF5C5C",
+  FluxRPC: "#F2C14E",
   Helius: "#E84125",
   Jito: "#A78BFA",
   QuickNode: "#6CFF75",


### PR DESCRIPTION
### Why

`#FF5C5C` for FluxRPC sits right next to Helius `#E84125`. On the RPC tab the two legend swatches read as the same colour at a glance, we'd like to switch FluxRPC to yellow so that the distinction is clearer:

```
alchemy      #2196F3
chainstack   #7B61FF
fluxrpc      #F2C14E   <- changed
helius       #E84125
quicknode    #6CFF75
triton       #A12CFF
```
