### PR TITLE
chore: Fix the WhatIsIt component

### DIFF
--- a/apps/web/src/components/solutions/hero.v2.tsx
+++ b/apps/web/src/components/solutions/hero.v2.tsx
@@ -115,7 +115,8 @@ export const SolutionHero: React.FC<SolutionHeroProps> = ({
           jsonFilePath={bgJsonFilePath}
           width="100%"
           height="100%"
-          scale={1}
+          // Lower down the scale to improve the performance
+          scale={0.8}
           fps={30}
           lazyLoad={true}
           production={true}

--- a/apps/web/src/components/solutions/report.v2.tsx
+++ b/apps/web/src/components/solutions/report.v2.tsx
@@ -75,7 +75,8 @@ export const SolutionReport: React.FC<SolutionReportProps> = ({
           width="100%"
           height="100%"
           jsonFilePath={bgJsonFilePath}
-          scale={1}
+          // Lower down the scale to improve the performance
+          scale={0.8}
           fps={30}
           lazyLoad={true}
           production={true}

--- a/apps/web/src/components/solutions/what-is-it.v2.tsx
+++ b/apps/web/src/components/solutions/what-is-it.v2.tsx
@@ -131,8 +131,8 @@ export const WhatIsIt = ({
         // offset. The exit fires 100px outside the viewport, so it is never
         // visible.
         setters.forEach(({ x, y }) => {
-          x.tween.kill();
-          y.tween.kill();
+          x.tween?.kill();
+          y.tween?.kill();
         });
         gsap.set(
           layers.map(({ el }) => el),

--- a/apps/web/src/components/solutions/what-is-it.v2.tsx
+++ b/apps/web/src/components/solutions/what-is-it.v2.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useId } from "react";
 import { useScrollTextHighlight } from "../../hooks/useScrollTextHighlight";
 import Image from "next/image";
 import { useViewportVisibility } from "@/hooks/useViewportVisibility";
-import debounce from "lodash/debounce";
+import { gsap } from "gsap";
 import { cn } from "@/app/components/utils";
 
 export type WhatIsItProps = {
@@ -56,40 +56,88 @@ export const WhatIsIt = ({
 
       if (!part1 || !part2 || !part3) return;
 
-      const debouncedMouseMoveHandler = debounce(
-        (event: MouseEvent) => {
-          // Calculate normalized mouse position (-1 to 1)
-          const mouseX = (event.clientX / node.clientWidth) * 2 - 1;
-          const mouseY = (event.clientY / node.clientHeight) * 2 - 1;
+      // Parallax effect: different layers move at different speeds.
+      // part1 (closest) moves most, part3 (farthest) moves least.
+      const layers = [
+        { el: part1, depth: 10 }, // 10% movement
+        { el: part2, depth: 6 }, // 6% movement
+        { el: part3, depth: 4 }, // 4% movement
+      ];
 
-          // Parallax effect: different layers move at different speeds
-          // part1 (closest layer) - moves more
-          const part1X = mouseX * 10; // 10% movement
-          const part1Y = mouseY * 10;
+      // The parallax is decorative and pointer-driven, so it is skipped
+      // entirely under reduced motion and on devices that cannot hover. Touch
+      // browsers emit one compatibility mousemove on tap and no reliable
+      // mouseleave, which would otherwise leave the layers offset for good —
+      // visible on touch devices wide enough to render them (the image column
+      // is max-xl:hidden, so tablets in landscape and up). In both cases the
+      // layers stay in their CSS-defined positions.
+      //
+      // Matched once per entry rather than through gsap.matchMedia() because
+      // GSAP never removes the change listener it registers, and this handler
+      // re-runs on every scroll-in — one leaked MediaQueryList per entry. The
+      // IntersectionObserver already scopes the effect's lifetime, so a live
+      // listener buys nothing: a preference change is picked up on the next
+      // entry.
+      if (
+        !window.matchMedia(
+          "(prefers-reduced-motion: no-preference) and (hover: hover)",
+        ).matches
+      ) {
+        return;
+      }
 
-          // part2 (middle layer) - moves moderately
-          const part2X = mouseX * 6; // 6% movement
-          const part2Y = mouseY * 6;
+      // quickTo batches writes onto the GSAP ticker and eases toward the
+      // latest pointer position, so the layers move at frame rate rather than
+      // stepping at the ~10 updates/sec a debounced handler allowed.
+      const setters = layers.map(({ el, depth }) => ({
+        depth,
+        x: gsap.quickTo(el, "xPercent", { duration: 0.6, ease: "power3" }),
+        y: gsap.quickTo(el, "yPercent", { duration: 0.6, ease: "power3" }),
+      }));
 
-          // part3 (farthest layer) - moves least
-          const part3X = mouseX * 4; // 4% movement
-          const part3Y = mouseY * 4;
+      const moveTo = (mouseX: number, mouseY: number) => {
+        setters.forEach(({ depth, x, y }) => {
+          x(mouseX * depth);
+          y(mouseY * depth);
+        });
+      };
 
-          if (part1X && part1Y)
-            part1.style.transform = `translateX(${part1X}%) translateY(${part1Y}%)`;
-          if (part2X && part2Y)
-            part2.style.transform = `translateX(${part2X}%) translateY(${part2Y}%)`;
-          if (part3X && part3Y)
-            part3.style.transform = `translateX(${part3X}%) translateY(${part3Y}%)`;
-        },
-        50,
-        { leading: true, maxWait: 100 },
-      );
+      const handleMouseMove = (event: MouseEvent) => {
+        const bounds = node.getBoundingClientRect();
 
-      node.addEventListener("mousemove", debouncedMouseMoveHandler);
+        // Normalized pointer position within the section (-1 to 1). Measured
+        // against the section's own box so the offset stays correct as the
+        // page scrolls.
+        moveTo(
+          ((event.clientX - bounds.left) / bounds.width) * 2 - 1,
+          ((event.clientY - bounds.top) / bounds.height) * 2 - 1,
+        );
+      };
+
+      const handleMouseLeave = () => moveTo(0, 0);
+
+      node.addEventListener("mousemove", handleMouseMove);
+      node.addEventListener("mouseleave", handleMouseLeave);
 
       return () => {
-        node.removeEventListener("mousemove", debouncedMouseMoveHandler);
+        node.removeEventListener("mousemove", handleMouseMove);
+        node.removeEventListener("mouseleave", handleMouseLeave);
+
+        // Scrolling the section out of view runs this cleanup without any
+        // mouseleave firing (the pointer never left the section), so the layers
+        // would otherwise be frozen wherever the easing had reached. Stop the
+        // tweens, then snap to rest — the set keeps GSAP's transform cache in
+        // sync so the next entry eases from centre rather than from a stale
+        // offset. The exit fires 100px outside the viewport, so it is never
+        // visible.
+        setters.forEach(({ x, y }) => {
+          x.tween.kill();
+          y.tween.kill();
+        });
+        gsap.set(
+          layers.map(({ el }) => el),
+          { xPercent: 0, yPercent: 0 },
+        );
       };
     },
     [id],
@@ -115,8 +163,8 @@ export const WhatIsIt = ({
           {title}
         </h2>
         <div className="flex flex-col xl:items-center xl:flex-row gap-8 xl:gap-16">
-          <div className="w-[35%] max-xl:hidden">
-            {imageSrc && (
+          {imageSrc && (
+            <div className="w-[35%] max-xl:hidden">
               <div className="relative overflow-hidden rounded-xl translate-z-0">
                 <Image
                   id={`what-is-part-1-${id}`}
@@ -154,9 +202,14 @@ export const WhatIsIt = ({
                   loading="lazy"
                 />
               </div>
+            </div>
+          )}
+          <div
+            className={cn(
+              "relative w-full",
+              imageSrc ? "xl:w-3/5 max-w-2xl" : " max-w-3xl",
             )}
-          </div>
-          <div className="relative w-full xl:w-3/5 max-w-2xl">
+          >
             <p
               className="text-xl md:text-[32px] mb-0 font-medium tracking-[-0.6px] md:tracking-[-0.96px] leading-[1.4] md:leading-[1.25]"
               ref={ref}

--- a/apps/web/src/hooks/useScrollTextHighlight.ts
+++ b/apps/web/src/hooks/useScrollTextHighlight.ts
@@ -22,53 +22,68 @@ export const useScrollTextHighlight = <T extends HTMLElement>(
 
     if (!element) return;
 
-    const triggers: ScrollTrigger[] = [];
+    const mm = gsap.matchMedia();
 
-    element.style.setProperty(
-      "--highlight-color",
-      highlightColor.replace(/\s+/g, ""),
-    );
-    const split = new SplitText(element, {
-      autoSplit: true,
-      type: "lines",
-      linesClass: cn(
-        `line whitespace-nowrap bg-[linear-gradient(to_right,var(--highlight-color)_50%,rgba(0,0,0,0)_50%)] bg-[length:201%_100%] bg-[position:100%_0] !inline-block rounded-sm`,
-        `before:content-[attr(data-content)] before:absolute before:inset-0 before:bg-[linear-gradient(to_right,#000_50%,rgba(0,0,0,0)_50%)] before:bg-[length:201%_100%] before:bg-[position:var(--progress,100%)_0] before:rounded-sm`,
-        `before:bg-clip-text before:text-transparent`,
-      ),
-      onSplit: (s) => {
+    // Under reduced motion the paragraph is left untouched: no split, no
+    // scroll-scrubbed reveal. The unrevealed state is already the readable one
+    // (the overlay's clip-path defaults to fully clipped), so plain text is the
+    // correct resting state rather than a statically applied highlight.
+    mm.add("(prefers-reduced-motion: no-preference)", () => {
+      const triggers: ScrollTrigger[] = [];
+      const killTriggers = () => {
         triggers.forEach((trigger) => trigger.kill());
+        triggers.length = 0;
+      };
 
-        s.lines.forEach((target) => {
-          target.setAttribute("data-content", target.textContent || "");
+      element.style.setProperty(
+        "--highlight-color",
+        highlightColor.replace(/\s+/g, ""),
+      );
+      const split = new SplitText(element, {
+        autoSplit: true,
+        type: "lines",
+        linesClass: cn(
+          `line whitespace-nowrap !inline-block`,
+          `before:content-[attr(data-content)] before:absolute before:inset-0 before:rounded-sm`,
+          `before:bg-[color:var(--highlight-color)] before:text-black`,
+          `before:[clip-path:inset(0_var(--progress,100%)_0_0)]`,
+        ),
+        onSplit: (s) => {
+          killTriggers();
 
-          const tween = gsap.to(target, {
-            backgroundPositionX: 0,
-            ease: "none",
-            scrollTrigger: {
-              trigger: target,
-              scrub: 0,
-              start: "top center",
-              end: "bottom center",
-            },
-            onUpdate: function () {
-              if (this?.progress)
-                gsap.set(target, {
-                  "--progress": `${100 - this.progress() * 100}%`,
-                });
-            },
+          s.lines.forEach((target) => {
+            target.setAttribute("data-content", target.textContent || "");
+
+            const tween = gsap.fromTo(
+              target,
+              { "--progress": "100%" },
+              {
+                "--progress": "0%",
+                ease: "none",
+                scrollTrigger: {
+                  trigger: target,
+                  scrub: 0.2,
+                  start: "top center",
+                  end: "bottom center",
+                },
+              },
+            );
+
+            if (tween.scrollTrigger) {
+              triggers.push(tween.scrollTrigger);
+            }
           });
+        },
+      });
 
-          if (tween.scrollTrigger) {
-            triggers.push(tween.scrollTrigger);
-          }
-        });
-      },
+      return () => {
+        killTriggers();
+        split.revert();
+      };
     });
 
     return () => {
-      split.revert();
-      triggers.forEach((trigger) => trigger.kill());
+      mm.revert();
     };
   }, [highlightColor]);
 


### PR DESCRIPTION
### Problem

<!-- What problem does this solve? Write enough that someone uninvolved can
     understand it six months from now — this feeds the auto-generated change
     log (SDLC §3.5.3). -->

Before
<img width="1281" height="551" alt="Screenshot 2026-08-18 at 16 29 39" src="https://github.com/user-attachments/assets/c35879cc-5b1b-4d28-86e1-2204ae6744d0" />

After
<img width="1219" height="452" alt="Screenshot 2026-08-20 at 11 55 35" src="https://github.com/user-attachments/assets/0be77ac9-3144-46ee-8b8f-60492c624d10" />


- **Empty gap next to the text.** The image column always rendered, but 2 of
  the 14 pages don't pass an image. On wide screens that left an empty 35%
  column and a 64px gap, pushing the paragraph off-centre.
- Improved the scroll-driven text highlight animation to make it run smoother.
- The hero and report background animations also rendered at full scale, which
costs more than the visual needs.


### Summary of Changes

<!-- What changed and why. Call out anything security-relevant explicitly. -->

**`useScrollTextHighlight.ts`**

- One animation drives the reveal now: a single tween on `--progress`, used by
  a `clip-path` on the overlay.
- Skipped entirely under reduced motion.
- ScrollTriggers are cleaned up when the text re-splits on resize or font load.

**`hero.v2.tsx`, `report.v2.tsx`**

- Background animation scale 1 → 0.8 for better performance.

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
