### PR TITLE
content(media): backfill payments links

### DIFF
--- a/apps/media/content/links/accelerate-ai-bringing-agentic-commerce-to-life.mdx
+++ b/apps/media/content/links/accelerate-ai-bringing-agentic-commerce-to-life.mdx
@@ -1,0 +1,16 @@
+---
+title: "Accelerate AI: Bringing Agentic Commerce to Life"
+url: "https://www.youtube.com/watch?v=4DNIGMRdY2U"
+linkType: video
+description: "Accelerate AI: Bringing Agentic Commerce to Life"
+source: "YouTube"
+publishedAt: 2026-05-14T16:54:55.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+  - tag: produced-by-solana
+featured: false
+---
+
+Accelerate AI: Bringing Agentic Commerce to Life

--- a/apps/media/content/links/accelerate-ai-eternal-agents-institutional-x402.mdx
+++ b/apps/media/content/links/accelerate-ai-eternal-agents-institutional-x402.mdx
@@ -1,0 +1,16 @@
+---
+title: "Accelerate AI: How we built Eternal Agents & Institutional x402"
+url: "https://www.youtube.com/watch?v=_buvMvf2JXg"
+linkType: video
+description: "Accelerate AI: How we built Eternal Agents & Institutional x402"
+source: "YouTube"
+publishedAt: 2026-05-14T16:56:38.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+  - tag: produced-by-solana
+featured: false
+---
+
+Accelerate AI: How we built Eternal Agents & Institutional x402

--- a/apps/media/content/links/accelerate-ai-moonpay-x-pay-skills.mdx
+++ b/apps/media/content/links/accelerate-ai-moonpay-x-pay-skills.mdx
@@ -1,0 +1,16 @@
+---
+title: "Accelerate AI: MoonPay x Pay Skills"
+url: "https://www.youtube.com/watch?v=Vz0bNlW9cvE"
+linkType: video
+description: "Accelerate AI: MoonPay x Pay Skills"
+source: "YouTube"
+publishedAt: 2026-05-15T11:08:58.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+  - tag: produced-by-solana
+featured: false
+---
+
+Accelerate AI: MoonPay x Pay Skills

--- a/apps/media/content/links/accelerate-ai-why-open-standards-matter-for-agentic-commerce.mdx
+++ b/apps/media/content/links/accelerate-ai-why-open-standards-matter-for-agentic-commerce.mdx
@@ -1,0 +1,16 @@
+---
+title: "Accelerate AI: Why open standards matter for agentic commerce with Erik Reppel, Founder of x402"
+url: "https://www.youtube.com/watch?v=6Dy9tPKone0"
+linkType: video
+description: "Accelerate AI: Why open standards matter for agentic commerce with Erik Reppel, Founder of x402"
+source: "YouTube"
+publishedAt: 2026-05-15T11:07:04.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+  - tag: produced-by-solana
+featured: false
+---
+
+Accelerate AI: Why open standards matter for agentic commerce with Erik Reppel, Founder of x402

--- a/apps/media/content/links/accelerate-fintech-building-global-payout-infrastructure.mdx
+++ b/apps/media/content/links/accelerate-fintech-building-global-payout-infrastructure.mdx
@@ -1,0 +1,15 @@
+---
+title: "Accelerate Fintech: Building Global Payout Infrastructure: Architecture, Options & Real Decisions"
+url: "https://www.youtube.com/watch?v=s7XgPlSxxoE"
+linkType: video
+description: "Accelerate Fintech: Building Global Payout Infrastructure: Architecture, Options & Real Decisions"
+source: "YouTube"
+publishedAt: 2026-05-13T15:54:11.000Z
+categories:
+  - category: payments
+tags:
+  - tag: produced-by-solana
+featured: false
+---
+
+Accelerate Fintech: Building Global Payout Infrastructure: Architecture, Options & Real Decisions

--- a/apps/media/content/links/accelerate-fintech-building-your-treasury-infrastructure.mdx
+++ b/apps/media/content/links/accelerate-fintech-building-your-treasury-infrastructure.mdx
@@ -1,0 +1,15 @@
+---
+title: "Accelerate Fintech: Building Your Treasury Infrastructure"
+url: "https://www.youtube.com/watch?v=oc_FCfBxhas"
+linkType: video
+description: "Accelerate Fintech: Building Your Treasury Infrastructure"
+source: "YouTube"
+publishedAt: 2026-08-05T19:41:59.000Z
+categories:
+  - category: payments
+tags:
+  - tag: produced-by-solana
+featured: false
+---
+
+Accelerate Fintech: Building Your Treasury Infrastructure

--- a/apps/media/content/links/accelerate-fintech-stablecoins-arent-tokens-theyre-systems.mdx
+++ b/apps/media/content/links/accelerate-fintech-stablecoins-arent-tokens-theyre-systems.mdx
@@ -1,0 +1,15 @@
+---
+title: "Accelerate Fintech: Stablecoins Aren't Tokens — They're Systems"
+url: "https://www.youtube.com/watch?v=W22Mq_Wna04"
+linkType: video
+description: "Accelerate Fintech: Stablecoins Aren't Tokens — They're Systems"
+source: "YouTube"
+publishedAt: 2026-05-13T15:49:17.000Z
+categories:
+  - category: payments
+tags:
+  - tag: produced-by-solana
+featured: false
+---
+
+Accelerate Fintech: Stablecoins Aren't Tokens — They're Systems

--- a/apps/media/content/links/agentic-payments-builders-perspective.mdx
+++ b/apps/media/content/links/agentic-payments-builders-perspective.mdx
@@ -1,0 +1,15 @@
+---
+title: "Agentic Payments — the Builder's Perspective"
+url: "https://youtu.be/R-qZt0PFAco"
+linkType: video
+description: "Agentic Payments — the Builder's Perspective"
+source: "Pantera Capital"
+publishedAt: 2026-04-14T18:53:41.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+featured: false
+---
+
+Agentic Payments — the Builder's Perspective

