### PR TITLE
fix(breakpoint): simplify travel options

### DIFF
--- a/apps/breakpoint/src/components/pages/travel/TravelHotelsSection.tsx
+++ b/apps/breakpoint/src/components/pages/travel/TravelHotelsSection.tsx
@@ -119,9 +119,11 @@ export default function HotelsSection() {
                       <p className="type-paragraph text-white">
                         {t(`items.${hotel.id}.description`)}
                       </p>
-                      <p className="type-eyebrow text-blue">
-                        {t(`items.${hotel.id}.distance`)}
-                      </p>
+                      {hotel.id !== "ares" && (
+                        <p className="type-eyebrow text-blue">
+                          {t(`items.${hotel.id}.distance`)}
+                        </p>
+                      )}
                       <Button
                         arrow
                         href={hotel.href}

--- a/apps/breakpoint/src/components/pages/travel/TravelHotelsSection.tsx
+++ b/apps/breakpoint/src/components/pages/travel/TravelHotelsSection.tsx
@@ -83,55 +83,42 @@ export default function HotelsSection() {
 
           <div className="flex min-w-0 flex-col gap-5 md:col-span-8 md:col-start-9">
             {HOTELS.map((hotel, index) => {
-              const open = index === activeIndex;
-              const panelId = `hotel-panel-${index}`;
+              const selected = index === activeIndex;
 
               return (
                 <div
                   key={hotel.id}
                   className={`border-t pb-3 pt-6 transition-colors ${
-                    open ? "border-white" : "border-neutral-700"
+                    selected ? "border-white" : "border-neutral-700"
                   }`}
                 >
                   <button
                     type="button"
-                    aria-expanded={open}
-                    aria-controls={panelId}
+                    aria-pressed={selected}
                     onClick={() => setActiveIndex(index)}
                     className="group/hotel flex w-full cursor-pointer items-start text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white"
                   >
-                    <h3
-                      className={`type-p-large-bold transition-[color,opacity] ${
-                        open
-                          ? "text-white opacity-100"
-                          : "text-text-secondary opacity-60 group-hover/hotel:text-white group-hover/hotel:opacity-100 group-focus-visible/hotel:text-white group-focus-visible/hotel:opacity-100"
-                      }`}
-                    >
+                    <h3 className="type-p-large-bold text-white">
                       {t(`items.${hotel.id}.name`)}
                     </h3>
                   </button>
 
-                  {open && (
-                    <div
-                      id={panelId}
-                      className="mt-4 flex flex-col items-start gap-4"
-                    >
-                      <p className="type-paragraph text-white">
-                        {t(`items.${hotel.id}.description`)}
+                  <div className="mt-4 flex flex-col items-start gap-4">
+                    <p className="type-paragraph text-white">
+                      {t(`items.${hotel.id}.description`)}
+                    </p>
+                    {hotel.id !== "ares" && (
+                      <p className="type-eyebrow text-blue">
+                        {t(`items.${hotel.id}.distance`)}
                       </p>
-                      {hotel.id !== "ares" && (
-                        <p className="type-eyebrow text-blue">
-                          {t(`items.${hotel.id}.distance`)}
-                        </p>
-                      )}
-                      <Button
-                        arrow
-                        href={hotel.href}
-                        label={t(`items.${hotel.id}.ctaLabel`)}
-                        variant="inline"
-                      />
-                    </div>
-                  )}
+                    )}
+                    <Button
+                      arrow
+                      href={hotel.href}
+                      label={t(`items.${hotel.id}.ctaLabel`)}
+                      variant="inline"
+                    />
+                  </div>
                 </div>
               );
             })}

--- a/apps/breakpoint/src/components/pages/travel/TravelPage.tsx
+++ b/apps/breakpoint/src/components/pages/travel/TravelPage.tsx
@@ -8,19 +8,14 @@ import PageShell from "@/components/PageShell";
 import SectionHeadline from "@/components/SectionHeadline";
 import SubpageHero from "@/components/SubpageHero";
 import Footer from "@/components/sections/Footer";
-import { publicAssetPath } from "@/config";
 import {
   BREAKPOINT_EMAIL_HREF,
-  BRITISH_AIRWAYS_HREF,
-  DELTA_AIRLINES_HREF,
   GENERAL_ADMISSION_HREF,
   GATWICK_AIRPORT_HREF,
   HEATHROW_AIRPORT_HREF,
   IAS_HREF,
   LONDON_CITY_AIRPORT_HREF,
-  LUFTHANSA_HREF,
   VISA_CHECK_HREF,
-  VIRGIN_ATLANTIC_HREF,
 } from "@/content/links";
 import { getAnchorLinkProps } from "@/lib/links";
 import TravelHotelsSection from "./TravelHotelsSection";
@@ -52,29 +47,6 @@ const AIRPORTS = [
   },
 ] as const;
 
-const AIRLINES = [
-  {
-    href: VIRGIN_ATLANTIC_HREF,
-    id: "virginAtlantic",
-    logo: "/img/travel/airline-virgin-atlantic.svg",
-  },
-  {
-    href: DELTA_AIRLINES_HREF,
-    id: "delta",
-    logo: "/img/travel/airline-delta.svg",
-  },
-  {
-    href: BRITISH_AIRWAYS_HREF,
-    id: "britishAirways",
-    logo: "/img/travel/airline-british-airways.svg",
-  },
-  {
-    href: LUFTHANSA_HREF,
-    id: "lufthansa",
-    logo: "/img/travel/airline-lufthansa.svg",
-  },
-] as const;
-
 function FlightsSection() {
   const t = useTranslations("breakpoint.travel.flights");
 
@@ -88,65 +60,28 @@ function FlightsSection() {
             headline={t("headline")}
           />
         </div>
-        <div className="grid gap-16 md:grid-cols-bp-desktop md:gap-x-s">
-          <div className="flex flex-col md:col-span-6">
-            {AIRPORTS.map((airport) => (
-              <a
-                key={airport.code}
-                href={airport.href}
-                className="group flex h-[140px] flex-col justify-center gap-3 border-b border-stroke-primary py-6 first:border-t md:h-[166px] md:px-8 md:py-8"
-                {...getAnchorLinkProps({ href: airport.href })}
-              >
-                <p className="font-bp26 text-h6 uppercase text-white">
-                  {airport.code}
-                </p>
-                <div className="flex flex-col gap-2">
-                  <span className="type-h5 inline-flex items-center gap-2 text-white transition-colors group-hover:text-neutral-100">
-                    {t(`airports.${airport.id}.name`)}
-                    <ArrowUpRightIcon className="size-3 shrink-0" />
-                  </span>
-                  <span className="type-eyebrow text-blue">
-                    {t(`airports.${airport.id}.distance`)}
-                  </span>
-                </div>
-              </a>
-            ))}
-          </div>
-          <div className="-mr-4 overflow-x-auto md:col-span-9 md:col-start-8 md:mr-0 md:overflow-visible">
-            <div className="grid w-max grid-flow-col auto-cols-[283.56px] gap-6 md:w-full md:auto-rows-[382px] md:grid-flow-row md:grid-cols-2 md:gap-8">
-              {AIRLINES.map((airline) => (
-                <article key={airline.id} className="w-full">
-                  <div className="flex h-[189px] items-center justify-center border border-stroke-primary bg-transparent-white-05 p-9 md:h-[246px] md:p-11">
-                    <img
-                      src={publicAssetPath(airline.logo)}
-                      alt={t("airlineLogo", {
-                        name: t(`airlines.${airline.id}.name`),
-                      })}
-                      width={281}
-                      height={68}
-                      className="max-h-[68px] w-auto max-w-full"
-                    />
-                  </div>
-                  <div className="flex flex-col items-start gap-4 py-6">
-                    <div className="flex flex-col gap-2">
-                      <h3 className="type-paragraph font-bold text-white">
-                        {t(`airlines.${airline.id}.name`)}
-                      </h3>
-                      <p className="type-paragraph text-text-secondary">
-                        {t(`airlines.${airline.id}.description`)}
-                      </p>
-                    </div>
-                    <Button
-                      arrow
-                      href={airline.href}
-                      label={t("viewFlights")}
-                      variant="inline"
-                    />
-                  </div>
-                </article>
-              ))}
-            </div>
-          </div>
+        <div className="grid border-y border-stroke-primary md:grid-cols-3">
+          {AIRPORTS.map((airport) => (
+            <a
+              key={airport.code}
+              href={airport.href}
+              className="group flex min-h-[140px] flex-col justify-center gap-3 border-b border-stroke-primary py-6 last:border-b-0 md:min-h-[166px] md:border-b-0 md:border-l md:px-8 md:py-8 md:first:border-l-0"
+              {...getAnchorLinkProps({ href: airport.href })}
+            >
+              <p className="font-bp26 text-h6 uppercase text-white">
+                {airport.code}
+              </p>
+              <div className="flex flex-col gap-2">
+                <span className="type-h5 inline-flex items-center gap-2 text-white transition-colors group-hover:text-neutral-100">
+                  {t(`airports.${airport.id}.name`)}
+                  <ArrowUpRightIcon className="size-3 shrink-0" />
+                </span>
+                <span className="type-eyebrow text-blue">
+                  {t(`airports.${airport.id}.distance`)}
+                </span>
+              </div>
+            </a>
+          ))}
         </div>
       </div>
     </section>

--- a/apps/breakpoint/src/content/links.ts
+++ b/apps/breakpoint/src/content/links.ts
@@ -26,12 +26,6 @@ export const NOMADZ_HREF = "https://nomadz.xyz/breakpoint";
 export const LONDON_CITY_AIRPORT_HREF = "https://www.londoncityairport.com/";
 export const HEATHROW_AIRPORT_HREF = "https://www.heathrow.com/";
 export const GATWICK_AIRPORT_HREF = "https://www.gatwickairport.com/";
-export const VIRGIN_ATLANTIC_HREF = "https://www.virginatlantic.com/en-gb";
-export const DELTA_AIRLINES_HREF =
-  "https://www.delta.com/us/en/flight-deals/europe-flights/flights-to-london";
-export const BRITISH_AIRWAYS_HREF =
-  "https://www.britishairways.com/travel/home/public/en_ws/";
-export const LUFTHANSA_HREF = "https://www.lufthansa.com/gb/en/homepage";
 export const BREAKPOINT_EMAIL_HREF = "mailto:breakpoint@solana.org";
 export const VISA_CHECK_HREF = "https://www.gov.uk/check-uk-visa";
 export const IAS_HREF =

--- a/apps/breakpoint/src/content/page.ts
+++ b/apps/breakpoint/src/content/page.ts
@@ -126,15 +126,6 @@ export type BreakpointMessages = {
     flights: {
       eyebrow: string;
       headline: string;
-      airlines: Record<
-        string,
-        {
-          name: string;
-          description: string;
-        }
-      >;
-      viewFlights: string;
-      airlineLogo: string;
       airports: Record<
         string,
         {
@@ -150,7 +141,7 @@ export type BreakpointMessages = {
         {
           name: string;
           description: string;
-          distance: string;
+          distance?: string;
           ctaLabel: string;
         }
       >;

--- a/packages/i18n/messages/breakpoint/en/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/en/breakpoint.json
@@ -178,21 +178,19 @@
     "travel": {
       "metadata": {
         "title": "Travel",
-        "description": "Plan travel to Breakpoint 2026 in London with airport, flight, hotel, visa, and local recommendations."
+        "description": "Plan travel to Breakpoint 2026 in London with airport, hotel, visa, and local recommendations."
       },
       "title": "Travel",
       "cta": "Get tickets",
       "subnav": {
         "label": "Travel sections",
-        "flights": "Flights",
+        "flights": "Airports",
         "hotels": "Hotels",
         "visas": "Visas"
       },
       "flights": {
-        "eyebrow": "Airports & flight deals",
+        "eyebrow": "Nearby airports",
         "headline": "Getting to London",
-        "viewFlights": "View flights",
-        "airlineLogo": "{name} logo",
         "airports": {
           "lcy": {
             "name": "London City Airport",
@@ -206,24 +204,6 @@
             "name": "London Gatwick Airport",
             "distance": "48km south of central London"
           }
-        },
-        "airlines": {
-          "virginAtlantic": {
-            "name": "Virgin Atlantic",
-            "description": "Explore flights to London."
-          },
-          "delta": {
-            "name": "Delta Air Lines",
-            "description": "Explore flights to London."
-          },
-          "britishAirways": {
-            "name": "British Airways",
-            "description": "Explore flights to London."
-          },
-          "lufthansa": {
-            "name": "Lufthansa",
-            "description": "Explore flights to London."
-          }
         }
       },
       "hotels": {
@@ -232,7 +212,6 @@
           "ares": {
             "name": "aRes Travel",
             "description": "Browse hotel accommodations for Breakpoint.",
-            "distance": "Hotel booking partner",
             "ctaLabel": "Book through aRes"
           },
           "nomadz": {


### PR DESCRIPTION
### Problem

The Breakpoint travel page lists airline recommendations that should be removed, the aRes hotel option includes a partner subtitle that is no longer wanted, and hotel details should be visible without expanding each item.

### Summary of Changes

- Remove the airline cards, related links, and translation copy.
- Present the three nearby airports in a responsive full-width layout.
- Update travel navigation and metadata copy to focus on airports.
- Remove the Hotel booking partner subtitle from aRes Travel.
- Keep every hotel detail panel open while retaining hotel image selection.

No security-relevant behavior changed.

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] No user or external-service input handling was added or changed.
- [ ] No dependencies were changed; pnpm audit was not run.
- [x] No production error-handling paths were added or changed.
- [ ] For **Critical** changes: not applicable.

New dependencies: none.

Threat-model note: n/a.

### Validation

- pnpm --filter solana-com-breakpoint lint
- pnpm --filter solana-com-breakpoint check-types
- pnpm --filter solana-com-breakpoint test (28 tests passed)