### PR TITLE
test(web): remove dead skipped translation-key coverage test (fix #680)

### DIFF
--- a/apps/web/src/__tests__/i18n/next-intl.test.tsx
+++ b/apps/web/src/__tests__/i18n/next-intl.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import { NextIntlClientProvider, useTranslations } from "next-intl";
 import { useParams, usePathname } from "next/navigation";
 import React from "react";
-import { readdirSync, readFileSync } from "fs";
+import { readFileSync } from "fs";
 import path from "path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { locales } from "@workspace/i18n/config";
@@ -146,27 +146,6 @@ describe("NextIntlClientProvider", () => {
       </NextIntlClientProvider>,
     );
     expect(screen.getByText("Close")).toBeInTheDocument();
-  });
-});
-
-describe.skip("Translations", () => {
-  const localesDir = path.join(
-    __dirname,
-    "../../../../../packages/i18n/messages/web",
-  );
-  const enTranslations = loadMessages("en");
-
-  readdirSync(localesDir).forEach((locale) => {
-    if (locale !== "en") {
-      it(`has no missing keys for ${locale}`, () => {
-        const translations = JSON.parse(
-          readFileSync(`${localesDir}/${locale}/common.json`, "utf8"),
-        );
-        Object.keys(enTranslations).forEach((key) => {
-          expect(translations).toHaveProperty(key);
-        });
-      });
-    }
   });
 });
 


### PR DESCRIPTION


## Description

The translation test that verifies all English keys exist in other language
files (`src/__tests__/i18n/next-intl.test.tsx`, lines 71-87) appears to be
blocking the standard workflow for adding new translatable content.

**Current issue (catch-22), per the issue author:**

- New translation keys added in English fail the test because they don't
  exist in other language files.
- Translations are only generated after merging to `main` via the Lingo
  GitHub Action (`.github/workflows/i18n.yml`).
- PRs can't be merged because the test fails.

The test was skipped in #679 to unblock work, with this issue opened to
track "un-skipping" it — i.e. resolving the catch-22 so the check can run
again.

## Investigation

**Read the skipped block itself first** (before touching anything), at
`apps/web/src/__tests__/i18n/next-intl.test.tsx`:

```ts
describe.skip("Translations", () => {
  const localesDir = path.join(
    __dirname,
    "../../../../../packages/i18n/messages/web",
  );
  const enTranslations = loadMessages("en");

  readdirSync(localesDir).forEach((locale) => {
    if (locale !== "en") {
      it(`has no missing keys for ${locale}`, () => {
        const translations = JSON.parse(
          readFileSync(`${localesDir}/${locale}/common.json`, "utf8"),
        );
        Object.keys(enTranslations).forEach((key) => {
          expect(translations).toHaveProperty(key);
        });
      });
    }
  });
});
```

Two separate problems, found by reading closely:

**Problem 1 — the block is independently broken, regardless of the skip.**
`loadMessages` (defined earlier in the file) is:

```ts
const loadMessages = (locale: string) =>
  loadMergedMessages({ app: "web", locale });
```

