### PR TITLE
docs(tokens): return execution context from confidential transfer plan executor

### DIFF
--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
@@ -627,7 +627,7 @@ serde_json = "1.0"
 <CodeTabs>
 
 ```ts !! title="index.ts"
-// !collapse(1:45) collapsed
+// !collapse(1:46) collapsed
 // Imports: dependencies used by this example.
 import {
   deriveAeKeyForOwnerMint,
@@ -654,6 +654,7 @@ import {
   createTransactionPlanner,
   extendClient,
   generateKeyPairSigner,
+  getSignatureFromTransaction,
   isSome,
   pipe,
   sendAndConfirmTransactionFactory,
@@ -684,7 +685,7 @@ const client = await createClient()
   )
   // Temporary custom plugin to skip the default compute-budget estimate
   // so proof instructions fit within the transaction message cap.
-  // !collapse(1:38) collapsed
+  // !collapse(1:39) collapsed
   .use((client) =>
     extendClient(client, {
       // A planner that builds a bare versioned message with no provisory
@@ -712,10 +713,11 @@ const client = await createClient()
           );
           assertIsSendableTransaction(transaction);
           assertIsTransactionWithBlockhashLifetime(transaction);
+          const signature = getSignatureFromTransaction(transaction);
           await sendAndConfirmTransactionFactory(client)(transaction, {
             commitment: "confirmed"
           });
-          return transaction;
+          return { signature, transaction };
         }
       })
     })


### PR DESCRIPTION
## Summary

- Migrates the custom transaction plan executor in the confidential transfer guide off a pattern that [`@solana/kit` v7.1.0](https://github.com/anza-xyz/kit/releases/tag/v7.1.0) deprecates.
- `createTransactionPlanExecutor`'s `executeTransactionMessage` callback should now return the **success context** rather than a `Signature` or a `Transaction` ([#1915](https://github.com/anza-xyz/kit/pull/1915)). Returning a `Transaction` still works, but IDEs now flag it via a deprecated overload. The snippet derives the signature and returns `{ signature, transaction }`; a returned context must carry a `signature`, since that is how the executor tells a context apart from a `Transaction`.
- Adds `getSignatureFromTransaction` to the file's `@solana/kit` import list.
- Updates two `!collapse` line ranges (`1:45` → `1:46`, `1:38` → `1:39`) so the collapsed regions still cover the intended blocks after the two added lines.

English source only — the `.lingo/` pipeline regenerates the other 18 locales. `git diff --name-only` against `main` is exactly one file.

The snippet is a plain inline fenced code block, not transcluded from `packages/docs-examples` (that package backs `content/cookbook` only), so no test harness compiles it.

## Test plan

- [x] `pnpm install`
- [x] `pnpm check-types` — 15/15 tasks successful
- [x] `pnpm lint` — 13/13 tasks successful, 0 errors in the changed file
- [x] Confirmed zero locale files touched

Skipped the full `pnpm build`: the changed snippet is not compiled or executed by any harness, and the build is slow.

Part of DEV-896.