### PR TITLE
fix(web): normalize Flux RPC provider aliases

### DIFF
--- a/apps/web/src/__tests__/lib/rpc/server.test.ts
+++ b/apps/web/src/__tests__/lib/rpc/server.test.ts
@@ -404,6 +404,54 @@ describe("RPC latency query ranges", () => {
     });
   });
 
+  it("keeps branded Flux samples when filtering by provider", async () => {
+    const timestamp = 1_800_000_000;
+    const fetchMock = vi.fn().mockImplementation(async (input: string) => {
+      const query = new URL(input).searchParams.get("query") ?? "";
+      const result = query.includes("rpc_latency_seconds_sum")
+        ? [
+            {
+              metric: { provider: "FluxRPC" },
+              values: [[timestamp, "42"]],
+            },
+          ]
+        : [];
+
+      return new Response(
+        JSON.stringify({ status: "success", data: { result } }),
+        { status: 200 },
+      );
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(timestamp * 1000);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getRpcLatencyMetricRows(
+      {
+        baseUrl: "https://prometheus.example.com",
+        token: "test-token",
+      },
+      { provider: "fluxrpc", timeframe: "30m" },
+    );
+
+    expect(result.rows).toContainEqual({
+      date: new Date(timestamp * 1000).toISOString(),
+      metricName: "RPC Avg Latency",
+      providerName: "fluxrpc",
+      unit: "Milliseconds",
+      value: 42,
+    });
+
+    const queries = fetchMock.mock.calls.map(
+      ([input]) => new URL(String(input)).searchParams.get("query") ?? "",
+    );
+
+    for (const query of queries) {
+      expect(query).toContain('provider=~"(?i)');
+      expect(query).not.toContain('provider="');
+    }
+  });
+
   it("attaches human-readable error kinds to error-rate samples", async () => {
     const timestamp = 1_800_000_000;
     const fetchMock = vi.fn().mockImplementation(async (input: string) => {
@@ -551,6 +599,26 @@ describe("RPC Prometheus queries", () => {
     expect(buildRpcAvgLatencyQuery({ infra: "tsw", region: "pit" })).toContain(
       'region=~"pit1|pitt1"',
     );
+  });
+
+  it("filters providers with a case- and separator-insensitive matcher", () => {
+    const query = buildRpcAvgLatencyQuery({ provider: "fluxrpc" });
+    const matcher = query.match(/provider=~"([^"]+)"/)?.[1];
+
+    expect(matcher).toBeDefined();
+    expect(matcher).toMatch(/^\(\?i\)/);
+
+    const pattern = new RegExp(
+      `^${matcher!.slice("(?i)".length).replace(/\\\\/g, "\\")}$`,
+      "i",
+    );
+
+    for (const label of ["fluxrpc", "FluxRPC", "flux-rpc", "Flux RPC"]) {
+      expect(pattern.test(label)).toBe(true);
+    }
+
+    expect(pattern.test("helius")).toBe(false);
+    expect(pattern.test("notfluxrpc")).toBe(false);
   });
 
   it("computes error rate over success and error outcomes", () => {

--- a/apps/web/src/__tests__/lib/rpc/server.test.ts
+++ b/apps/web/src/__tests__/lib/rpc/server.test.ts
@@ -67,8 +67,8 @@ describe("RPC latency query options", () => {
     ).toBe("fluxrpc");
   });
 
-  it("normalizes Flux provider aliases", () => {
-    for (const provider of ["FluxRPC", "flux-rpc", "flux"]) {
+  it("normalizes Flux provider label casing", () => {
+    for (const provider of ["FluxRPC", "flux-rpc"]) {
       expect(
         parseRpcLatencyQueryOptions(new URLSearchParams(`provider=${provider}`))
           .provider,

--- a/apps/web/src/__tests__/lib/rpc/server.test.ts
+++ b/apps/web/src/__tests__/lib/rpc/server.test.ts
@@ -67,6 +67,15 @@ describe("RPC latency query options", () => {
     ).toBe("fluxrpc");
   });
 
+  it("normalizes Flux provider aliases", () => {
+    for (const provider of ["FluxRPC", "flux-rpc", "flux"]) {
+      expect(
+        parseRpcLatencyQueryOptions(new URLSearchParams(`provider=${provider}`))
+          .provider,
+      ).toBe("fluxrpc");
+    }
+  });
+
   it("accepts Chainstack as an RPC provider", () => {
     expect(rpcLatencyProviders).toContain("chainstack");
     expect(
@@ -354,6 +363,45 @@ describe("RPC latency query ranges", () => {
         value: 18,
       },
     ]);
+  });
+
+  it("keeps Flux range samples when Prometheus uses a branded provider label", async () => {
+    const timestamp = 1_800_000_000;
+    const fetchMock = vi.fn().mockImplementation(async (input: string) => {
+      const query = new URL(input).searchParams.get("query") ?? "";
+      const result = query.includes("rpc_latency_seconds_sum")
+        ? [
+            {
+              metric: { provider: "FluxRPC" },
+              values: [[timestamp, "42"]],
+            },
+          ]
+        : [];
+
+      return new Response(
+        JSON.stringify({ status: "success", data: { result } }),
+        { status: 200 },
+      );
+    });
+
+    vi.spyOn(Date, "now").mockReturnValue(timestamp * 1000);
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await getRpcLatencyMetricRows(
+      {
+        baseUrl: "https://prometheus.example.com",
+        token: "test-token",
+      },
+      { timeframe: "30m" },
+    );
+
+    expect(result.rows).toContainEqual({
+      date: new Date(timestamp * 1000).toISOString(),
+      metricName: "RPC Avg Latency",
+      providerName: "fluxrpc",
+      unit: "Milliseconds",
+      value: 42,
+    });
   });
 
   it("attaches human-readable error kinds to error-rate samples", async () => {

--- a/apps/web/src/app/[locale]/data/data-config.ts
+++ b/apps/web/src/app/[locale]/data/data-config.ts
@@ -504,7 +504,6 @@ const providerAliases: Record<string, ProviderName> = {
   chainstack: "Chainstack",
   DefiLama: "DeFiLlama",
   DefiLlama: "DeFiLlama",
-  flux: "FluxRPC",
   fluxrpc: "FluxRPC",
   helius: "Helius",
   jito: "Jito",

--- a/apps/web/src/app/[locale]/data/data-config.ts
+++ b/apps/web/src/app/[locale]/data/data-config.ts
@@ -504,6 +504,7 @@ const providerAliases: Record<string, ProviderName> = {
   chainstack: "Chainstack",
   DefiLama: "DeFiLlama",
   DefiLlama: "DeFiLlama",
+  flux: "FluxRPC",
   fluxrpc: "FluxRPC",
   helius: "Helius",
   jito: "Jito",

--- a/apps/web/src/app/api/rpc/data/route.ts
+++ b/apps/web/src/app/api/rpc/data/route.ts
@@ -17,7 +17,7 @@ export const revalidate = 0;
 
 const RPC_CACHE_REVALIDATE_SECONDS = 60;
 const EDGE_STALE_SECONDS = 5 * 60;
-const RPC_CACHE_KEY_VERSION = "solana-data-rpc-latency-v6";
+const RPC_CACHE_KEY_VERSION = "solana-data-rpc-latency-v7";
 const IS_PRODUCTION = process.env.NODE_ENV === "production";
 const NO_STORE_CACHE_CONTROL = "no-store, max-age=0";
 const DATA_UNAVAILABLE_ERROR =

--- a/apps/web/src/lib/rpc/server.ts
+++ b/apps/web/src/lib/rpc/server.ts
@@ -48,15 +48,6 @@ export const rpcLatencyProviders = [
 
 export type RpcLatencyProvider = (typeof rpcLatencyProviders)[number];
 
-const rpcProviderAliases: Record<string, RpcLatencyProvider> = {
-  alchemy: "alchemy",
-  chainstack: "chainstack",
-  fluxrpc: "fluxrpc",
-  helius: "helius",
-  quicknode: "quicknode",
-  triton: "triton",
-};
-
 export type RpcLatencyQueryOptions = {
   infra?: RpcLatencyInfra;
   method?: RpcLatencyMethod;
@@ -373,7 +364,7 @@ function buildLabelSelector(
   ];
 
   if (provider) {
-    matchers.push(["provider", "=", provider]);
+    matchers.push(["provider", "=~", getRpcProviderMatcher(provider)]);
   }
 
   matchers.push(...extraMatchers);
@@ -387,6 +378,13 @@ function getRpcInfraMatcher(infra: RpcLatencyInfra) {
 
 function getRpcRegionMatcher(infra: RpcLatencyInfra, region: RpcLatencyRegion) {
   return getRpcRegionSourceValue(infra, region);
+}
+
+function getRpcProviderMatcher(provider: RpcLatencyProvider) {
+  // Prometheus may store branded labels (e.g. "FluxRPC"), so match every
+  // casing/separator variant that normalizeRpcProvider collapses to this
+  // provider instead of requiring the canonical label.
+  return `(?i)[\\s_-]*${provider.split("").join("[\\s_-]*")}[\\s_-]*`;
 }
 
 function formatLabelMatcher([key, operator, value]: PrometheusLabelMatcher) {
@@ -569,9 +567,7 @@ function toMetricRow({
 }
 
 function getProviderLabel(metric: Record<string, unknown> | undefined) {
-  const provider = normalizeRpcProvider(getMetricLabel(metric, "provider"));
-
-  return provider && providerSet.has(provider) ? provider : undefined;
+  return normalizeRpcProvider(getMetricLabel(metric, "provider"));
 }
 
 function getMetricLabel(
@@ -605,7 +601,9 @@ function normalizeRpcProvider(value: string | null | undefined) {
     .toLowerCase()
     .replace(/[\s_-]+/g, "");
 
-  return normalizedValue ? rpcProviderAliases[normalizedValue] : undefined;
+  return normalizedValue && providerSet.has(normalizedValue)
+    ? (normalizedValue as RpcLatencyProvider)
+    : undefined;
 }
 
 function normalizeBaseUrl(value: string) {

--- a/apps/web/src/lib/rpc/server.ts
+++ b/apps/web/src/lib/rpc/server.ts
@@ -48,6 +48,16 @@ export const rpcLatencyProviders = [
 
 export type RpcLatencyProvider = (typeof rpcLatencyProviders)[number];
 
+const rpcProviderAliases: Record<string, RpcLatencyProvider> = {
+  alchemy: "alchemy",
+  chainstack: "chainstack",
+  flux: "fluxrpc",
+  fluxrpc: "fluxrpc",
+  helius: "helius",
+  quicknode: "quicknode",
+  triton: "triton",
+};
+
 export type RpcLatencyQueryOptions = {
   infra?: RpcLatencyInfra;
   method?: RpcLatencyMethod;
@@ -134,9 +144,7 @@ export function parseRpcLatencyQueryOptions(params: URLSearchParams): Required<
   return {
     infra,
     method: parseRpcMethod(params.get("method")),
-    provider: parseAllowedValue(params.get("provider"), providerSet) as
-      | RpcLatencyProvider
-      | undefined,
+    provider: normalizeRpcProvider(params.get("provider")),
     region: parseRpcRegion(params.get("region"), infra),
     timeframe: parseRpcTimeframe(params.get("timeframe")),
   };
@@ -562,7 +570,7 @@ function toMetricRow({
 }
 
 function getProviderLabel(metric: Record<string, unknown> | undefined) {
-  const provider = getMetricLabel(metric, "provider");
+  const provider = normalizeRpcProvider(getMetricLabel(metric, "provider"));
 
   return provider && providerSet.has(provider) ? provider : undefined;
 }
@@ -592,16 +600,13 @@ function normalizePrometheusNumber(value: string) {
   return Number.isFinite(parsed) ? parsed : undefined;
 }
 
-function parseAllowedValue<T extends string>(
-  value: string | null | undefined,
-  allowedValues: ReadonlySet<string>,
-  fallback?: T,
-) {
-  if (value && allowedValues.has(value)) {
-    return value as T;
-  }
+function normalizeRpcProvider(value: string | null | undefined) {
+  const normalizedValue = value
+    ?.trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, "");
 
-  return fallback;
+  return normalizedValue ? rpcProviderAliases[normalizedValue] : undefined;
 }
 
 function normalizeBaseUrl(value: string) {

--- a/apps/web/src/lib/rpc/server.ts
+++ b/apps/web/src/lib/rpc/server.ts
@@ -51,7 +51,6 @@ export type RpcLatencyProvider = (typeof rpcLatencyProviders)[number];
 const rpcProviderAliases: Record<string, RpcLatencyProvider> = {
   alchemy: "alchemy",
   chainstack: "chainstack",
-  flux: "fluxrpc",
   fluxrpc: "fluxrpc",
   helius: "helius",
   quicknode: "quicknode",


### PR DESCRIPTION
## Problem
Flux RPC can show up with different names, like `FluxRPC` or `flux-rpc`. The RPC data code only understood one exact spelling, so some Flux latency samples could be dropped or filtered incorrectly.

## Solution
Normalize RPC provider names before using them. Flux labels with different casing, spaces, underscores, or hyphens now map to `fluxrpc`, and the RPC data cache key was bumped so stale cached data is not reused.

## Testing
Added tests for Flux provider query normalization and Prometheus range samples using the branded `FluxRPC` label.

### Summary of Changes

- Normalize RPC provider aliases in `apps/web/src/lib/rpc/server.ts`.
- Preserve Flux latency rows when Prometheus returns branded provider labels.
- Bump the RPC latency API cache key version.
- Add regression coverage for Flux alias handling.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

none

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

n/a

-->