### PR TITLE
fix(web): add missing links to pyusd payments/commerce cards (fix #477)

### DIFF
--- a/apps/web/src/data/pyusd.ts
+++ b/apps/web/src/data/pyusd.ts
@@ -93,7 +93,7 @@ export const PRIMARY_CARD_DECK_CARDS = [
     callToAction: {
       endIcon: "none",
       hierarchy: "outline",
-      url: "",
+      url: "/solutions/payments-tooling",
     },
   },
   {
@@ -103,7 +103,7 @@ export const PRIMARY_CARD_DECK_CARDS = [
     callToAction: {
       endIcon: "none",
       hierarchy: "outline",
-      url: "",
+      url: "/solutions/commerce-tooling",
     },
   },
 ] as const;


### PR DESCRIPTION


## Investigation

The `/pyusd` route is a legacy landing page. The repo still has an old
Builder.io content export at `apps/web/builder/section-page/en/pyusd.json`
(from before the "Migrate from Builder.io" rewrite, commit `7af4494d9`), but
that file is **not read by any code** — grepping `apps/web/src` for
`builder/section-page` returns nothing. It's a stale snapshot, not the
live source, so editing it would not have fixed the bug.

The real source is:

- `apps/web/src/data/pyusd.ts` — static data for the page (card copy,
  gradients, URLs)
- `apps/web/src/app/[locale]/pyusd/pyusd.tsx` — client component that maps
  the data array and injects translated strings
- `apps/web/src/app/[locale]/pyusd/page.tsx` — server component that pulls
  translations via `getTranslations("pyusd")` from
  `packages/i18n/messages/web/en/common.json`

In `pyusd.ts`, `PRIMARY_CARD_DECK_CARDS` (an array of 9 cards) had the last
two entries with `callToAction.url: ""`. Since `CardDeck`/`callToAction`
renders whatever `url` it's given, an empty string produces a card with no
functional link — matching the screenshot in the issue exactly.

To identify which two cards these were and what they should link to, I
cross-referenced the array index against
`packages/i18n/messages/web/en/common.json` (the `pyusd.primaryCardDeck.cards`
key), which carries the heading/body text for each card by the same index:

- Index 7: heading **"Fast, Borderless Payments"**, body "Get familiar with
  the tooling in the Solana ecosystem for payments issuers." eyebrow "Site"
- Index 8: heading **"Next-Gen Commerce"**, body "Learn about point-of-sales
  systems, business to business tooling, and other resources merchants can
  use for Solana payments." eyebrow "Site"

Both are eyebrow "Site" cards, i.e. they're meant to link to an internal
Solana.com page about that topic (unlike the other cards in the deck, which
link to external PayPal/press content). I checked the existing `/solutions/*`
routes under `apps/web/src/app/[locale]/solutions/` and found an exact
topical match for each:

- `/solutions/payments-tooling` — matches "tooling ... for payments issuers"
- `/solutions/commerce-tooling` — matches "point-of-sales systems, business
  to business tooling ... for Solana payments"

## Implementation

**File changed:** `apps/web/src/data/pyusd.ts`

```diff
   {
     type: "gradient",
     headingAs: "h2",
     backgroundGradient: "purple",
     callToAction: {
       endIcon: "none",
       hierarchy: "outline",
-      url: "",
+      url: "/solutions/payments-tooling",
     },
   },
   {
     type: "gradient",
     headingAs: "h2",
     backgroundGradient: "purple",
     callToAction: {
       endIcon: "none",
       hierarchy: "outline",
-      url: "",
+      url: "/solutions/commerce-tooling",
     },
   },
 ] as const;
```

Two-line change, no other files touched. Used relative paths (`/solutions/...`)
to match the convention already used elsewhere in the same array (e.g. the
`"/docs/intro/quick-start"` and `"/developers"` entries in
`SECONDARY_CARD_DECK_CARDS` further down the same file), rather than
absolute `https://solana.com/...` URLs like the external card links use.

## Why this approach

- No component/behavior changes — `CardDeck` already handles a populated
  `url` correctly; the only defect was the two empty strings.
- Didn't touch the stale Builder.io JSON export, since it's dead code and
  editing it would be a no-op on the live site.
- Picked destinations by matching each card's own copy to an existing page,
  rather than guessing or linking both to the same generic page.

## Validation performed

- `pnpm exec eslint src/data/pyusd.ts` (scoped, from `apps/web`) — no
  errors/warnings.
- Manual read-through of `pyusd.tsx` and `page.tsx` to confirm `url` flows
  straight into the rendered `callToAction` with no other transformation.
- Did **not** run the dev server / visually confirm in-browser (no browser
  tooling available in this session) — flagged below for manual check.

