### PR TITLE
feat(breakpoint): link speaker applications

### DIFF
--- a/apps/breakpoint/src/app/[locale]/faq/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/faq/page.tsx
@@ -17,6 +17,12 @@ export async function generateMetadata({
   });
 }
 
-export default function LocaleFAQPage() {
-  return <FAQPage />;
+export default async function LocaleFAQPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+
+  return <FAQPage locale={locale} />;
 }

--- a/apps/breakpoint/src/app/[locale]/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/page.tsx
@@ -15,7 +15,7 @@ import AnnouncementsSection from "@/components/sections/AnnouncementsSection";
 import FAQSection from "@/components/sections/FAQSection";
 import Footer from "@/components/sections/Footer";
 import { GENERAL_ADMISSION_HREF } from "@/content/links";
-import { buildBreakpointJsonLd } from "@/lib/structured-data";
+import { buildBreakpointJsonLd, serializeJsonLd } from "@/lib/structured-data";
 
 export const dynamic = "force-dynamic";
 
@@ -39,7 +39,7 @@ export default async function HomePage({
       beforeNavigation={
         <script
           type="application/ld+json"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+          dangerouslySetInnerHTML={{ __html: serializeJsonLd(jsonLd) }}
         />
       }
     >

--- a/apps/breakpoint/src/app/[locale]/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/page.tsx
@@ -1,3 +1,4 @@
+import { getTranslations } from "@workspace/i18n/server";
 import HeroSection from "@/components/sections/HeroSection";
 import PageShell from "@/components/PageShell";
 import Marquee from "@/components/Marquee";
@@ -24,15 +25,16 @@ export default async function HomePage({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "breakpoint" });
   const initialNow = Date.now();
-  const jsonLd = buildBreakpointJsonLd(locale);
+  const jsonLd = await buildBreakpointJsonLd(locale);
 
   return (
     <PageShell
       contentId="breakpoint-content"
       navigation={{
         ctaHref: GENERAL_ADMISSION_HREF,
-        ctaLabel: "Register",
+        ctaLabel: t("menu.items.register"),
       }}
       beforeNavigation={
         <script

--- a/apps/breakpoint/src/app/[locale]/registration/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/registration/page.tsx
@@ -19,6 +19,12 @@ export async function generateMetadata({
   });
 }
 
-export default function LocaleRegistrationPage() {
-  return <RegistrationPage />;
+export default async function LocaleRegistrationPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+
+  return <RegistrationPage locale={locale} />;
 }

--- a/apps/breakpoint/src/app/[locale]/schedule/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/schedule/page.tsx
@@ -17,8 +17,16 @@ export async function generateMetadata({
   });
 }
 
-export default async function LocaleSchedulePage() {
-  const t = await getTranslations("breakpoint.pages.schedule");
+export default async function LocaleSchedulePage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({
+    locale,
+    namespace: "breakpoint.pages.schedule",
+  });
 
   return <ComingSoonPage title={t("title")} description={t("description")} />;
 }

--- a/apps/breakpoint/src/app/[locale]/speakers/page.tsx
+++ b/apps/breakpoint/src/app/[locale]/speakers/page.tsx
@@ -18,8 +18,16 @@ export async function generateMetadata({
   });
 }
 
-export default async function LocaleSpeakersPage() {
-  const t = await getTranslations("breakpoint.pages.speakers");
+export default async function LocaleSpeakersPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const t = await getTranslations({
+    locale,
+    namespace: "breakpoint.pages.speakers",
+  });
 
   return (
     <ComingSoonPage

--- a/apps/breakpoint/src/app/metadata.ts
+++ b/apps/breakpoint/src/app/metadata.ts
@@ -6,10 +6,7 @@ import { locales, defaultLocale } from "@workspace/i18n/config";
 import { getTranslations } from "@workspace/i18n/server";
 import { config, publicLocalizedRouteUrl } from "@/config";
 
-const socialImageAlt =
-  "Breakpoint 2026 social card with the Breakpoint logo over a purple London skyline";
-
-function createBreakpointSocialImage() {
+function createBreakpointSocialImage(alt: string) {
   const url = config.siteMetadata.socialShare;
 
   return {
@@ -17,7 +14,7 @@ function createBreakpointSocialImage() {
     secureUrl: url,
     width: 1200,
     height: 630,
-    alt: socialImageAlt,
+    alt,
     type: "image/jpeg",
   };
 }
@@ -43,6 +40,7 @@ export async function getBaseMetadata(
 ): Promise<Metadata> {
   const t = await getTranslations({ locale, namespace: "breakpoint.metadata" });
   const { publicSiteOrigin, siteMetadata, social } = config;
+  const socialImageAlt = t("socialImageAlt");
 
   const title = t("title");
   const titleTemplate = t("titleTemplate");
@@ -73,14 +71,14 @@ export async function getBaseMetadata(
       siteName,
       title: ogTitle,
       description: ogDescription,
-      images: [createBreakpointSocialImage()],
+      images: [createBreakpointSocialImage(socialImageAlt)],
     },
     twitter: {
       card: "summary_large_image",
       site: `@${social.twitter.name}`,
       title: ogTitle,
       description: ogDescription,
-      images: [createBreakpointSocialImage()],
+      images: [createBreakpointSocialImage(socialImageAlt)],
     },
     icons: [
       { url: faviconPng.src, rel: "icon", type: "image/png" },

--- a/apps/breakpoint/src/components/CarouselControls.tsx
+++ b/apps/breakpoint/src/components/CarouselControls.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { useTranslations } from "@workspace/i18n/client";
 
 interface CarouselControlsProps {
   onPrev: () => void;
@@ -15,10 +16,13 @@ export default function CarouselControls({
   className = "",
   labelPrefix,
 }: CarouselControlsProps) {
+  const t = useTranslations("breakpoint.accessibility");
   const previousLabel = labelPrefix
-    ? `Previous ${labelPrefix}`
-    : "Previous item";
-  const nextLabel = labelPrefix ? `Next ${labelPrefix}` : "Next item";
+    ? t("previous", { label: labelPrefix })
+    : t("previousItem");
+  const nextLabel = labelPrefix
+    ? t("next", { label: labelPrefix })
+    : t("nextItem");
   const buttonClassName =
     "flex size-12 items-center justify-center border border-stroke-secondary text-white transition-colors hover:border-neutral-500 hover:bg-neutral-600 focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-4 focus-visible:outline-white disabled:border-stroke-primary disabled:text-neutral-700 disabled:hover:bg-transparent";
 

--- a/apps/breakpoint/src/components/EmailSubscribeDialog.tsx
+++ b/apps/breakpoint/src/components/EmailSubscribeDialog.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useId, useRef, useState } from "react";
+import { useTranslations } from "@workspace/i18n/client";
 import Button from "@/components/Button";
 
 const ITERABLE_BASE_URL =
@@ -14,6 +15,8 @@ interface Props {
 }
 
 export default function EmailSubscribeDialog({ open, onClose }: Props) {
+  const t = useTranslations("breakpoint.subscribe");
+  const tAccessibility = useTranslations("breakpoint.accessibility");
   const [email, setEmail] = useState("");
   const [status, setStatus] = useState<"idle" | "sending" | "done" | "error">(
     "idle",
@@ -121,12 +124,12 @@ export default function EmailSubscribeDialog({ open, onClose }: Props) {
       >
         <div className="flex items-start justify-between gap-4">
           <h2 id={titleId} className="type-h4 text-white">
-            Follow BP26
+            {t("title")}
           </h2>
           <button
             type="button"
             onClick={onClose}
-            aria-label="Close"
+            aria-label={tAccessibility("close")}
             className="text-white/60 transition-colors hover:text-white focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-4 focus-visible:outline-white"
           >
             <svg
@@ -145,7 +148,7 @@ export default function EmailSubscribeDialog({ open, onClose }: Props) {
           </button>
         </div>
         <p id={descriptionId} className="type-paragraph mt-3 text-white/72">
-          Get news, event updates, and reveal drops for Breakpoint 2026.
+          {t("description")}
         </p>
 
         {status === "done" ? (
@@ -154,12 +157,12 @@ export default function EmailSubscribeDialog({ open, onClose }: Props) {
             aria-live="polite"
             className="type-caption mt-6 text-green"
           >
-            You&rsquo;re subscribed.
+            {t("success")}
           </p>
         ) : (
           <form onSubmit={submit} className="mt-6 flex flex-col gap-3">
             <label htmlFor="bp-email" className="sr-only">
-              Email
+              {t("emailLabel")}
             </label>
             <input
               id="bp-email"
@@ -175,18 +178,18 @@ export default function EmailSubscribeDialog({ open, onClose }: Props) {
                   setStatus("idle");
                 }
               }}
-              placeholder="you@domain.com"
+              placeholder={t("emailPlaceholder")}
               disabled={status === "sending"}
               className="type-field h-[40px] border border-white/15 bg-transparent px-3 text-white placeholder:text-white/40 focus:border-white/40 focus:outline-none"
             />
             {status === "error" && (
               <p role="alert" className="type-caption text-pink">
-                Please enter a valid email address and try again.
+                {t("error")}
               </p>
             )}
             <Button
               disabled={status === "sending"}
-              label={status === "sending" ? "Subscribing…" : "Subscribe"}
+              label={status === "sending" ? t("submitting") : t("submit")}
               type="submit"
               variant="primary"
             />

--- a/apps/breakpoint/src/components/FAQAnswer.tsx
+++ b/apps/breakpoint/src/components/FAQAnswer.tsx
@@ -14,12 +14,14 @@ export default function FAQAnswer({
     ? breakpointHref(item.answerHref)
     : undefined;
 
+  const answerText = item.answer?.trim() ?? "";
+
   return (
     <p className={className}>
-      {item.answer}
+      {answerText}
       {resolvedHref && (
         <>
-          {" "}
+          {answerText ? " " : null}
           <a
             href={resolvedHref}
             className="underline decoration-white/40 underline-offset-4 transition-opacity hover:opacity-80"

--- a/apps/breakpoint/src/components/SkipLink.tsx
+++ b/apps/breakpoint/src/components/SkipLink.tsx
@@ -1,18 +1,21 @@
+"use client";
+
+import { useTranslations } from "@workspace/i18n/client";
+
 type SkipLinkProps = {
   label?: string;
   targetId: string;
 };
 
-export default function SkipLink({
-  label = "Skip to content",
-  targetId,
-}: SkipLinkProps) {
+export default function SkipLink({ label, targetId }: SkipLinkProps) {
+  const t = useTranslations("breakpoint.accessibility");
+
   return (
     <a
       href={`#${targetId}`}
       className="type-button sr-only absolute left-5 top-5 z-50 focus:not-sr-only focus:bg-white focus:px-4 focus:py-2 focus:text-black"
     >
-      {label}
+      {label ?? t("skipToContent")}
     </a>
   );
 }

--- a/apps/breakpoint/src/components/YouTubeModal.tsx
+++ b/apps/breakpoint/src/components/YouTubeModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useEffect, useId, useRef } from "react";
+import { useTranslations } from "@workspace/i18n/client";
 
 interface Props {
   open: boolean;
@@ -9,12 +10,9 @@ interface Props {
   title?: string;
 }
 
-export default function YouTubeModal({
-  open,
-  onClose,
-  videoId,
-  title = "YouTube video player",
-}: Props) {
+export default function YouTubeModal({ open, onClose, videoId, title }: Props) {
+  const t = useTranslations("breakpoint.accessibility");
+  const resolvedTitle = title ?? t("youtubeVideoPlayer");
   const dialogRef = useRef<HTMLDivElement>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
   const titleId = useId();
@@ -78,13 +76,13 @@ export default function YouTubeModal({
         onClick={(e) => e.stopPropagation()}
       >
         <h2 id={titleId} className="sr-only">
-          {title}
+          {resolvedTitle}
         </h2>
         <button
           ref={closeButtonRef}
           type="button"
           onClick={onClose}
-          aria-label="Close"
+          aria-label={t("close")}
           className="absolute -top-12 right-0 inline-flex size-8 items-center justify-center text-white/80 transition-colors hover:text-white focus-visible:outline focus-visible:outline-1 focus-visible:outline-offset-4 focus-visible:outline-white"
         >
           <svg
@@ -104,7 +102,7 @@ export default function YouTubeModal({
         <div className="relative aspect-video w-full bg-black">
           <iframe
             src={`https://www.youtube.com/embed/${videoId}?rel=0&modestbranding=1&autoplay=1`}
-            title={title}
+            title={resolvedTitle}
             className="absolute inset-0 h-full w-full"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             allowFullScreen

--- a/apps/breakpoint/src/components/pages/FAQPage.tsx
+++ b/apps/breakpoint/src/components/pages/FAQPage.tsx
@@ -5,9 +5,13 @@ import SubpageHero from "@/components/SubpageHero";
 import FAQSubnav from "@/components/pages/FAQSubnav";
 import type { FAQPageSection } from "@/content/faq-page";
 import { GENERAL_ADMISSION_HREF } from "@/content/links";
+import { getTranslations } from "@workspace/i18n/server";
 
-export default async function FAQPage() {
-  const t = await getTranslations("breakpoint.pages.faq");
+export default async function FAQPage({ locale }: { locale: string }) {
+  const t = await getTranslations({
+    locale,
+    namespace: "breakpoint.pages.faq",
+  });
   const sections = t.raw("sections") as FAQPageSection[];
 
   return (
@@ -27,4 +31,3 @@ export default async function FAQPage() {
     </PageShell>
   );
 }
-import { getTranslations } from "@workspace/i18n/server";

--- a/apps/breakpoint/src/components/pages/registration/RegistrationPage.tsx
+++ b/apps/breakpoint/src/components/pages/registration/RegistrationPage.tsx
@@ -223,8 +223,11 @@ function ExpectationsSection({
   );
 }
 
-export default async function RegistrationPage() {
-  const t = await getTranslations("breakpoint.pages.registration");
+export default async function RegistrationPage({ locale }: { locale: string }) {
+  const t = await getTranslations({
+    locale,
+    namespace: "breakpoint.pages.registration",
+  });
   const initialNow = Date.now();
   const tickets = ticketSeeds.map((ticket) => ({
     ...ticket,

--- a/apps/breakpoint/src/components/pages/sponsors/SponsorsPage.tsx
+++ b/apps/breakpoint/src/components/pages/sponsors/SponsorsPage.tsx
@@ -321,6 +321,7 @@ function SponsorCard({
   mobileLogoScale: number;
   onClick: () => void;
 }) {
+  const t = useTranslations("breakpoint.pages.sponsors");
   const logo = getLogo(sponsor);
   const logoStyle = {
     "--logo-width": `${sponsor.width}px`,
@@ -332,7 +333,7 @@ function SponsorCard({
     <button
       type="button"
       onClick={onClick}
-      aria-label={`View ${logo.alt} sponsor details`}
+      aria-label={t("viewDetails", { name: logo.alt })}
       className={`group flex ${cellAspect} min-w-0 cursor-pointer items-center justify-center overflow-hidden border-0 bg-white/[0.05] p-[10px] transition-colors hover:bg-white/[0.08] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white`}
     >
       <span

--- a/apps/breakpoint/src/components/sections/AnnouncementsCarousel.tsx
+++ b/apps/breakpoint/src/components/sections/AnnouncementsCarousel.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useCallback, useId, useRef } from "react";
+import { useTranslations } from "@workspace/i18n/client";
 import { Link } from "@workspace/i18n/routing";
 import CarouselControls from "@/components/CarouselControls";
 import type { BreakpointAnnouncementLink } from "@/lib/media-links";
@@ -19,6 +20,7 @@ export default function AnnouncementsCarousel({
   headline,
   items,
 }: AnnouncementsCarouselProps) {
+  const t = useTranslations("breakpoint");
   const scrollRef = useRef<HTMLUListElement>(null);
   const headingId = useId();
 
@@ -81,11 +83,13 @@ export default function AnnouncementsCarousel({
           const content = (
             <>
               <span className="type-eyebrow text-white opacity-80">
-                {item.tags?.[0] ?? "Article"}
+                {item.tags?.[0] ?? t("announcements.article")}
               </span>
               <span className="type-h5 text-white">{item.title}</span>
               {!isRelativeHref(resolvedUrl) && (
-                <span className="sr-only">(opens in a new tab)</span>
+                <span className="sr-only">
+                  {t("accessibility.opensInNewTab")}
+                </span>
               )}
             </>
           );

--- a/apps/breakpoint/src/components/sections/EventsCarousel.tsx
+++ b/apps/breakpoint/src/components/sections/EventsCarousel.tsx
@@ -2,7 +2,7 @@
 
 import React, { useCallback, useId, useRef } from "react";
 import Image from "next/image";
-import { useLocale } from "next-intl";
+import { useLocale, useTranslations } from "@workspace/i18n/client";
 import Button from "@/components/Button";
 import CarouselControls from "@/components/CarouselControls";
 import type { HighlightedEvent } from "@/content/events/types";
@@ -76,6 +76,7 @@ export default function EventsCarousel({
   items,
 }: EventsCarouselProps) {
   const locale = useLocale();
+  const t = useTranslations("breakpoint.accessibility");
   const scrollRef = useRef<HTMLUListElement>(null);
   const headingId = useId();
 
@@ -184,7 +185,7 @@ export default function EventsCarousel({
                       </>
                     )}
                   </span>
-                  <span className="sr-only">(opens in a new tab)</span>
+                  <span className="sr-only">{t("opensInNewTab")}</span>
                 </span>
               </a>
             </li>

--- a/apps/breakpoint/src/components/sections/FAQSection.tsx
+++ b/apps/breakpoint/src/components/sections/FAQSection.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useTranslations } from "@workspace/i18n/client";
 import Accordion from "@/components/Accordion";
 import FAQAnswer from "@/components/FAQAnswer";
-import { SPONSOR_FORM_HREF } from "@/content/links";
+import { APPLY_TO_SPEAK_HREF, SPONSOR_FORM_HREF } from "@/content/links";
 
 export default function FAQSection() {
   const t = useTranslations("breakpoint");
@@ -27,7 +27,9 @@ export default function FAQSection() {
     {
       id: "q4",
       question: t("faq.items.q4.question"),
-      answer: t("faq.items.q4.answer"),
+      answer: "",
+      answerHref: APPLY_TO_SPEAK_HREF,
+      answerLinkLabel: t("faq.items.q4.answerLinkLabel"),
     },
     {
       id: "q5",

--- a/apps/breakpoint/src/components/sections/Footer.tsx
+++ b/apps/breakpoint/src/components/sections/Footer.tsx
@@ -221,6 +221,7 @@ export default function Footer({
   backgroundColor = "purple",
 }: FooterProps = {}) {
   const t = useTranslations("breakpoint.footer");
+  const tAccessibility = useTranslations("breakpoint.accessibility");
   const { days, hours, minutes, seconds } = useCountdown(EVENT_START);
   const footerStyle: FooterStyle = {
     "--footer-background-color": FOOTER_BACKGROUND_COLORS[backgroundColor],
@@ -244,7 +245,9 @@ export default function Footer({
                 href={social.href}
                 target="_blank"
                 rel="noreferrer"
-                aria-label={`${social.name} (opens in a new tab)`}
+                aria-label={tAccessibility("externalLink", {
+                  name: social.name,
+                })}
                 className="flex size-[24px] items-center justify-center transition-opacity hover:opacity-70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
               >
                 <img

--- a/apps/breakpoint/src/components/sections/GallerySection.tsx
+++ b/apps/breakpoint/src/components/sections/GallerySection.tsx
@@ -87,7 +87,7 @@ export default function GallerySection() {
         open={recapOpen}
         onClose={() => setRecapOpen(false)}
         videoId={BP25_RECAP_YOUTUBE_ID}
-        title="Breakpoint 2025 Recap"
+        title={t("gallery.videoTitle")}
       />
     </section>
   );

--- a/apps/breakpoint/src/components/sections/HighlightsSection.tsx
+++ b/apps/breakpoint/src/components/sections/HighlightsSection.tsx
@@ -211,6 +211,7 @@ function QuoteCard({
   glitchDurationMs?: number;
   glitchIntensity?: number;
 }) {
+  const t = useTranslations("breakpoint");
   const cardRef = useRef<HTMLDivElement>(null);
   const quoteRef = useRef<HTMLQuoteElement>(null);
   const metaRef = useRef<HTMLDivElement>(null);
@@ -338,7 +339,7 @@ function QuoteCard({
             className="type-p-large-bold text-black underline decoration-solid underline-offset-[3px] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black"
           >
             {quote.handle}
-            <span className="sr-only"> (opens in a new tab)</span>
+            <span className="sr-only"> {t("accessibility.opensInNewTab")}</span>
           </a>
           <p className="type-caption text-black/70">
             {quote.author}

--- a/apps/breakpoint/src/components/sections/ParticipateSection.tsx
+++ b/apps/breakpoint/src/components/sections/ParticipateSection.tsx
@@ -18,7 +18,6 @@ const PARTICIPATE_ACTIONS = [
   {
     href: APPLY_TO_SPEAK_HREF,
     key: "speaker",
-    label: "Apply to Speak",
     variant: "secondary",
   },
   {
@@ -48,7 +47,7 @@ function ParticipateButton({ action }: { action: ParticipateAction }) {
       arrow
       className="w-full md:w-auto"
       href={action.href}
-      label={action.label ?? t(`participate.actions.${action.key}.label`)}
+      label={t(`participate.actions.${action.key}.label`)}
       variant={action.variant}
     />
   );

--- a/apps/breakpoint/src/content/faq-page.ts
+++ b/apps/breakpoint/src/content/faq-page.ts
@@ -39,7 +39,7 @@ export const faqPageSections = [
       {
         id: "general-speaking",
         question: "How can I apply to speak at Breakpoint?",
-        answer: "Speaker applications for Breakpoint 2026 are open.",
+        answer: "",
         answerHref: APPLY_TO_SPEAK_HREF,
         answerLinkLabel: "Apply to speak",
       },

--- a/apps/breakpoint/src/content/page.ts
+++ b/apps/breakpoint/src/content/page.ts
@@ -11,6 +11,7 @@ export type BreakpointMessages = {
     ogTitle: string;
     ogDescription: string;
     keywords: string;
+    socialImageAlt: string;
   };
   hero: {
     headline: string;
@@ -63,6 +64,7 @@ export type BreakpointMessages = {
     eyebrow: string;
     headline: string;
     cta: string;
+    videoTitle: string;
   };
   stats: {
     headline: string;
@@ -90,6 +92,7 @@ export type BreakpointMessages = {
   };
   announcements: {
     headline: string;
+    article: string;
     items: Record<
       string,
       {
@@ -169,6 +172,27 @@ export type BreakpointMessages = {
     };
   };
   pages: MessageRecord;
+  accessibility: {
+    close: string;
+    opensInNewTab: string;
+    externalLink: string;
+    previous: string;
+    next: string;
+    previousItem: string;
+    nextItem: string;
+    skipToContent: string;
+    youtubeVideoPlayer: string;
+  };
+  subscribe: {
+    title: string;
+    description: string;
+    success: string;
+    emailLabel: string;
+    emailPlaceholder: string;
+    error: string;
+    submit: string;
+    submitting: string;
+  };
   footer: {
     copyright: string;
     contact: string;

--- a/apps/breakpoint/src/lib/structured-data.ts
+++ b/apps/breakpoint/src/lib/structured-data.ts
@@ -1,12 +1,11 @@
+import { getTranslations } from "@workspace/i18n/server";
 import { config, publicLocalizedRouteUrl } from "@/config";
-import { homepageFaqItems } from "@/content/faq-page";
 import { GENERAL_ADMISSION_HREF } from "@/content/links";
 import { GENERAL_ADMISSION_PRICE_CHANGE } from "@/content/ticket-pricing";
 
 type JsonLd = Record<string, unknown>;
 
 type OfferSeed = {
-  name: string;
   price: number;
   priceValidUntil?: string;
   url: string;
@@ -19,30 +18,55 @@ function asPlainTextMessage(value: unknown) {
 
 const TICKET_OFFERS: OfferSeed[] = [
   {
-    name: "General Admission",
     price: GENERAL_ADMISSION_PRICE_CHANGE.current.amount,
     priceValidUntil: "2026-08-01T08:59:59Z",
     url: GENERAL_ADMISSION_HREF,
     validFrom: "2026-01-01",
   },
   {
-    name: "General Admission",
     price: GENERAL_ADMISSION_PRICE_CHANGE.increased.amount,
     url: GENERAL_ADMISSION_HREF,
     validFrom: GENERAL_ADMISSION_PRICE_CHANGE.increasesAt,
   },
 ];
 
-export function buildBreakpointJsonLd(locale: string): JsonLd {
+export async function buildBreakpointJsonLd(locale: string): Promise<JsonLd> {
+  const t = await getTranslations({ locale, namespace: "breakpoint" });
   const { publicUrl, siteMetadata, event } = config;
   const pageUrl = publicLocalizedRouteUrl(locale);
   const socialImage = new URL(siteMetadata.socialShare, publicUrl).toString();
+  const eventName = t("metadata.siteName");
+  const ticketName = t("tickets.categories.general.label");
+  const localizedFaqItems = [
+    {
+      question: t("faq.items.q1.question"),
+      answer: t("faq.items.q1.answer"),
+    },
+    {
+      question: t("faq.items.q2.question"),
+      answer: t("faq.items.q2.answer"),
+    },
+    {
+      question: t("faq.items.q3.question"),
+      answer: t("faq.items.q3.answer"),
+    },
+    {
+      question: t("faq.items.q4.question"),
+      answer: "",
+      answerLinkLabel: t("faq.items.q4.answerLinkLabel"),
+    },
+    {
+      question: t("faq.items.q5.question"),
+      answer: t("faq.items.q5.answerPrefix"),
+      answerLinkLabel: t("faq.items.q5.answerLinkLabel"),
+    },
+  ];
 
   const eventNode: JsonLd = {
     "@type": "Event",
     "@id": `${publicUrl}#event`,
-    name: event.name,
-    description: event.description,
+    name: eventName,
+    description: t("metadata.description"),
     startDate: event.startDate,
     endDate: event.endDate,
     eventAttendanceMode: "https://schema.org/OfflineEventAttendanceMode",
@@ -51,11 +75,11 @@ export function buildBreakpointJsonLd(locale: string): JsonLd {
     url: pageUrl,
     location: {
       "@type": "Place",
-      name: event.venue,
+      name: t("hero.venue"),
       address: {
         "@type": "PostalAddress",
         streetAddress: "Hammersmith Road",
-        addressLocality: event.city,
+        addressLocality: t("hero.location"),
         postalCode: "W14 8UX",
         addressCountry: "GB",
       },
@@ -65,7 +89,7 @@ export function buildBreakpointJsonLd(locale: string): JsonLd {
     },
     offers: TICKET_OFFERS.map((offer) => ({
       "@type": "Offer",
-      name: offer.name,
+      name: ticketName,
       price: offer.price,
       priceCurrency: "USD",
       url: offer.url,
@@ -95,17 +119,15 @@ export function buildBreakpointJsonLd(locale: string): JsonLd {
   const faqNode: JsonLd = {
     "@type": "FAQPage",
     "@id": `${pageUrl}#faq`,
-    mainEntity: homepageFaqItems.map((item) => ({
+    mainEntity: localizedFaqItems.map((item) => ({
       "@type": "Question",
       name: asPlainTextMessage(item.question),
       acceptedAnswer: {
         "@type": "Answer",
         text: asPlainTextMessage(
-          item.answerHref
-            ? [item.answer, `${item.answerLinkLabel ?? item.answerHref}.`]
-                .filter((part) => part.trim().length > 0)
-                .join(" ")
-            : item.answer,
+          [item.answer, item.answerLinkLabel && `${item.answerLinkLabel}.`]
+            .filter((part) => part?.trim().length)
+            .join(" "),
         ),
       },
     })),

--- a/apps/breakpoint/src/lib/structured-data.ts
+++ b/apps/breakpoint/src/lib/structured-data.ts
@@ -5,6 +5,10 @@ import { GENERAL_ADMISSION_PRICE_CHANGE } from "@/content/ticket-pricing";
 
 type JsonLd = Record<string, unknown>;
 
+export function serializeJsonLd(data: unknown) {
+  return JSON.stringify(data).replace(/</g, "\\u003c");
+}
+
 type OfferSeed = {
   price: number;
   priceValidUntil?: string;

--- a/apps/breakpoint/src/lib/structured-data.ts
+++ b/apps/breakpoint/src/lib/structured-data.ts
@@ -102,7 +102,9 @@ export function buildBreakpointJsonLd(locale: string): JsonLd {
         "@type": "Answer",
         text: asPlainTextMessage(
           item.answerHref
-            ? `${item.answer} ${item.answerLinkLabel ?? item.answerHref}.`
+            ? [item.answer, `${item.answerLinkLabel ?? item.answerHref}.`]
+                .filter((part) => part.trim().length > 0)
+                .join(" ")
             : item.answer,
         ),
       },

--- a/apps/breakpoint/src/tests/EmailSubscribeDialog.test.tsx
+++ b/apps/breakpoint/src/tests/EmailSubscribeDialog.test.tsx
@@ -1,9 +1,19 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { NextIntlClientProvider } from "@workspace/i18n/client";
 import EmailSubscribeDialog from "@/components/EmailSubscribeDialog";
+import messages from "../../../../packages/i18n/messages/breakpoint/en/breakpoint.json";
 
 const NEWSLETTER_ACTION_URL =
   "https://links.iterable.com/lists/publicAddSubscriberForm?publicIdString=16189fcd-ac6c-4cc9-ac4a-94aa102fccc1";
+
+function renderDialog(onClose = () => {}) {
+  return render(
+    <NextIntlClientProvider locale="en" messages={messages}>
+      <EmailSubscribeDialog open onClose={onClose} />
+    </NextIntlClientProvider>,
+  );
+}
 
 describe("EmailSubscribeDialog", () => {
   afterEach(() => {
@@ -15,7 +25,7 @@ describe("EmailSubscribeDialog", () => {
       .spyOn(globalThis, "fetch")
       .mockResolvedValue({ ok: true } as Response);
 
-    render(<EmailSubscribeDialog open onClose={() => {}} />);
+    renderDialog();
 
     fireEvent.change(screen.getByLabelText("Email"), {
       target: { value: "builder@example.com" },
@@ -40,7 +50,7 @@ describe("EmailSubscribeDialog", () => {
   it("shows an error for invalid email without submitting", () => {
     const fetchMock = vi.spyOn(globalThis, "fetch");
 
-    render(<EmailSubscribeDialog open onClose={() => {}} />);
+    renderDialog();
 
     fireEvent.change(screen.getByLabelText("Email"), {
       target: { value: "not-an-email" },

--- a/apps/breakpoint/src/tests/structured-data.test.ts
+++ b/apps/breakpoint/src/tests/structured-data.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { serializeJsonLd } from "@/lib/structured-data";
+
+describe("serializeJsonLd", () => {
+  it("escapes HTML-significant opening brackets", () => {
+    expect(serializeJsonLd({ description: "</script><script>" })).toBe(
+      '{"description":"\\u003c/script>\\u003cscript>"}',
+    );
+  });
+});

--- a/packages/i18n/messages/breakpoint/ar/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/ar/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "كيف يمكنني التقدم للتحدث في Breakpoint؟",
-          "answer": "لم تُفتح طلبات المتحدثين بعد. سيتم مشاركة مزيد من المعلومات في الأشهر القادمة."
+          "answer": "<link>قدّم للحديث</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "قدّم للحديث",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "كيف يمكنني رعاية Breakpoint؟",

--- a/packages/i18n/messages/breakpoint/de/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/de/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Wie kann ich mich als Sprecher bei der Breakpoint bewerben?",
-          "answer": "Bewerbungen für Sprecher sind noch nicht geöffnet. Weitere Informationen werden in den kommenden Monaten bekannt gegeben."
+          "answer": "<link>Als Sprecher bewerben</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Als Sprecher bewerben",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Wie kann ich die Breakpoint sponsern?",

--- a/packages/i18n/messages/breakpoint/el/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/el/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Πώς μπορώ να υποβάλω αίτηση ως ομιλητής στο Breakpoint;",
-          "answer": "Οι αιτήσεις ομιλητών δεν έχουν ανοίξει ακόμα. Περισσότερες πληροφορίες θα κοινοποιηθούν τους επόμενους μήνες."
+          "answer": "<link>Υποβολή αίτησης</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Υποβολή αίτησης",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Πώς μπορώ να χορηγήσω το Breakpoint;",

--- a/packages/i18n/messages/breakpoint/en/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/en/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "How can I apply to speak at Breakpoint?",
-          "answer": "Speaker applications are not open yet. More information will be shared in the coming months."
+          "answer": "<link>Apply to speak</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Apply to speak",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "How can I sponsor Breakpoint?",
@@ -365,7 +368,7 @@
               {
                 "id": "general-speaking",
                 "question": "How can I apply to speak at Breakpoint?",
-                "answer": "Speaker applications for Breakpoint 2026 are open.",
+                "answer": "",
                 "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form",
                 "answerLinkLabel": "Apply to speak"
               },

--- a/packages/i18n/messages/breakpoint/en/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/en/breakpoint.json
@@ -7,7 +7,8 @@
       "description": "Breakpoint 2026 is Solana's flagship conference at Olympia London, November 15–17. Builders, institutions, and policymakers shaping Internet Capital Markets.",
       "ogTitle": "Breakpoint 2026 — Solana's flagship conference in London",
       "ogDescription": "Three days of product launches, ecosystem strategy, and culture at Olympia London, November 15–17, 2026. 6,000+ attendees from 100+ countries.",
-      "keywords": "Breakpoint 2026, Breakpoint conference, Solana conference, Solana London, Solana Foundation, Web3 conference London, Olympia London, Internet Capital Markets, blockchain conference 2026, Solana event"
+      "keywords": "Breakpoint 2026, Breakpoint conference, Solana conference, Solana London, Solana Foundation, Web3 conference London, Olympia London, Internet Capital Markets, blockchain conference 2026, Solana event",
+      "socialImageAlt": "Breakpoint 2026 social card with the Breakpoint logo over a purple London skyline"
     },
     "hero": {
       "headline": "Breakpoint is headed\nto London",
@@ -66,6 +67,9 @@
       "eyebrow": "Get Involved",
       "headline": "Find ways to take part",
       "actions": {
+        "speaker": {
+          "label": "Apply to speak"
+        },
         "sponsor": {
           "label": "Become a Sponsor",
           "ctaLabel": "Reach out",
@@ -86,7 +90,8 @@
     "gallery": {
       "eyebrow": "Breakpoint 2025",
       "headline": "See all the highlights from Abu Dhabi",
-      "cta": "Watch the Recap"
+      "cta": "Watch the Recap",
+      "videoTitle": "Breakpoint 2025 Recap"
     },
     "stats": {
       "headline": "Bringing together the blockchain community",
@@ -124,6 +129,7 @@
     },
     "announcements": {
       "headline": "Latest announcements",
+      "article": "Article",
       "items": {
         "article1": {
           "eyebrow": "Travel",
@@ -487,6 +493,7 @@
         "intro": "<span class=\"text-purple\">7,000+</span> high-intent <span class=\"text-purple\">builders</span>, <span class=\"text-green\">investors</span>, and <span class=\"text-blue\">institutions</span> in one room. Direct access to Solana's decision-makers in London's financial hub. Your brand, their attention. ROI starts day one.",
         "contactCta": "Contact us",
         "closeDetails": "Close sponsor details",
+        "viewDetails": "View {name} sponsor details",
         "social": {
           "website": "Website",
           "linkedin": "LinkedIn",
@@ -500,6 +507,27 @@
           "gold": "Gold"
         }
       }
+    },
+    "accessibility": {
+      "close": "Close",
+      "opensInNewTab": "(opens in a new tab)",
+      "externalLink": "{name} (opens in a new tab)",
+      "previous": "Previous {label}",
+      "next": "Next {label}",
+      "previousItem": "Previous item",
+      "nextItem": "Next item",
+      "skipToContent": "Skip to content",
+      "youtubeVideoPlayer": "YouTube video player"
+    },
+    "subscribe": {
+      "title": "Follow BP26",
+      "description": "Get news, event updates, and reveal drops for Breakpoint 2026.",
+      "success": "You’re subscribed.",
+      "emailLabel": "Email",
+      "emailPlaceholder": "you@domain.com",
+      "error": "Please enter a valid email address and try again.",
+      "submit": "Subscribe",
+      "submitting": "Subscribing…"
     },
     "navigation": {
       "travel": "Travel",

--- a/packages/i18n/messages/breakpoint/es/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/es/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "¿Cómo puedo solicitar hablar en Breakpoint?",
-          "answer": "Las solicitudes para ponentes aún no están abiertas. Se compartirá más información en los próximos meses."
+          "answer": "<link>Solicitar ser ponente</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Solicitar ser ponente",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "¿Cómo puedo patrocinar Breakpoint?",

--- a/packages/i18n/messages/breakpoint/fi/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/fi/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Miten voin hakea puhujaksi Breakpointiin?",
-          "answer": "Puhujakutsut eivät ole vielä avoinna. Lisätietoja jaetaan tulevina kuukausina."
+          "answer": "<link>Hae puhujaksi</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Hae puhujaksi",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Miten voin sponsoroida Breakpointia?",

--- a/packages/i18n/messages/breakpoint/fr/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/fr/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Comment puis-je candidater pour intervenir à Breakpoint ?",
-          "answer": "Les candidatures pour les intervenants ne sont pas encore ouvertes. De plus amples informations seront communiquées dans les mois à venir."
+          "answer": "<link>Candidater pour intervenir</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Candidater pour intervenir",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Comment puis-je sponsoriser Breakpoint ?",

--- a/packages/i18n/messages/breakpoint/id/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/id/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Bagaimana cara mendaftar sebagai pembicara di Breakpoint?",
-          "answer": "Pendaftaran pembicara belum dibuka. Informasi lebih lanjut akan dibagikan dalam beberapa bulan ke depan."
+          "answer": "<link>Daftar sebagai pembicara</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Daftar sebagai pembicara",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Bagaimana cara menjadi sponsor Breakpoint?",

--- a/packages/i18n/messages/breakpoint/it/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/it/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Come posso candidarmi come relatore a Breakpoint?",
-          "answer": "Le candidature per i relatori non sono ancora aperte. Ulteriori informazioni verranno condivise nei prossimi mesi."
+          "answer": "<link>Candidati come relatore</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Candidati come relatore",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Come posso sponsorizzare Breakpoint?",

--- a/packages/i18n/messages/breakpoint/ja/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/ja/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Breakpointでの登壇を申し込むにはどうすればよいですか？",
-          "answer": "スピーカーの申し込みはまだ受け付けていません。詳細は今後数ヶ月以内にお知らせします。"
+          "answer": "<link>登壇を申し込む</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "登壇を申し込む",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Breakpointのスポンサーになるにはどうすればよいですか？",

--- a/packages/i18n/messages/breakpoint/ko/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/ko/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Breakpoint 연사로 지원하려면 어떻게 해야 하나요?",
-          "answer": "연사 신청은 아직 열리지 않았습니다. 향후 몇 달 내에 더 많은 정보가 공개될 예정입니다."
+          "answer": "<link>연사 지원하기</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "연사 지원하기",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Breakpoint 스폰서는 어떻게 할 수 있나요?",

--- a/packages/i18n/messages/breakpoint/nl/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/nl/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Hoe kan ik me aanmelden als spreker op Breakpoint?",
-          "answer": "Sprekeraanmeldingen zijn nog niet open. Meer informatie volgt de komende maanden."
+          "answer": "<link>Aanmelden als spreker</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Aanmelden als spreker",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Hoe kan ik Breakpoint sponsoren?",

--- a/packages/i18n/messages/breakpoint/pl/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/pl/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Jak mogę zgłosić się jako prelegent na Breakpoint?",
-          "answer": "Zgłoszenia prelegentów nie są jeszcze otwarte. Więcej informacji zostanie udostępnionych w nadchodzących miesiącach."
+          "answer": "<link>Zgłoś się jako prelegent</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Zgłoś się jako prelegent",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Jak mogę zostać sponsorem Breakpoint?",

--- a/packages/i18n/messages/breakpoint/pt/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/pt/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Como posso candidatar-me para falar na Breakpoint?",
-          "answer": "As candidaturas para oradores ainda não estão abertas. Mais informações serão partilhadas nos próximos meses."
+          "answer": "<link>Candidatar-me a orador</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Candidatar-me a orador",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Como posso patrocinar a Breakpoint?",

--- a/packages/i18n/messages/breakpoint/ru/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/ru/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Как подать заявку на выступление на Breakpoint?",
-          "answer": "Приём заявок от спикеров ещё не открыт. Подробная информация будет опубликована в ближайшие месяцы."
+          "answer": "<link>Подать заявку</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Подать заявку",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Как стать спонсором Breakpoint?",

--- a/packages/i18n/messages/breakpoint/tr/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/tr/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Breakpoint'te konuşmacı olmak için nasıl başvurabilirim?",
-          "answer": "Konuşmacı başvuruları henüz açık değil. Önümüzdeki aylarda daha fazla bilgi paylaşılacaktır."
+          "answer": "<link>Konuşmacı olmak için başvur</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Konuşmacı olmak için başvur",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Breakpoint'e nasıl sponsor olabilirim?",

--- a/packages/i18n/messages/breakpoint/uk/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/uk/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Як можна подати заявку на виступ на Breakpoint?",
-          "answer": "Заявки спікерів ще не відкрито. Додаткова інформація буде опублікована найближчими місяцями."
+          "answer": "<link>Подати заявку</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Подати заявку",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Як стати спонсором Breakpoint?",

--- a/packages/i18n/messages/breakpoint/vi/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/vi/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "Làm thế nào để đăng ký phát biểu tại Breakpoint?",
-          "answer": "Đơn đăng ký diễn giả chưa được mở. Thông tin thêm sẽ được chia sẻ trong những tháng tới."
+          "answer": "<link>Đăng ký diễn giả</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "Đăng ký diễn giả",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "Làm thế nào để tài trợ cho Breakpoint?",

--- a/packages/i18n/messages/breakpoint/zh/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/zh/breakpoint.json
@@ -164,7 +164,10 @@
         },
         "q4": {
           "question": "如何申请在 Breakpoint 上发言？",
-          "answer": "演讲申请尚未开放，详细信息将在未来几个月内公布。"
+          "answer": "<link>申请演讲</link>",
+          "answerPrefix": "",
+          "answerLinkLabel": "申请演讲",
+          "answerHref": "https://airtable.com/appCy7M2j24UF6QqT/pagRLZbQJSUsyz3Tn/form"
         },
         "q5": {
           "question": "如何赞助 Breakpoint？",


### PR DESCRIPTION
## Problem

Breakpoint pages still had some English-only text, so localized pages could show the wrong language. The FAQ also said speaker applications were not open even though there is now an application form.

## Solution

Localized the remaining Breakpoint page copy, metadata, accessibility labels, subscribe dialog text, and JSON-LD content. Updated the speaker FAQ and participation CTA to link directly to the speaker application form across supported locales.

## Testing

Updated `EmailSubscribeDialog` tests to render with `NextIntlClientProvider` and English Breakpoint messages.

### Summary of Changes

- Localized remaining Breakpoint page copy and accessibility strings.
- Localized metadata social image alt text and structured data values.
- Passed locale params into FAQ, registration, schedule, and speakers pages.
- Added speaker application links to homepage and FAQ content in all Breakpoint locale message files.
- Updated subscribe dialog tests for the new i18n provider dependency.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

none

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

n/a

-->