### PR TITLE
fix(rpc): query average latency over selected range

### DIFF
--- a/apps/web/src/__tests__/lib/rpc/server.test.ts
+++ b/apps/web/src/__tests__/lib/rpc/server.test.ts
@@ -224,12 +224,136 @@ describe("RPC latency query ranges", () => {
       .map(([input]) => new URL(String(input)))
       .filter((url) => url.pathname.endsWith("/query_range"));
 
-    expect(rangeUrls).toHaveLength(5);
+    expect(rangeUrls).toHaveLength(6);
     for (const url of rangeUrls) {
       expect(url.searchParams.get("start")).toBe(String(nowSeconds - 30 * 60));
       expect(url.searchParams.get("end")).toBe(String(nowSeconds));
       expect(url.searchParams.get("step")).toBe("60");
     }
+  });
+
+  it("keeps average latency providers with valid samples in the selected range", async () => {
+    const nowSeconds = 1_800_000_000;
+    const fetchMock = vi.fn().mockImplementation(async (input: string) => {
+      const query = new URL(input).searchParams.get("query") ?? "";
+      const result = query.includes("rpc_latency_seconds_sum")
+        ? [
+            {
+              metric: { provider: "helius" },
+              values: [
+                [nowSeconds - 300, "42"],
+                [nowSeconds, "43"],
+              ],
+            },
+          ]
+        : [];
+
+      return new Response(
+        JSON.stringify({ status: "success", data: { result } }),
+        { status: 200 },
+      );
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(nowSeconds * 1000);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getRpcLatencyMetricRows(
+      {
+        baseUrl: "https://prometheus.example.com",
+        token: "test-token",
+      },
+      { timeframe: "30m" },
+    );
+
+    expect(result.rows).toEqual([
+      {
+        date: new Date((nowSeconds - 300) * 1000).toISOString(),
+        metricName: "RPC Avg Latency",
+        providerName: "helius",
+        unit: "Milliseconds",
+        value: 42,
+      },
+      {
+        date: new Date(nowSeconds * 1000).toISOString(),
+        metricName: "RPC Avg Latency",
+        providerName: "helius",
+        unit: "Milliseconds",
+        value: 43,
+      },
+    ]);
+
+    const avgLatencyUrl = fetchMock.mock.calls
+      .map(([input]) => new URL(String(input)))
+      .find((url) =>
+        (url.searchParams.get("query") ?? "").includes(
+          "rpc_latency_seconds_sum",
+        ),
+      );
+
+    expect(avgLatencyUrl?.pathname).toBe("/api/v1/query_range");
+    expect(avgLatencyUrl?.searchParams.get("start")).toBe(
+      String(nowSeconds - 30 * 60),
+    );
+    expect(avgLatencyUrl?.searchParams.get("end")).toBe(String(nowSeconds));
+    expect(avgLatencyUrl?.searchParams.get("step")).toBe("60");
+  });
+
+  it("keeps a provider whose latest average sample is missing or non-finite", async () => {
+    const nowSeconds = 1_800_000_000;
+    const fetchMock = vi.fn().mockImplementation(async (input: string) => {
+      const query = new URL(input).searchParams.get("query") ?? "";
+      const result = query.includes("rpc_latency_seconds_sum")
+        ? [
+            {
+              metric: { provider: "helius" },
+              values: [
+                [nowSeconds - 600, "21"],
+                [nowSeconds - 300, "NaN"],
+                [nowSeconds, "+Inf"],
+              ],
+            },
+            {
+              metric: { provider: "chainstack" },
+              values: [[nowSeconds, "18"]],
+            },
+          ]
+        : [];
+
+      return new Response(
+        JSON.stringify({ status: "success", data: { result } }),
+        { status: 200 },
+      );
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(nowSeconds * 1000);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getRpcLatencyMetricRows(
+      {
+        baseUrl: "https://prometheus.example.com",
+        token: "test-token",
+      },
+      { timeframe: "1h" },
+    );
+
+    expect(
+      result.rows.filter((row) => row.metricName === "RPC Avg Latency"),
+    ).toEqual([
+      {
+        date: new Date((nowSeconds - 600) * 1000).toISOString(),
+        metricName: "RPC Avg Latency",
+        providerName: "helius",
+        unit: "Milliseconds",
+        value: 21,
+      },
+      {
+        date: new Date(nowSeconds * 1000).toISOString(),
+        metricName: "RPC Avg Latency",
+        providerName: "chainstack",
+        unit: "Milliseconds",
+        value: 18,
+      },
+    ]);
   });
 
   it("attaches human-readable error kinds to error-rate samples", async () => {

--- a/apps/web/src/app/api/rpc/data/route.ts
+++ b/apps/web/src/app/api/rpc/data/route.ts
@@ -17,7 +17,7 @@ export const revalidate = 0;
 
 const RPC_CACHE_REVALIDATE_SECONDS = 60;
 const EDGE_STALE_SECONDS = 5 * 60;
-const RPC_CACHE_KEY_VERSION = "solana-data-rpc-latency-v5";
+const RPC_CACHE_KEY_VERSION = "solana-data-rpc-latency-v6";
 const IS_PRODUCTION = process.env.NODE_ENV === "production";
 const NO_STORE_CACHE_CONTROL = "no-store, max-age=0";
 const DATA_UNAVAILABLE_ERROR =

--- a/apps/web/src/lib/rpc/server.ts
+++ b/apps/web/src/lib/rpc/server.ts
@@ -244,8 +244,11 @@ export async function getRpcLatencyMetricRows(
       start: String(start),
       step: String(timeframe.stepSeconds),
     }),
-    queryPrometheus<PrometheusInstantResult>(config, QUERY_API_PATH, {
+    queryPrometheus<PrometheusRangeResult>(config, QUERY_RANGE_API_PATH, {
+      end: String(end),
       query: buildRpcAvgLatencyQuery(normalizedOptions),
+      start: String(start),
+      step: String(timeframe.stepSeconds),
     }),
     queryPrometheus<PrometheusRangeResult>(config, QUERY_RANGE_API_PATH, {
       end: String(end),
@@ -271,7 +274,7 @@ export async function getRpcLatencyMetricRows(
     generatedAt: new Date().toISOString(),
     rows: [
       ...toErrorRateMetricRows(errorRateResults, errorRateBreakdownResults),
-      ...toInstantMetricRows(avgLatencyResults, "RPC Avg Latency"),
+      ...toRangeMetricRows(avgLatencyResults, "RPC Avg Latency"),
       ...toRangeMetricRows(p50LatencyResults, "RPC P50 Latency"),
       ...toRangeMetricRows(p95LatencyResults, "RPC P95 Latency"),
       ...toRangeMetricRows(p99LatencyResults, "RPC P99 Latency"),
@@ -501,29 +504,6 @@ function formatErrorKindLabel(value: string) {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
-}
-
-function toInstantMetricRows(
-  results: PrometheusInstantResult[],
-  metricName: string,
-  unit = "Milliseconds",
-): MetricRow[] {
-  return results.flatMap((result) => {
-    const providerName = getProviderLabel(result.metric);
-    const sample = result.value;
-
-    if (!providerName || !sample) {
-      return [];
-    }
-
-    return toMetricRow({
-      metricName,
-      providerName,
-      timestamp: sample[0],
-      unit,
-      value: sample[1],
-    });
-  });
 }
 
 function toRangeMetricRows(


### PR DESCRIPTION
## Problem

The RPC data endpoint only asked Prometheus for the latest average latency sample. That meant providers like Helius could disappear from charts when the latest sample was missing or not a real number, even if they had good samples in the selected time range.

## Solution

Query average latency with the same range API used by the other latency metrics. This keeps valid historical samples in the selected window, filters bad samples, and bumps the RPC cache key so stale cached responses are not reused.

## Testing

Updated RPC server tests cover the extra range query and verify average latency rows are kept when valid samples exist in the selected range, including when the latest sample is missing or non-finite.

### Summary of Changes

- Switched RPC average latency from an instant Prometheus query to a range query.
- Reused range metric row conversion for RPC average latency.
- Added regression tests for selected-range average latency data.
- Bumped the RPC data cache key version.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->