### PR TITLE
Add JWT-authenticated raw data API for RPC latency partners

### DIFF
--- a/apps/web/src/__tests__/lib/rpc-raw.test.ts
+++ b/apps/web/src/__tests__/lib/rpc-raw.test.ts
@@ -1,0 +1,128 @@
+import { createHmac } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  parseRawQuery,
+  toCsv,
+  verifyRawApiToken,
+  RawQueryError,
+} from "@/lib/rpc/raw";
+
+const SECRET = "test-secret";
+
+function mintToken(
+  payload: Record<string, unknown>,
+  secret = SECRET,
+  header: Record<string, unknown> = { alg: "HS256", typ: "JWT" },
+) {
+  const encode = (value: Record<string, unknown>) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  const body = `${encode(header)}.${encode(payload)}`;
+  const signature = createHmac("sha256", secret)
+    .update(body)
+    .digest("base64url");
+
+  return `${body}.${signature}`;
+}
+
+const futureExp = Math.floor(Date.now() / 1000) + 3600;
+
+describe("verifyRawApiToken", () => {
+  it("accepts a valid token", () => {
+    const token = mintToken({ sub: "chainstack", exp: futureExp });
+
+    expect(verifyRawApiToken(token, SECRET)).toEqual({ sub: "chainstack" });
+  });
+
+  it("rejects a bad signature", () => {
+    const token = mintToken({ sub: "chainstack", exp: futureExp }, "wrong");
+
+    expect(verifyRawApiToken(token, SECRET)).toBeUndefined();
+  });
+
+  it("rejects an expired token", () => {
+    const token = mintToken({
+      sub: "chainstack",
+      exp: Math.floor(Date.now() / 1000) - 1,
+    });
+
+    expect(verifyRawApiToken(token, SECRET)).toBeUndefined();
+  });
+
+  it("rejects missing sub or exp", () => {
+    expect(
+      verifyRawApiToken(mintToken({ exp: futureExp }), SECRET),
+    ).toBeUndefined();
+    expect(
+      verifyRawApiToken(mintToken({ sub: "chainstack" }), SECRET),
+    ).toBeUndefined();
+  });
+
+  it("rejects non-HS256 algorithms", () => {
+    const token = mintToken({ sub: "chainstack", exp: futureExp }, SECRET, {
+      alg: "none",
+    });
+
+    expect(verifyRawApiToken(token, SECRET)).toBeUndefined();
+  });
+});
+
+describe("parseRawQuery", () => {
+  it("applies defaults", () => {
+    const query = parseRawQuery("latency", new URLSearchParams());
+
+    expect(query.template).toBe("latency");
+    expect(query.end - query.start).toBe(24 * 60 * 60);
+    expect(query.step).toBe(180);
+    expect(query.quantiles).toEqual([0.5, 0.95, 0.99]);
+    expect(query.format).toBe("json");
+  });
+
+  it("rejects unknown templates, providers, and oversized ranges", () => {
+    expect(() => parseRawQuery("promql", new URLSearchParams())).toThrow(
+      RawQueryError,
+    );
+    expect(() =>
+      parseRawQuery("latency", new URLSearchParams({ provider: "evil" })),
+    ).toThrow(RawQueryError);
+    expect(() =>
+      parseRawQuery(
+        "latency",
+        new URLSearchParams({ start: "0", end: "999999999", step: "60" }),
+      ),
+    ).toThrow(RawQueryError);
+  });
+
+  it("rejects region without infra and infra filters on claim_checks", () => {
+    expect(() =>
+      parseRawQuery("latency", new URLSearchParams({ region: "fra" })),
+    ).toThrow(RawQueryError);
+    expect(() =>
+      parseRawQuery("claim_checks", new URLSearchParams({ infra: "tsw" })),
+    ).toThrow(RawQueryError);
+  });
+});
+
+describe("toCsv", () => {
+  it("renders point series", () => {
+    const csv = toCsv([
+      {
+        labels: { provider: "helius", quantile: "0.99" },
+        points: [[1755561600, 42.5]],
+      },
+    ]);
+
+    expect(csv).toBe(
+      "timestamp,provider,quantile,value\n2025-08-19T00:00:00.000Z,helius,0.99,42.5",
+    );
+  });
+
+  it("renders win rate summaries", () => {
+    const csv = toCsv([
+      { labels: { provider: "helius" }, wins: 3, samples: 4, winPct: 75 },
+    ]);
+
+    expect(csv).toBe("provider,wins,samples,win_pct\nhelius,3,4,75");
+  });
+});