--- a/apps/media/content/links/allunity-eurau-solana.mdx
+++ b/apps/media/content/links/allunity-eurau-solana.mdx
@@ -1,0 +1,15 @@
+---
+title: "Germany's AllUnity expands EURAU to Solana as euro stablecoins gain traction"
+url: "https://www.coindesk.com/business/2026/04/30/germany-s-allunity-expands-eurau-to-solana-as-euro-stablecoins-gain-traction"
+linkType: article
+description: "Germany's AllUnity expands EURAU to Solana as euro stablecoins gain traction"
+source: "CoinDesk"
+publishedAt: 2026-04-30T11:58:32.642Z
+categories:
+  - category: institutions
+tags:
+  - tag: payments
+featured: false
+---
+
+Germany's AllUnity expands EURAU to Solana as euro stablecoins gain traction

--- a/apps/media/content/links/altitude-cards-rain-stablecoin-os.mdx
+++ b/apps/media/content/links/altitude-cards-rain-stablecoin-os.mdx
@@ -1,0 +1,14 @@
+---
+title: "$18M From Solana Ventures: Altitude Launches Cards With Rain and a Stablecoin OS for Businesses"
+url: "https://www.youtube.com/watch?v=mmzrRN35BIY"
+linkType: video
+description: "$18M From Solana Ventures: Altitude Launches Cards With Rain and a Stablecoin OS for Businesses"
+source: "Genfinity"
+publishedAt: 2026-05-20T19:55:25.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+$18M From Solana Ventures: Altitude Launches Cards With Rain and a Stablecoin OS for Businesses

--- a/apps/media/content/links/alvarez-and-marsal-accepted-its-first-stablecoin-payment-on-solana.mdx
+++ b/apps/media/content/links/alvarez-and-marsal-accepted-its-first-stablecoin-payment-on-solana.mdx
@@ -4,9 +4,10 @@ url: >-
   https://www.alvarezandmarsal.com/press-release/alvarez-marsal-accepts-its-first-stablecoin-payment-on-solana-for-professional-services
 linkType: article
 source: A&M
-publishedAt: 2026-07-20T03:11:00.000Z
+publishedAt: 2026-07-08T14:46:02.000Z
 categories:
   - category: institutions
-tags: []
+tags:
+  - tag: payments
 featured: false
 ---

--- a/apps/media/content/links/arnold-lee-from-sphere-labs-on-the-index-podcast-building-stablecoin-rails-for-t.mdx
+++ b/apps/media/content/links/arnold-lee-from-sphere-labs-on-the-index-podcast-building-stablecoin-rails-for-t.mdx
@@ -5,7 +5,7 @@ linkType: podcast
 description: >
   Arnold Lee from Sphere Labs on The Index Podcast: Building Stablecoin Rails for the World's Forgotten Markets
 source: "YouTube"
-publishedAt: 2026-04-03T12:00:00.000Z
+publishedAt: 2026-03-31T21:45:00.000Z
 categories:
   - category: payments
   - category: defi

--- a/apps/media/content/links/aws-stablecoin-payments-ai-traffic.mdx
+++ b/apps/media/content/links/aws-stablecoin-payments-ai-traffic.mdx
@@ -1,0 +1,15 @@
+---
+title: "AWS Cloud Introduces Solana Stablecoin Payments for AI Traffic Monetization"
+url: "https://solanafloor.com/news/aws-cloud-introduces-solana-stablecoin-payments"
+linkType: article
+description: "AWS Cloud Introduces Solana Stablecoin Payments for AI Traffic Monetization"
+source: "SolanaFloor"
+publishedAt: 2026-06-18T16:14:18.970Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+featured: false
+---
+
+AWS Cloud Introduces Solana Stablecoin Payments for AI Traffic Monetization

--- a/apps/media/content/links/b2-c2-designates-solana-as-its-primary-stablecoin-settlement-network.mdx
+++ b/apps/media/content/links/b2-c2-designates-solana-as-its-primary-stablecoin-settlement-network.mdx
@@ -4,7 +4,7 @@ url: >-
   https://www.theblock.co/post/395985/b2c2-solana-institutional-stablecoin-network-sbi-holdings
 linkType: article
 source: TheBlock
-publishedAt: 2026-04-01T18:51:00.000Z
+publishedAt: 2026-04-01T09:00:00.000Z
 categories:
   - category: institutions
   - category: payments

--- a/apps/media/content/links/banks-and-stablecoin-companies-can-work-well-together.mdx
+++ b/apps/media/content/links/banks-and-stablecoin-companies-can-work-well-together.mdx
@@ -1,0 +1,15 @@
+---
+title: "Banks and Stablecoin Companies Can Work Well Together — Lead Bank CEO Jackie Reses"
+url: "https://www.youtube.com/watch?v=Z5P_Tot5Now"
+linkType: video
+description: "Banks and Stablecoin Companies Can Work Well Together — Lead Bank CEO Jackie Reses"
+source: "YouTube"
+publishedAt: 2026-05-07T19:45:56.000Z
+categories:
+  - category: payments
+tags:
+  - tag: produced-by-solana
+featured: false
+---
+
+Banks and Stablecoin Companies Can Work Well Together — Lead Bank CEO Jackie Reses

--- a/apps/media/content/links/beyond-humans-solana-payment-rails-ai.mdx
+++ b/apps/media/content/links/beyond-humans-solana-payment-rails-ai.mdx
@@ -1,0 +1,15 @@
+---
+title: "Beyond Humans: Lily Liu Says Solana Is Building the Payment Rails for the 'AI Machine Economy'"
+url: "https://www.coindesk.com/business/2026/05/06/beyond-humans-lily-liu-says-solana-is-building-the-payment-rails-for-the-ai-machine-economy"
+linkType: article
+description: "Beyond Humans: Lily Liu Says Solana Is Building the Payment Rails for the 'AI Machine Economy'"
+source: "CoinDesk"
+publishedAt: 2026-05-06T08:35:24.409Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+featured: false
+---
+
+Beyond Humans: Lily Liu Says Solana Is Building the Payment Rails for the 'AI Machine Economy'