`loadMergedMessages` is `async` (it's imported from
`@workspace/i18n/messages` and does file I/O). The skipped block calls
`loadMessages("en")` **without `await`**, so `enTranslations` is bound to a
`Promise`, not the resolved messages object. `Object.keys(aPromise)` returns
`[]` (a Promise's own enumerable properties are empty) — so
`Object.keys(enTranslations).forEach(...)` never runs its callback, and the
`it(...)` block's assertions never execute at all, for any locale. Even if
someone removed `.skip` as-is, the test would report green while checking
nothing.

**Problem 2 — the catch-22 is real and still exists today.** I checked
`.github/workflows/i18n.yml` to see when translations actually get
generated:

```yaml
on:
  push:
    branches:
      - main
    paths:
      - "packages/i18n/messages/*/en/*.json"
      - "apps/docs/content/docs/en/**/*.mdx"
      # ...
```

This workflow (which runs Lingo.dev and opens a follow-up `i18n/lingo` PR
with the generated translations) only triggers on **push to `main`** — never
on a pull request. So a contributor's PR that adds new English keys to
`packages/i18n/messages/web/en/common.json` will *always* be missing those
keys in every other locale's `common.json` at PR-review time, no matter how
correct the PR is. Fixing the `await` bug and re-enabling the test as-is
would immediately fail CI on any PR that adds translatable UI copy — the
exact blocking scenario the issue describes, just now for a different
(if-you-fix-the-bug-first) reason.

**Is there already a non-blocking version of this check somewhere?** Yes —
`scripts/i18n/verify-target-coverage.mjs`, run as a step in that same
`i18n.yml` workflow, **after** the Lingo.dev step runs (i.e. after
translations for the new keys have already been generated and committed to
the `i18n/lingo` branch). It does effectively the same leaf-key-diffing work
as the skipped test (plus a lock-file hash check for drift), but at the
correct point in the pipeline — post-translation, not pre-translation. It is
not referenced anywhere else in `.github/workflows/`, so it's not
accidentally also gating PRs some other way.

## Implementation

**File changed:**
`apps/web/src/__tests__/i18n/next-intl.test.tsx`

**Change 1 — remove the dead block entirely** (not just remove `.skip`):

```diff
-describe.skip("Translations", () => {
-  const localesDir = path.join(
-    __dirname,
-    "../../../../../packages/i18n/messages/web",
-  );
-  const enTranslations = loadMessages("en");
-
-  readdirSync(localesDir).forEach((locale) => {
-    if (locale !== "en") {
-      it(`has no missing keys for ${locale}`, () => {
-        const translations = JSON.parse(
-          readFileSync(`${localesDir}/${locale}/common.json`, "utf8"),
-        );
-        Object.keys(enTranslations).forEach((key) => {
-          expect(translations).toHaveProperty(key);
-        });
-      });
-    }
-  });
-});
-
```

**Change 2 — drop the now-unused import** (`readdirSync` was only used by
the removed block; `readFileSync` is still used elsewhere in the file, e.g.
the `NextIntlClientProvider` describe block, so it's kept):

```diff
-import { readdirSync, readFileSync } from "fs";
+import { readFileSync } from "fs";
```

Nothing else in the file changed. `loadMessages`/`loadMergedMessages` is
still used (correctly, with `await`) by the `Smoke Tests for UI Elements
Across Locales` describe block further down the same file, so that helper
stays as-is.

## Why this approach (vs. alternatives considered)

I considered and rejected two other ways to resolve this:

1. **Fix the `await` bug and re-enable the test as-is.** Rejected — this
   reintroduces the exact catch-22 the issue is about, since
   `verify-target-coverage.mjs` already proves the workflow genuinely can't
   have complete translations at PR time.
2. **Fix the `await` bug and make the test tolerant of "pending" keys**
   (e.g. by diffing against `.lingo/lock.json` the way
   `verify-target-coverage.mjs` does, so only *previously-translated* keys
   that later went missing would fail, not brand-new ones). Rejected as
   out of scope for this fix — this would mean re-implementing
   `verify-target-coverage.mjs`'s lock-diffing logic a second time, in a
   different tool (Vitest vs. a standalone script), duplicating logic that
   already exists and is already correctly wired into the one place
   (`i18n.yml`, post-Lingo) where it's safe to run. That's a larger,
   debatable design change I didn't feel was mine to make unilaterally in a
   "smallest correct fix" PR — flagged as an option below for maintainers.

Given those two are out, the smallest correct fix is: the check this test
was trying to be already exists and already runs in the right place, so the
literal instruction "un-skip the tests" is best satisfied by removing the
dead, broken, redundant duplicate — closing the tracked work instead of
leaving a permanently-skipped block as tech debt.

## Validation performed

- `pnpm exec eslint src/__tests__/i18n/next-intl.test.tsx` (scoped, from
  `apps/web`) — no errors/warnings.
- `pnpm exec vitest run src/__tests__/i18n/next-intl.test.tsx` (scoped) —
  **1 test file passed, 60 tests passed**, confirming the remaining
  `NextIntlClientProvider` and `Smoke Tests for UI Elements Across Locales`
  suites (which iterate all 19 supported locales) still pass untouched.
- `pnpm --filter solana-com test` (full app suite) — 27 test files / 156
  tests passed; the run's non-zero exit came from 3 unrelated
  `vitest-pool-runner` worker-startup timeouts in other files
  (`lib/rpc/server.test.ts`, `components/data/solana-data-dashboard.test.ts`,
  `components/data/sender-provider-experience.test.tsx`) — environment/
  infra flakiness on this machine, not assertion failures, and none in a
  file this change touches. Re-ran the scoped i18n file alone to confirm it
  wasn't part of that flakiness.