--- a/apps/web/src/app/api/rpc/raw/[template]/route.ts
+++ b/apps/web/src/app/api/rpc/raw/[template]/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import {
+  parseRawQuery,
+  runRawQuery,
+  toCsv,
+  verifyRawApiToken,
+  RawQueryError,
+} from "@/lib/rpc/raw";
+import { getRpcLatencyConfig } from "@/lib/rpc/server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+
+const RATE_LIMIT_PER_MINUTE = 60;
+const RATE_WINDOW_MS = 60_000;
+const NO_STORE_CACHE_CONTROL = "no-store, max-age=0";
+
+const rateWindows = new Map<string, { windowStart: number; count: number }>();
+
+export async function GET(
+  request: NextRequest,
+  context: { params: Promise<{ template: string }> },
+) {
+  const secret = process.env.RAW_API_JWT_SECRET?.trim();
+
+  if (!secret) {
+    return errorResponse(503, "The raw data API is not configured.");
+  }
+
+  const claims = verifyRawApiToken(getBearerToken(request), secret);
+
+  if (!claims) {
+    return errorResponse(401, "Invalid, expired, or missing token.");
+  }
+
+  const retryAfterSeconds = takeRateLimitSlot(claims.sub);
+
+  if (retryAfterSeconds > 0) {
+    return errorResponse(429, "Rate limit exceeded.", {
+      "Retry-After": String(retryAfterSeconds),
+    });
+  }
+
+  const configResult = getRpcLatencyConfig();
+
+  if (!configResult.ok) {
+    return errorResponse(503, "The RPC latency data source is not configured.");
+  }
+
+  const { template } = await context.params;
+
+  try {
+    const query = parseRawQuery(template, request.nextUrl.searchParams);
+    const series = await runRawQuery(configResult.config, query);
+
+    if (query.format === "csv") {
+      return new NextResponse(toCsv(series), {
+        headers: {
+          "Cache-Control": NO_STORE_CACHE_CONTROL,
+          "Content-Type": "text/csv; charset=utf-8",
+        },
+      });
+    }
+
+    return NextResponse.json(
+      {
+        generatedAt: new Date().toISOString(),
+        template: query.template,
+        series,
+      },
+      { headers: { "Cache-Control": NO_STORE_CACHE_CONTROL } },
+    );
+  } catch (error) {
+    if (error instanceof RawQueryError) {
+      return errorResponse(400, error.message);
+    }
+
+    console.error("Raw data API query failed", error);
+
+    return errorResponse(502, "Upstream query failed. Try again in a moment.");
+  }
+}
+
+function getBearerToken(request: NextRequest) {
+  const header = request.headers.get("authorization");
+
+  return header?.startsWith("Bearer ") ? header.slice(7).trim() : undefined;
+}
+
+function takeRateLimitSlot(sub: string) {
+  const now = Date.now();
+  const window = rateWindows.get(sub);
+
+  if (!window || now - window.windowStart >= RATE_WINDOW_MS) {
+    rateWindows.set(sub, { windowStart: now, count: 1 });
+
+    return 0;
+  }
+
+  if (window.count >= RATE_LIMIT_PER_MINUTE) {
+    return Math.ceil((window.windowStart + RATE_WINDOW_MS - now) / 1000);
+  }
+
+  window.count += 1;
+
+  return 0;
+}
+
+function errorResponse(
+  status: number,
+  message: string,
+  headers: Record<string, string> = {},
+) {
+  return NextResponse.json(
+    { error: message },
+    {
+      status,
+      headers: { "Cache-Control": NO_STORE_CACHE_CONTROL, ...headers },
+    },
+  );
+}