--- a/apps/media/content/links/big-banks-stablecoin-settlement-solana.mdx
+++ b/apps/media/content/links/big-banks-stablecoin-settlement-solana.mdx
@@ -1,0 +1,14 @@
+---
+title: "Solana exec says 'big banks' are already preparing to settle in stablecoins"
+url: "https://www.thestreet.com/crypto/innovation/solana-exec-says-big-banks-are-already-preparing-to-settle-in-stablecoins"
+linkType: article
+description: "Solana exec says 'big banks' are already preparing to settle in stablecoins"
+source: "TheStreet"
+publishedAt: 2026-05-15T19:41:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Solana exec says 'big banks' are already preparing to settle in stablecoins

--- a/apps/media/content/links/blackrock-google-back-new-stablecoin.mdx
+++ b/apps/media/content/links/blackrock-google-back-new-stablecoin.mdx
@@ -1,0 +1,15 @@
+---
+title: "BlackRock, Google Join Banks and Crypto Firms in Backing New Stablecoin"
+url: "https://www.wsj.com/livecoverage/stock-market-today-dow-sp-500-nasdaq-06-30-2026/card/blackrock-google-join-banks-and-crypto-firms-in-backing-new-stablecoin-czjc2S3yJVxmofXLQpzP"
+linkType: article
+description: "BlackRock, Google Join Banks and Crypto Firms in Backing New Stablecoin"
+source: "The Wall Street Journal"
+publishedAt: 2026-06-30T15:31:22.013Z
+categories:
+  - category: institutions
+tags:
+  - tag: payments
+featured: false
+---
+
+BlackRock, Google Join Banks and Crypto Firms in Backing New Stablecoin

--- a/apps/media/content/links/card-issuance-on-solana-making-stablecoins-usable.mdx
+++ b/apps/media/content/links/card-issuance-on-solana-making-stablecoins-usable.mdx
@@ -1,0 +1,15 @@
+---
+title: "Card Issuance on Solana: Making Stablecoins Usable"
+url: "https://www.youtube.com/watch?v=4ADbS0TQMaY"
+linkType: video
+description: "Card Issuance on Solana: Making Stablecoins Usable"
+source: "YouTube"
+publishedAt: 2026-05-15T05:53:56.000Z
+categories:
+  - category: payments
+tags:
+  - tag: produced-by-solana
+featured: false
+---
+
+Card Issuance on Solana: Making Stablecoins Usable

--- a/apps/media/content/links/coinbase-cushy-tokenized-superstate.mdx
+++ b/apps/media/content/links/coinbase-cushy-tokenized-superstate.mdx
@@ -1,0 +1,15 @@
+---
+title: "Coinbase's 'CUSHY' stablecoin fund to launch tokenized share class via Superstate in Q2"
+url: "https://www.theblock.co/post/399652/coinbase-cushy-stablecoin-fund-launch-tokenized-share-class-superstate-q2"
+linkType: article
+description: "Coinbase's 'CUSHY' stablecoin fund to launch tokenized share class via Superstate in Q2"
+source: "The Block"
+publishedAt: 2026-04-30T17:37:00.000Z
+categories:
+  - category: finance
+tags:
+  - tag: payments
+featured: false
+---
+
+Coinbase's 'CUSHY' stablecoin fund to launch tokenized share class via Superstate in Q2

--- a/apps/media/content/links/coinbase-stablecoin-credit-fund-tokenized.mdx
+++ b/apps/media/content/links/coinbase-stablecoin-credit-fund-tokenized.mdx
@@ -1,0 +1,15 @@
+---
+title: "Coinbase's asset manager to offer stablecoin credit fund with tokenized share class"
+url: "https://www.coindesk.com/business/2026/04/30/coinbase-s-asset-manager-to-offer-stablecoin-credit-fund-with-tokenized-share-class"
+linkType: article
+description: "Coinbase's asset manager to offer stablecoin credit fund with tokenized share class"
+source: "CoinDesk"
+publishedAt: 2026-04-30T14:00:00.000Z
+categories:
+  - category: finance
+tags:
+  - tag: payments
+featured: false
+---
+
+Coinbase's asset manager to offer stablecoin credit fund with tokenized share class

--- a/apps/media/content/links/coindesk-wsop-solana-payments.mdx
+++ b/apps/media/content/links/coindesk-wsop-solana-payments.mdx
@@ -1,0 +1,14 @@
+---
+title: "World Series of Poker Adds Solana Payments for Tournament Buy-Ins"
+url: "https://www.coindesk.com/tech/2026/06/09/world-series-of-poker-adds-solana-payments-for-tournament-buy-ins"
+linkType: article
+description: "World Series of Poker Adds Solana Payments for Tournament Buy-Ins"
+source: "CoinDesk"
+publishedAt: 2026-06-10T13:00:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+World Series of Poker Adds Solana Payments for Tournament Buy-Ins

--- a/apps/media/content/links/decrypt-pay-sh-google-cloud-ai-agents.mdx
+++ b/apps/media/content/links/decrypt-pay-sh-google-cloud-ai-agents.mdx
@@ -1,0 +1,15 @@
+---
+title: "Solana and Google Cloud Launch Stablecoin Payments Service for AI Agents"
+url: "https://decrypt.co/366876/solana-google-cloud-launch-stablecoin-payments-service-ai-agents"
+linkType: article
+description: "Solana and Google Cloud Launch Stablecoin Payments Service for AI Agents"
+source: "Decrypt"
+publishedAt: 2026-05-05T20:10:09.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+featured: false
+---
+
+Solana and Google Cloud Launch Stablecoin Payments Service for AI Agents

--- a/apps/media/content/links/decrypt-solana-wsop-crypto-entry-fees.mdx
+++ b/apps/media/content/links/decrypt-solana-wsop-crypto-entry-fees.mdx
@@ -1,0 +1,14 @@
+---
+title: "Solana Sponsors the World Series of Poker, Enabling Crypto Entry Fees and Payouts"
+url: "https://decrypt.co/370578/solana-sponsors-world-series-poker-crypto-entry-fees-payouts"
+linkType: article
+description: "Solana Sponsors the World Series of Poker, Enabling Crypto Entry Fees and Payouts"
+source: "Decrypt"
+publishedAt: 2026-06-10T13:01:20.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Solana Sponsors the World Series of Poker, Enabling Crypto Entry Fees and Payouts

