### PR TITLE
fix(security): isolate gitleaks scans for PRs

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,7 +35,18 @@ jobs:
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+      - name: Scan pull request commits for secrets
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        # Only the commits introduced by the PR branch; history already on
+        # main is covered by the push and weekly full scans below.
+        run: |
+          /tmp/gitleaks git --redact --exit-code 1 \
+            --log-opts "--no-merges --first-parent ${BASE_SHA}..${HEAD_SHA}" .
       - name: Scan full git history for secrets
+        if: github.event_name != 'pull_request'
         run: /tmp/gitleaks git --redact --exit-code 1 .
 
   dependency-audit:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,11 +40,13 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        # Only the commits introduced by the PR branch; history already on
-        # main is covered by the push and weekly full scans below.
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        # Every commit the PR introduces, including side branches merged into
+        # it, but nothing already reachable from the base branch — that
+        # history is covered by the push and weekly full scans below.
         run: |
           /tmp/gitleaks git --redact --exit-code 1 \
-            --log-opts "--no-merges --first-parent ${BASE_SHA}..${HEAD_SHA}" .
+            --log-opts "${HEAD_SHA} --not ${BASE_SHA} origin/${BASE_REF}" .
       - name: Scan full git history for secrets
         if: github.event_name != 'pull_request'
         run: /tmp/gitleaks git --redact --exit-code 1 .


### PR DESCRIPTION
## Problem
Pull request secret scans checked the full git history, so a PR could fail because of leaks that already existed on the base branch instead of only issues introduced by the PR.

## Solution
For pull_request events, gitleaks now scans only the commits between the PR base SHA and head SHA. Push and scheduled runs still scan the full git history.

### Summary of Changes

- Added a pull_request-only gitleaks step using BASE_SHA..HEAD_SHA.
- Kept full-history gitleaks scans for non-pull_request events.
- Security-relevant: this isolates PR findings to changes introduced by the PR while preserving full scans elsewhere.

## Testing
TODO: Not run / not provided.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [x] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

none

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

This changes the CI trust boundary for pull_request secret scanning. PR scans now trust the GitHub-provided base and head SHAs to define the review range, so the worst case is a mis-scoped PR scan that misses or misattributes findings. Full-history push and scheduled scans remain in place as a backstop.

-->