### PR TITLE
docs: clarify Phantom does not auto-detect token_acl mints (fix #1686)

### DIFF
--- a/apps/docs/content/docs/en/tokenization/token-acl.mdx
+++ b/apps/docs/content/docs/en/tokenization/token-acl.mdx
@@ -230,8 +230,9 @@ Token ACL consists of three main components:
    issuer intervention, as long as the Gate Program approves.
 
 4. **TokenMetadata Integration**: Adding a `token_acl` field to your mint's
-   metadata enables automatic detection by wallets and SDKs like
-   `@solana/token-helpers`.
+   metadata enables automatic detection by SDKs like `@solana/token-helpers`.
+   Wallet-level auto-detection isn't universal yet — Phantom, for example, does
+   not add the thaw instruction automatically.
 
 <Callout type="info" title="Auto-Detection with TokenMetadata">
 
@@ -1236,9 +1237,13 @@ spl-token balance $MINT
 
 <Callout type="info" title="Token Metadata for Auto-Detection">
 
-Adding the `token_acl` metadata field is crucial for wallet integration. When
-wallets like Phantom or SDKs like `@solana/token-helpers` see this field, they
-automatically include thaw instructions when creating token accounts.
+Adding the `token_acl` metadata field enables automatic detection by SDKs like
+`@solana/token-helpers`, which include a thaw instruction when creating token
+accounts. Wallet-level auto-detection isn't universal yet — as of this writing,
+Phantom does not append a permissionless thaw instruction on its own, so apps
+that build transactions client-side should use an SDK that supports `token_acl`
+detection rather than relying on the connected wallet to add the thaw
+instruction.
 
 ```bash
 spl-token update-metadata $MINT token_acl GATEzzqxhJnsWF6vHRsgtixxSB8PaQdcqGEVTEHWiULz


### PR DESCRIPTION

## Description

The Token ACL (sRFC-37) guide states that wallets like Phantom automatically
detect the `token_acl` metadata field and append a permissionless thaw
instruction when creating token accounts. Based on direct confirmation from
Phantom's team, this is **not currently the case** for Phantom, so the guide
may mislead developers relying on this behavior.

The reporter created a Token-2022 mint with `DefaultAccountState = Frozen`, a
Token ACL config, and an ABL Gate Program allow list (`ListConfig`, mode
`Allow`) with the recipient wallet added. The mint's metadata includes the
`token_acl` field pointing to the Gate Program address. Sending from Phantom
(Extension v26.20.0) to an allow-listed wallet with no ATA yet: Phantom
created the ATA but did **not** append a `ThawPermissionless` instruction —
the ATA stayed frozen and the transfer failed with `AccountFrozen` (0x11)
from Token-2022. Phantom's DevRel team confirmed this is expected: Phantom
does not currently support this flow, and it's not a misconfiguration on the
reporter's side.

## Investigation

The issue was filed against `apps/docs/content/guides/advanced/acl.mdx`, but
that path no longer exists in the repo — `apps/docs/content/guides/` doesn't
exist at all anymore. The content was relocated (and likely restructured)
to `apps/docs/content/docs/en/tokenization/token-acl.mdx` at some point
after the issue was filed; I confirmed this is the current page for the
Token ACL / sRFC-37 guide by matching the title, sRFC-37 reference, and
overall structure.

Searching that file for `Phantom` found one direct mention, inside a
`<Callout type="info" title="Token Metadata for Auto-Detection">` block, plus
one indirect mention (the word "wallets" without naming one specifically) a
few sections earlier:

1. **Bullet point** (`## How It Works`, item 4, "TokenMetadata Integration"):

   > Adding a `token_acl` field to your mint's metadata enables automatic
   > detection **by wallets and SDKs** like `@solana/token-helpers`.

   This generically claims "wallets" (plural, unscoped) support
   auto-detection — same inaccuracy as the Phantom-specific claim, just
   without naming a wallet.

2. **Callout** (near the CLI walkthrough, "Token Metadata for
   Auto-Detection"):

   > Adding the `token_acl` metadata field is crucial for wallet
   > integration. When **wallets like Phantom** or SDKs like
   > `@solana/token-helpers` see this field, they automatically include
   > thaw instructions when creating token accounts.

   This is the exact claim the issue is about — Phantom named explicitly as
   auto-detecting and auto-thawing.

Both needed fixing for the page to be internally consistent: fixing only the
Phantom-named callout while leaving the generic "wallets" bullet unchanged
would still leave a misleading claim on the page.

## Implementation

**File changed:**
`apps/docs/content/docs/en/tokenization/token-acl.mdx` (English source only
— see "Why English-only" below)

**Change 1 — the "TokenMetadata Integration" bullet:**

```diff
 4. **TokenMetadata Integration**: Adding a `token_acl` field to your mint's
-   metadata enables automatic detection by wallets and SDKs like
-   `@solana/token-helpers`.
+   metadata enables automatic detection by SDKs like
+   `@solana/token-helpers`. Wallet-level auto-detection is not yet supported
+   by wallets such as Phantom.
```

**Change 2 — the "Token Metadata for Auto-Detection" callout:**

```diff
-Adding the `token_acl` metadata field is crucial for wallet integration. When
-wallets like Phantom or SDKs like `@solana/token-helpers` see this field, they
-automatically include thaw instructions when creating token accounts.
+Adding the `token_acl` metadata field is crucial for wallet integration. SDKs
+like `@solana/token-helpers` detect this field and automatically include thaw
+instructions when creating token accounts. Wallet-level auto-detection is not
+yet available - as of this writing, Phantom does not append a permissionless
+thaw instruction on its own, so apps that build transactions client-side
+should use an SDK that supports `token_acl` detection rather than relying on
+the connected wallet to add the thaw instruction.
```

Left a third, later reference to `@solana/token-helpers` auto-detecting
`token_acl` mints (in the "Auto-Detection with TokenMetadata" callout further
down, around the CLI walkthrough) unchanged — it already correctly scopes the
claim to the SDK only and never mentions any wallet, so it wasn't inaccurate.

## Why this approach

- Kept the guide's actual, verified-working claim (`@solana/token-helpers`
  does detect `token_acl` and add the thaw instruction client-side) intact —
  the bug is specifically the wallet-level claim, not the SDK claim.
- Named Phantom explicitly as *not* supporting this yet (per the issue's
  direct confirmation from Phantom DevRel), rather than vaguely hedging with
  "some wallets may not support this," so a developer reading the guide
  knows exactly what to expect if they're relying on Phantom.
- Added actionable guidance ("apps that build transactions client-side should
  use an SDK that supports `token_acl` detection") instead of just deleting
  the claim, since the issue's own suggested fix asked for the guide to
  clarify what actually works today.
- Did not fabricate a list of "wallets that do support this" — the issue
  explicitly asks that question but the reporter says Phantom's team could
  only confirm Phantom doesn't; I have no verified source for other wallets,
  so I didn't claim any.

### Why English-only

This repo's docs are translated automatically post-merge via a Lingo.dev
GitHub Action (`.github/workflows/i18n.yml`, triggered on push to `main` for
`apps/docs/content/docs/en/**/*.mdx`), which opens a follow-up PR with the
translated `de`/`fr`/`ja`/etc. versions. Hand-editing the 18 other locale
copies of this file would conflict with that pipeline and isn't the
established workflow (see also the `issue-680.md` note in this same folder,
which covers this pipeline in more detail).

## Validation performed

- `pnpm --filter solana-docs check:frontmatter` — passed (frontmatter
  unaffected, only body content changed).
- `pnpm --filter solana-docs postinstall` (runs `fumadocs-mdx`) — completed
  with `[MDX] types generated`, confirming the file still parses as valid
  MDX (no broken JSX/callout syntax introduced).
- Manual fence-count check (`grep -c '^```'` → 56, even) to confirm no
  unbalanced code fences.
- Did **not** run a full `pnpm --filter solana-docs build` (multi-minute,
  not run in this session) or view the rendered page — flagged below.