--- a/apps/media/content/links/deel-stablecoin-salary-payouts-solana.mdx
+++ b/apps/media/content/links/deel-stablecoin-salary-payouts-solana.mdx
@@ -1,0 +1,14 @@
+---
+title: "Deel launches stablecoin salary payouts via Solana"
+url: "https://www.thestreet.com/crypto/markets/deel-launches-stablecoin-salary-payouts-via-solana"
+linkType: article
+description: "Deel launches stablecoin salary payouts via Solana"
+source: "TheStreet"
+publishedAt: 2026-05-21T12:00:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Deel launches stablecoin salary payouts via Solana

--- a/apps/media/content/links/future-cross-border-finance-daren-guo-reap.mdx
+++ b/apps/media/content/links/future-cross-border-finance-daren-guo-reap.mdx
@@ -1,0 +1,14 @@
+---
+title: "The Future of Cross-Border Finance with Daren Guo, Co-Founder of Reap Global"
+url: "https://solana.com/podcasts/bits-to-bricks-with-amira-valliani/episodes/the-future-of-cross-border-finance-with-daren-guo-co-founder-of-reap-global-e3lnihd"
+linkType: podcast
+description: "The Future of Cross-Border Finance with Daren Guo, Co-Founder of Reap Global"
+source: "Solana Media"
+publishedAt: 2026-07-06T14:16:37.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+The Future of Cross-Border Finance with Daren Guo, Co-Founder of Reap Global

--- a/apps/media/content/links/inside-reap-stablecoin-powered-card-infrastructure.mdx
+++ b/apps/media/content/links/inside-reap-stablecoin-powered-card-infrastructure.mdx
@@ -1,0 +1,14 @@
+---
+title: "Inside Reap's Stablecoin-Powered Card Infrastructure"
+url: "https://solana.com/podcasts/mint-condition/episodes/19503095-inside-reap-s-stablecoin-powered-card-infrastructure"
+linkType: podcast
+description: "Inside Reap's Stablecoin-Powered Card Infrastructure"
+source: "Solana Media"
+publishedAt: 2026-07-16T00:00:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Inside Reap's Stablecoin-Powered Card Infrastructure

--- a/apps/media/content/links/kg-group-solana-digital-asset-payments.mdx
+++ b/apps/media/content/links/kg-group-solana-digital-asset-payments.mdx
@@ -1,0 +1,14 @@
+---
+title: "South Korea's KG Group Picks Solana to Roll Out a Digital Asset Payments Push"
+url: "https://beincrypto.com/south-korea-kg-group-solana-digital-asset-payments-network/"
+linkType: article
+description: "South Korea's KG Group Picks Solana to Roll Out a Digital Asset Payments Push"
+source: "BeInCrypto"
+publishedAt: 2026-06-24T05:03:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+South Korea's KG Group Picks Solana to Roll Out a Digital Asset Payments Push

--- a/apps/media/content/links/korea-s-1-card-issuer-shinhan-card-signs-an-mou-with-solana-foundation.mdx
+++ b/apps/media/content/links/korea-s-1-card-issuer-shinhan-card-signs-an-mou-with-solana-foundation.mdx
@@ -3,9 +3,10 @@ title: "Korea's #1 card issuer Shinhan Card signs an MOU with Solana Foundation"
 url: https://www.koreaherald.com/article/10729331
 linkType: article
 source: Korea Herald
-publishedAt: 2026-05-04T07:28:00.000Z
+publishedAt: 2026-04-30T03:59:43.000Z
 categories:
   - category: institutions
-tags: []
+tags:
+  - tag: payments
 featured: false
 ---

--- a/apps/media/content/links/krwq-stablecoin-expands-solana.mdx
+++ b/apps/media/content/links/krwq-stablecoin-expands-solana.mdx
@@ -1,0 +1,15 @@
+---
+title: "Korean won stablecoin KRWQ expands to Solana following March EDX Markets listing"
+url: "https://www.theblock.co/post/401093/krwq-expands-solana"
+linkType: article
+description: "Korean won stablecoin KRWQ expands to Solana following March EDX Markets listing"
+source: "The Block"
+publishedAt: 2026-05-13T08:44:00.000Z
+categories:
+  - category: finance
+tags:
+  - tag: payments
+featured: false
+---
+
+Korean won stablecoin KRWQ expands to Solana following March EDX Markets listing

--- a/apps/media/content/links/ksnet-trials-solana-pay-south-korea.mdx
+++ b/apps/media/content/links/ksnet-trials-solana-pay-south-korea.mdx
@@ -1,0 +1,14 @@
+---
+title: "Fintech giant KSNet joins Solana Foundation to trial Solana Pay in South Korea"
+url: "https://crypto.news/fintech-giant-ksnet-joins-solana-foundation-to-trial-solana-pay-in-south-korea/"
+linkType: article
+description: "Fintech giant KSNet joins Solana Foundation to trial Solana Pay in South Korea"
+source: "crypto.news"
+publishedAt: 2026-07-31T11:12:38.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Fintech giant KSNet joins Solana Foundation to trial Solana Pay in South Korea

--- a/apps/media/content/links/malcolm-clarke-western-union-stabledash.mdx
+++ b/apps/media/content/links/malcolm-clarke-western-union-stabledash.mdx
@@ -1,0 +1,14 @@
+---
+title: "Malcolm Clarke, VP of Digital Assets at Western Union"
+url: "https://x.com/stabledash/status/2049870954721943785"
+linkType: tweet
+description: "Malcolm Clarke, VP of Digital Assets at Western Union"
+source: "X (Twitter)"
+publishedAt: 2026-04-30T15:18:15.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Malcolm Clarke, VP of Digital Assets at Western Union