--- a/apps/web/src/lib/rpc/raw.ts
+++ b/apps/web/src/lib/rpc/raw.ts
@@ -1,0 +1,540 @@
+import "server-only";
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+import {
+  getRpcInfraSourceValue,
+  getRpcRegionSourceValue,
+  isRpcLatencyInfra,
+  isRpcLatencyRegion,
+  rpcMethodOptions,
+  type RpcLatencyInfra,
+  type RpcLatencyMethod,
+  type RpcLatencyRegion,
+} from "@/app/[locale]/data/data-config";
+import {
+  escapePrometheusLabelValue,
+  queryPrometheus,
+  rpcLatencyProviders,
+  type PrometheusRangeResult,
+  type RpcLatencyConfig,
+  type RpcLatencyProvider,
+} from "@/lib/rpc/server";
+
+export const rawTemplates = [
+  "latency",
+  "latency_buckets",
+  "requests",
+  "win_rate",
+  "claim_checks",
+] as const;
+
+export type RawTemplate = (typeof rawTemplates)[number];
+
+export type RawQuery = {
+  template: RawTemplate;
+  provider?: RpcLatencyProvider;
+  method?: RpcLatencyMethod;
+  infra?: RpcLatencyInfra;
+  region?: RpcLatencyRegion;
+  start: number;
+  end: number;
+  step: number;
+  quantiles: number[];
+  by: "status" | "error_kind";
+  format: "json" | "csv";
+};
+
+export type RawSeries = {
+  labels: Record<string, string>;
+  points?: Array<[number, number]>;
+  wins?: number;
+  samples?: number;
+  winPct?: number;
+};
+
+export class RawQueryError extends Error {}
+
+const QUERY_RANGE_API_PATH = "/api/v1/query_range";
+const MAX_POINTS = 5000;
+const MAX_RANGE_SECONDS = 400 * 24 * 60 * 60;
+const MIN_STEP_SECONDS = 60;
+const DEFAULT_RANGE_SECONDS = 24 * 60 * 60;
+const DEFAULT_TARGET_POINTS = 500;
+const DEFAULT_QUANTILES = [0.5, 0.95, 0.99];
+const ALLOWED_QUANTILES = new Set([0.5, 0.9, 0.95, 0.99]);
+
+const templateSet = new Set<string>(rawTemplates);
+const providerSet = new Set<string>(rpcLatencyProviders);
+const methodSet = new Set<string>(
+  rpcMethodOptions.map((option) => option.value),
+);
+
+export function verifyRawApiToken(
+  token: string | undefined,
+  secret: string,
+): { sub: string } | undefined {
+  if (!token) {
+    return undefined;
+  }
+
+  const parts = token.split(".");
+
+  if (parts.length !== 3) {
+    return undefined;
+  }
+
+  const [headerPart, payloadPart, signaturePart] = parts;
+  const expected = createHmac("sha256", secret)
+    .update(`${headerPart}.${payloadPart}`)
+    .digest();
+  const given = Buffer.from(signaturePart, "base64url");
+
+  if (given.length !== expected.length || !timingSafeEqual(given, expected)) {
+    return undefined;
+  }
+
+  let header: unknown;
+  let payload: unknown;
+
+  try {
+    header = JSON.parse(Buffer.from(headerPart, "base64url").toString("utf8"));
+    payload = JSON.parse(
+      Buffer.from(payloadPart, "base64url").toString("utf8"),
+    );
+  } catch {
+    return undefined;
+  }
+
+  if (getField(header, "alg") !== "HS256") {
+    return undefined;
+  }
+
+  const sub = getField(payload, "sub");
+  const exp = getField(payload, "exp");
+
+  if (typeof sub !== "string" || !sub) {
+    return undefined;
+  }
+
+  if (typeof exp !== "number" || exp * 1000 <= Date.now()) {
+    return undefined;
+  }
+
+  return { sub };
+}
+
+export function parseRawQuery(
+  template: string,
+  params: URLSearchParams,
+): RawQuery {
+  if (!templateSet.has(template)) {
+    throw new RawQueryError(
+      `unknown template "${template}"; expected one of ${rawTemplates.join(", ")}`,
+    );
+  }
+
+  const provider = parseEnumParam(params, "provider", providerSet) as
+    | RpcLatencyProvider
+    | undefined;
+  const method = parseEnumParam(params, "method", methodSet) as
+    | RpcLatencyMethod
+    | undefined;
+  const infra = parseInfraParam(params);
+  const region = parseRegionParam(params, infra);
+
+  if (template === "claim_checks" && (infra || region)) {
+    throw new RawQueryError(
+      "claim_checks has no infra or region dimension; remove those filters",
+    );
+  }
+
+  const end = parseTimeParam(params, "end", nowSeconds());
+  const start = parseTimeParam(params, "start", end - DEFAULT_RANGE_SECONDS);
+
+  if (start >= end) {
+    throw new RawQueryError("start must be before end");
+  }
+
+  if (end - start > MAX_RANGE_SECONDS) {
+    throw new RawQueryError(
+      `range exceeds retention; maximum is ${MAX_RANGE_SECONDS} seconds`,
+    );
+  }
+
+  const step = parseStepParam(params, end - start);
+
+  if ((end - start) / step > MAX_POINTS) {
+    throw new RawQueryError(
+      `too many points; keep (end - start) / step at or below ${MAX_POINTS}`,
+    );
+  }
+
+  return {
+    template: template as RawTemplate,
+    provider,
+    method,
+    infra,
+    region,
+    start,
+    end,
+    step,
+    quantiles: parseQuantilesParam(params),
+    by: parseByParam(params),
+    format: parseFormatParam(params),
+  };
+}
+
+export async function runRawQuery(
+  config: RpcLatencyConfig,
+  query: RawQuery,
+): Promise<RawSeries[]> {
+  switch (query.template) {
+    case "latency":
+      return runLatencyQuery(config, query);
+    case "latency_buckets":
+      return runRangeQuery(
+        config,
+        query,
+        `sum by (provider, le)(increase(rpc_latency_seconds_bucket${buildSelector(query, ['status="success"'])}[${query.step}s]))`,
+        ["provider", "le"],
+      );
+    case "requests":
+      return runRequestsQuery(config, query);
+    case "win_rate":
+      return runWinRateQuery(config, query);
+    case "claim_checks":
+      return runRangeQuery(
+        config,
+        query,
+        `sum by (provider, method, result)(increase(rpc_claim_check_total${buildSelector(query)}[${query.step}s]))`,
+        ["provider", "method", "result"],
+      );
+  }
+}
+
+export function toCsv(series: RawSeries[]): string {
+  const labelKeys = [
+    ...new Set(series.flatMap((entry) => Object.keys(entry.labels))),
+  ].sort();
+
+  if (series.some((entry) => entry.points === undefined)) {
+    const rows = series.map((entry) => [
+      ...labelKeys.map((key) => entry.labels[key] ?? ""),
+      String(entry.wins ?? 0),
+      String(entry.samples ?? 0),
+      String(entry.winPct ?? 0),
+    ]);
+
+    return formatCsv([...labelKeys, "wins", "samples", "win_pct"], rows);
+  }
+
+  const rows = series.flatMap((entry) =>
+    (entry.points ?? []).map(([timestamp, value]) => [
+      new Date(timestamp * 1000).toISOString(),
+      ...labelKeys.map((key) => entry.labels[key] ?? ""),
+      String(value),
+    ]),
+  );
+
+  return formatCsv(["timestamp", ...labelKeys, "value"], rows);
+}
+
+function runLatencyQuery(config: RpcLatencyConfig, query: RawQuery) {
+  const selector = buildSelector(query, ['status="success"']);
+
+  return Promise.all(
+    query.quantiles.map((quantile) =>
+      runRangeQuery(
+        config,
+        query,
+        `1000 * histogram_quantile(${quantile}, sum by (le, provider)(rate(rpc_latency_seconds_bucket${selector}[${query.step}s])))`,
+        ["provider"],
+        { quantile: String(quantile) },
+      ),
+    ),
+  ).then((results) => results.flat());
+}
+
+function runRequestsQuery(config: RpcLatencyConfig, query: RawQuery) {
+  const extraMatchers = query.by === "error_kind" ? ['status="error"'] : [];
+
+  return runRangeQuery(
+    config,
+    query,
+    `sum by (provider, ${query.by})(increase(rpc_requests_total${buildSelector(query, extraMatchers)}[${query.step}s]))`,
+    ["provider", query.by],
+  );
+}
+
+async function runWinRateQuery(config: RpcLatencyConfig, query: RawQuery) {
+  const selector = buildSelector(query, ['status="success"']);
+  const series = await runRangeQuery(
+    config,
+    query,
+    `1000 * sum by (provider)(rate(rpc_latency_seconds_sum${selector}[${query.step}s])) / sum by (provider)(rate(rpc_latency_seconds_count${selector}[${query.step}s]))`,
+    ["provider"],
+  );
+  const winners = new Map<number, { provider: string; value: number }>();
+
+  for (const entry of series) {
+    for (const [timestamp, value] of entry.points ?? []) {
+      const current = winners.get(timestamp);
+
+      if (!current || value < current.value) {
+        winners.set(timestamp, { provider: entry.labels.provider, value });
+      }
+    }
+  }
+
+  return series.map((entry) => {
+    const samples = entry.points?.length ?? 0;
+    const wins = (entry.points ?? []).filter(
+      ([timestamp]) =>
+        winners.get(timestamp)?.provider === entry.labels.provider,
+    ).length;
+
+    return {
+      labels: entry.labels,
+      wins,
+      samples,
+      winPct: samples ? Math.round((10000 * wins) / samples) / 100 : 0,
+    };
+  });
+}
+
+async function runRangeQuery(
+  config: RpcLatencyConfig,
+  query: RawQuery,
+  promql: string,
+  labelKeys: string[],
+  extraLabels: Record<string, string> = {},
+): Promise<RawSeries[]> {
+  const results = await queryPrometheus<PrometheusRangeResult>(
+    config,
+    QUERY_RANGE_API_PATH,
+    {
+      end: String(query.end),
+      query: promql,
+      start: String(query.start),
+      step: String(query.step),
+    },
+  );
+
+  return results.flatMap((result) => {
+    const labels: Record<string, string> = { ...extraLabels };
+
+    for (const key of labelKeys) {
+      const value = result.metric?.[key];
+
+      if (typeof value !== "string") {
+        return [];
+      }
+
+      labels[key] = value;
+    }
+
+    if (!providerSet.has(labels.provider)) {
+      return [];
+    }
+
+    const points = (result.values ?? []).flatMap(([timestamp, value]) => {
+      const normalizedTimestamp = Number(timestamp);
+      const normalizedValue = Number(value);
+
+      return Number.isFinite(normalizedTimestamp) &&
+        Number.isFinite(normalizedValue)
+        ? [[normalizedTimestamp, normalizedValue] as [number, number]]
+        : [];
+    });
+
+    return [{ labels, points }];
+  });
+}
+
+function buildSelector(query: RawQuery, extraMatchers: string[] = []) {
+  const matchers = [...extraMatchers];
+
+  if (query.provider) {
+    matchers.push(`provider="${escapePrometheusLabelValue(query.provider)}"`);
+  }
+
+  if (query.method) {
+    matchers.push(`method="${escapePrometheusLabelValue(query.method)}"`);
+  }
+
+  if (query.infra) {
+    matchers.push(`infra=~"${getRpcInfraSourceValue(query.infra)}"`);
+
+    if (query.region) {
+      matchers.push(
+        `region=~"${getRpcRegionSourceValue(query.infra, query.region)}"`,
+      );
+    }
+  }
+
+  return matchers.length ? `{${matchers.join(",")}}` : "";
+}
+
+function parseEnumParam(
+  params: URLSearchParams,
+  key: string,
+  allowedValues: ReadonlySet<string>,
+) {
+  const value = params.get(key);
+
+  if (!value) {
+    return undefined;
+  }
+
+  if (!allowedValues.has(value)) {
+    throw new RawQueryError(
+      `invalid ${key} "${value}"; expected one of ${[...allowedValues].join(", ")}`,
+    );
+  }
+
+  return value;
+}
+
+function parseInfraParam(params: URLSearchParams) {
+  const value = params.get("infra");
+
+  if (!value) {
+    return undefined;
+  }
+
+  if (!isRpcLatencyInfra(value)) {
+    throw new RawQueryError(`invalid infra "${value}"`);
+  }
+
+  return value;
+}
+
+function parseRegionParam(
+  params: URLSearchParams,
+  infra: RpcLatencyInfra | undefined,
+) {
+  const value = params.get("region");
+
+  if (!value) {
+    return undefined;
+  }
+
+  if (!infra) {
+    throw new RawQueryError("region requires infra");
+  }
+
+  if (!isRpcLatencyRegion(value)) {
+    throw new RawQueryError(`invalid region "${value}"`);
+  }
+
+  return value;
+}
+
+function parseTimeParam(
+  params: URLSearchParams,
+  key: string,
+  fallback: number,
+) {
+  const value = params.get(key);
+
+  if (!value) {
+    return fallback;
+  }
+
+  if (/^\d+$/.test(value)) {
+    return Number(value);
+  }
+
+  const milliseconds = Date.parse(value);
+
+  if (Number.isNaN(milliseconds)) {
+    throw new RawQueryError(
+      `invalid ${key} "${value}"; use unix seconds or RFC 3339`,
+    );
+  }
+
+  return Math.floor(milliseconds / 1000);
+}
+
+function parseStepParam(params: URLSearchParams, rangeSeconds: number) {
+  const value = params.get("step");
+
+  if (!value) {
+    return Math.max(
+      MIN_STEP_SECONDS,
+      Math.ceil(rangeSeconds / DEFAULT_TARGET_POINTS / MIN_STEP_SECONDS) *
+        MIN_STEP_SECONDS,
+    );
+  }
+
+  const step = /^\d+$/.test(value) ? Number(value) : NaN;
+
+  if (!Number.isFinite(step) || step < MIN_STEP_SECONDS) {
+    throw new RawQueryError(
+      `invalid step "${value}"; use whole seconds, minimum ${MIN_STEP_SECONDS}`,
+    );
+  }
+
+  return step;
+}
+
+function parseQuantilesParam(params: URLSearchParams) {
+  const value = params.get("q");
+
+  if (!value) {
+    return DEFAULT_QUANTILES;
+  }
+
+  const quantiles = value.split(",").map(Number);
+
+  for (const quantile of quantiles) {
+    if (!ALLOWED_QUANTILES.has(quantile)) {
+      throw new RawQueryError(
+        `invalid quantile "${value}"; allowed: ${[...ALLOWED_QUANTILES].join(", ")}`,
+      );
+    }
+  }
+
+  return [...new Set(quantiles)];
+}
+
+function parseByParam(params: URLSearchParams) {
+  const value = params.get("by") ?? "status";
+
+  if (value !== "status" && value !== "error_kind") {
+    throw new RawQueryError(`invalid by "${value}"; use status or error_kind`);
+  }
+
+  return value;
+}
+
+function parseFormatParam(params: URLSearchParams) {
+  const value = params.get("format") ?? "json";
+
+  if (value !== "json" && value !== "csv") {
+    throw new RawQueryError(`invalid format "${value}"; use json or csv`);
+  }
+
+  return value;
+}
+
+function formatCsv(header: string[], rows: string[][]) {
+  return [header, ...rows]
+    .map((row) => row.map(escapeCsvField).join(","))
+    .join("\n");
+}
+
+function escapeCsvField(value: string) {
+  return /[",\n]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+function getField(value: unknown, key: string) {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)[key]
+    : undefined;
+}
+
+function nowSeconds() {
+  return Math.floor(Date.now() / 1000);
+}

--- a/apps/web/src/lib/rpc/server.ts
+++ b/apps/web/src/lib/rpc/server.ts
@@ -78,12 +78,12 @@ type PrometheusResponse<T> = {
   status?: string;
 };
 
-type PrometheusInstantResult = {
+export type PrometheusInstantResult = {
   metric?: Record<string, unknown>;
   value?: [number | string, string];
 };
 
-type PrometheusRangeResult = {
+export type PrometheusRangeResult = {
   metric?: Record<string, unknown>;
   values?: Array<[number | string, string]>;
 };
@@ -383,14 +383,14 @@ function formatLabelMatcher([key, operator, value]: PrometheusLabelMatcher) {
   return `${key}${operator}"${escapePrometheusLabelValue(value)}"`;
 }
 
-function escapePrometheusLabelValue(value: string) {
+export function escapePrometheusLabelValue(value: string) {
   return value
     .replace(/\\/g, "\\\\")
     .replace(/\n/g, "\\n")
     .replace(/"/g, '\\"');
 }
 
-async function queryPrometheus<T>(
+export async function queryPrometheus<T>(
   config: RpcLatencyConfig,
   path: string,
   params: Record<string, string>,


### PR DESCRIPTION
Partner-facing read API over the RPC latency Prometheus series (Tier 1 of the raw-data plan). No raw request/response bodies exist — the prober measures and discards — so this exposes time-series only.

## Endpoints

`GET /api/rpc/raw/{template}` with `Authorization: Bearer <JWT>`:

- `latency` — histogram_quantile per provider (`q` ⊆ 0.5, 0.9, 0.95, 0.99; default 0.5, 0.95, 0.99)
- `latency_buckets` — raw histogram bucket increases by provider/le
- `requests` — request counts by provider + `by=status|error_kind`
- `win_rate` — per-provider fastest-at-timestamp share, computed server-side from avg latency
- `claim_checks` — `rpc_claim_check_total` increases by provider/method/result

Common params: `provider`, `method`, `region` (requires `infra`), `infra`, `start`/`end` (unix or RFC 3339, default last 24h), `step` (≥60s), `format=json|csv`. Allowlisted query templates only — no free-form PromQL (the Grafana stack also holds private data). Guards: ≤5000 points, range ≤ retention (~13 months).

## Auth & limits

- HS256 JWT against `RAW_API_JWT_SECRET` (new env, needs to be set in Vercel; secret lives in Doppler `rpc-latency-monitor/prd`). Claims: `sub` = partner name, `exp` mandatory.
- 60 req/min per `sub`, fixed window, in-memory (per lambda instance — acceptable for allowlisted bounded queries; upgrade to a shared store if abused).
- Responses are `no-store`; deliberately not using `unstable_cache`.

Reuses `getRpcLatencyConfig`/`queryPrometheus` from `lib/rpc/server.ts` (four symbols exported, no behavior change). Unit tests cover token verification, param validation, and CSV output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)