### PR TITLE
feat(content): /upgrades redesign

### DIFF
--- a/apps/media/__tests__/group-by-release.test.ts
+++ b/apps/media/__tests__/group-by-release.test.ts
@@ -154,4 +154,78 @@ describe("groupUpgradesByRelease", () => {
 
     expect(groups).toEqual([]);
   });
+
+  it("excludes an upgrade from a release's list if it is any release's overview (cross-release mismatch)", () => {
+    const releases: ReleaseInput[] = [
+      release({
+        slug: "a",
+        name: "Release A",
+        status: "shipped",
+        expectedDate: "2026-06-01",
+        overview: "x",
+      }),
+      release({
+        slug: "b",
+        name: "Release B",
+        status: "shipped",
+        expectedDate: "2026-07-01",
+      }),
+    ];
+    const upgrades: UpgradeListItem[] = [
+      upgrade({ slug: "x", release: "b" }),
+      upgrade({ slug: "other", release: "b" }),
+    ];
+
+    const groups = groupUpgradesByRelease(upgrades, releases);
+
+    const groupA = groups.find((g) => g.key === "a");
+    const groupB = groups.find((g) => g.key === "b");
+
+    expect(groupA?.overview?.slug).toBe("x");
+    expect(groupB?.upgrades.map((item) => item.slug)).toEqual(["other"]);
+  });
+
+  it("treats order: 0 as present (not falsy)", () => {
+    const releases: ReleaseInput[] = [
+      release({ slug: "r", status: "shipped", expectedDate: "2026-06-01" }),
+    ];
+    const upgrades: UpgradeListItem[] = [
+      upgrade({ slug: "ordered-zero", release: "r", order: 0 }),
+      upgrade({ slug: "ordered-one", release: "r", order: 1 }),
+      upgrade({
+        slug: "no-order",
+        release: "r",
+        order: null,
+        publishedAt: "2026-05-01",
+      }),
+    ];
+
+    const groups = groupUpgradesByRelease(upgrades, releases);
+
+    expect(groups[0].upgrades.map((item) => item.slug)).toEqual([
+      "ordered-zero",
+      "ordered-one",
+      "no-order",
+    ]);
+  });
+
+  it("renders a release with overview but no regular upgrades", () => {
+    const releases: ReleaseInput[] = [
+      release({
+        slug: "r",
+        status: "shipped",
+        expectedDate: "2026-06-01",
+        overview: "overview-article",
+      }),
+    ];
+    const upgrades: UpgradeListItem[] = [
+      upgrade({ slug: "overview-article", release: "r" }),
+    ];
+
+    const groups = groupUpgradesByRelease(upgrades, releases);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].overview?.slug).toBe("overview-article");
+    expect(groups[0].upgrades).toEqual([]);
+  });
 });