--- a/apps/media/content/links/mastercard-agent-micropayments-fortune.mdx
+++ b/apps/media/content/links/mastercard-agent-micropayments-fortune.mdx
@@ -1,0 +1,15 @@
+---
+title: "Exclusive: Mastercard launches protocol to let AI agents pay each other, send micropayments"
+url: "https://fortune.com/2026/06/10/mastercard-ai-payments-protocol-launch-agentic-finance/"
+linkType: article
+description: "Exclusive: Mastercard launches protocol to let AI agents pay each other, send micropayments"
+source: "Fortune"
+publishedAt: 2026-06-10T12:00:00.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+featured: false
+---
+
+Exclusive: Mastercard launches protocol to let AI agents pay each other, send micropayments

--- a/apps/media/content/links/mastercard-expands-stablecoin-settlement.mdx
+++ b/apps/media/content/links/mastercard-expands-stablecoin-settlement.mdx
@@ -1,0 +1,14 @@
+---
+title: "Mastercard expands settlement capabilities to include stablecoin, intraday, holiday and weekend options"
+url: "https://www.mastercard.com/global/en/news-and-trends/press/2026/june/mastercard-expands-settlement-capabilities-to-include-stablecoin.html"
+linkType: article
+description: "Mastercard expands settlement capabilities to include stablecoin, intraday, holiday and weekend options"
+source: "Mastercard"
+publishedAt: 2026-06-03T12:00:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Mastercard expands settlement capabilities to include stablecoin, intraday, holiday and weekend options

--- a/apps/media/content/links/meta-adds-support-for-usdc-payments-on-solana-for-creators-in-colombia-and-philippines.mdx
+++ b/apps/media/content/links/meta-adds-support-for-usdc-payments-on-solana-for-creators-in-colombia-and-philippines.mdx
@@ -5,9 +5,10 @@ title: >-
 url: https://fortune.com/2026/04/29/meta-stablecoins-crypto-usdc-polygon-solana/
 linkType: article
 source: Fortune
-publishedAt: 2026-05-04T07:29:00.000Z
+publishedAt: 2026-04-29T18:10:44.000Z
 categories:
   - category: institutions
-tags: []
+tags:
+  - tag: payments
 featured: false
 ---

--- a/apps/media/content/links/meta-stablecoin-creators-solana-schwab.mdx
+++ b/apps/media/content/links/meta-stablecoin-creators-solana-schwab.mdx
@@ -1,0 +1,15 @@
+---
+title: "Meta Stablecoin Move: Big Bet on Creators & Solana"
+url: "https://schwabnetwork.com/video/meta-stablecoin-move-big-bet-on-creators-solana"
+linkType: video
+description: "Meta Stablecoin Move: Big Bet on Creators & Solana"
+source: "Schwab Network"
+publishedAt: 2026-05-06T00:25:23.277Z
+categories:
+  - category: consumer
+tags:
+  - tag: payments
+featured: false
+---
+
+Meta Stablecoin Move: Big Bet on Creators & Solana

--- a/apps/media/content/links/money-collective-choice-stablecoin-infra.mdx
+++ b/apps/media/content/links/money-collective-choice-stablecoin-infra.mdx
@@ -1,0 +1,14 @@
+---
+title: "Money Is a Collective Choice | Ryne on Stablecoin Infra, Currency Access and Building for Optimism"
+url: "https://www.youtube.com/watch?v=daiTVO_x7YE"
+linkType: podcast
+description: "Money Is a Collective Choice | Ryne on Stablecoin Infra, Currency Access and Building for Optimism"
+source: "Unblock'd Podcast"
+publishedAt: 2026-04-16T17:44:08.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Money Is a Collective Choice | Ryne on Stablecoin Infra, Currency Access and Building for Optimism

--- a/apps/media/content/links/moneygram-solana-validator-payment-rails-thestreet.mdx
+++ b/apps/media/content/links/moneygram-solana-validator-payment-rails-thestreet.mdx
@@ -1,0 +1,14 @@
+---
+title: "MoneyGram joins Solana as validator to help run blockchain payment rails"
+url: "https://www.thestreet.com/crypto/markets/moneygram-joins-solana-as-validator-to-help-run-blockchain-payment-rails"
+linkType: article
+description: "MoneyGram joins Solana as validator to help run blockchain payment rails"
+source: "TheStreet"
+publishedAt: 2026-06-22T17:00:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+MoneyGram joins Solana as validator to help run blockchain payment rails

--- a/apps/media/content/links/moneygram-validator-stablecoin-payment-push-coindesk.mdx
+++ b/apps/media/content/links/moneygram-validator-stablecoin-payment-push-coindesk.mdx
@@ -1,0 +1,14 @@
+---
+title: "MoneyGram Joins Solana as Validator Amid Stablecoin Payment Push"
+url: "https://www.coindesk.com/business/2026/06/22/moneygram-joins-solana-as-validator-amid-stablecoin-payment-push"
+linkType: article
+description: "MoneyGram Joins Solana as Validator Amid Stablecoin Payment Push"
+source: "CoinDesk"
+publishedAt: 2026-06-22T13:53:16.242Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+MoneyGram Joins Solana as Validator Amid Stablecoin Payment Push

--- a/apps/media/content/links/moonpay-paybox-ai-agent-wallet-solana-x402.mdx
+++ b/apps/media/content/links/moonpay-paybox-ai-agent-wallet-solana-x402.mdx
@@ -1,0 +1,15 @@
+---
+title: "MoonPay PayBox Turns Claude and ChatGPT Prompts Into Solana Trades and Real Payments"
+url: "https://genfinity.io/2026/07/29/moonpay-paybox-ai-agent-wallet-solana-x402/"
+linkType: article
+description: "MoonPay PayBox Turns Claude and ChatGPT Prompts Into Solana Trades and Real Payments"
+source: "Genfinity"
+publishedAt: 2026-07-29T14:48:15.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+featured: false
+---
+
+MoonPay PayBox Turns Claude and ChatGPT Prompts Into Solana Trades and Real Payments

