### PR TITLE
Add Rendben to the ecosystem company registry

### DIFF
--- a/packages/ecosystem-data/assets/companies/rendben/logo.svg
+++ b/packages/ecosystem-data/assets/companies/rendben/logo.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="200" height="180" viewBox="0 0 200 180" fill="none" role="img" aria-labelledby="title description">
+  <title id="title">Rendben R partnership mark</title>
+  <desc id="description">A geometric red R divided at its waist, bridged by a restrained navy handshake and followed by a red terminal dot.</desc>
+
+  <!-- Upper R: a squared stem and controlled circular bowl. -->
+  <path d="M22 20h70c36 0 56 18.2 56 50 0 20.6-8.6 34.8-25.3 43.2L107 101.5c14.8-6 21.8-16.3 21.8-31.5 0-20.6-12.4-31-36.8-31H59v52.5L22 79.8V20Z" fill="#C9272C"/>
+
+  <!-- Lower stem and leg keep the silhouette unmistakably an R. -->
+  <path d="m22 105.5 37 12.3V158H22v-52.5Z" fill="#C9272C"/>
+  <path d="m111.5 108.5 15.7-9.5 39.3 59h-40.8l-28.2-33.8 14-15.7Z" fill="#C9272C"/>
+
+  <!-- A reduced outline handshake bridges the split without cartoon finger shapes. -->
+  <g transform="translate(65 87) scale(2.05)" fill="none" stroke="#15122D" stroke-width="1.8" stroke-linecap="square" stroke-linejoin="round">
+    <path d="m11 17 2 2a1 1 0 1 0 3-3"/>
+    <path d="m14 14 2.5 2.5a1 1 0 1 0 3-3l-3.88-3.88a3 3 0 0 0-4.24 0l-.88.88a1 1 0 1 1-3-3l2.81-2.81a5.79 5.79 0 0 1 7.06-.87l.47.28a2 2 0 0 0 1.42.25L21 4"/>
+    <path d="m21 3 1 11"/>
+    <path d="M3 3 2 14l6.5 6.5a1 1 0 1 0 3-3"/>
+  </g>
+
+  <circle cx="184" cy="150" r="7.5" fill="#C9272C"/>
+</svg>

--- a/packages/ecosystem-data/src/companies/records/rendben.ts
+++ b/packages/ecosystem-data/src/companies/records/rendben.ts
@@ -15,6 +15,7 @@ export const rendben = {
     type: "Company",
     links: {
       website: "https://rendben.com",
+      docs: "https://rendben.com/docs/api",
     },
     socials: {
       x: "https://x.com/joelsstafford",

--- a/packages/ecosystem-data/src/companies/records/rendben.ts
+++ b/packages/ecosystem-data/src/companies/records/rendben.ts
@@ -1,0 +1,32 @@
+import type { CompanyRecord } from "../../types";
+import rendbenLogo from "../../../assets/companies/rendben/logo.svg";
+
+export const rendben = {
+  id: "rendben",
+  slug: "rendben",
+  name: "Rendben",
+  profile: {
+    tagline: "The payment layer for AI agents and internet businesses",
+    summary:
+      "Rendben is a non-custodial checkout that settles USDC payments on Solana directly into a merchant's own wallet.",
+    description:
+      "Rendben provides hosted checkout pages, a payments API and a Model Context Protocol server for accepting USDC on Solana. The customer signs a single atomic transaction that transfers the merchant's share to a wallet Rendben holds no key for and the fee to Rendben, so both transfers settle or neither does. The Solana transaction is built server-side from a frozen payment intent and verified against on-chain data before a payment is treated as complete.",
+    sector: "Payments",
+    type: "Company",
+    links: {
+      website: "https://rendben.com",
+    },
+    socials: {
+      x: "https://x.com/joelsstafford",
+    },
+  },
+  defaultLogoId: "logo",
+  logos: [
+    {
+      id: "logo",
+      fileName: "logo.svg",
+      format: "svg",
+      source: rendbenLogo,
+    },
+  ],
+} satisfies CompanyRecord;

--- a/packages/ecosystem-data/src/companies/registry.ts
+++ b/packages/ecosystem-data/src/companies/registry.ts
@@ -74,6 +74,7 @@ import { rain } from "./records/rain";
 import { ramp } from "./records/ramp";
 import { raydium } from "./records/raydium";
 import { reap } from "./records/reap";
+import { rendben } from "./records/rendben";
 import { renderNetwork } from "./records/render-network";
 import { rockawayx } from "./records/rockawayx";
 import { ryder } from "./records/ryder";
@@ -187,6 +188,7 @@ export const companies = [
   ramp,
   raydium,
   reap,
+  rendben,
   renderNetwork,
   rockawayx,
   ryder,


### PR DESCRIPTION
Adds Rendben as a company record in `packages/ecosystem-data`, following the Level 3 (profile) path in that package's CONTRIBUTING.md.

**What Rendben is:** a non-custodial checkout that settles USDC payments on Solana directly into the merchant's own wallet. The customer signs one atomic transaction that pays the merchant and the fee together, so both transfers settle or neither does. Rendben stores public addresses only.

**Files**
- `assets/companies/rendben/logo.svg` — SVG, pure path geometry (no font dependency, so it renders identically everywhere)
- `src/companies/records/rendben.ts` — record with a full profile
- `src/companies/registry.ts` — import and array entry, both alphabetical between `reap` and `renderNetwork`

**Against the package conventions**
- `id` and `slug` match the asset folder name (`rendben`); export name is the camelCase slug
- `sector: "Payments"` and `type: "Company"` are both from the `COMPANY_PROFILE_SECTORS` / `COMPANY_PROFILE_TYPES` unions in `types.ts`
- Only verified links included: website, docs and X. No LinkedIn/Discord/Telegram claimed
- Description is factual and present tense with Solana-specific context, per the writing guidelines — no superlatives or investor language

Disclosure: I build Rendben.