### PR TITLE
fix(web): align enterprise solutions page with v2 layout

### DIFF
--- a/apps/web/src/app/[locale]/solutions/enterprise/solutions-enterprise.tsx
+++ b/apps/web/src/app/[locale]/solutions/enterprise/solutions-enterprise.tsx
@@ -4,9 +4,11 @@ import { useTranslations } from "next-intl";
 import { SolutionHero, SolutionHeroStat } from "@/components/solutions/hero.v2";
 import { WhatIsIt } from "@/components/solutions/what-is-it.v2";
 import { Products } from "@/components/solutions/products.v2";
+import { Performance } from "@/components/solutions/performance.v2";
 import { Divider } from "@/components/solutions/divider.v2";
+import { Decor } from "@/components/solutions/decor.v2";
+import { SolutionReport } from "@/components/solutions/report.v2";
 import { SelectionColor } from "@/component-library/selection-color";
-import { Envelope as Mail } from "@boxicons/react/Envelope";
 import {
   SOLUTION_LINKS,
   TECHNICAL_GUIDES,
@@ -18,6 +20,8 @@ import {
   ArrowsIcon,
   DiscountIcon,
 } from "@solana-com/ui-chrome/icons";
+
+const CONTACT_HREF = "mailto:enterprise@solana.org";
 
 export function SolutionsEnterprisePage() {
   const t = useTranslations();
@@ -69,11 +73,11 @@ export function SolutionsEnterprisePage() {
           })}
           description={t("partners.features.description")}
           highlightColor="#14F195"
+          imageSrc="/src/img/solutions/icm/what-is.webp"
         />
 
         <Divider />
 
-        {/* Solutions Section */}
         <Products
           className="z-[1]"
           title={t("partners.solutions.title")}