--- a/apps/media/content/links/open-standard-ousd-stablecoin-internet-economy.mdx
+++ b/apps/media/content/links/open-standard-ousd-stablecoin-internet-economy.mdx
@@ -1,0 +1,15 @@
+---
+title: "Open Standard Unveils $OUSD, a Stablecoin For the Internet Economy"
+url: "https://solanafloor.com/news/open-standard-unveils-ousd-a-stablecoin-for-the-internet-economy"
+linkType: article
+description: "Open Standard Unveils $OUSD, a Stablecoin For the Internet Economy"
+source: "SolanaFloor"
+publishedAt: 2026-06-30T17:29:41.894Z
+categories:
+  - category: institutions
+tags:
+  - tag: payments
+featured: false
+---
+
+Open Standard Unveils $OUSD, a Stablecoin For the Internet Economy

--- a/apps/media/content/links/pay-sh.mdx
+++ b/apps/media/content/links/pay-sh.mdx
@@ -1,0 +1,15 @@
+---
+title: "Pay.sh"
+url: "https://pay.sh/"
+linkType: other
+description: "Pay.sh"
+source: "Pay.sh"
+publishedAt: 2026-05-05T12:00:00.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+featured: false
+---
+
+Pay.sh

--- a/apps/media/content/links/ramp-stablecoin-accounts-settle-on-solana.mdx
+++ b/apps/media/content/links/ramp-stablecoin-accounts-settle-on-solana.mdx
@@ -1,0 +1,14 @@
+---
+title: "Ramp opens stablecoin accounts to every business, settling on Solana"
+url: "https://www.thestreet.com/crypto/innovation/ramp-opens-stablecoin-accounts-to-every-business-settling-on-solana"
+linkType: article
+description: "Ramp opens stablecoin accounts to every business, settling on Solana"
+source: "TheStreet"
+publishedAt: 2026-07-21T12:00:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Ramp opens stablecoin accounts to every business, settling on Solana

--- a/apps/media/content/links/sofi-stablecoin-launch-solana.mdx
+++ b/apps/media/content/links/sofi-stablecoin-launch-solana.mdx
@@ -1,0 +1,15 @@
+---
+title: "SoFi to launch its stablecoin on Solana, citing speed and cost"
+url: "https://www.theblock.co/post/400098/sofi-to-launch-its-stablecoin-on-solana-citing-speed-and-cost"
+linkType: article
+description: "SoFi to launch its stablecoin on Solana, citing speed and cost"
+source: "The Block"
+publishedAt: 2026-05-05T19:15:00.000Z
+categories:
+  - category: institutions
+tags:
+  - tag: payments
+featured: false
+---
+
+SoFi to launch its stablecoin on Solana, citing speed and cost

--- a/apps/media/content/links/sofi-stablecoin-liquidity-hub-talking-tokens.mdx
+++ b/apps/media/content/links/sofi-stablecoin-liquidity-hub-talking-tokens.mdx
@@ -1,0 +1,14 @@
+---
+title: "SoFi Wants to Be the Stablecoin Liquidity Hub for Banks with Ben Reynolds"
+url: "https://solana.com/podcasts/talking-tokens/episodes/sofi-wants-to-be-the-stablecoin-liquidity-hub-for-banks-ben-reynolds-e3jj510"
+linkType: podcast
+description: "SoFi Wants to Be the Stablecoin Liquidity Hub for Banks with Ben Reynolds"
+source: "Solana Media"
+publishedAt: 2026-05-19T10:00:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+SoFi Wants to Be the Stablecoin Liquidity Hub for Banks with Ben Reynolds

--- a/apps/media/content/links/solana-native-subscriptions-allowances-payments-rail.mdx
+++ b/apps/media/content/links/solana-native-subscriptions-allowances-payments-rail.mdx
@@ -1,0 +1,15 @@
+---
+title: "Solana Ships Native Payments Rail for Subscriptions and Allowances"
+url: "https://thedefiant.io/converge/blockchains/solana-ships-native-payments-rail-for-subscriptions-and-allowances"
+linkType: article
+description: "Solana Ships Native Payments Rail for Subscriptions and Allowances"
+source: "The Defiant"
+publishedAt: 2026-06-02T12:00:00.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+featured: false
+---
+
+Solana Ships Native Payments Rail for Subscriptions and Allowances

--- a/apps/media/content/links/solana-stories-we-bought-a-bank.mdx
+++ b/apps/media/content/links/solana-stories-we-bought-a-bank.mdx
@@ -1,0 +1,15 @@
+---
+title: "Solana Stories: We Bought A Bank"
+url: "https://www.youtube.com/watch?v=qMspBj3xwqA"
+linkType: video
+description: "Solana Stories: We Bought A Bank"
+source: "YouTube"
+publishedAt: 2026-07-21T10:53:26.000Z
+categories:
+  - category: payments
+tags:
+  - tag: produced-by-solana
+featured: false
+---
+
+Solana Stories: We Bought A Bank

--- a/apps/media/content/links/solana-walletconnect-payments-pulse.mdx
+++ b/apps/media/content/links/solana-walletconnect-payments-pulse.mdx
@@ -1,0 +1,14 @@
+---
+title: "Solana and WalletConnect Pay: What it Takes to Build a Trillion-Dollar Black Hole for Payments Projects and the Finance Rails of the Future"
+url: "https://open.spotify.com/episode/52epD9XaGdUImfurX4j3Cl"
+linkType: podcast
+description: "Solana and WalletConnect Pay: What it Takes to Build a Trillion-Dollar Black Hole for Payments Projects and the Finance Rails of the Future"
+source: "The Payments Pulse"
+publishedAt: 2026-05-26T12:00:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Solana and WalletConnect Pay: What it Takes to Build a Trillion-Dollar Black Hole for Payments Projects and the Finance Rails of the Future

