### PR TITLE
ci: scope secret scans by event

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,7 +35,19 @@ jobs:
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+      - name: Scan pull request commits for secrets
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run:
+          /tmp/gitleaks git --redact --exit-code 1
+          --log-opts="$BASE_SHA..$HEAD_SHA" .
+      - name: Scan main history for secrets
+        if: github.event_name == 'push'
+        run: /tmp/gitleaks git --redact --exit-code 1 --log-opts=HEAD .
       - name: Scan full git history for secrets
+        if: github.event_name == 'schedule'
         run: /tmp/gitleaks git --redact --exit-code 1 .
 
   dependency-audit:


### PR DESCRIPTION
## Summary

- scan only `base..head` commits for pull requests
- scan history reachable from `main` on pushes
- preserve the weekly repository-wide history scan

This prevents findings on unrelated remote branches from failing every pull request while retaining full scheduled coverage.

## Context

PR #1807 has no gitleaks findings, but its checkout fetched `docs/cookbook-examples-runner` and the unconstrained scan inspected every remote branch. Three generated cookbook output snapshots on that branch matched the generic API-key rule.
