### PR TITLE
fix(wallets): correct open-source classifications

### DIFF
--- a/packages/ecosystem-data/src/wallets/metadata.ts
+++ b/packages/ecosystem-data/src/wallets/metadata.ts
@@ -6,6 +6,7 @@ export const WALLET_VERIFICATION_DATES = {
   directoryLaunch: "2026-07-15",
   solflareAudit: "2026-07-16",
   walletResearch20260806: "2026-08-06",
+  openSourceAudit20260818: "2026-08-18",
 } as const satisfies Record<string, `${number}-${number}-${number}`>;
 
 export type WalletVerificationDate =

--- a/packages/ecosystem-data/src/wallets/taxonomy.ts
+++ b/packages/ecosystem-data/src/wallets/taxonomy.ts
@@ -104,8 +104,7 @@ export const WALLET_FEATURE_METADATA = {
   },
   open_source: {
     label: "Open source",
-    description:
-      "Publishes the wallet application's source code under an open-source license.",
+    description: "Publishes relevant source code or SDKs.",
   },
   hardware: {
     label: "Hardware support",

--- a/packages/ecosystem-data/src/wallets/taxonomy.ts
+++ b/packages/ecosystem-data/src/wallets/taxonomy.ts
@@ -104,7 +104,8 @@ export const WALLET_FEATURE_METADATA = {
   },
   open_source: {
     label: "Open source",
-    description: "Publishes relevant source code or SDKs.",
+    description:
+      "Publishes the wallet application's source code under an open-source license.",
   },
   hardware: {
     label: "Hardware support",

--- a/packages/ecosystem-data/src/wallets/wallet-data.ts
+++ b/packages/ecosystem-data/src/wallets/wallet-data.ts
@@ -2010,7 +2010,12 @@ const walletRecords = {
     aliases: ["phantom-embedded-wallets", "phantom-wallet-sdk"],
     category: "infrastructure",
     platforms: ["sdk"],
-    features: ["non_custodial", "private_key_infrastructure", "solana_native"],
+    features: [
+      "non_custodial",
+      "open_source",
+      "private_key_infrastructure",
+      "solana_native",
+    ],
     description:
       "Client SDKs for embedding Phantom wallet creation and signing in web and React Native apps, with full Solana network support and social-login onboarding",
     website: "https://docs.phantom.com/wallet-sdks-overview",

--- a/packages/ecosystem-data/src/wallets/wallet-data.ts
+++ b/packages/ecosystem-data/src/wallets/wallet-data.ts
@@ -1145,7 +1145,6 @@ const walletRecords = {
       "social_recovery",
       "staking",
       "spending_limits",
-      "open_source",
       "hardware",
       "solana_native",
       "multi_sig",
@@ -1154,7 +1153,7 @@ const walletRecords = {
       "Solana smart wallet on Squads Protocol with multifactor approvals and recovery keys, programmable spending limits, sponsored transactions, SOL staking, bank on/off-ramps, and a virtual Visa card",
     website: "https://www.fusewallet.com/",
     icon: fuseIcon,
-    lastVerified: "2026-07-15",
+    lastVerified: "2026-08-18",
   },
   fxwallet: {
     name: "FxWallet",
@@ -1510,7 +1509,7 @@ const walletRecords = {
       "Open-source self-custody Solana wallet with browser, web, and Android access, smart-account security, configurable spending caps, and destination allowlists",
     website: "https://askloyal.com/",
     icon: loyalIcon,
-    lastVerified: "2026-07-16",
+    lastVerified: "2026-08-18",
   },
   magic: {
     name: "Magic SDK",
@@ -2003,7 +2002,7 @@ const walletRecords = {
       "Self-custody wallet for Solana and other networks with mobile apps and Chromium browser extensions, Google and Apple account recovery, gasless Solana transactions, and in-app crypto purchases plus bank cash-out for eligible US users",
     website: "https://phantom.com/",
     icon: phantomIcon,
-    lastVerified: "2026-07-15",
+    lastVerified: "2026-08-18",
   },
   "phantom-connect": {
     name: "Phantom SDK",
@@ -2011,17 +2010,12 @@ const walletRecords = {
     aliases: ["phantom-embedded-wallets", "phantom-wallet-sdk"],
     category: "infrastructure",
     platforms: ["sdk"],
-    features: [
-      "non_custodial",
-      "open_source",
-      "private_key_infrastructure",
-      "solana_native",
-    ],
+    features: ["non_custodial", "private_key_infrastructure", "solana_native"],
     description:
-      "Open-source client SDKs for embedding Phantom wallet creation and signing in web and React Native apps, with full Solana network support and social-login onboarding",
+      "Client SDKs for embedding Phantom wallet creation and signing in web and React Native apps, with full Solana network support and social-login onboarding",
     website: "https://docs.phantom.com/wallet-sdks-overview",
     icon: phantomIcon,
-    lastVerified: "2026-07-16",
+    lastVerified: "2026-08-18",
   },
   pontem: {
     name: "Pontem",
@@ -2365,7 +2359,6 @@ const walletRecords = {
       "non_custodial",
       "gas_abstraction",
       "spending_limits",
-      "open_source",
       "solana_native",
       "multi_sig",
     ],
@@ -2374,7 +2367,7 @@ const walletRecords = {
     website:
       "https://chromewebstore.google.com/detail/squadsx/jhmfofkpljgmilikdmkglcmekjnlekda",
     icon: squadsxIcon,
-    lastVerified: "2026-07-15",
+    lastVerified: "2026-08-18",
   },
   starkey: {
     name: "StarKey",


### PR DESCRIPTION
## Summary
- define the Open source wallet feature as publishing the wallet application under an open-source license
- remove the feature from Fuse, SquadsX, and Phantom SDK
- retain Loyal as open source and refresh the researched records

## Validation
- `pnpm --filter @workspace/ecosystem-data check-types`
- `pnpm --filter @workspace/ecosystem-data audit:data` *(reports pre-existing unrelated company profile and unreferenced asset findings)*