--- a/apps/media/content/links/solanafloor-pay-sh-google-cloud.mdx
+++ b/apps/media/content/links/solanafloor-pay-sh-google-cloud.mdx
@@ -1,0 +1,15 @@
+---
+title: "Solana Foundation, Google Cloud Unveil Pay.sh, Bringing Enterprise-Scale Infrastructure to the Agentic Economy"
+url: "https://solanafloor.com/news/solana-foundation-google-cloud-unveil-pay-sh-bringing-enterprise-scale-infrastructure-to-the-agentic-economy"
+linkType: article
+description: "Solana Foundation, Google Cloud Unveil Pay.sh, Bringing Enterprise-Scale Infrastructure to the Agentic Economy"
+source: "SolanaFloor"
+publishedAt: 2026-05-05T16:05:08.384Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+featured: false
+---
+
+Solana Foundation, Google Cloud Unveil Pay.sh, Bringing Enterprise-Scale Infrastructure to the Agentic Economy

--- a/apps/media/content/links/squads-altitude-18m-funding.mdx
+++ b/apps/media/content/links/squads-altitude-18m-funding.mdx
@@ -1,0 +1,14 @@
+---
+title: "Solana Ventures leads $18 million round in Squads to scale its stablecoin platform Altitude"
+url: "https://www.theblock.co/post/399386/solana-ventures-squads-funding-stablecoin-altitude"
+linkType: article
+description: "Solana Ventures leads $18 million round in Squads to scale its stablecoin platform Altitude"
+source: "The Block"
+publishedAt: 2026-04-29T13:55:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Solana Ventures leads $18 million round in Squads to scale its stablecoin platform Altitude

--- a/apps/media/content/links/squads-finops-stablecoin-rails-pirates-parley.mdx
+++ b/apps/media/content/links/squads-finops-stablecoin-rails-pirates-parley.mdx
@@ -1,0 +1,14 @@
+---
+title: "The New Financial OS from Squads — Building FinOps on Stablecoin Rails"
+url: "https://solana.com/podcasts/pirates-parley/episodes/the-new-financial-os-from-squads-building-finops-on-stablecoin-rails-e3jklpp"
+linkType: podcast
+description: "The New Financial OS from Squads — Building FinOps on Stablecoin Rails"
+source: "Solana Media"
+publishedAt: 2026-05-20T12:57:58.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+The New Financial OS from Squads — Building FinOps on Stablecoin Rails

--- a/apps/media/content/links/stablecoins-currencies-commodities-credit-treasuries-cnbc.mdx
+++ b/apps/media/content/links/stablecoins-currencies-commodities-credit-treasuries-cnbc.mdx
@@ -1,0 +1,15 @@
+---
+title: "Stablecoins Backed By Various Currencies, Commodities, Credit Structures, Treasuries: Solana Foundation"
+url: "https://www.youtube.com/watch?v=fuLNke74Qxo"
+linkType: video
+description: "Stablecoins Backed By Various Currencies, Commodities, Credit Structures, Treasuries: Solana Foundation"
+source: "CNBC-TV18"
+publishedAt: 2026-04-24T07:58:20.000Z
+categories:
+  - category: finance
+tags:
+  - tag: payments
+featured: false
+---
+
+Stablecoins Backed By Various Currencies, Commodities, Credit Structures, Treasuries: Solana Foundation

--- a/apps/media/content/links/the-block-y-combinator-settles-first-all-stablecoin-funding-in-usdc-on-solana.mdx
+++ b/apps/media/content/links/the-block-y-combinator-settles-first-all-stablecoin-funding-in-usdc-on-solana.mdx
@@ -5,7 +5,7 @@ linkType: article
 description: >
   The Block: Y Combinator settles first all-stablecoin funding in USDC on Solana
 source: "The Block"
-publishedAt: 2026-04-17T12:00:00.000Z
+publishedAt: 2026-04-14T03:56:00.000Z
 categories:
   - category: payments
   - category: finance

--- a/apps/media/content/links/thestreet-mastercard-stablecoin-settlement-solana.mdx
+++ b/apps/media/content/links/thestreet-mastercard-stablecoin-settlement-solana.mdx
@@ -1,0 +1,14 @@
+---
+title: "Mastercard taps Solana as it brings stablecoin settlement to its global card network"
+url: "https://www.thestreet.com/crypto/markets/mastercard-taps-solana-as-it-brings-stablecoin-settlement"
+linkType: article
+description: "Mastercard taps Solana as it brings stablecoin settlement to its global card network"
+source: "TheStreet"
+publishedAt: 2026-06-03T16:01:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Mastercard taps Solana as it brings stablecoin settlement to its global card network

--- a/apps/media/content/links/thestreet-pay-sh-google-cloud.mdx
+++ b/apps/media/content/links/thestreet-pay-sh-google-cloud.mdx
@@ -1,0 +1,15 @@
+---
+title: "Solana rolls out Pay.sh with Google Cloud to bring pay-per-use API payments to AI"
+url: "https://www.thestreet.com/crypto/innovation/solana-rolls-out-pay-sh-with-google-cloud-to-bring-pay-per-use-api-payments-to-ai"
+linkType: article
+description: "Solana rolls out Pay.sh with Google Cloud to bring pay-per-use API payments to AI"
+source: "TheStreet"
+publishedAt: 2026-05-05T16:15:00.000Z
+categories:
+  - category: developers
+tags:
+  - tag: payments
+featured: false
+---
+
+Solana rolls out Pay.sh with Google Cloud to bring pay-per-use API payments to AI

--- a/apps/media/content/links/thestreet-wsop-solana-payments.mdx
+++ b/apps/media/content/links/thestreet-wsop-solana-payments.mdx
@@ -1,0 +1,14 @@
+---
+title: "Solana brings crypto payments to WSOP for the first time"
+url: "https://www.thestreet.com/crypto/innovation/solana-brings-crypto-payments-to-wsop-for-the-first-time"
+linkType: video
+description: "Solana brings crypto payments to WSOP for the first time"
+source: "TheStreet"
+publishedAt: 2026-06-10T13:08:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Solana brings crypto payments to WSOP for the first time

