### PR TITLE
docs: fix 404 links in resources.md

### DIFF
--- a/apps/web/public/resources.md
+++ b/apps/web/public/resources.md
@@ -18,8 +18,8 @@
 ## Modern JS/TS SDK
 
 - [@solana/kit Repository](https://github.com/anza-xyz/kit)
-- [Solana Kit Docs](https://solana.com/docs/clients/kit) (installation, upgrade
-  guide)
+- [Solana Kit Docs](https://solana.com/docs/frontend/client) (installation,
+  upgrade guide)
 
 ## UI and Wallet Infrastructure
 
@@ -69,7 +69,7 @@
 ## IDLs and Codegen
 
 - [Codama Repository](https://github.com/codama-idl/codama)
-- [Codama Generating Clients](https://solana.com/docs/programs/codama-generating-clients)
+- [Codama Generating Clients](https://solana.com/docs/programs/codama/clients)
 - [Shank (Metaplex)](https://github.com/metaplex-foundation/shank)
 - [Kinobi (Metaplex)](https://github.com/metaplex-foundation/kinobi)
 


### PR DESCRIPTION
`apps/web/public/resources.md` links to three solana.com docs pages that return 404. Two have clear successors in this repo's own `apps/docs/content/docs/en` tree:

| Old (404) | New (200) |
| --- | --- |
| `/docs/clients/kit` | [`/docs/frontend/client`](https://solana.com/docs/frontend/client) — `frontend/client.mdx`, titled "Kit client" |
| `/docs/programs/codama-generating-clients` | [`/docs/programs/codama/clients`](https://solana.com/docs/programs/codama/clients) — `programs/codama/clients.mdx` |

**Third one left unfixed, deliberately:** line 91 links "Solana Security Best Practices" to `/docs/programs/security`, which also 404s. There is no successor page — nothing under `en/programs/` covers general security, and the only security file in the en docs is `tools/kora/security-audits.mdx`, which is a different topic. The two plausible targets are:

- https://solana.com/developers/courses/program-security (200)
- https://solana.com/docs/toolkit/test-suite/security (200)

Both change what the entry means, and the Security section already lists a Blueshift program-security course, so I'd rather you pick. Tell me which and I'll add it here, or I can drop the line.

`prettier --check` passes on the changed file.