### PR TITLE
fix(media): Changing title and description of /upgrades page

### DIFF
--- a/apps/media/lib/metadata.ts
+++ b/apps/media/lib/metadata.ts
@@ -657,10 +657,9 @@ export async function podcastEpisodeMetadata(
 // Upgrades listing  /upgrades
 // ---------------------------------------------------------------------------
 
-export const UPGRADES_SEO_TITLE =
-  "Solana Network Upgrades and Validator Actions";
+export const UPGRADES_SEO_TITLE = "Solana Network Upgrades";
 export const UPGRADES_SEO_DESCRIPTION =
-  "Track Solana network upgrades, validator actions, client support, protocol changes, rollout status, and performance improvements across the ecosystem.";
+  "Track Solana network upgrades, client support, protocol changes, rollout status, and performance improvements across the ecosystem.";
 
 export function upgradesListingMetadata(locale?: string): Metadata {
   const resolvedLocale = resolveLocale(locale);


### PR DESCRIPTION
### Problem
The /upgrades html title is currently Solana Network Upgrades and Validator Actions

### Summary of Changes

Remove validator actions from the title. It is not important for the average reader.

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