--- a/apps/media/content/links/toss-bank-blockchain-financial-infrastructure-solana.mdx
+++ b/apps/media/content/links/toss-bank-blockchain-financial-infrastructure-solana.mdx
@@ -1,0 +1,14 @@
+---
+title: "South Korea's Toss Bank to test blockchain-based financial infrastructure on Solana"
+url: "https://www.theblock.co/post/405505/toss-solana-partnership"
+linkType: article
+description: "South Korea's Toss Bank to test blockchain-based financial infrastructure on Solana"
+source: "The Block"
+publishedAt: 2026-06-22T06:37:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+South Korea's Toss Bank to test blockchain-based financial infrastructure on Solana

--- a/apps/media/content/links/toss-bank-solana-cross-border-remittances-bitcoincom.mdx
+++ b/apps/media/content/links/toss-bank-solana-cross-border-remittances-bitcoincom.mdx
@@ -1,0 +1,14 @@
+---
+title: "Leading South Korean Bank Toss Taps Solana to Test Cross-Border Remittances for 15 Million Customers"
+url: "https://news.bitcoin.com/toss-bank-solana-foundation-remittances-stablecoin/"
+linkType: article
+description: "Leading South Korean Bank Toss Taps Solana to Test Cross-Border Remittances for 15 Million Customers"
+source: "Bitcoin News"
+publishedAt: 2026-06-22T21:20:40.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Leading South Korean Bank Toss Taps Solana to Test Cross-Border Remittances for 15 Million Customers

--- a/apps/media/content/links/western-union-launches-stablecard-107b-network-solana.mdx
+++ b/apps/media/content/links/western-union-launches-stablecard-107b-network-solana.mdx
@@ -1,0 +1,14 @@
+---
+title: "Western Union Launches Stablecard, Betting Its $107B Network on Solana Instead of Itself"
+url: "https://forkast.news/western-union-launches-stablecard-betting-its-107b-network-on-solana-instead-of-itself/"
+linkType: article
+description: "Western Union Launches Stablecard, Betting Its $107B Network on Solana Instead of Itself"
+source: "Forkast"
+publishedAt: 2026-08-05T01:00:23.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Western Union Launches Stablecard, Betting Its $107B Network on Solana Instead of Itself

--- a/apps/media/content/links/western-union-onchain-settlement-mint-condition.mdx
+++ b/apps/media/content/links/western-union-onchain-settlement-mint-condition.mdx
@@ -1,0 +1,14 @@
+---
+title: "Western Union's Bet on On-Chain Settlement"
+url: "https://solana.com/podcasts/mint-condition/episodes/19387716-western-union-s-bet-on-on-chain-settlement"
+linkType: podcast
+description: "Western Union's Bet on On-Chain Settlement"
+source: "Solana Media"
+publishedAt: 2026-06-23T00:00:00.000Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Western Union's Bet on On-Chain Settlement

--- a/apps/media/content/links/western-union-s-federally-regulated-digital-dollar-usdpt-goes-live-on-solana.mdx
+++ b/apps/media/content/links/western-union-s-federally-regulated-digital-dollar-usdpt-goes-live-on-solana.mdx
@@ -7,6 +7,7 @@ source: WesternUnion
 publishedAt: 2026-05-04T19:31:00.000Z
 categories:
   - category: institutions
-tags: []
+tags:
+  - tag: payments
 featured: false
 ---

--- a/apps/media/content/links/western-union-stablecoin-payment-model.mdx
+++ b/apps/media/content/links/western-union-stablecoin-payment-model.mdx
@@ -1,0 +1,14 @@
+---
+title: "Western Union's Solana-based stablecoin could reshape its payment model, analyst says"
+url: "https://www.coindesk.com/business/2026/05/05/western-union-s-solana-based-stablecoin-could-reshape-its-payment-model-analyst-says"
+linkType: article
+description: "Western Union's Solana-based stablecoin could reshape its payment model, analyst says"
+source: "CoinDesk"
+publishedAt: 2026-05-05T17:22:22.589Z
+categories:
+  - category: payments
+tags: []
+featured: false
+---
+
+Western Union's Solana-based stablecoin could reshape its payment model, analyst says

--- a/apps/media/content/links/what-comes-next-for-merchants-on-solana.mdx
+++ b/apps/media/content/links/what-comes-next-for-merchants-on-solana.mdx
@@ -1,0 +1,15 @@
+---
+title: "What comes next for merchants on Solana"
+url: "https://www.youtube.com/watch?v=ScVvq1Xdr7U"
+linkType: video
+description: "What comes next for merchants on Solana"
+source: "YouTube"
+publishedAt: 2026-05-29T13:00:21.000Z
+categories:
+  - category: payments
+tags:
+  - tag: produced-by-solana
+featured: false
+---
+
+What comes next for merchants on Solana


### PR DESCRIPTION
### Problem

The payments.org insights backlog was missing recent payment, stablecoin, fintech, and agentic-commerce links from Solana Media. Existing matching records also had some roundup dates or taxonomy that would keep them out of the payments.org selector.

### Summary of Changes

- Add 56 new media Link records and reuse 9 existing records from the 65-item backlog.
- Use source publication/upload timestamps instead of roundup dates.
- Mark videos with `linkType: video` and make every video eligible under the payments.org Payments category/tag contract.
- Tag official Solana YouTube videos with `produced-by-solana`.
- Correct dates and Payments taxonomy on existing matching records.
- Canonicalize URLs and verify each backlog URL resolves to exactly one record.

No security-relevant behavior or dependencies changed.

Fixes: n/a

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials added.
- [x] No new user or external-service input handling introduced.
- [x] No dependencies changed.
- [x] No production error-handling paths changed.
- [x] Critical-change threat model is not applicable.

New dependencies: none

Threat-model note: n/a

### Validation

- `pnpm --filter solana-com-media lint` (0 errors; existing warnings only)
- `pnpm --filter solana-com-media test` (20 files, 130 tests passed)
- Prettier check passed for all media links
- Backlog audit: 65/65 URLs resolve to exactly one record; no added duplicate groups
- Video audit: 16/16 new videos are payments.org-eligible; all 11 official Solana videos have `produced-by-solana`

### Note

The repository-wide `dedupe:links` dry run still reports one unrelated pre-existing duplicate X URL outside this backlog; this PR does not modify or add that duplicate.