@@ -81,139 +85,60 @@ export function SolutionsEnterprisePage() {
           products={SOLUTION_LINKS}
           translationBase="partners.solutions"
           highlightColor="#14F195"
+          imageSrc="/src/img/solutions/icm/toolkit.svg"
+        />
+
+        <Decor imageSrc="/src/img/solutions/icm/bg-1.webp" />
+
+        <Products
+          className="z-[1]"
+          title={t("partners.guides.title")}
+          description={t("partners.guides.description")}
+          products={TECHNICAL_GUIDES.map((guide) => ({
+            key: guide.key,
+            href: guide.href,
+            eyebrow: t(`partners.guides.items.${guide.key}.tag`),
+          }))}
+          translationBase="partners.guides.items"
+          highlightColor="#14F195"
         />
 
         <Divider />
 
-        {/* Technical Guides Section */}
-        <section className="tw-py-16 md:tw-py-24">
-          <div className="tw-container tw-mx-auto tw-px-4">
-            <h2 className="tw-text-3xl md:tw-text-4xl tw-font-bold tw-text-white tw-mb-4">
-              {t("partners.guides.title")}
-            </h2>
-            <p className="tw-text-gray-400 tw-mb-12 tw-max-w-2xl">
-              {t("partners.guides.description")}
-            </p>
-            <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-3 tw-gap-6">
-              {TECHNICAL_GUIDES.map((guide) => (
-                <a
-                  key={guide.key}
-                  href={guide.href}
-                  className="tw-group tw-bg-gray-900 tw-border tw-border-gray-800 tw-rounded-xl tw-p-6 hover:tw-border-[#14F195] tw-transition-all tw-duration-300"
-                >
-                  <div className="tw-text-[#14F195] tw-text-sm tw-font-medium tw-mb-2">
-                    {t(`partners.guides.items.${guide.key}.tag`)}
-                  </div>
-                  <h3 className="tw-text-xl tw-font-semibold tw-text-white tw-mb-3 group-hover:tw-text-[#14F195] tw-transition-colors">
-                    {t(`partners.guides.items.${guide.key}.title`)}
-                  </h3>
-                  <p className="tw-text-gray-400 tw-text-sm">
-                    {t(`partners.guides.items.${guide.key}.description`)}
-                  </p>
-                </a>
-              ))}
-            </div>
-          </div>
-        </section>
+        <Performance
+          title={t("partners.faq.title")}
+          description={t("partners.faq.description")}
+          items={FAQ_ITEMS}
+          translationBase="partners.faq.items"
+          titleKey="question"
+          descriptionKey="answer"
+          linkLabel={t("partners.faq.learnMore")}
+        />
 
         <Divider />
 
-        {/* FAQ Section */}
-        <section className="tw-py-16 md:tw-py-24">
-          <div className="tw-container tw-mx-auto tw-px-4">
-            <h2 className="tw-text-3xl md:tw-text-4xl tw-font-bold tw-text-white tw-mb-4">
-              {t("partners.faq.title")}
-            </h2>
-            <p className="tw-text-gray-400 tw-mb-12 tw-max-w-2xl">
-              {t("partners.faq.description")}
-            </p>
-            <div className="tw-grid tw-grid-cols-1 lg:tw-grid-cols-2 tw-gap-6">
-              {FAQ_ITEMS.map((faq) => (
-                <div
-                  key={faq.key}
-                  className="tw-bg-gray-900 tw-border tw-border-gray-800 tw-rounded-xl tw-p-6 tw-flex tw-flex-col"
-                >
-                  <h3 className="tw-text-lg tw-font-semibold tw-text-white tw-mb-4">
-                    {t(`partners.faq.items.${faq.key}.question`)}
-                  </h3>
-                  <p className="tw-text-gray-400 tw-leading-relaxed tw-flex-1">
-                    {t(`partners.faq.items.${faq.key}.answer`)}
-                  </p>
-                  {(faq.link || faq.secondaryLink) && (
-                    <div className="tw-flex tw-flex-wrap tw-gap-4 tw-mt-5 tw-pt-4 tw-border-t tw-border-gray-800">
-                      {faq.link && (
-                        <a
-                          href={faq.link}
-                          className="tw-text-[#14F195] hover:tw-underline tw-text-sm tw-font-medium"
-                        >
-                          {t("partners.faq.learnMore")} →
-                        </a>
-                      )}
-                      {faq.secondaryLink && (
-                        <a
-                          href={faq.secondaryLink}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="tw-text-[#14F195] hover:tw-underline tw-text-sm tw-font-medium"
-                        >
-                          {faq.secondaryLinkLabel} →
-                        </a>
-                      )}
-                    </div>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
-        </section>
+        <Products
+          className="z-[1]"
+          title={t("partners.resources.title")}
+          description={t("partners.resources.description")}
+          products={RESOURCES.map((resource) => ({
+            key: resource.key,
+            href: resource.href,
+          }))}
+          translationBase="partners.resources.items"
+          highlightColor="#14F195"
+        />
 
-        <Divider />
+        <Divider hideOnDesktop />
 
-        {/* Resources Section */}
-        <section className="tw-py-16 md:tw-py-24">
-          <div className="tw-container tw-mx-auto tw-px-4">
-            <h2 className="tw-text-3xl md:tw-text-4xl tw-font-bold tw-text-white tw-mb-4">
-              {t("partners.resources.title")}
-            </h2>
-            <p className="tw-text-gray-400 tw-mb-12 tw-max-w-2xl">
-              {t("partners.resources.description")}
-            </p>
-            <div className="tw-grid tw-grid-cols-1 md:tw-grid-cols-2 lg:tw-grid-cols-4 tw-gap-6">
-              {RESOURCES.map((resource) => (
-                <a
-                  key={resource.key}
-                  href={resource.href}
-                  target={resource.external ? "_blank" : undefined}
-                  rel={resource.external ? "noopener noreferrer" : undefined}
-                  className="tw-group tw-bg-gray-900 tw-border tw-border-gray-800 tw-rounded-xl tw-p-6 hover:tw-border-[#14F195] tw-transition-all tw-duration-300"
-                >
-                  <h3 className="tw-text-lg tw-font-semibold tw-text-white tw-mb-2 group-hover:tw-text-[#14F195] tw-transition-colors">
-                    {t(`partners.resources.items.${resource.key}.title`)}
-                  </h3>
-                  <p className="tw-text-gray-400 tw-text-sm">
-                    {t(`partners.resources.items.${resource.key}.description`)}
-                  </p>
-                </a>
-              ))}
-            </div>
-          </div>
-        </section>
-
-        {/* Get in Touch */}
-        <section className="tw-py-12 tw-border-t tw-border-gray-800">
-          <div className="tw-container tw-mx-auto tw-px-4 tw-flex tw-flex-col sm:tw-flex-row tw-items-center tw-justify-center tw-gap-4">
-            <span className="tw-text-gray-400 tw-text-lg">
-              {t("partners.contact.text")}
-            </span>
-            <a
-              href="mailto:enterprise@solana.org"
-              className="tw-inline-flex tw-items-center tw-gap-2 tw-bg-[#14F195] tw-text-black tw-font-semibold tw-px-6 tw-py-3 tw-rounded-full hover:tw-bg-[#14F195]/90 tw-transition-colors"
-            >
-              <Mail className="tw-w-4 tw-h-4" />
-              {t("partners.contact.button")}
-            </a>
-          </div>
-        </section>
+        <SolutionReport
+          eyebrow={t("partners.contact.text")}
+          emailCta={t("partners.contact.button")}
+          onEmailClick={() => {
+            window.location.href = CONTACT_HREF;
+          }}
+          bgJsonFilePath="/src/img/solutions/icm/hero-bg.json"
+        />
       </div>
     </>
   );

--- a/apps/web/src/app/[locale]/solutions/enterprise/solutions-enterprise.tsx
+++ b/apps/web/src/app/[locale]/solutions/enterprise/solutions-enterprise.tsx
@@ -98,6 +98,7 @@ export function SolutionsEnterprisePage() {
             key: guide.key,
             href: guide.href,
             eyebrow: t(`partners.guides.items.${guide.key}.tag`),
+            external: false,
           }))}
           translationBase="partners.guides.items"
           highlightColor="#14F195"
@@ -124,6 +125,7 @@ export function SolutionsEnterprisePage() {
           products={RESOURCES.map((resource) => ({
             key: resource.key,
             href: resource.href,
+            external: resource.external,
           }))}
           translationBase="partners.resources.items"
           highlightColor="#14F195"

--- a/apps/web/src/components/solutions/performance.v2.tsx
+++ b/apps/web/src/components/solutions/performance.v2.tsx
@@ -7,18 +7,29 @@ import { useState } from "react";
 
 export type PerformanceItem = {
   key?: string;
+  link?: string;
+  secondaryLink?: string;
+  secondaryLinkLabel?: string;
 };
 
 type PerformanceProps = {
   title?: ReactNode;
+  description?: ReactNode;
   items: PerformanceItem[];
   translationBase: string;
+  titleKey?: string;
+  descriptionKey?: string;
+  linkLabel?: string;
 };
 
 export const Performance = ({
   items,
   title,
+  description,
   translationBase,
+  titleKey = "title",
+  descriptionKey = "description",
+  linkLabel,
 }: PerformanceProps) => {
   const t = useTranslations();
   const [expandedItems, setExpandedItems] = useState<Set<string>>(new Set());
@@ -40,57 +51,99 @@ export const Performance = ({
       <div className="max-w-[1440px] mx-auto px-[20px] md:px-[32px] xl:px-[40px] py-[64px] md:py-[112px] xl:py-[160px] flex flex-col xl:flex-row max-xl:gap-6 xl:gap-20">
         <div className={cn("w-full xl:w-1/2")}>
           {title && (
-            <h2 className="font-brand font-medium leading-none text-[32px] md:text-[40px] xl:text-[64px] mb-[32px] xl:mb-[48px]">
+            <h2
+              className={cn(
+                "font-brand font-medium leading-none text-[32px] md:text-[40px] xl:text-[64px]",
+                description ? "mb-5" : "mb-[32px] xl:mb-[48px]",
+              )}
+            >
               {title}
             </h2>
+          )}
+          {description && (
+            <p className="text-[#ABABBA] text-lg md:text-2xl mb-0 max-w-md tracking-[-0.36px] md:tracking-[-0.48px] leading-[1.33]">
+              {description}
+            </p>
           )}
         </div>
         <div className="w-full xl:w-1/2">
           <ul className="pl-0">
-            {items.map(({ key }, index) => {
-              const productTitle = t(`${translationBase}.${key}.title`);
-              const productDescription = t(
-                `${translationBase}.${key}.description`,
-              );
-              const isExpanded = expandedItems.has(key || "");
+            {items.map(
+              ({ key, link, secondaryLink, secondaryLinkLabel }, index) => {
+                const productTitle = t(`${translationBase}.${key}.${titleKey}`);
+                const productDescription = t(
+                  `${translationBase}.${key}.${descriptionKey}`,
+                );
+                const isExpanded = expandedItems.has(key || "");
 
-              return (
-                <li key={key} className="group flex flex-col list-none w-full">
-                  <div
-                    className={cn(
-                      "box-border content-stretch flex gap-[18px] items-start px-0 py-[20px] relative shrink-0 w-full cursor-pointer transition-all duration-200 ",
-                      {
-                        "border-t border-white/10": index !== 0,
-                      },
-                    )}
-                    onClick={() => key && toggleExpanded(key)}
+                return (
+                  <li
+                    key={key}
+                    className="group flex flex-col list-none w-full"
                   >
-                    <div className="xl:w-8 xl:h-8 max-xl:w-6 max-xl:h-6 md:mt-0 shrink-0 grow-0 bg-none rounded-full flex items-center justify-center text-white border-[1px] border-white group-hover:bg-white group-hover:!text-black transition-all duration-200">
-                      <span className="text-sm font-medium leading-8">
-                        {index + 1}
-                      </span>
-                    </div>
-                    <div className="basis-0 grow shrink-0">
-                      <p className="font-medium mb-0 font-brand text-lg md:text-2xl">
-                        {productTitle}
-                      </p>
-                      <div className="overflow-hidden transition-all duration-300 ease-in-out">
-                        <p
-                          className={cn(
-                            "text-[#ABABBA] font-brand text-lg md:text-2xl mb-0 mt-1 transition-all duration-300",
-                            isExpanded
-                              ? "opacity-100 max-h-96"
-                              : "opacity-60 max-h-0",
-                          )}
-                        >
-                          {productDescription}
+                    <div
+                      className={cn(
+                        "box-border content-stretch flex gap-[18px] items-start px-0 py-[20px] relative shrink-0 w-full cursor-pointer transition-all duration-200 ",
+                        {
+                          "border-t border-white/10": index !== 0,
+                        },
+                      )}
+                      onClick={() => key && toggleExpanded(key)}
+                    >
+                      <div className="xl:w-8 xl:h-8 max-xl:w-6 max-xl:h-6 md:mt-0 shrink-0 grow-0 bg-none rounded-full flex items-center justify-center text-white border-[1px] border-white group-hover:bg-white group-hover:!text-black transition-all duration-200">
+                        <span className="text-sm font-medium leading-8">
+                          {index + 1}
+                        </span>
+                      </div>
+                      <div className="basis-0 grow shrink-0">
+                        <p className="font-medium mb-0 font-brand text-lg md:text-2xl">
+                          {productTitle}
                         </p>
+                        <div className="overflow-hidden transition-all duration-300 ease-in-out">
+                          <div
+                            className={cn(
+                              "transition-all duration-300",
+                              isExpanded
+                                ? "opacity-100 max-h-[1200px]"
+                                : "opacity-60 max-h-0",
+                            )}
+                          >
+                            <p className="text-[#ABABBA] font-brand text-lg md:text-2xl mb-0 mt-1">
+                              {productDescription}
+                            </p>
+                            {(link || secondaryLink) && (
+                              <div
+                                className="flex flex-wrap gap-4 mt-4"
+                                onClick={(event) => event.stopPropagation()}
+                              >
+                                {link && linkLabel && (
+                                  <a
+                                    href={link}
+                                    className="text-white hover:underline text-base md:text-lg font-medium tracking-[-0.16px] md:tracking-[-0.18px]"
+                                  >
+                                    {linkLabel} →
+                                  </a>
+                                )}
+                                {secondaryLink && secondaryLinkLabel && (
+                                  <a
+                                    href={secondaryLink}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="text-white hover:underline text-base md:text-lg font-medium tracking-[-0.16px] md:tracking-[-0.18px]"
+                                  >
+                                    {secondaryLinkLabel} →
+                                  </a>
+                                )}
+                              </div>
+                            )}
+                          </div>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </li>
-              );
-            })}
+                  </li>
+                );
+              },
+            )}
           </ul>
         </div>
       </div>

--- a/apps/web/src/components/solutions/products.v2.tsx
+++ b/apps/web/src/components/solutions/products.v2.tsx
@@ -11,6 +11,7 @@ export type Product = {
   key: string;
   href?: string;
   eyebrow?: string;
+  external?: boolean;
   Icon?: ComponentType<{
     className?: string;
     "aria-hidden"?: boolean;
@@ -99,8 +100,9 @@ export const Products = ({
                 !oneColumn,
             })}
           >
-            {products.map(({ key, href, eyebrow, Icon }, index) => {
+            {products.map(({ key, href, eyebrow, external, Icon }, index) => {
               const hasLink = Boolean(href);
+              const opensInNewTab = external !== false;
               const productTitle = t(`${translationBase}.${key}.title`);
               const productDescription = t(
                 `${translationBase}.${key}.description`,
@@ -179,8 +181,8 @@ export const Products = ({
                   {hasLink ? (
                     <a
                       href={href}
-                      target="_blank"
-                      rel="noopener noreferrer"
+                      target={opensInNewTab ? "_blank" : undefined}
+                      rel={opensInNewTab ? "noopener noreferrer" : undefined}
                       className="group flex flex-row w-full p-[24px_0] xl:p-[24px_12px] text-inherit focus:outline-none focus:ring-2 focus:ring-primary-500 rounded-xl"
                     >
                       {content}

--- a/apps/web/src/components/solutions/products.v2.tsx
+++ b/apps/web/src/components/solutions/products.v2.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/app/components/utils";
 export type Product = {
   key: string;
   href?: string;
+  eyebrow?: string;
   Icon?: ComponentType<{
     className?: string;
     "aria-hidden"?: boolean;
@@ -98,7 +99,7 @@ export const Products = ({
                 !oneColumn,
             })}
           >
-            {products.map(({ key, href, Icon }, index) => {
+            {products.map(({ key, href, eyebrow, Icon }, index) => {
               const hasLink = Boolean(href);
               const productTitle = t(`${translationBase}.${key}.title`);
               const productDescription = t(
@@ -134,6 +135,14 @@ export const Products = ({
                     )}
                   </div>
                   <div className="grow">
+                    {eyebrow && (
+                      <p
+                        className="text-sm font-medium mb-1 tracking-[-0.14px] leading-[1.4]"
+                        style={{ color: highlightColor }}
+                      >
+                        {eyebrow}
+                      </p>
+                    )}
                     <p className="font-medium mb-0 text-base md:text-2xl tracking-[-0.36px] md:tracking-[-0.48px] leading-[1.5] md:leading-[1.33]">
                       {productTitle}
                     </p>


### PR DESCRIPTION
### Problem

`/solutions/enterprise` is the only v2 solutions page that does not pass an image into `WhatIsIt`. On wide screens that left an empty 35% column and pushed the paragraph off-centre.

#1941 tried to hide the empty column inside the shared component, plus unrelated animation and Unicorn `scale` changes. The layout bug is a missing image on this page. Tokenization and DeFi already show the intended design.

### Summary of Changes

Restyles `/solutions/enterprise` with the same v2 components as tokenization / DeFi. Copy, links, and sections are unchanged.

- `WhatIsIt` now uses `/src/img/solutions/icm/what-is.webp` (same asset family as the enterprise hero)
- Solution areas, technical guides, and developer resources render through `Products`
- FAQ renders through `Performance`
- Bottom contact CTA renders through `SolutionReport`
- `Decor` uses the existing ICM background
- Small, backward-compatible props on `Products` (`eyebrow`) and `Performance` (`description`, FAQ keys, optional links) so those sections fit without new page-local UI

Supersedes #1941.

Fixes #

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":
none
-->

<!-- Threat-model note for Critical changes, or "n/a":
n/a
-->