--- a/apps/media/__tests__/group-by-release.test.ts
+++ b/apps/media/__tests__/group-by-release.test.ts
@@ -101,7 +101,7 @@ describe("groupUpgradesByRelease", () => {
 
     const groups = groupUpgradesByRelease(upgrades, releases);
 
-    expect(groups[0].upgrades.map((item) => item.slug)).toEqual([
+    expect(groups[0]!.upgrades.map((item) => item.slug)).toEqual([
       "first",
       "second",
       "no-order-newer",
@@ -125,8 +125,8 @@ describe("groupUpgradesByRelease", () => {
 
     const groups = groupUpgradesByRelease(upgrades, releases);
 
-    expect(groups[0].overview?.slug).toBe("overview-article");
-    expect(groups[0].upgrades.map((item) => item.slug)).toEqual([
+    expect(groups[0]!.overview?.slug).toBe("overview-article");
+    expect(groups[0]!.upgrades.map((item) => item.slug)).toEqual([
       "regular-article",
     ]);
   });
@@ -202,7 +202,7 @@ describe("groupUpgradesByRelease", () => {
 
     const groups = groupUpgradesByRelease(upgrades, releases);
 
-    expect(groups[0].upgrades.map((item) => item.slug)).toEqual([
+    expect(groups[0]!.upgrades.map((item) => item.slug)).toEqual([
       "ordered-zero",
       "ordered-one",
       "no-order",
@@ -225,7 +225,7 @@ describe("groupUpgradesByRelease", () => {
     const groups = groupUpgradesByRelease(upgrades, releases);
 
     expect(groups).toHaveLength(1);
-    expect(groups[0].overview?.slug).toBe("overview-article");
-    expect(groups[0].upgrades).toEqual([]);
+    expect(groups[0]!.overview?.slug).toBe("overview-article");
+    expect(groups[0]!.upgrades).toEqual([]);
   });
 });

--- a/apps/media/__tests__/group-by-release.test.ts
+++ b/apps/media/__tests__/group-by-release.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  groupUpgradesByRelease,
+  type ReleaseInput,
+  type UpgradeListItem,
+} from "@/lib/upgrades/group-by-release";
+
+function upgrade(overrides: Partial<UpgradeListItem>): UpgradeListItem {
+  return {
+    slug: "example",
+    title: "Example",
+    description: "",
+    subtitle: "",
+    publishedAt: null,
+    stage: "in_development",
+    metrics: [],
+    release: null,
+    order: null,
+    ...overrides,
+  };
+}
+
+function release(overrides: Partial<ReleaseInput>): ReleaseInput {
+  return {
+    slug: "example-release",
+    name: "Example Release",
+    status: "planned",
+    expectedDate: null,
+    overview: null,
+    ...overrides,
+  };
+}
+
+describe("groupUpgradesByRelease", () => {
+  it("orders planned releases soonest-first, then shipped most-recent-first, then unscheduled last", () => {
+    const releases: ReleaseInput[] = [
+      release({
+        slug: "shipped-old",
+        name: "Shipped Old",
+        status: "shipped",
+        expectedDate: "2026-01-01",
+      }),
+      release({
+        slug: "planned-far",
+        name: "Planned Far",
+        status: "planned",
+        expectedDate: "2027-01-01",
+      }),
+      release({
+        slug: "shipped-new",
+        name: "Shipped New",
+        status: "shipped",
+        expectedDate: "2026-06-01",
+      }),
+      release({
+        slug: "planned-near",
+        name: "Planned Near",
+        status: "planned",
+        expectedDate: "2026-09-01",
+      }),
+    ];
+    const upgrades: UpgradeListItem[] = [
+      upgrade({ slug: "a", release: "shipped-old" }),
+      upgrade({ slug: "b", release: "planned-far" }),
+      upgrade({ slug: "c", release: "shipped-new" }),
+      upgrade({ slug: "d", release: "planned-near" }),
+      upgrade({ slug: "e", release: null }),
+    ];
+
+    const groups = groupUpgradesByRelease(upgrades, releases);
+
+    expect(groups.map((group) => group.key)).toEqual([
+      "planned-near",
+      "planned-far",
+      "shipped-new",
+      "shipped-old",
+      "unscheduled",
+    ]);
+  });
+
+  it("sorts within a group by order ascending, falling back to publishedAt descending", () => {
+    const releases: ReleaseInput[] = [
+      release({ slug: "r", status: "shipped", expectedDate: "2026-06-01" }),
+    ];
+    const upgrades: UpgradeListItem[] = [
+      upgrade({
+        slug: "no-order-newer",
+        release: "r",
+        order: null,
+        publishedAt: "2026-05-01",
+      }),
+      upgrade({
+        slug: "no-order-older",
+        release: "r",
+        order: null,
+        publishedAt: "2026-01-01",
+      }),
+      upgrade({ slug: "second", release: "r", order: 2 }),
+      upgrade({ slug: "first", release: "r", order: 1 }),
+    ];
+
+    const groups = groupUpgradesByRelease(upgrades, releases);
+
+    expect(groups[0].upgrades.map((item) => item.slug)).toEqual([
+      "first",
+      "second",
+      "no-order-newer",
+      "no-order-older",
+    ]);
+  });
+
+  it("excludes a release's overview upgrade from its regular list and returns it separately", () => {
+    const releases: ReleaseInput[] = [
+      release({
+        slug: "r",
+        status: "shipped",
+        expectedDate: "2026-06-01",
+        overview: "overview-article",
+      }),
+    ];
+    const upgrades: UpgradeListItem[] = [
+      upgrade({ slug: "overview-article", release: "r" }),
+      upgrade({ slug: "regular-article", release: "r" }),
+    ];
+
+    const groups = groupUpgradesByRelease(upgrades, releases);
+
+    expect(groups[0].overview?.slug).toBe("overview-article");
+    expect(groups[0].upgrades.map((item) => item.slug)).toEqual([
+      "regular-article",
+    ]);
+  });
+
+  it("treats an upgrade referencing an unknown release as unscheduled", () => {
+    const releases: ReleaseInput[] = [
+      release({ slug: "r", status: "shipped", expectedDate: "2026-06-01" }),
+    ];
+    const upgrades: UpgradeListItem[] = [
+      upgrade({ slug: "orphan", release: "does-not-exist" }),
+    ];
+
+    const groups = groupUpgradesByRelease(upgrades, releases);
+
+    const unscheduled = groups.find((group) => group.key === "unscheduled");
+    expect(unscheduled?.upgrades.map((item) => item.slug)).toEqual(["orphan"]);
+  });
+
+  it("drops a release group with no overview and no upgrades", () => {
+    const releases: ReleaseInput[] = [
+      release({ slug: "empty", status: "planned", expectedDate: "2026-06-01" }),
+    ];
+
+    const groups = groupUpgradesByRelease([], releases);
+
+    expect(groups).toEqual([]);
+  });
+});

--- a/apps/media/__tests__/group-by-release.test.ts
+++ b/apps/media/__tests__/group-by-release.test.ts
@@ -185,6 +185,38 @@ describe("groupUpgradesByRelease", () => {
     expect(groupB?.upgrades.map((item) => item.slug)).toEqual(["other"]);
   });
 
+  it("drops a release entirely if its only assigned upgrade is actually another release's overview", () => {
+    const releases: ReleaseInput[] = [
+      release({
+        slug: "a",
+        name: "Release A",
+        status: "shipped",
+        expectedDate: "2026-06-01",
+        overview: "x",
+      }),
+      release({
+        slug: "b",
+        name: "Release B",
+        status: "shipped",
+        expectedDate: "2026-07-01",
+      }),
+    ];
+    const upgrades: UpgradeListItem[] = [upgrade({ slug: "x", release: "b" })];
+
+    const groups = groupUpgradesByRelease(upgrades, releases);
+
+    // "x" is claimed as release "a"'s overview but tagged with release "b" —
+    // a content-authoring mistake (its release field should be "a"). Since it's
+    // globally excluded from every release's regular list to avoid rendering
+    // twice, and "b" has no other content, "b" disappears from the page
+    // entirely rather than showing an empty section. This is the accepted
+    // trade-off of the cross-release-mismatch fix above: catch the underlying
+    // mistake with the release-overview-consistency content check instead of
+    // trying to make the grouping logic paper over it.
+    expect(groups.map((group) => group.key)).toEqual(["a"]);
+    expect(groups.find((group) => group.key === "b")).toBeUndefined();
+  });
+
   it("treats order: 0 as present (not falsy)", () => {
     const releases: ReleaseInput[] = [
       release({ slug: "r", status: "shipped", expectedDate: "2026-06-01" }),

--- a/apps/media/__tests__/keystatic-config.test.ts
+++ b/apps/media/__tests__/keystatic-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { githubStorage } from "../keystatic.config";
+import config, { githubStorage } from "../keystatic.config";
 
 describe("Keystatic GitHub storage", () => {
   it("passes the dedicated staging branch policy to Keystatic", () => {
@@ -9,5 +9,28 @@ describe("Keystatic GitHub storage", () => {
       branchPrefix: "staging-",
       pathPrefix: "apps/media",
     });
+  });
+});
+
+describe("releases collection", () => {
+  it("defines the fields the grouped listing page relies on", () => {
+    const releaseFields = Object.keys(
+      config.collections?.releases?.schema ?? {},
+    );
+    expect(releaseFields).toEqual(
+      expect.arrayContaining(["name", "expectedDate", "status", "overview"]),
+    );
+  });
+});
+
+describe("upgrades schema", () => {
+  it("replaces the freeform badges field with stage, release, and order", () => {
+    const upgradeFields = Object.keys(
+      config.collections?.upgrades?.schema ?? {},
+    );
+    expect(upgradeFields).not.toContain("badges");
+    expect(upgradeFields).toEqual(
+      expect.arrayContaining(["stage", "release", "order"]),
+    );
   });
 });

--- a/apps/media/__tests__/release-overview-consistency.test.ts
+++ b/apps/media/__tests__/release-overview-consistency.test.ts
@@ -1,0 +1,76 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const RELEASES_DIR = join(import.meta.dirname, "../content/releases");
+const UPGRADES_DIR = join(import.meta.dirname, "../content/upgrades");
+
+function readFrontmatterField(content: string, field: string): string | null {
+  const frontmatter = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!frontmatter) {
+    return null;
+  }
+
+  const match = (frontmatter[1] ?? "").match(
+    new RegExp(`^${field}:\\s*(\\S+)\\s*$`, "m"),
+  );
+  return match?.[1] ?? null;
+}
+
+function slugFromFilename(filename: string): string {
+  return filename.replace(/\.mdx$/, "");
+}
+
+describe("release/overview content contract", () => {
+  it("every release's overview article is itself tagged with that same release", () => {
+    // groupUpgradesByRelease (lib/upgrades/group-by-release.ts) excludes an
+    // upgrade from EVERY release's regular list the moment any release names
+    // it as an `overview`, regardless of what the upgrade's own `release`
+    // field says. That's intentional — it stops the same article rendering
+    // twice — but it means an overview article whose own `release` field
+    // points elsewhere silently vanishes from the release it actually claims,
+    // and can even make that other release disappear from the page entirely
+    // if it had no other content. This check catches the authoring mistake
+    // (release.overview and the target article's own `release` disagreeing)
+    // before it reaches the grouping logic.
+    const upgradeReleaseBySlug = new Map<string, string | null>();
+    for (const filename of readdirSync(UPGRADES_DIR).filter((name) =>
+      name.endsWith(".mdx"),
+    )) {
+      const content = readFileSync(join(UPGRADES_DIR, filename), "utf8");
+      upgradeReleaseBySlug.set(
+        slugFromFilename(filename),
+        readFrontmatterField(content, "release"),
+      );
+    }
+
+    const mismatches: string[] = [];
+    for (const filename of readdirSync(RELEASES_DIR).filter((name) =>
+      name.endsWith(".mdx"),
+    )) {
+      const releaseSlug = slugFromFilename(filename);
+      const content = readFileSync(join(RELEASES_DIR, filename), "utf8");
+      const overviewSlug = readFrontmatterField(content, "overview");
+
+      if (!overviewSlug) {
+        continue;
+      }
+
+      if (!upgradeReleaseBySlug.has(overviewSlug)) {
+        mismatches.push(
+          `${filename}: overview "${overviewSlug}" does not match any upgrade article`,
+        );
+        continue;
+      }
+
+      const overviewOwnRelease = upgradeReleaseBySlug.get(overviewSlug);
+      if (overviewOwnRelease !== releaseSlug) {
+        mismatches.push(
+          `${filename}: overview "${overviewSlug}" has release "${overviewOwnRelease ?? "(none)"}", expected "${releaseSlug}"`,
+        );
+      }
+    }
+
+    expect(mismatches).toEqual([]);
+  });
+});

--- a/apps/media/__tests__/upgrade-stage.test.ts
+++ b/apps/media/__tests__/upgrade-stage.test.ts
@@ -6,10 +6,11 @@ import {
 } from "@/lib/upgrades/stage";
 
 describe("upgrade stage helper", () => {
-  it("has a label and badge class for all four stages", () => {
+  it("has a label and badge class for all five stages", () => {
     const stages = [
       "planned",
       "in_development",
+      "pending_activation",
       "live",
       "action_required",
     ] as const;
@@ -21,6 +22,7 @@ describe("upgrade stage helper", () => {
 
   it("validates stage values from untrusted content data", () => {
     expect(isUpgradeStage("live")).toBe(true);
+    expect(isUpgradeStage("pending_activation")).toBe(true);
     expect(isUpgradeStage("mainnet-live")).toBe(false);
     expect(isUpgradeStage(undefined)).toBe(false);
   });

--- a/apps/media/__tests__/upgrade-stage.test.ts
+++ b/apps/media/__tests__/upgrade-stage.test.ts
@@ -6,13 +6,12 @@ import {
 } from "@/lib/upgrades/stage";
 
 describe("upgrade stage helper", () => {
-  it("has a label and badge class for all five stages", () => {
+  it("has a label and badge class for all four stages", () => {
     const stages = [
       "planned",
       "in_development",
       "pending_activation",
       "live",
-      "action_required",
     ] as const;
     for (const stage of stages) {
       expect(STAGE_LABELS[stage]).toBeTruthy();
@@ -24,6 +23,7 @@ describe("upgrade stage helper", () => {
     expect(isUpgradeStage("live")).toBe(true);
     expect(isUpgradeStage("pending_activation")).toBe(true);
     expect(isUpgradeStage("mainnet-live")).toBe(false);
+    expect(isUpgradeStage("action_required")).toBe(false);
     expect(isUpgradeStage(undefined)).toBe(false);
   });
 });

--- a/apps/media/__tests__/upgrade-stage.test.ts
+++ b/apps/media/__tests__/upgrade-stage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import {
+  isUpgradeStage,
+  STAGE_BADGE_CLASSES,
+  STAGE_LABELS,
+} from "@/lib/upgrades/stage";
+
+describe("upgrade stage helper", () => {
+  it("has a label and badge class for all four stages", () => {
+    const stages = [
+      "planned",
+      "in_development",
+      "live",
+      "action_required",
+    ] as const;
+    for (const stage of stages) {
+      expect(STAGE_LABELS[stage]).toBeTruthy();
+      expect(STAGE_BADGE_CLASSES[stage]).toBeTruthy();
+    }
+  });
+
+  it("validates stage values from untrusted content data", () => {
+    expect(isUpgradeStage("live")).toBe(true);
+    expect(isUpgradeStage("mainnet-live")).toBe(false);
+    expect(isUpgradeStage(undefined)).toBe(false);
+  });
+});

--- a/apps/media/app/[locale]/upgrades/[slug]/page.tsx
+++ b/apps/media/app/[locale]/upgrades/[slug]/page.tsx
@@ -15,17 +15,16 @@ import { JsonLd } from "@/components/seo/json-ld";
 import { buildUpgradeJsonLd } from "@/lib/content-structured-data";
 import { getUpgradeSocialImageUrl } from "@/lib/upgrades/social-image";
 import { isPublishedUpgrade } from "@/lib/keystatic/upgrade-status";
+import {
+  isUpgradeStage,
+  STAGE_BADGE_CLASSES,
+  STAGE_LABELS,
+  type UpgradeStage,
+} from "@/lib/upgrades/stage";
 
 export const revalidate = 300;
 
 type Props = { params: Promise<{ slug: string; locale: string }> };
-
-const badgeColorMap: Record<string, string> = {
-  green: "bg-[#14F195]/10 border-[#14F195]/30 text-[#14F195]",
-  yellow: "bg-yellow-500/10 border-yellow-500/30 text-yellow-400",
-  red: "bg-red-500/10 border-red-500/30 text-red-400",
-  purple: "bg-purple-500/10 border-purple-500/30 text-purple-400",
-};
 
 function SocialShare({ title, slug }: { title: string; slug: string }) {
   const url = encodeURIComponent(`https://solana.com/upgrades/${slug}`);
@@ -85,6 +84,9 @@ export default async function Page({ params }: Props) {
     ? await reader.collections.authors.read(entry.author)
     : null;
   const authorName = String(authorEntry?.name ?? "Solana Foundation");
+  const stage: UpgradeStage = isUpgradeStage(entry.stage)
+    ? entry.stage
+    : "in_development";
   const publishedDate = entry.publishedAt
     ? new Date(entry.publishedAt).toLocaleDateString("en-US", {
         month: "long",
@@ -116,28 +118,13 @@ export default async function Page({ params }: Props) {
               <span>Back to Upgrades</span>
             </Link>
           </div>
-          {entry.badges && entry.badges.length > 0 && (
-            <div className="flex flex-wrap items-center gap-2 mb-6">
-              {entry.badges.map(
-                (
-                  badge: { text: string; color: string; variant: string },
-                  i: number,
-                ) =>
-                  badge.variant === "text" ? (
-                    <span key={i} className="text-xs text-gray-500">
-                      {badge.text}
-                    </span>
-                  ) : (
-                    <span
-                      key={i}
-                      className={`text-xs px-3 py-1 rounded-full border font-medium ${badgeColorMap[badge.color] ?? badgeColorMap.green}`}
-                    >
-                      {badge.text}
-                    </span>
-                  ),
-              )}
-            </div>
-          )}
+          <div className="flex flex-wrap items-center gap-2 mb-6">
+            <span
+              className={`rounded-full border px-3 py-1 text-xs font-medium ${STAGE_BADGE_CLASSES[stage]}`}
+            >
+              {STAGE_LABELS[stage]}
+            </span>
+          </div>
           <h1 className="text-5xl md:text-6xl font-bold tracking-tight mb-6">
             {titleDisplay}
           </h1>

--- a/apps/media/app/[locale]/upgrades/[slug]/social-image/route.tsx
+++ b/apps/media/app/[locale]/upgrades/[slug]/social-image/route.tsx
@@ -8,6 +8,7 @@ import {
   UPGRADE_SOCIAL_IMAGE_TYPE,
 } from "@/lib/upgrades/social-image";
 import { isPublishedUpgrade } from "@/lib/keystatic/upgrade-status";
+import { isUpgradeStage, type UpgradeStage } from "@/lib/upgrades/stage";
 
 export const runtime = "nodejs";
 export const revalidate = 300;
@@ -45,6 +46,9 @@ export async function GET(_request: Request, { params }: RouteContext) {
   const authorEntry = entry.author
     ? await reader.collections.authors.read(entry.author)
     : null;
+  const stage: UpgradeStage = isUpgradeStage(entry.stage)
+    ? entry.stage
+    : "in_development";
   let regularFont: Buffer;
   let mediumFont: Buffer;
 
@@ -66,7 +70,7 @@ export async function GET(_request: Request, { params }: RouteContext) {
       subtitle={entry.subtitle ? String(entry.subtitle) : null}
       publishedAt={entry.publishedAt ? String(entry.publishedAt) : null}
       authorName={String(authorEntry?.name ?? "Solana Foundation")}
-      badges={entry.badges ?? []}
+      stage={stage}
       metrics={entry.metrics ?? []}
     />,
     {

--- a/apps/media/app/[locale]/upgrades/client-page.tsx
+++ b/apps/media/app/[locale]/upgrades/client-page.tsx
@@ -41,7 +41,7 @@ function StageBadge({ stage }: { stage: UpgradeListItem["stage"] }) {
   return (
     <span
       className={cn(
-        "rounded-full border px-3 py-1 text-xs font-medium",
+        "whitespace-nowrap rounded-full border px-3 py-1 text-xs font-medium",
         STAGE_BADGE_CLASSES[stage],
       )}
     >
@@ -161,16 +161,16 @@ function TableView({ groups }: { groups: ReleaseGroup[] }) {
           <ReleaseHeader group={group} />
           {group.overview && <OverviewCallout overview={group.overview} />}
           <div className="overflow-x-auto border border-white/10">
-            <table className="w-full min-w-[480px] border-collapse">
+            <table className="w-full min-w-[480px] table-fixed border-collapse">
               <thead>
                 <tr className="border-b border-white/10 bg-white/[0.02]">
-                  <th className="p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
+                  <th className="w-[45%] p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
                     Upgrade
                   </th>
-                  <th className="p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
+                  <th className="w-[27%] p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
                     Key metric
                   </th>
-                  <th className="p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
+                  <th className="w-[28%] p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
                     Status
                   </th>
                 </tr>

--- a/apps/media/app/[locale]/upgrades/client-page.tsx
+++ b/apps/media/app/[locale]/upgrades/client-page.tsx
@@ -174,15 +174,17 @@ function TableView({ groups }: { groups: ReleaseGroup[] }) {
                   return (
                     <tr
                       key={upgrade.slug}
-                      className="border-b border-white/10 transition-colors last:border-b-0 hover:bg-white/[0.06]"
+                      className="group relative border-b border-white/10 transition-colors last:border-b-0 hover:bg-white/[0.06]"
                     >
                       <td className="p-4 px-5 align-top">
                         <Link
                           href={`/upgrades/${upgrade.slug}`}
-                          className="text-[15px] font-semibold hover:underline"
-                        >
+                          className="absolute inset-0"
+                          aria-label={upgrade.title}
+                        />
+                        <div className="text-[15px] font-semibold group-hover:underline">
                           {upgrade.title}
-                        </Link>
+                        </div>
                         <div className="mt-1 text-[13px] leading-5 text-[#ABABBA]">
                           {upgrade.subtitle || upgrade.description}
                         </div>

--- a/apps/media/app/[locale]/upgrades/client-page.tsx
+++ b/apps/media/app/[locale]/upgrades/client-page.tsx
@@ -322,7 +322,7 @@ export default function UpgradesClientPage({
               view === "table" ? "bg-white text-black" : "text-white/70",
             )}
           >
-            Table
+            List
           </button>
           <button
             type="button"
@@ -333,7 +333,7 @@ export default function UpgradesClientPage({
               view === "cards" ? "bg-white text-black" : "text-white/70",
             )}
           >
-            Cards
+            Grid
           </button>
         </div>
       </div>

--- a/apps/media/app/[locale]/upgrades/client-page.tsx
+++ b/apps/media/app/[locale]/upgrades/client-page.tsx
@@ -1,0 +1,327 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Link } from "@workspace/i18n/routing";
+import { ArrowUpRight } from "@boxicons/react/ArrowUpRight";
+import { cn } from "@/lib/utils";
+import { STAGE_BADGE_CLASSES, STAGE_LABELS } from "@/lib/upgrades/stage";
+import type {
+  ReleaseGroup,
+  UpgradeListItem,
+} from "@/lib/upgrades/group-by-release";
+
+type View = "table" | "cards";
+
+interface UpgradesClientPageProps {
+  groups: ReleaseGroup[];
+}
+
+function formatReleaseDate(group: ReleaseGroup): string | null {
+  if (!group.expectedDate) {
+    return null;
+  }
+
+  const formatted = new Date(group.expectedDate).toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+
+  return group.status === "planned" ? `Expected ${formatted}` : formatted;
+}
+
+function StageBadge({ stage }: { stage: UpgradeListItem["stage"] }) {
+  return (
+    <span
+      className={cn(
+        "rounded-full border px-3 py-1 text-xs font-medium",
+        STAGE_BADGE_CLASSES[stage],
+      )}
+    >
+      {STAGE_LABELS[stage]}
+    </span>
+  );
+}
+
+function UpgradeCard({ upgrade }: { upgrade: UpgradeListItem }) {
+  return (
+    <Link
+      href={`/upgrades/${upgrade.slug}`}
+      className="group flex min-h-[320px] flex-col justify-between border border-white/10 bg-white/[0.03] p-6 transition-colors hover:border-white/25 hover:bg-white/[0.06] md:p-7"
+    >
+      <div>
+        <div className="mb-5 flex flex-wrap items-center gap-2">
+          <StageBadge stage={upgrade.stage} />
+        </div>
+        <h3 className="text-2xl font-semibold tracking-[-0.48px] md:text-3xl">
+          {upgrade.title}
+        </h3>
+        {(upgrade.subtitle || upgrade.description) && (
+          <p className="mt-4 line-clamp-3 text-base leading-7 text-[#ABABBA]">
+            {upgrade.subtitle || upgrade.description}
+          </p>
+        )}
+        {upgrade.metrics.length > 0 && (
+          <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
+            {upgrade.metrics.slice(0, 2).map((metric) => (
+              <div
+                key={`${upgrade.slug}-${metric.value}-${metric.label}`}
+                className="border border-white/10 bg-black/30 p-4"
+              >
+                <div className="text-2xl font-semibold text-white">
+                  {metric.value}
+                </div>
+                <div className="mt-1 text-xs leading-5 text-white/55">
+                  {metric.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+      <div className="mt-8 flex items-center justify-end gap-4 border-t border-white/10 pt-5">
+        <span className="inline-flex items-center gap-2 text-sm font-medium text-white">
+          View details
+          <ArrowUpRight className="size-4 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+function OverviewCallout({ overview }: { overview: UpgradeListItem }) {
+  return (
+    <Link
+      href={`/upgrades/${overview.slug}`}
+      className="mb-4 block border border-[#14F195]/35 bg-[#14F195]/5 p-6 transition-colors hover:border-[#14F195]/55 hover:bg-[#14F195]/[0.08]"
+    >
+      <div className="mb-2.5 text-xs font-semibold uppercase tracking-[0.08em] text-[#14F195]">
+        Release overview
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-5">
+        <div className="max-w-xl">
+          <p className="text-sm leading-6 text-[#ABABBA] md:text-[14.5px]">
+            {overview.subtitle || overview.description}
+          </p>
+        </div>
+        {overview.metrics.length > 0 && (
+          <div className="flex flex-wrap gap-6">
+            {overview.metrics.slice(0, 3).map((metric) => (
+              <div key={`${overview.slug}-${metric.value}-${metric.label}`}>
+                <div className="text-xl font-semibold tabular-nums text-white">
+                  {metric.value}
+                </div>
+                <div className="mt-1 max-w-[11rem] text-[11px] text-white/55">
+                  {metric.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </Link>
+  );
+}
+
+function ReleaseHeader({ group }: { group: ReleaseGroup }) {
+  const dateLabel = formatReleaseDate(group);
+
+  return (
+    <div className="mb-4 flex flex-wrap items-baseline gap-3">
+      <h2 className="m-0 text-[22px] font-semibold tracking-[-0.3px]">
+        {group.name}
+      </h2>
+      {group.status === "planned" && (
+        <span className="rounded-full border border-[#14F195]/35 bg-[#14F195]/[0.08] px-2.5 py-0.5 text-[11.5px] font-semibold text-[#14F195]">
+          Planned
+        </span>
+      )}
+      {group.status === "shipped" && (
+        <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-0.5 text-[11.5px] font-semibold text-white/70">
+          Shipped
+        </span>
+      )}
+      {dateLabel && <span className="text-sm text-white/50">{dateLabel}</span>}
+    </div>
+  );
+}
+
+function TableView({ groups }: { groups: ReleaseGroup[] }) {
+  return (
+    <>
+      {groups.map((group) => (
+        <section key={group.key} className="mb-12 last:mb-0">
+          <ReleaseHeader group={group} />
+          {group.overview && <OverviewCallout overview={group.overview} />}
+          <div className="overflow-x-auto border border-white/10">
+            <table className="w-full min-w-[480px] border-collapse">
+              <thead>
+                <tr className="border-b border-white/10 bg-white/[0.02]">
+                  <th className="p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
+                    Upgrade
+                  </th>
+                  <th className="p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
+                    Key metric
+                  </th>
+                  <th className="p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
+                    Status
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {group.upgrades.map((upgrade) => {
+                  const metric = upgrade.metrics[0];
+                  return (
+                    <tr
+                      key={upgrade.slug}
+                      className="border-b border-white/10 transition-colors last:border-b-0 hover:bg-white/[0.06]"
+                    >
+                      <td className="p-4 px-5 align-top">
+                        <Link
+                          href={`/upgrades/${upgrade.slug}`}
+                          className="text-[15px] font-semibold hover:underline"
+                        >
+                          {upgrade.title}
+                        </Link>
+                        <div className="mt-1 text-[13px] leading-5 text-[#ABABBA]">
+                          {upgrade.subtitle || upgrade.description}
+                        </div>
+                      </td>
+                      <td className="p-4 px-5 align-top">
+                        {metric && (
+                          <>
+                            <div className="font-semibold tabular-nums">
+                              {metric.value}
+                            </div>
+                            <div className="mt-0.5 text-xs text-white/50">
+                              {metric.label}
+                            </div>
+                          </>
+                        )}
+                      </td>
+                      <td className="p-4 px-5 align-top">
+                        <StageBadge stage={upgrade.stage} />
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ))}
+    </>
+  );
+}
+
+function CardsView({ groups }: { groups: ReleaseGroup[] }) {
+  return (
+    <>
+      {groups.map((group) => {
+        const items = group.overview
+          ? [group.overview, ...group.upgrades]
+          : group.upgrades;
+
+        return (
+          <section key={group.key} className="mb-12 last:mb-0">
+            <ReleaseHeader group={group} />
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6 xl:grid-cols-3">
+              {items.map((upgrade) => (
+                <UpgradeCard key={upgrade.slug} upgrade={upgrade} />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </>
+  );
+}
+
+export default function UpgradesClientPage({
+  groups,
+}: UpgradesClientPageProps) {
+  const [view, setView] = useState<View>("table");
+  const [selectedRelease, setSelectedRelease] = useState("all");
+
+  const releaseOptions = useMemo(
+    () =>
+      groups
+        .filter((group) => group.status !== null)
+        .map((group) => ({
+          key: group.key,
+          label: `${group.name} — ${group.status === "planned" ? "Planned" : "Shipped"}`,
+        })),
+    [groups],
+  );
+
+  const visibleGroups =
+    selectedRelease === "all"
+      ? groups
+      : groups.filter((group) => group.key === selectedRelease);
+
+  if (groups.length === 0) {
+    return (
+      <div className="py-20 text-center text-lg tracking-[-0.18px] text-white/60">
+        No published upgrades found.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-8 flex flex-wrap items-end justify-between gap-4">
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="release-select"
+            className="text-[11px] font-semibold uppercase tracking-[0.08em] text-white/50"
+          >
+            Release
+          </label>
+          <select
+            id="release-select"
+            value={selectedRelease}
+            onChange={(event) => setSelectedRelease(event.target.value)}
+            className="min-w-[220px] rounded-lg border border-white/10 bg-white/[0.03] px-3.5 py-2.5 text-[14.5px] font-medium text-white hover:border-white/25"
+          >
+            <option value="all">All releases</option>
+            {releaseOptions.map((option) => (
+              <option key={option.key} value={option.key}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="inline-flex flex-shrink-0 gap-0.5 rounded-lg border border-white/10 p-[3px]">
+          <button
+            type="button"
+            aria-pressed={view === "table"}
+            onClick={() => setView("table")}
+            className={cn(
+              "rounded-md px-4 py-1.5 text-[13.5px] font-medium",
+              view === "table" ? "bg-white text-black" : "text-white/70",
+            )}
+          >
+            Table
+          </button>
+          <button
+            type="button"
+            aria-pressed={view === "cards"}
+            onClick={() => setView("cards")}
+            className={cn(
+              "rounded-md px-4 py-1.5 text-[13.5px] font-medium",
+              view === "cards" ? "bg-white text-black" : "text-white/70",
+            )}
+          >
+            Cards
+          </button>
+        </div>
+      </div>
+
+      {view === "table" ? (
+        <TableView groups={visibleGroups} />
+      ) : (
+        <CardsView groups={visibleGroups} />
+      )}
+    </div>
+  );
+}

--- a/apps/media/app/[locale]/upgrades/client-page.tsx
+++ b/apps/media/app/[locale]/upgrades/client-page.tsx
@@ -170,7 +170,7 @@ function TableView({ groups }: { groups: ReleaseGroup[] }) {
                   <th className="w-[27%] p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
                     Key metric
                   </th>
-                  <th className="w-[28%] p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
+                  <th className="w-[28%] py-3 pl-12 pr-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
                     Status
                   </th>
                 </tr>
@@ -208,7 +208,7 @@ function TableView({ groups }: { groups: ReleaseGroup[] }) {
                           </>
                         )}
                       </td>
-                      <td className="p-4 px-5 align-top">
+                      <td className="py-4 pl-12 pr-5 align-top">
                         <StageBadge stage={upgrade.stage} />
                       </td>
                     </tr>

--- a/apps/media/app/[locale]/upgrades/client-page.tsx
+++ b/apps/media/app/[locale]/upgrades/client-page.tsx
@@ -4,6 +4,13 @@ import { useMemo, useState } from "react";
 import { Link } from "@workspace/i18n/routing";
 import { ArrowUpRight } from "@boxicons/react/ArrowUpRight";
 import { cn } from "@/lib/utils";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { STAGE_BADGE_CLASSES, STAGE_LABELS } from "@/lib/upgrades/stage";
 import type {
   ReleaseGroup,
@@ -279,19 +286,31 @@ export default function UpgradesClientPage({
           >
             Release
           </label>
-          <select
-            id="release-select"
-            value={selectedRelease}
-            onChange={(event) => setSelectedRelease(event.target.value)}
-            className="min-w-[220px] rounded-lg border border-white/10 bg-white/[0.03] px-3.5 py-2.5 text-[14.5px] font-medium text-white hover:border-white/25"
-          >
-            <option value="all">All releases</option>
-            {releaseOptions.map((option) => (
-              <option key={option.key} value={option.key}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+          <Select value={selectedRelease} onValueChange={setSelectedRelease}>
+            <SelectTrigger
+              id="release-select"
+              className="min-w-[220px] rounded-lg border-white/10 bg-white/[0.03] px-3.5 py-2.5 text-[14.5px] font-medium text-white ring-offset-0 hover:border-white/25 focus:ring-0 focus:ring-offset-0"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent className="min-w-[220px] rounded-lg border-white/10 bg-black text-white shadow-xl">
+              <SelectItem
+                value="all"
+                className="text-[14.5px] focus:bg-white/10 focus:text-white"
+              >
+                All releases
+              </SelectItem>
+              {releaseOptions.map((option) => (
+                <SelectItem
+                  key={option.key}
+                  value={option.key}
+                  className="text-[14.5px] focus:bg-white/10 focus:text-white"
+                >
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
         <div className="inline-flex flex-shrink-0 gap-0.5 rounded-lg border border-white/10 p-[3px]">
           <button

--- a/apps/media/app/[locale]/upgrades/client-page.tsx
+++ b/apps/media/app/[locale]/upgrades/client-page.tsx
@@ -312,7 +312,7 @@ export default function UpgradesClientPage({
             </SelectContent>
           </Select>
         </div>
-        <div className="inline-flex flex-shrink-0 gap-0.5 rounded-lg border border-white/10 p-[3px]">
+        <div className="hidden flex-shrink-0 gap-0.5 rounded-lg border border-white/10 p-[3px] md:inline-flex">
           <button
             type="button"
             aria-pressed={view === "table"}
@@ -338,11 +338,17 @@ export default function UpgradesClientPage({
         </div>
       </div>
 
-      {view === "table" ? (
-        <TableView groups={visibleGroups} />
-      ) : (
+      {/* Mobile always gets Grid — the table's horizontal scroll doesn't work well at that width. */}
+      <div className="md:hidden">
         <CardsView groups={visibleGroups} />
-      )}
+      </div>
+      <div className="hidden md:block">
+        {view === "table" ? (
+          <TableView groups={visibleGroups} />
+        ) : (
+          <CardsView groups={visibleGroups} />
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/media/app/[locale]/upgrades/page.tsx
+++ b/apps/media/app/[locale]/upgrades/page.tsx
@@ -157,14 +157,14 @@ export default async function UpgradesPage({
     <section className="relative min-h-screen bg-black text-left text-white">
       <JsonLd data={structuredData} />
       <div className="mx-auto w-full max-w-[1440px] px-[20px] md:px-[32px] xl:px-[40px]">
-        <div className="flex max-w-5xl flex-col py-[64px] md:py-[112px] xl:py-[160px]">
-          <span className="mb-5 text-xs font-medium uppercase tracking-[0.28em] text-[#14F195]">
+        <div className="flex max-w-3xl flex-col gap-2 py-8 md:py-10">
+          <span className="text-xs font-medium uppercase tracking-[0.28em] text-[#14F195]">
             Network upgrade notifications
           </span>
-          <h1 className="m-0 text-[40px] font-medium leading-[1.1] tracking-[-1px] md:text-[56px] md:tracking-[-1.4px] xl:text-[88px] xl:tracking-[-2px]">
+          <h1 className="m-0 text-[28px] font-medium leading-[1.15] tracking-[-0.5px] md:text-[34px] md:tracking-[-0.6px]">
             Solana Upgrades
           </h1>
-          <p className="mb-0 mt-[12px] max-w-2xl text-lg leading-[1.33] tracking-[-0.18px] text-[#ABABBA] md:text-2xl md:tracking-[-0.24px] xl:mt-[24px]">
+          <p className="m-0 max-w-2xl text-base leading-[1.4] text-[#ABABBA] md:text-lg">
             Track network changes, validator actions, client support, and
             rollout status for Solana protocol and performance upgrades.
           </p>

--- a/apps/media/app/[locale]/upgrades/page.tsx
+++ b/apps/media/app/[locale]/upgrades/page.tsx
@@ -1,8 +1,5 @@
-import { Link } from "@workspace/i18n/routing";
-import { ArrowUpRight } from "@boxicons/react/ArrowUpRight";
 import type { Metadata } from "next";
 import { reader } from "@/lib/reader";
-import { cn } from "@/lib/utils";
 import {
   UPGRADES_SEO_DESCRIPTION,
   UPGRADES_SEO_TITLE,
@@ -11,39 +8,15 @@ import {
 import { JsonLd } from "@/components/seo/json-ld";
 import { buildUpgradeCollectionJsonLd } from "@/lib/content-structured-data";
 import { isPublishedUpgrade } from "@/lib/keystatic/upgrade-status";
+import { isUpgradeStage } from "@/lib/upgrades/stage";
+import {
+  groupUpgradesByRelease,
+  type ReleaseInput,
+  type UpgradeListItem,
+} from "@/lib/upgrades/group-by-release";
+import UpgradesClientPage from "./client-page";
 
 export const revalidate = 300;
-
-type BadgeColor = "green" | "yellow" | "red" | "purple";
-type BadgeVariant = "badge" | "text";
-
-type UpgradeBadge = {
-  text: string;
-  color: BadgeColor;
-  variant: BadgeVariant;
-};
-
-type UpgradeMetric = {
-  value: string;
-  label: string;
-};
-
-type UpgradeCard = {
-  slug: string;
-  title: string;
-  description: string;
-  subtitle: string;
-  publishedAt: string | null;
-  badges: UpgradeBadge[];
-  metrics: UpgradeMetric[];
-};
-
-const badgeColorMap: Record<BadgeColor, string> = {
-  green: "border-[#14F195]/30 bg-[#14F195]/10 text-[#14F195]",
-  yellow: "border-yellow-500/30 bg-yellow-500/10 text-yellow-300",
-  red: "border-red-500/30 bg-red-500/10 text-red-300",
-  purple: "border-purple-500/30 bg-purple-500/10 text-purple-300",
-};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -53,45 +26,7 @@ function toStringValue(value: unknown): string {
   return typeof value === "string" ? value : "";
 }
 
-function normalizeBadgeColor(value: unknown): BadgeColor {
-  return value === "yellow" ||
-    value === "red" ||
-    value === "purple" ||
-    value === "green"
-    ? value
-    : "green";
-}
-
-function normalizeBadgeVariant(value: unknown): BadgeVariant {
-  return value === "text" ? "text" : "badge";
-}
-
-function normalizeBadges(value: unknown): UpgradeBadge[] {
-  if (!Array.isArray(value)) {
-    return [];
-  }
-
-  return value
-    .map((item) => {
-      if (!isRecord(item)) {
-        return null;
-      }
-
-      const text = toStringValue(item.text);
-      if (!text) {
-        return null;
-      }
-
-      return {
-        text,
-        color: normalizeBadgeColor(item.color),
-        variant: normalizeBadgeVariant(item.variant),
-      };
-    })
-    .filter((item): item is UpgradeBadge => item !== null);
-}
-
-function normalizeMetrics(value: unknown): UpgradeMetric[] {
+function normalizeMetrics(value: unknown): UpgradeListItem["metrics"] {
   if (!Array.isArray(value)) {
     return [];
   }
@@ -109,21 +44,12 @@ function normalizeMetrics(value: unknown): UpgradeMetric[] {
 
       return metric.value && metric.label ? metric : null;
     })
-    .filter((item): item is UpgradeMetric => item !== null);
+    .filter(
+      (item): item is UpgradeListItem["metrics"][number] => item !== null,
+    );
 }
 
-function formatPublishedAt(value: string | null) {
-  if (!value) {
-    return null;
-  }
-
-  return new Date(value).toLocaleDateString("en-US", {
-    month: "long",
-    year: "numeric",
-  });
-}
-
-async function getPublishedUpgrades(): Promise<UpgradeCard[]> {
+async function getPublishedUpgrades(): Promise<UpgradeListItem[]> {
   const slugs = await reader.collections.upgrades.list();
   const upgrades = await Promise.all(
     slugs.map(async (slug: string) => {
@@ -142,24 +68,45 @@ async function getPublishedUpgrades(): Promise<UpgradeCard[]> {
         description: toStringValue(entry.description),
         subtitle: toStringValue(entry.subtitle),
         publishedAt: toStringValue(entry.publishedAt) || null,
-        badges: normalizeBadges(entry.badges),
+        stage: isUpgradeStage(entry.stage) ? entry.stage : "in_development",
         metrics: normalizeMetrics(entry.metrics),
-      };
+        release: toStringValue(entry.release) || null,
+        order: typeof entry.order === "number" ? entry.order : null,
+      } satisfies UpgradeListItem;
     }),
   );
 
-  return upgrades
-    .filter((upgrade): upgrade is UpgradeCard => upgrade !== null)
-    .sort((left, right) => {
-      const leftDate = left.publishedAt
-        ? new Date(left.publishedAt).getTime()
-        : 0;
-      const rightDate = right.publishedAt
-        ? new Date(right.publishedAt).getTime()
-        : 0;
+  return upgrades.filter(
+    (upgrade): upgrade is UpgradeListItem => upgrade !== null,
+  );
+}
 
-      return rightDate - leftDate;
-    });
+async function getReleases(): Promise<ReleaseInput[]> {
+  const slugs = await reader.collections.releases.list();
+  const releases = await Promise.all(
+    slugs.map(async (slug: string) => {
+      const entry = (await reader.collections.releases.read(slug)) as Record<
+        string,
+        unknown
+      > | null;
+
+      if (!entry) {
+        return null;
+      }
+
+      return {
+        slug,
+        name: toStringValue(entry.name) || slug,
+        status: entry.status === "shipped" ? "shipped" : "planned",
+        expectedDate: toStringValue(entry.expectedDate) || null,
+        overview: toStringValue(entry.overview) || null,
+      } satisfies ReleaseInput;
+    }),
+  );
+
+  return releases.filter(
+    (release): release is ReleaseInput => release !== null,
+  );
 }
 
 export async function generateMetadata({
@@ -177,7 +124,12 @@ export default async function UpgradesPage({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const upgrades = await getPublishedUpgrades();
+  const [upgrades, releases] = await Promise.all([
+    getPublishedUpgrades(),
+    getReleases(),
+  ]);
+  const groups = groupUpgradesByRelease(upgrades, releases);
+
   const structuredData = buildUpgradeCollectionJsonLd({
     upgrades: upgrades.map((upgrade) => ({
       slug: upgrade.slug,
@@ -210,108 +162,7 @@ export default async function UpgradesPage({
 
       <div className="mx-auto w-full max-w-[1440px] px-[20px] pb-[64px] md:px-[32px] md:pb-[112px] xl:px-[40px] xl:pb-[160px]">
         <div className="border-t border-white/10 pt-8 md:pt-10">
-          <div className="mb-6 flex flex-wrap items-center gap-2">
-            <span className="rounded-full bg-white px-4 py-1.5 text-sm text-black">
-              All
-            </span>
-            <span className="rounded-full bg-white/10 px-4 py-1.5 text-sm text-white/80">
-              Validator actions
-            </span>
-            <span className="rounded-full bg-white/10 px-4 py-1.5 text-sm text-white/80">
-              Protocol changes
-            </span>
-            <span className="rounded-full bg-white/10 px-4 py-1.5 text-sm text-white/80">
-              Performance
-            </span>
-          </div>
-
-          {upgrades.length > 0 ? (
-            <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6 xl:grid-cols-3">
-              {upgrades.map((upgrade) => {
-                const publishedAt = formatPublishedAt(upgrade.publishedAt);
-
-                return (
-                  <Link
-                    key={upgrade.slug}
-                    href={`/upgrades/${upgrade.slug}`}
-                    className="group flex min-h-[360px] flex-col justify-between border border-white/10 bg-white/[0.03] p-6 transition-colors hover:border-white/25 hover:bg-white/[0.06] md:p-7"
-                  >
-                    <div>
-                      <div className="mb-5 flex flex-wrap items-center gap-2">
-                        {upgrade.badges.length > 0 ? (
-                          upgrade.badges.map((badge, index) =>
-                            badge.variant === "text" ? (
-                              <span
-                                key={`${upgrade.slug}-${badge.text}-${index}`}
-                                className="text-xs text-white/50"
-                              >
-                                {badge.text}
-                              </span>
-                            ) : (
-                              <span
-                                key={`${upgrade.slug}-${badge.text}-${index}`}
-                                className={cn(
-                                  "rounded-full border px-3 py-1 text-xs font-medium",
-                                  badgeColorMap[badge.color],
-                                )}
-                              >
-                                {badge.text}
-                              </span>
-                            ),
-                          )
-                        ) : (
-                          <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1 text-xs font-medium text-white/70">
-                            Published
-                          </span>
-                        )}
-                      </div>
-
-                      <h2 className="text-2xl font-semibold tracking-[-0.48px] md:text-3xl">
-                        {upgrade.title}
-                      </h2>
-                      {(upgrade.subtitle || upgrade.description) && (
-                        <p className="mt-4 line-clamp-4 text-base leading-7 text-[#ABABBA]">
-                          {upgrade.subtitle || upgrade.description}
-                        </p>
-                      )}
-
-                      {upgrade.metrics.length > 0 && (
-                        <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-2">
-                          {upgrade.metrics.slice(0, 2).map((metric) => (
-                            <div
-                              key={`${upgrade.slug}-${metric.value}-${metric.label}`}
-                              className="border border-white/10 bg-black/30 p-4"
-                            >
-                              <div className="text-2xl font-semibold text-white">
-                                {metric.value}
-                              </div>
-                              <div className="mt-1 text-xs leading-5 text-white/55">
-                                {metric.label}
-                              </div>
-                            </div>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="mt-8 flex items-center justify-between gap-4 border-t border-white/10 pt-5">
-                      <span className="text-sm text-white/55">
-                        {publishedAt ?? "Upgrade"}
-                      </span>
-                      <span className="inline-flex items-center gap-2 text-sm font-medium text-white">
-                        View details
-                        <ArrowUpRight className="size-4 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
-                      </span>
-                    </div>
-                  </Link>
-                );
-              })}
-            </div>
-          ) : (
-            <div className="py-20 text-center text-lg tracking-[-0.18px] text-white/60">
-              No published upgrades found.
-            </div>
-          )}
+          <UpgradesClientPage groups={groups} />
         </div>
       </div>
     </section>

--- a/apps/media/app/[locale]/upgrades/page.tsx
+++ b/apps/media/app/[locale]/upgrades/page.tsx
@@ -131,12 +131,23 @@ export default async function UpgradesPage({
   const groups = groupUpgradesByRelease(upgrades, releases);
 
   const structuredData = buildUpgradeCollectionJsonLd({
-    upgrades: upgrades.map((upgrade) => ({
-      slug: upgrade.slug,
-      title: upgrade.title,
-      description: upgrade.description || upgrade.subtitle,
-      publishedAt: upgrade.publishedAt,
-    })),
+    upgrades: [...upgrades]
+      .sort((left, right) => {
+        const leftDate = left.publishedAt
+          ? new Date(left.publishedAt).getTime()
+          : 0;
+        const rightDate = right.publishedAt
+          ? new Date(right.publishedAt).getTime()
+          : 0;
+
+        return rightDate - leftDate;
+      })
+      .map((upgrade) => ({
+        slug: upgrade.slug,
+        title: upgrade.title,
+        description: upgrade.description || upgrade.subtitle,
+        publishedAt: upgrade.publishedAt,
+      })),
     locale,
     title: UPGRADES_SEO_TITLE,
     description: UPGRADES_SEO_DESCRIPTION,

--- a/apps/media/components/ui/select.tsx
+++ b/apps/media/components/ui/select.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check } from "@boxicons/react/Check";
+import { ChevronDown } from "@boxicons/react/ChevronDown";
+import { ChevronUp } from "@boxicons/react/ChevronUp";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-10 w-full items-center justify-between rounded-md border border-zinc-200 bg-zinc-50 px-3 py-2 text-sm ring-offset-white data-[placeholder]:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-zinc-950 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1 dark:border-zinc-800 dark:bg-zinc-950 dark:ring-offset-zinc-950 dark:data-[placeholder]:text-zinc-400 dark:focus:ring-zinc-300",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className,
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border border-zinc-200 bg-zinc-50 text-zinc-950 shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-50",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className,
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-zinc-100 focus:text-zinc-900 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 dark:focus:bg-zinc-800 dark:focus:text-zinc-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-zinc-100 dark:bg-zinc-800", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/apps/media/components/upgrades/upgrade-social-image.tsx
+++ b/apps/media/components/upgrades/upgrade-social-image.tsx
@@ -32,6 +32,11 @@ const stageColorMap: Record<
     borderColor: "rgba(234, 179, 8, 0.35)",
     color: "#FACC15",
   },
+  pending_activation: {
+    backgroundColor: "rgba(96, 165, 250, 0.08)",
+    borderColor: "rgba(96, 165, 250, 0.35)",
+    color: "#93C5FD",
+  },
   live: {
     backgroundColor: "rgba(20, 241, 149, 0.08)",
     borderColor: "rgba(20, 241, 149, 0.35)",

--- a/apps/media/components/upgrades/upgrade-social-image.tsx
+++ b/apps/media/components/upgrades/upgrade-social-image.tsx
@@ -2,12 +2,7 @@ import {
   formatUpgradePublishedDate,
   getUpgradeTitleFontSize,
 } from "@/lib/upgrades/social-image";
-
-type UpgradeBadge = {
-  text: string;
-  color: string;
-  variant: string;
-};
+import { STAGE_LABELS, type UpgradeStage } from "@/lib/upgrades/stage";
 
 type UpgradeMetric = {
   value: string;
@@ -19,33 +14,33 @@ type UpgradeSocialImageProps = {
   subtitle?: string | null;
   publishedAt?: string | null;
   authorName: string;
-  badges: UpgradeBadge[];
+  stage: UpgradeStage;
   metrics: UpgradeMetric[];
 };
 
-const badgeColorMap: Record<
-  string,
+const stageColorMap: Record<
+  UpgradeStage,
   { backgroundColor: string; borderColor: string; color: string }
 > = {
-  green: {
-    backgroundColor: "rgba(20, 241, 149, 0.08)",
-    borderColor: "rgba(20, 241, 149, 0.35)",
-    color: "#42E6A3",
+  planned: {
+    backgroundColor: "rgba(255, 255, 255, 0.05)",
+    borderColor: "rgba(255, 255, 255, 0.25)",
+    color: "#B3B3C2",
   },
-  yellow: {
+  in_development: {
     backgroundColor: "rgba(234, 179, 8, 0.08)",
     borderColor: "rgba(234, 179, 8, 0.35)",
     color: "#FACC15",
   },
-  red: {
+  live: {
+    backgroundColor: "rgba(20, 241, 149, 0.08)",
+    borderColor: "rgba(20, 241, 149, 0.35)",
+    color: "#42E6A3",
+  },
+  action_required: {
     backgroundColor: "rgba(244, 63, 94, 0.08)",
     borderColor: "rgba(244, 63, 94, 0.35)",
     color: "#FB7185",
-  },
-  purple: {
-    backgroundColor: "rgba(153, 69, 255, 0.08)",
-    borderColor: "rgba(153, 69, 255, 0.35)",
-    color: "#C084FC",
   },
 };
 
@@ -54,10 +49,11 @@ export function UpgradeSocialImage({
   subtitle,
   publishedAt,
   authorName,
-  badges,
+  stage,
   metrics,
 }: UpgradeSocialImageProps) {
   const publishedDate = formatUpgradePublishedDate(publishedAt);
+  const palette = stageColorMap[stage];
 
   return (
     <div
@@ -96,52 +92,31 @@ export function UpgradeSocialImage({
         }}
       >
         <div style={{ display: "flex", flexDirection: "column" }}>
-          {badges.length > 0 && (
-            <div
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
+              marginBottom: 28,
+            }}
+          >
+            <span
               style={{
                 display: "flex",
                 alignItems: "center",
-                gap: 12,
-                marginBottom: 28,
+                padding: "8px 18px 7px",
+                border: `1px solid ${palette.borderColor}`,
+                borderRadius: 999,
+                backgroundColor: palette.backgroundColor,
+                color: palette.color,
+                fontSize: 18,
+                fontWeight: 500,
+                lineHeight: 1,
               }}
             >
-              {badges.map((badge, index) => {
-                const palette =
-                  badgeColorMap[badge.color] ?? badgeColorMap.green!;
-
-                return badge.variant === "text" ? (
-                  <span
-                    key={`${badge.text}-${index}`}
-                    style={{
-                      color: "#8D8D9D",
-                      fontSize: 18,
-                      lineHeight: 1,
-                    }}
-                  >
-                    {badge.text}
-                  </span>
-                ) : (
-                  <span
-                    key={`${badge.text}-${index}`}
-                    style={{
-                      display: "flex",
-                      alignItems: "center",
-                      padding: "8px 18px 7px",
-                      border: `1px solid ${palette.borderColor}`,
-                      borderRadius: 999,
-                      backgroundColor: palette.backgroundColor,
-                      color: palette.color,
-                      fontSize: 18,
-                      fontWeight: 500,
-                      lineHeight: 1,
-                    }}
-                  >
-                    {badge.text}
-                  </span>
-                );
-              })}
-            </div>
-          )}
+              {STAGE_LABELS[stage]}
+            </span>
+          </div>
 
           <div
             style={{

--- a/apps/media/components/upgrades/upgrade-social-image.tsx
+++ b/apps/media/components/upgrades/upgrade-social-image.tsx
@@ -42,11 +42,6 @@ const stageColorMap: Record<
     borderColor: "rgba(20, 241, 149, 0.35)",
     color: "#42E6A3",
   },
-  action_required: {
-    backgroundColor: "rgba(244, 63, 94, 0.08)",
-    borderColor: "rgba(244, 63, 94, 0.35)",
-    color: "#FB7185",
-  },
 };
 
 export function UpgradeSocialImage({

--- a/apps/media/content/releases/agave-4-1.mdx
+++ b/apps/media/content/releases/agave-4-1.mdx
@@ -1,0 +1,5 @@
+---
+name: Agave 4.1
+expectedDate: 2026-05-01
+status: shipped
+---

--- a/apps/media/content/releases/agave-4-2.mdx
+++ b/apps/media/content/releases/agave-4-2.mdx
@@ -1,0 +1,6 @@
+---
+name: Agave 4.2
+expectedDate: 2026-08-01
+status: shipped
+overview: agave-4-2-release-overview
+---

--- a/apps/media/content/releases/agave-4-3.mdx
+++ b/apps/media/content/releases/agave-4-3.mdx
@@ -1,0 +1,5 @@
+---
+name: Agave 4.3
+expectedDate: 2026-10-01
+status: planned
+---

--- a/apps/media/content/upgrades/100m-cu-blocks.mdx
+++ b/apps/media/content/upgrades/100m-cu-blocks.mdx
@@ -10,8 +10,7 @@ publishedAt: 2026-07-27T00:00:00.000Z
 status: published
 author: solana-foundation
 stage: live
-release: agave-4-2
-order: 4
+release: agave-4-1
 metrics:
   - value: 100M
     label: Compute units per block, up from 60M

--- a/apps/media/content/upgrades/100m-cu-blocks.mdx
+++ b/apps/media/content/upgrades/100m-cu-blocks.mdx
@@ -9,10 +9,9 @@ subtitle: Raising Solana's block limit from 60M to 100M compute units
 publishedAt: 2026-07-27T00:00:00.000Z
 status: published
 author: solana-foundation
-badges:
-  - text: "Mainnet Live"
-    color: green
-    variant: badge
+stage: live
+release: agave-4-2
+order: 4
 metrics:
   - value: 100M
     label: Compute units per block, up from 60M

--- a/apps/media/content/upgrades/AGENTS.md
+++ b/apps/media/content/upgrades/AGENTS.md
@@ -51,7 +51,7 @@ subtitle: <Short subtitle shown in the hero section>
 publishedAt: <YYYY-MM-DDT00:00:00.000Z>
 status: draft
 author: solana-foundation
-stage: in_development # planned | in_development | live | action_required
+stage: in_development # planned | in_development | pending_activation | live | action_required
 release: <release slug, e.g. agave-4-3> # optional, omit for Unscheduled
 order: <integer, e.g. 1> # optional, manual sort within the release
 metrics:
@@ -93,22 +93,22 @@ tags:
 
 Fields defined in `apps/media/keystatic.config.tsx`, `upgrades` collection:
 
-| Field         | Type                      | Notes                                                        |
-| ------------- | ------------------------- | ------------------------------------------------------------ |
-| `title`       | slug/text                 | Required, becomes the URL slug                               |
-| `status`      | select                    | `draft` \| `published`, defaults to `draft`                  |
-| `description` | text                      | SEO meta description                                         |
-| `subtitle`    | text                      | Shown below title in hero                                    |
-| `stage`       | select                    | `planned` \| `in_development` \| `live` \| `action_required` |
-| `metrics`     | array of `{value, label}` | Key stat cards                                               |
-| `heroImage`   | image                     | Optional, used as `og:image`                                 |
-| `author`      | relationship              | Author entry                                                 |
-| `publishedAt` | datetime                  | Required                                                     |
-| `release`     | relationship → releases   | Optional; unset = Unscheduled                                |
-| `order`       | integer                   | Optional; manual sort position within the release            |
-| `categories`  | array → categories        | Typically just `upgrades`                                    |
-| `tags`        | array → tags              | Typically `announcements`                                    |
-| `body`        | MDX                       | The article content itself                                   |
+| Field         | Type                      | Notes                                                                                                                                                                                                                             |
+| ------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `title`       | slug/text                 | Required, becomes the URL slug                                                                                                                                                                                                    |
+| `status`      | select                    | `draft` \| `published`, defaults to `draft`                                                                                                                                                                                       |
+| `description` | text                      | SEO meta description                                                                                                                                                                                                              |
+| `subtitle`    | text                      | Shown below title in hero                                                                                                                                                                                                         |
+| `stage`       | select                    | `planned` \| `in_development` \| `pending_activation` \| `live` \| `action_required` — use `pending_activation` instead of `in_development` once the article's release has shipped but this specific feature hasn't activated yet |
+| `metrics`     | array of `{value, label}` | Key stat cards                                                                                                                                                                                                                    |
+| `heroImage`   | image                     | Optional, used as `og:image`                                                                                                                                                                                                      |
+| `author`      | relationship              | Author entry                                                                                                                                                                                                                      |
+| `publishedAt` | datetime                  | Required                                                                                                                                                                                                                          |
+| `release`     | relationship → releases   | Optional; unset = Unscheduled                                                                                                                                                                                                     |
+| `order`       | integer                   | Optional; manual sort position within the release                                                                                                                                                                                 |
+| `categories`  | array → categories        | Typically just `upgrades`                                                                                                                                                                                                         |
+| `tags`        | array → tags              | Typically `announcements`                                                                                                                                                                                                         |
+| `body`        | MDX                       | The article content itself                                                                                                                                                                                                        |
 
 ## Accuracy
 

--- a/apps/media/content/upgrades/AGENTS.md
+++ b/apps/media/content/upgrades/AGENTS.md
@@ -51,10 +51,9 @@ subtitle: <Short subtitle shown in the hero section>
 publishedAt: <YYYY-MM-DDT00:00:00.000Z>
 status: draft
 author: solana-foundation
-badges:
-  - text: <e.g. "Under Development">
-    color: yellow # green | yellow | red | purple
-    variant: badge # badge | text
+stage: in_development # planned | in_development | live | action_required
+release: <release slug, e.g. agave-4-3> # optional, omit for Unscheduled
+order: <integer, e.g. 1> # optional, manual sort within the release
 metrics:
   - value: <e.g. "150ms">
     label: <e.g. "Target finality">
@@ -94,20 +93,22 @@ tags:
 
 Fields defined in `apps/media/keystatic.config.tsx`, `upgrades` collection:
 
-| Field         | Type                              | Notes                                                   |
-| ------------- | --------------------------------- | ------------------------------------------------------- |
-| `title`       | slug/text                         | Required, becomes the URL slug                          |
-| `status`      | select                            | `draft` \| `published`, defaults to `draft`             |
-| `description` | text                              | SEO meta description                                    |
-| `subtitle`    | text                              | Shown below title in hero                               |
-| `badges`      | array of `{text, color, variant}` | `color`: green/yellow/red/purple; `variant`: badge/text |
-| `metrics`     | array of `{value, label}`         | Key stat cards                                          |
-| `heroImage`   | image                             | Optional, used as `og:image`                            |
-| `author`      | relationship                      | Author entry                                            |
-| `publishedAt` | datetime                          | Required                                                |
-| `categories`  | array → categories                | Typically just `upgrades`                               |
-| `tags`        | array → tags                      | Typically `announcements`                               |
-| `body`        | MDX                               | The article content itself                              |
+| Field         | Type                      | Notes                                                        |
+| ------------- | ------------------------- | ------------------------------------------------------------ |
+| `title`       | slug/text                 | Required, becomes the URL slug                               |
+| `status`      | select                    | `draft` \| `published`, defaults to `draft`                  |
+| `description` | text                      | SEO meta description                                         |
+| `subtitle`    | text                      | Shown below title in hero                                    |
+| `stage`       | select                    | `planned` \| `in_development` \| `live` \| `action_required` |
+| `metrics`     | array of `{value, label}` | Key stat cards                                               |
+| `heroImage`   | image                     | Optional, used as `og:image`                                 |
+| `author`      | relationship              | Author entry                                                 |
+| `publishedAt` | datetime                  | Required                                                     |
+| `release`     | relationship → releases   | Optional; unset = Unscheduled                                |
+| `order`       | integer                   | Optional; manual sort position within the release            |
+| `categories`  | array → categories        | Typically just `upgrades`                                    |
+| `tags`        | array → tags              | Typically `announcements`                                    |
+| `body`        | MDX                       | The article content itself                                   |
 
 ## Accuracy
 

--- a/apps/media/content/upgrades/AGENTS.md
+++ b/apps/media/content/upgrades/AGENTS.md
@@ -51,7 +51,7 @@ subtitle: <Short subtitle shown in the hero section>
 publishedAt: <YYYY-MM-DDT00:00:00.000Z>
 status: draft
 author: solana-foundation
-stage: in_development # planned | in_development | pending_activation | live | action_required
+stage: in_development # planned | in_development | pending_activation | live
 release: <release slug, e.g. agave-4-3> # optional, omit for Unscheduled
 order: <integer, e.g. 1> # optional, manual sort within the release
 metrics:
@@ -93,22 +93,22 @@ tags:
 
 Fields defined in `apps/media/keystatic.config.tsx`, `upgrades` collection:
 
-| Field         | Type                      | Notes                                                                                                                                                                                                                             |
-| ------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `title`       | slug/text                 | Required, becomes the URL slug                                                                                                                                                                                                    |
-| `status`      | select                    | `draft` \| `published`, defaults to `draft`                                                                                                                                                                                       |
-| `description` | text                      | SEO meta description                                                                                                                                                                                                              |
-| `subtitle`    | text                      | Shown below title in hero                                                                                                                                                                                                         |
-| `stage`       | select                    | `planned` \| `in_development` \| `pending_activation` \| `live` \| `action_required` — use `pending_activation` instead of `in_development` once the article's release has shipped but this specific feature hasn't activated yet |
-| `metrics`     | array of `{value, label}` | Key stat cards                                                                                                                                                                                                                    |
-| `heroImage`   | image                     | Optional, used as `og:image`                                                                                                                                                                                                      |
-| `author`      | relationship              | Author entry                                                                                                                                                                                                                      |
-| `publishedAt` | datetime                  | Required                                                                                                                                                                                                                          |
-| `release`     | relationship → releases   | Optional; unset = Unscheduled                                                                                                                                                                                                     |
-| `order`       | integer                   | Optional; manual sort position within the release                                                                                                                                                                                 |
-| `categories`  | array → categories        | Typically just `upgrades`                                                                                                                                                                                                         |
-| `tags`        | array → tags              | Typically `announcements`                                                                                                                                                                                                         |
-| `body`        | MDX                       | The article content itself                                                                                                                                                                                                        |
+| Field         | Type                      | Notes                                                                                                                                                                                                        |
+| ------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `title`       | slug/text                 | Required, becomes the URL slug                                                                                                                                                                               |
+| `status`      | select                    | `draft` \| `published`, defaults to `draft`                                                                                                                                                                  |
+| `description` | text                      | SEO meta description                                                                                                                                                                                         |
+| `subtitle`    | text                      | Shown below title in hero                                                                                                                                                                                    |
+| `stage`       | select                    | `planned` \| `in_development` \| `pending_activation` \| `live` — use `pending_activation` instead of `in_development` once the article's release has shipped but this specific feature hasn't activated yet |
+| `metrics`     | array of `{value, label}` | Key stat cards                                                                                                                                                                                               |
+| `heroImage`   | image                     | Optional, used as `og:image`                                                                                                                                                                                 |
+| `author`      | relationship              | Author entry                                                                                                                                                                                                 |
+| `publishedAt` | datetime                  | Required                                                                                                                                                                                                     |
+| `release`     | relationship → releases   | Optional; unset = Unscheduled                                                                                                                                                                                |
+| `order`       | integer                   | Optional; manual sort position within the release                                                                                                                                                            |
+| `categories`  | array → categories        | Typically just `upgrades`                                                                                                                                                                                    |
+| `tags`        | array → tags              | Typically `announcements`                                                                                                                                                                                    |
+| `body`        | MDX                       | The article content itself                                                                                                                                                                                   |
 
 ## Accuracy
 

--- a/apps/media/content/upgrades/agave-4-2-release-overview.mdx
+++ b/apps/media/content/upgrades/agave-4-2-release-overview.mdx
@@ -8,7 +8,7 @@ subtitle: Cheaper rent, larger transactions, and faster slots — with Alpenglow
 publishedAt: 2026-07-24T00:00:00.000Z
 status: published
 author: solana-foundation
-stage: pending_activation
+stage: live
 release: agave-4-2
 metrics:
   - value: 90%

--- a/apps/media/content/upgrades/agave-4-2-release-overview.mdx
+++ b/apps/media/content/upgrades/agave-4-2-release-overview.mdx
@@ -8,7 +8,7 @@ subtitle: Cheaper rent, larger transactions, and faster slots — with Alpenglow
 publishedAt: 2026-07-24T00:00:00.000Z
 status: published
 author: solana-foundation
-stage: in_development
+stage: pending_activation
 release: agave-4-2
 metrics:
   - value: 90%

--- a/apps/media/content/upgrades/agave-4-2-release-overview.mdx
+++ b/apps/media/content/upgrades/agave-4-2-release-overview.mdx
@@ -8,10 +8,8 @@ subtitle: Cheaper rent, larger transactions, and faster slots — with Alpenglow
 publishedAt: 2026-07-24T00:00:00.000Z
 status: published
 author: solana-foundation
-badges:
-  - text: Under Development
-    color: yellow
-    variant: badge
+stage: in_development
+release: agave-4-2
 metrics:
   - value: 90%
     label: Rent reduction, phased over 5 steps

--- a/apps/media/content/upgrades/alpenglow.mdx
+++ b/apps/media/content/upgrades/alpenglow.mdx
@@ -8,10 +8,8 @@ subtitle: Faster finality with Solana's next consensus protocol
 publishedAt: 2026-06-24T00:00:00.000Z
 status: published
 author: solana-foundation
-badges:
-  - text: Under Development
-    color: yellow
-    variant: badge
+stage: in_development
+release: agave-4-3
 metrics:
   - value: 150ms
     label: Target finality

--- a/apps/media/content/upgrades/bls-pubkey-vat.mdx
+++ b/apps/media/content/upgrades/bls-pubkey-vat.mdx
@@ -8,9 +8,8 @@ subtitle: The VAT feature gate is live on mainnet, register a BLS pubkey to stay
 publishedAt: 2026-07-16T00:00:00.000Z
 status: published
 author: solana-foundation
-stage: action_required
-release: agave-4-2
-order: 1
+stage: live
+release: agave-4-1
 metrics:
   - value: "2,000"
     label: Max validators admitted under VAT

--- a/apps/media/content/upgrades/bls-pubkey-vat.mdx
+++ b/apps/media/content/upgrades/bls-pubkey-vat.mdx
@@ -8,16 +8,9 @@ subtitle: The VAT feature gate is live on mainnet, register a BLS pubkey to stay
 publishedAt: 2026-07-16T00:00:00.000Z
 status: published
 author: solana-foundation
-badges:
-  - text: BLS Pubkeys Live on Mainnet
-    color: green
-    variant: badge
-  - text: VAT Live on Mainnet
-    color: green
-    variant: badge
-  - text: Unregistered Validators Now Excluded
-    color: red
-    variant: badge
+stage: action_required
+release: agave-4-2
+order: 1
 metrics:
   - value: "2,000"
     label: Max validators admitted under VAT

--- a/apps/media/content/upgrades/larger-transaction-sizes.mdx
+++ b/apps/media/content/upgrades/larger-transaction-sizes.mdx
@@ -8,7 +8,7 @@ subtitle: Raising the maximum transaction size from 1232 to 4096 bytes
 publishedAt: 2026-06-09T00:00:00.000Z
 status: published
 author: solana-foundation
-stage: in_development
+stage: pending_activation
 release: agave-4-2
 order: 3
 metrics:

--- a/apps/media/content/upgrades/larger-transaction-sizes.mdx
+++ b/apps/media/content/upgrades/larger-transaction-sizes.mdx
@@ -8,10 +8,9 @@ subtitle: Raising the maximum transaction size from 1232 to 4096 bytes
 publishedAt: 2026-06-09T00:00:00.000Z
 status: published
 author: solana-foundation
-badges:
-  - text: "Target Mainnet: Agave 4.2"
-    color: green
-    variant: text
+stage: in_development
+release: agave-4-2
+order: 3
 metrics:
   - value: "4096"
     label: Bytes per transaction, up from 1232

--- a/apps/media/content/upgrades/new-cryptography.mdx
+++ b/apps/media/content/upgrades/new-cryptography.mdx
@@ -8,10 +8,8 @@ subtitle: Native syscalls for BN254 G2 and BLS12-381 curve operations
 publishedAt: 2026-06-09T00:00:00.000Z
 status: published
 author: solana-foundation
-badges:
-  - text: Under Development
-    color: yellow
-    variant: badge
+stage: in_development
+release: agave-4-3
 metrics:
   - value: 10-20x
     label: Lower compute vs pure-BPF implementations

--- a/apps/media/content/upgrades/p-token.mdx
+++ b/apps/media/content/upgrades/p-token.mdx
@@ -8,10 +8,8 @@ subtitle: Up to 98% More Efficient Token Operations on Solana
 publishedAt: 2026-04-01T00:00:00.000Z
 status: published
 author: solana-foundation
-badges:
-  - text: "Mainnet Live"
-    color: green
-    variant: badge
+stage: live
+release: agave-4-1
 metrics:
   - value: 95-98%
     label: Reduction in Compute Units

--- a/apps/media/content/upgrades/reduced-rent.mdx
+++ b/apps/media/content/upgrades/reduced-rent.mdx
@@ -8,10 +8,9 @@ subtitle: Cutting the cost of on-chain storage by 90%
 publishedAt: 2026-07-24T00:00:00.000Z
 status: published
 author: solana-foundation
-badges:
-  - text: Under Development
-    color: yellow
-    variant: badge
+stage: in_development
+release: agave-4-2
+order: 2
 metrics:
   - value: 90%
     label: Rent reduction, phased over 5 steps

--- a/apps/media/content/upgrades/reduced-rent.mdx
+++ b/apps/media/content/upgrades/reduced-rent.mdx
@@ -8,7 +8,7 @@ subtitle: Cutting the cost of on-chain storage by 90%
 publishedAt: 2026-07-24T00:00:00.000Z
 status: published
 author: solana-foundation
-stage: in_development
+stage: pending_activation
 release: agave-4-2
 order: 2
 metrics:

--- a/apps/media/content/upgrades/reduced-slot-times.mdx
+++ b/apps/media/content/upgrades/reduced-slot-times.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-06-09T00:00:00.000Z
 status: published
 author: solana-foundation
 stage: in_development
-release: agave-4-3
+release: agave-4-2
 metrics:
   - value: 200ms
     label: New slot time, down from 400ms

--- a/apps/media/content/upgrades/reduced-slot-times.mdx
+++ b/apps/media/content/upgrades/reduced-slot-times.mdx
@@ -8,10 +8,8 @@ subtitle: Cutting slot times from 400ms to 200ms
 publishedAt: 2026-06-09T00:00:00.000Z
 status: published
 author: solana-foundation
-badges:
-  - text: "Target: Agave 4.2"
-    color: yellow
-    variant: badge
+stage: in_development
+release: agave-4-3
 metrics:
   - value: 200ms
     label: New slot time, down from 400ms

--- a/apps/media/content/upgrades/reduced-slot-times.mdx
+++ b/apps/media/content/upgrades/reduced-slot-times.mdx
@@ -8,8 +8,9 @@ subtitle: Cutting slot times from 400ms to 200ms
 publishedAt: 2026-06-09T00:00:00.000Z
 status: published
 author: solana-foundation
-stage: in_development
-release: agave-4-3
+stage: pending_activation
+release: agave-4-2
+order: 1
 metrics:
   - value: 200ms
     label: New slot time, down from 400ms

--- a/apps/media/content/upgrades/reduced-slot-times.mdx
+++ b/apps/media/content/upgrades/reduced-slot-times.mdx
@@ -9,7 +9,7 @@ publishedAt: 2026-06-09T00:00:00.000Z
 status: published
 author: solana-foundation
 stage: in_development
-release: agave-4-2
+release: agave-4-3
 metrics:
   - value: 200ms
     label: New slot time, down from 400ms

--- a/apps/media/content/upgrades/xdp.mdx
+++ b/apps/media/content/upgrades/xdp.mdx
@@ -8,16 +8,8 @@ subtitle: Kernel-bypass networking for faster block propagation on Solana
 publishedAt: 2026-05-29T00:00:00.000Z
 status: published
 author: solana-foundation
-badges:
-  - text: "🟢 Supermajority Stake Adopted"
-    color: green
-    variant: badge
-  - text: "🟢 Firedancer: Default on"
-    color: purple
-    variant: badge
-  - text: "Default in Agave 4.2"
-    color: green
-    variant: badge
+stage: live
+release: agave-4-1
 metrics:
   - value: 200x
     label: Latency Reduction vs. Standard Networking

--- a/apps/media/keystatic.config.tsx
+++ b/apps/media/keystatic.config.tsx
@@ -211,7 +211,6 @@ export default config({
               value: "pending_activation",
             },
             { label: "Live on Mainnet", value: "live" },
-            { label: "Action Required", value: "action_required" },
           ],
           defaultValue: "in_development",
         }),

--- a/apps/media/keystatic.config.tsx
+++ b/apps/media/keystatic.config.tsx
@@ -206,6 +206,10 @@ export default config({
           options: [
             { label: "Planned", value: "planned" },
             { label: "In Development", value: "in_development" },
+            {
+              label: "Pending Feature Activation",
+              value: "pending_activation",
+            },
             { label: "Live on Mainnet", value: "live" },
             { label: "Action Required", value: "action_required" },
           ],

--- a/apps/media/keystatic.config.tsx
+++ b/apps/media/keystatic.config.tsx
@@ -199,36 +199,18 @@ export default config({
           label: "Subtitle",
           description: "Displayed below the title in the hero section",
         }),
-        badges: fields.array(
-          fields.object({
-            text: fields.text({
-              label: "Text",
-              validation: { isRequired: true },
-            }),
-            color: fields.select({
-              label: "Color",
-              options: [
-                { label: "Green", value: "green" },
-                { label: "Yellow", value: "yellow" },
-                { label: "Red", value: "red" },
-                { label: "Purple", value: "purple" },
-              ],
-              defaultValue: "green",
-            }),
-            variant: fields.select({
-              label: "Variant",
-              options: [
-                { label: "Badge (pill style)", value: "badge" },
-                { label: "Text (plain)", value: "text" },
-              ],
-              defaultValue: "badge",
-            }),
-          }),
-          {
-            label: "Status Badges",
-            itemLabel: (props) => props.fields.text.value || "Badge",
-          },
-        ),
+        stage: fields.select({
+          label: "Stage",
+          description:
+            "Standardized rollout stage shown as the upgrade's badge.",
+          options: [
+            { label: "Planned", value: "planned" },
+            { label: "In Development", value: "in_development" },
+            { label: "Live on Mainnet", value: "live" },
+            { label: "Action Required", value: "action_required" },
+          ],
+          defaultValue: "in_development",
+        }),
         metrics: fields.array(
           fields.object({
             value: fields.text({
@@ -251,6 +233,17 @@ export default config({
           description:
             "Date and time in UTC when the upgrade becomes visible on the site.",
           validation: { isRequired: true },
+        }),
+        release: fields.relationship({
+          label: "Release",
+          collection: "releases",
+          description:
+            "The release this upgrade ships in. Leave unset for Unscheduled.",
+        }),
+        order: fields.integer({
+          label: "Order",
+          description:
+            "Manual sort position within this upgrade's release. Lower numbers appear first; leave blank to sort by publish date.",
         }),
         categories: fields.array(
           fields.object({
@@ -287,6 +280,38 @@ export default config({
           },
           components: componentBlocks,
         }),
+      },
+    }),
+
+    releases: collection({
+      label: "Releases",
+      slugField: "name",
+      path: "content/releases/*",
+      format: { contentField: "description" },
+      schema: {
+        name: fields.slug({
+          name: { label: "Name", validation: { isRequired: true } },
+        }),
+        expectedDate: fields.date({
+          label: "Expected Date",
+          description: "When this release is expected to ship, or shipped.",
+          validation: { isRequired: true },
+        }),
+        status: fields.select({
+          label: "Status",
+          options: [
+            { label: "Planned", value: "planned" },
+            { label: "Shipped", value: "shipped" },
+          ],
+          defaultValue: "planned",
+        }),
+        overview: fields.relationship({
+          label: "Overview Article",
+          collection: "upgrades",
+          description:
+            "The upgrade article featured as this release's overview.",
+        }),
+        description: fields.mdx({ label: "Description" }),
       },
     }),
 

--- a/apps/media/lib/upgrades/group-by-release.ts
+++ b/apps/media/lib/upgrades/group-by-release.ts
@@ -2,8 +2,7 @@ export type UpgradeStage =
   | "planned"
   | "in_development"
   | "pending_activation"
-  | "live"
-  | "action_required";
+  | "live";
 
 export type UpgradeMetric = {
   value: string;

--- a/apps/media/lib/upgrades/group-by-release.ts
+++ b/apps/media/lib/upgrades/group-by-release.ts
@@ -1,0 +1,133 @@
+export type UpgradeStage =
+  | "planned"
+  | "in_development"
+  | "live"
+  | "action_required";
+
+export type UpgradeMetric = {
+  value: string;
+  label: string;
+};
+
+export type UpgradeListItem = {
+  slug: string;
+  title: string;
+  description: string;
+  subtitle: string;
+  publishedAt: string | null;
+  stage: UpgradeStage;
+  metrics: UpgradeMetric[];
+  release: string | null;
+  order: number | null;
+};
+
+export type ReleaseInput = {
+  slug: string;
+  name: string;
+  status: "planned" | "shipped";
+  expectedDate: string | null;
+  overview: string | null;
+};
+
+export type ReleaseGroup = {
+  key: string;
+  name: string;
+  status: "planned" | "shipped" | null;
+  expectedDate: string | null;
+  overview: UpgradeListItem | null;
+  upgrades: UpgradeListItem[];
+};
+
+const UNSCHEDULED_KEY = "unscheduled";
+
+function dateValue(value: string | null): number {
+  return value ? new Date(value).getTime() : 0;
+}
+
+function compareUpgradeOrder(a: UpgradeListItem, b: UpgradeListItem): number {
+  if (a.order !== null && b.order !== null) {
+    return a.order - b.order;
+  }
+  if (a.order !== null) {
+    return -1;
+  }
+  if (b.order !== null) {
+    return 1;
+  }
+
+  return dateValue(b.publishedAt) - dateValue(a.publishedAt);
+}
+
+export function groupUpgradesByRelease(
+  upgrades: UpgradeListItem[],
+  releases: ReleaseInput[],
+): ReleaseGroup[] {
+  const upgradeBySlug = new Map(
+    upgrades.map((upgrade) => [upgrade.slug, upgrade] as const),
+  );
+  const releaseSlugs = new Set(releases.map((release) => release.slug));
+
+  const groups: ReleaseGroup[] = releases.map((release) => {
+    const overview = release.overview
+      ? (upgradeBySlug.get(release.overview) ?? null)
+      : null;
+
+    const groupUpgrades = upgrades
+      .filter(
+        (upgrade) =>
+          upgrade.release === release.slug && upgrade.slug !== release.overview,
+      )
+      .sort(compareUpgradeOrder);
+
+    return {
+      key: release.slug,
+      name: release.name,
+      status: release.status,
+      expectedDate: release.expectedDate,
+      overview,
+      upgrades: groupUpgrades,
+    };
+  });
+
+  const overviewSlugs = new Set(
+    releases
+      .map((release) => release.overview)
+      .filter((slug): slug is string => Boolean(slug)),
+  );
+  const unscheduledUpgrades = upgrades
+    .filter(
+      (upgrade) =>
+        !overviewSlugs.has(upgrade.slug) &&
+        (!upgrade.release || !releaseSlugs.has(upgrade.release)),
+    )
+    .sort(compareUpgradeOrder);
+
+  if (unscheduledUpgrades.length > 0) {
+    groups.push({
+      key: UNSCHEDULED_KEY,
+      name: "Unscheduled",
+      status: null,
+      expectedDate: null,
+      overview: null,
+      upgrades: unscheduledUpgrades,
+    });
+  }
+
+  const nonEmptyGroups = groups.filter(
+    (group) => group.overview !== null || group.upgrades.length > 0,
+  );
+
+  const plannedGroups = nonEmptyGroups
+    .filter((group) => group.status === "planned")
+    .sort((a, b) => dateValue(a.expectedDate) - dateValue(b.expectedDate));
+
+  const shippedGroups = nonEmptyGroups
+    .filter((group) => group.status === "shipped")
+    .sort((a, b) => dateValue(b.expectedDate) - dateValue(a.expectedDate));
+
+  const unscheduledGroup = nonEmptyGroups.filter(
+    (group) => group.status === null,
+  );
+
+  return [...plannedGroups, ...shippedGroups, ...unscheduledGroup];
+}

--- a/apps/media/lib/upgrades/group-by-release.ts
+++ b/apps/media/lib/upgrades/group-by-release.ts
@@ -67,6 +67,12 @@ export function groupUpgradesByRelease(
   );
   const releaseSlugs = new Set(releases.map((release) => release.slug));
 
+  const overviewSlugs = new Set(
+    releases
+      .map((release) => release.overview)
+      .filter((slug): slug is string => Boolean(slug)),
+  );
+
   const groups: ReleaseGroup[] = releases.map((release) => {
     const overview = release.overview
       ? (upgradeBySlug.get(release.overview) ?? null)
@@ -75,7 +81,7 @@ export function groupUpgradesByRelease(
     const groupUpgrades = upgrades
       .filter(
         (upgrade) =>
-          upgrade.release === release.slug && upgrade.slug !== release.overview,
+          upgrade.release === release.slug && !overviewSlugs.has(upgrade.slug),
       )
       .sort(compareUpgradeOrder);
 
@@ -88,12 +94,6 @@ export function groupUpgradesByRelease(
       upgrades: groupUpgrades,
     };
   });
-
-  const overviewSlugs = new Set(
-    releases
-      .map((release) => release.overview)
-      .filter((slug): slug is string => Boolean(slug)),
-  );
   const unscheduledUpgrades = upgrades
     .filter(
       (upgrade) =>

--- a/apps/media/lib/upgrades/group-by-release.ts
+++ b/apps/media/lib/upgrades/group-by-release.ts
@@ -1,6 +1,7 @@
 export type UpgradeStage =
   | "planned"
   | "in_development"
+  | "pending_activation"
   | "live"
   | "action_required";
 

--- a/apps/media/lib/upgrades/stage.ts
+++ b/apps/media/lib/upgrades/stage.ts
@@ -5,6 +5,7 @@ export type { UpgradeStage };
 export const STAGE_LABELS: Record<UpgradeStage, string> = {
   planned: "Planned",
   in_development: "In Development",
+  pending_activation: "Pending Feature Activation",
   live: "Live on Mainnet",
   action_required: "Action Required",
 };
@@ -12,6 +13,7 @@ export const STAGE_LABELS: Record<UpgradeStage, string> = {
 export const STAGE_BADGE_CLASSES: Record<UpgradeStage, string> = {
   planned: "border-white/25 bg-white/5 text-white/70",
   in_development: "border-yellow-500/30 bg-yellow-500/10 text-yellow-300",
+  pending_activation: "border-blue-400/30 bg-blue-400/10 text-blue-300",
   live: "border-[#14F195]/30 bg-[#14F195]/10 text-[#14F195]",
   action_required: "border-red-500/30 bg-red-500/10 text-red-300",
 };
@@ -20,6 +22,7 @@ export function isUpgradeStage(value: unknown): value is UpgradeStage {
   return (
     value === "planned" ||
     value === "in_development" ||
+    value === "pending_activation" ||
     value === "live" ||
     value === "action_required"
   );

--- a/apps/media/lib/upgrades/stage.ts
+++ b/apps/media/lib/upgrades/stage.ts
@@ -7,7 +7,6 @@ export const STAGE_LABELS: Record<UpgradeStage, string> = {
   in_development: "In Development",
   pending_activation: "Pending Feature Activation",
   live: "Live on Mainnet",
-  action_required: "Action Required",
 };
 
 export const STAGE_BADGE_CLASSES: Record<UpgradeStage, string> = {
@@ -15,7 +14,6 @@ export const STAGE_BADGE_CLASSES: Record<UpgradeStage, string> = {
   in_development: "border-yellow-500/30 bg-yellow-500/10 text-yellow-300",
   pending_activation: "border-blue-400/30 bg-blue-400/10 text-blue-300",
   live: "border-[#14F195]/30 bg-[#14F195]/10 text-[#14F195]",
-  action_required: "border-red-500/30 bg-red-500/10 text-red-300",
 };
 
 export function isUpgradeStage(value: unknown): value is UpgradeStage {
@@ -23,7 +21,6 @@ export function isUpgradeStage(value: unknown): value is UpgradeStage {
     value === "planned" ||
     value === "in_development" ||
     value === "pending_activation" ||
-    value === "live" ||
-    value === "action_required"
+    value === "live"
   );
 }

--- a/apps/media/lib/upgrades/stage.ts
+++ b/apps/media/lib/upgrades/stage.ts
@@ -1,0 +1,24 @@
+import type { UpgradeStage } from "./group-by-release";
+
+export const STAGE_LABELS: Record<UpgradeStage, string> = {
+  planned: "Planned",
+  in_development: "In Development",
+  live: "Live on Mainnet",
+  action_required: "Action Required",
+};
+
+export const STAGE_BADGE_CLASSES: Record<UpgradeStage, string> = {
+  planned: "border-white/25 bg-white/5 text-white/70",
+  in_development: "border-yellow-500/30 bg-yellow-500/10 text-yellow-300",
+  live: "border-[#14F195]/30 bg-[#14F195]/10 text-[#14F195]",
+  action_required: "border-red-500/30 bg-red-500/10 text-red-300",
+};
+
+export function isUpgradeStage(value: unknown): value is UpgradeStage {
+  return (
+    value === "planned" ||
+    value === "in_development" ||
+    value === "live" ||
+    value === "action_required"
+  );
+}

--- a/apps/media/lib/upgrades/stage.ts
+++ b/apps/media/lib/upgrades/stage.ts
@@ -1,5 +1,7 @@
 import type { UpgradeStage } from "./group-by-release";
 
+export type { UpgradeStage };
+
 export const STAGE_LABELS: Record<UpgradeStage, string> = {
   planned: "Planned",
   in_development: "In Development",

--- a/apps/media/package.json
+++ b/apps/media/package.json
@@ -27,6 +27,7 @@
     "@keystatic/core": "^0.6.0",
     "@keystatic/next": "^5.0.4",
     "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-select": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.4",
     "@sentry/nextjs": "^10.11.0",
     "@solana-com/ui-chrome": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,7 +456,7 @@ importers:
     devDependencies:
       "@next/bundle-analyzer":
         specifier: 15.0.8
-        version: 15.0.8(bufferutil@4.1.0)
+        version: 15.0.8(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       "@svgr/webpack":
         specifier: ^8.1.0
         version: 8.1.0(typescript@5.8.3)
@@ -523,6 +523,9 @@ importers:
       "@radix-ui/react-avatar":
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      "@radix-ui/react-select":
+        specifier: ^2.1.7
+        version: 2.2.6(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@radix-ui/react-slot":
         specifier: ^1.2.4
         version: 1.2.4(@types/react@19.1.12)(react@19.2.6)
@@ -1017,7 +1020,7 @@ importers:
     devDependencies:
       "@next/bundle-analyzer":
         specifier: 15.0.8
-        version: 15.0.8(bufferutil@4.1.0)
+        version: 15.0.8(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       "@playwright/test":
         specifier: 1.58.2
         version: 1.58.2
@@ -9095,6 +9098,7 @@ packages:
       {
         integrity: sha512-8ipTFoiX3WBRrvXLjSrmgAiwtMDQk3EgSxe8N7v2rXBz39NBIIyoGXeVbJRoBcP8WEuVnvjvIQsggbGU7ZKrMw==,
       }
+    engines: { node: ">= 20" }
 
   "@vercel/related-projects@1.1.0":
     resolution:
@@ -20951,9 +20955,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  "@next/bundle-analyzer@15.0.8(bufferutil@4.1.0)":
+  "@next/bundle-analyzer@15.0.8(bufferutil@4.1.0)(utf-8-validate@6.0.6)":
     dependencies:
-      webpack-bundle-analyzer: 4.10.1(bufferutil@4.1.0)
+      webpack-bundle-analyzer: 4.10.1(bufferutil@4.1.0)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -30790,7 +30794,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-bundle-analyzer@4.10.1(bufferutil@4.1.0):
+  webpack-bundle-analyzer@4.10.1(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     dependencies:
       "@discoveryjs/json-ext": 0.5.7
       acorn: 8.16.0


### PR DESCRIPTION
### Problem

The /upgrades page is currently a reverse-chronological grid with no relationship between an
article and the client release it ships in. With many feature now and release summaries, the page
has become harder to navigate. Also articles have inconsistent text and colors across
articles ("Mainnet Live", "Q3 2026", "Agave 4.x + Opt in", "Under Development", ...).

### Summary of Changes

Data model (apps/media/keystatic.config.tsx)
- New releases Keystatic collection: name, expectedDate, status (planned/shipped), overview (the
upgrade article featured as that release's summary).
- upgrades collection: replaced badges[] with a single standardized stage field (planned /
in_development / pending_activation / live), plus optional release and order fields for grouping and
manual sort order within a release. 
- Migrated all 9 existing upgrade articles and added 3 release entries (Agave 4.1, 4.2, 4.3) to the
new schema.

Page redesign (apps/media/app/[locale]/upgrades/)
* Upgrades now render grouped by release: planned releases soonest-first, shipped releases
most-recent-first, with an "Unscheduled" bucket last for anything without a release. Ordering logic
lives in a new, independently unit-tested lib/upgrades/group-by-release.ts. 
* Each release gets a header (name, status pill, date) and, where set, its overview article rendered
as a distinct callout separate from the regular list.
* Added a List/Grid view toggle (List is the desktop default) and a release filter, replacing the old
unwired category pills. The filter dropdown is a themed Radix Select matching the site's dark palette
instead of an unstyled native select.
* Tightened the hero into a simpler, denser header per maintainer feedback, since this is a status
page, not a marketing page. 
* Mobile always renders Grid with the toggle hidden — the table's horizontal scroll didn't work well at that width.
* Table rows are fully clickable (not just the title), and column alignment/spacing is now consistent
across every release's table.

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

### New Dependencies
Yes, @radix-ui/react-select@^2.1.7 was added for the release version drop down.  radix-ui is used in the repo already.


<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
