### PR TITLE
feat(media): add translation support to /upgrades

### DIFF
--- a/apps/docs/content/docs/en/tools/surfpool/sdk/kit-plugin.mdx
+++ b/apps/docs/content/docs/en/tools/surfpool/sdk/kit-plugin.mdx
@@ -1,8 +1,8 @@
 ---
 title: Kit Plugin
 description:
-  Run an embedded Surfnet behind a Solana Kit client. One .use(surfpool()) gives
-  you a pre-funded payer, the full RPC stack, and typed cheatcodes.
+  Run an embedded Surfnet behind a Solana Kit client. One plugin gives you a
+  pre-funded payer, the full RPC stack, and typed cheatcodes.
 ---
 
 `@solana/surfpool/kit` runs a Surfnet — a local, Solana-compatible network —

--- a/apps/media/__tests__/seo-metadata.test.ts
+++ b/apps/media/__tests__/seo-metadata.test.ts
@@ -468,8 +468,8 @@ describe("reportsListingMetadata", () => {
 });
 
 describe("upgradesListingMetadata", () => {
-  it("has complete, localized, indexable metadata", () => {
-    const meta = upgradesListingMetadata("ja");
+  it("has complete, localized, indexable metadata", async () => {
+    const meta = await upgradesListingMetadata("ja");
 
     expectOgFields(meta.openGraph as any);
     expectTwitterFields(meta.twitter as any);

--- a/apps/media/__tests__/upgrade-stage.test.ts
+++ b/apps/media/__tests__/upgrade-stage.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest";
-import {
-  isUpgradeStage,
-  STAGE_BADGE_CLASSES,
-  STAGE_LABELS,
-} from "@/lib/upgrades/stage";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { isUpgradeStage, STAGE_BADGE_CLASSES } from "@/lib/upgrades/stage";
+
+const messages = JSON.parse(
+  readFileSync(
+    path.join(
+      __dirname,
+      "../../../packages/i18n/messages/media/en/common.json",
+    ),
+    "utf8",
+  ),
+);
 
 describe("upgrade stage helper", () => {
-  it("has a label and badge class for all four stages", () => {
+  it("has a translated label and badge class for all four stages", () => {
     const stages = [
       "planned",
       "in_development",
@@ -14,7 +22,7 @@ describe("upgrade stage helper", () => {
       "live",
     ] as const;
     for (const stage of stages) {
-      expect(STAGE_LABELS[stage]).toBeTruthy();
+      expect(messages.upgrades.stage[stage]).toBeTruthy();
       expect(STAGE_BADGE_CLASSES[stage]).toBeTruthy();
     }
   });

--- a/apps/media/app/[locale]/upgrades/[slug]/page.tsx
+++ b/apps/media/app/[locale]/upgrades/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { getFormatter, getTranslations } from "next-intl/server";
 import { Link } from "@workspace/i18n/routing";
 import { ArrowLeft } from "@boxicons/react/ArrowLeft";
 import { Twitter } from "@boxicons/react/Twitter";
@@ -19,7 +20,6 @@ import { isPublishedUpgrade } from "@/lib/keystatic/upgrade-status";
 import {
   isUpgradeStage,
   STAGE_BADGE_CLASSES,
-  STAGE_LABELS,
   type UpgradeStage,
 } from "@/lib/upgrades/stage";
 
@@ -27,18 +27,19 @@ export const revalidate = 300;
 
 type Props = { params: Promise<{ slug: string; locale: string }> };
 
-function SocialShare({ title, slug }: { title: string; slug: string }) {
+async function SocialShare({ title, slug }: { title: string; slug: string }) {
+  const t = await getTranslations("upgrades.detail");
   const url = encodeURIComponent(`https://solana.com/upgrades/${slug}`);
   const text = encodeURIComponent(title);
   return (
     <div className="flex items-center gap-3 mb-6">
-      <span className="text-sm text-gray-400">Share:</span>
+      <span className="text-sm text-gray-400">{t("share")}</span>
       <a
         href={`https://twitter.com/intent/tweet?text=${text}&url=${url}`}
         target="_blank"
         rel="noopener noreferrer"
         className="text-gray-400 hover:text-[#14F195] transition-colors"
-        aria-label="Share on Twitter"
+        aria-label={t("shareOnTwitter")}
       >
         <Twitter className="size-5" />
       </a>
@@ -47,7 +48,7 @@ function SocialShare({ title, slug }: { title: string; slug: string }) {
         target="_blank"
         rel="noopener noreferrer"
         className="text-gray-400 hover:text-[#14F195] transition-colors"
-        aria-label="Share on Facebook"
+        aria-label={t("shareOnFacebook")}
       >
         <Facebook className="size-5" />
       </a>
@@ -56,7 +57,7 @@ function SocialShare({ title, slug }: { title: string; slug: string }) {
         target="_blank"
         rel="noopener noreferrer"
         className="text-gray-400 hover:text-[#14F195] transition-colors"
-        aria-label="Share on LinkedIn"
+        aria-label={t("shareOnLinkedin")}
       >
         <Linkedin className="size-5" />
       </a>
@@ -65,7 +66,7 @@ function SocialShare({ title, slug }: { title: string; slug: string }) {
         target="_blank"
         rel="noopener noreferrer"
         className="text-gray-400 hover:text-[#14F195] transition-colors"
-        aria-label="Share on Telegram"
+        aria-label={t("shareOnTelegram")}
       >
         <Send className="size-5" />
       </a>
@@ -75,6 +76,8 @@ function SocialShare({ title, slug }: { title: string; slug: string }) {
 
 export default async function Page({ params }: Props) {
   const { locale, slug } = await params;
+  const t = await getTranslations("upgrades");
+  const format = await getFormatter();
   const entry = await reader.collections.upgrades.read(slug);
 
   if (!isPublishedUpgrade(entry)) notFound();
@@ -89,7 +92,7 @@ export default async function Page({ params }: Props) {
     ? entry.stage
     : "in_development";
   const publishedDate = entry.publishedAt
-    ? new Date(entry.publishedAt).toLocaleDateString("en-US", {
+    ? format.dateTime(new Date(entry.publishedAt), {
         month: "long",
         year: "numeric",
       })
@@ -116,14 +119,14 @@ export default async function Page({ params }: Props) {
               className="inline-flex items-center gap-2 text-sm text-gray-400 hover:text-[#14F195] transition-colors"
             >
               <ArrowLeft className="size-4" />
-              <span>Back to Upgrades</span>
+              <span>{t("detail.back")}</span>
             </Link>
           </div>
           <div className="flex flex-wrap items-center gap-2 mb-6">
             <span
               className={`rounded-full border px-3 py-1 text-xs font-medium ${STAGE_BADGE_CLASSES[stage]}`}
             >
-              {STAGE_LABELS[stage]}
+              {t(`stage.${stage}`)}
             </span>
           </div>
           <h1 className="text-5xl md:text-6xl font-bold tracking-tight mb-6">
@@ -135,13 +138,14 @@ export default async function Page({ params }: Props) {
             </p>
           )}
           <SocialShare title={titleDisplay} slug={slug} />
-          {(publishedDate || authorName) && (
-            <p className="text-base text-gray-400 mb-8">
-              {publishedDate && <span>{publishedDate}</span>}
-              {publishedDate && authorName && <span>, by </span>}
-              {authorName && <span>{authorName}</span>}
-            </p>
-          )}
+          <p className="text-base text-gray-400 mb-8">
+            {publishedDate
+              ? t("detail.bylineWithDate", {
+                  date: publishedDate,
+                  author: authorName,
+                })
+              : t("detail.byline", { author: authorName })}
+          </p>
           {entry.metrics && entry.metrics.length > 0 && (
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mt-8">
               {entry.metrics.map(

--- a/apps/media/app/[locale]/upgrades/[slug]/social-image/route.tsx
+++ b/apps/media/app/[locale]/upgrades/[slug]/social-image/route.tsx
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { ImageResponse } from "next/og";
+import { getTranslations } from "next-intl/server";
 import { UpgradeSocialImage } from "@/components/upgrades/upgrade-social-image";
 import { reader } from "@/lib/reader";
 import {
@@ -36,13 +37,14 @@ function loadFontFiles(): Promise<FontFiles> {
 }
 
 export async function GET(_request: Request, { params }: RouteContext) {
-  const { slug } = await params;
+  const { locale, slug } = await params;
   const entry = await reader.collections.upgrades.read(slug);
 
   if (!isPublishedUpgrade(entry)) {
     return new Response("Upgrade not found", { status: 404 });
   }
 
+  const t = await getTranslations({ locale, namespace: "upgrades.stage" });
   const authorEntry = entry.author
     ? await reader.collections.authors.read(entry.author)
     : null;
@@ -71,6 +73,8 @@ export async function GET(_request: Request, { params }: RouteContext) {
       publishedAt={entry.publishedAt ? String(entry.publishedAt) : null}
       authorName={String(authorEntry?.name ?? "Solana Foundation")}
       stage={stage}
+      stageLabel={t(stage)}
+      locale={locale}
       metrics={entry.metrics ?? []}
     />,
     {

--- a/apps/media/app/[locale]/upgrades/client-page.tsx
+++ b/apps/media/app/[locale]/upgrades/client-page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useFormatter, useTranslations } from "next-intl";
 import { Link } from "@workspace/i18n/routing";
 import { ArrowUpRight } from "@boxicons/react/ArrowUpRight";
 import { cn } from "@/lib/utils";
@@ -11,7 +12,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { STAGE_BADGE_CLASSES, STAGE_LABELS } from "@/lib/upgrades/stage";
+import { STAGE_BADGE_CLASSES } from "@/lib/upgrades/stage";
 import type {
   ReleaseGroup,
   UpgradeListItem,
@@ -23,21 +24,28 @@ interface UpgradesClientPageProps {
   groups: ReleaseGroup[];
 }
 
-function formatReleaseDate(group: ReleaseGroup): string | null {
+function useReleaseDateLabel(group: ReleaseGroup): string | null {
+  const t = useTranslations("upgrades.listing");
+  const format = useFormatter();
+
   if (!group.expectedDate) {
     return null;
   }
 
-  const formatted = new Date(group.expectedDate).toLocaleDateString("en-US", {
+  const formatted = format.dateTime(new Date(group.expectedDate), {
     month: "long",
     year: "numeric",
     timeZone: "UTC",
   });
 
-  return group.status === "planned" ? `Expected ${formatted}` : formatted;
+  return group.status === "planned"
+    ? t("expectedDate", { date: formatted })
+    : formatted;
 }
 
 function StageBadge({ stage }: { stage: UpgradeListItem["stage"] }) {
+  const t = useTranslations("upgrades.stage");
+
   return (
     <span
       className={cn(
@@ -45,12 +53,14 @@ function StageBadge({ stage }: { stage: UpgradeListItem["stage"] }) {
         STAGE_BADGE_CLASSES[stage],
       )}
     >
-      {STAGE_LABELS[stage]}
+      {t(stage)}
     </span>
   );
 }
 
 function UpgradeCard({ upgrade }: { upgrade: UpgradeListItem }) {
+  const t = useTranslations("upgrades.listing");
+
   return (
     <Link
       href={`/upgrades/${upgrade.slug}`}
@@ -88,7 +98,7 @@ function UpgradeCard({ upgrade }: { upgrade: UpgradeListItem }) {
       </div>
       <div className="mt-8 flex items-center justify-end gap-4 border-t border-white/10 pt-5">
         <span className="inline-flex items-center gap-2 text-sm font-medium text-white">
-          View details
+          {t("viewDetails")}
           <ArrowUpRight className="size-4 transition-transform group-hover:-translate-y-0.5 group-hover:translate-x-0.5" />
         </span>
       </div>
@@ -97,13 +107,15 @@ function UpgradeCard({ upgrade }: { upgrade: UpgradeListItem }) {
 }
 
 function OverviewCallout({ overview }: { overview: UpgradeListItem }) {
+  const t = useTranslations("upgrades.listing");
+
   return (
     <Link
       href={`/upgrades/${overview.slug}`}
       className="mb-4 block border border-[#14F195]/35 bg-[#14F195]/5 p-6 transition-colors hover:border-[#14F195]/55 hover:bg-[#14F195]/[0.08]"
     >
       <div className="mb-2.5 text-xs font-semibold uppercase tracking-[0.08em] text-[#14F195]">
-        Release overview
+        {t("releaseOverview")}
       </div>
       <div className="flex flex-wrap items-center justify-between gap-5">
         <div className="max-w-xl">
@@ -131,7 +143,8 @@ function OverviewCallout({ overview }: { overview: UpgradeListItem }) {
 }
 
 function ReleaseHeader({ group }: { group: ReleaseGroup }) {
-  const dateLabel = formatReleaseDate(group);
+  const t = useTranslations("upgrades.releaseStatus");
+  const dateLabel = useReleaseDateLabel(group);
 
   return (
     <div className="mb-4 flex flex-wrap items-baseline gap-3">
@@ -140,12 +153,12 @@ function ReleaseHeader({ group }: { group: ReleaseGroup }) {
       </h2>
       {group.status === "planned" && (
         <span className="rounded-full border border-[#14F195]/35 bg-[#14F195]/[0.08] px-2.5 py-0.5 text-[11.5px] font-semibold text-[#14F195]">
-          Planned
+          {t("planned")}
         </span>
       )}
       {group.status === "shipped" && (
         <span className="rounded-full border border-white/10 bg-white/[0.04] px-2.5 py-0.5 text-[11.5px] font-semibold text-white/70">
-          Shipped
+          {t("shipped")}
         </span>
       )}
       {dateLabel && <span className="text-sm text-white/50">{dateLabel}</span>}
@@ -154,6 +167,8 @@ function ReleaseHeader({ group }: { group: ReleaseGroup }) {
 }
 
 function TableView({ groups }: { groups: ReleaseGroup[] }) {
+  const t = useTranslations("upgrades.listing");
+
   return (
     <>
       {groups.map((group) => (
@@ -165,13 +180,13 @@ function TableView({ groups }: { groups: ReleaseGroup[] }) {
               <thead>
                 <tr className="border-b border-white/10 bg-white/[0.02]">
                   <th className="w-[45%] p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
-                    Upgrade
+                    {t("columnUpgrade")}
                   </th>
                   <th className="w-[27%] p-3 px-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
-                    Key metric
+                    {t("columnKeyMetric")}
                   </th>
                   <th className="w-[28%] py-3 pl-12 pr-5 text-left text-[11px] font-semibold uppercase tracking-[0.06em] text-white/50">
-                    Status
+                    {t("columnStatus")}
                   </th>
                 </tr>
               </thead>
@@ -249,6 +264,8 @@ function CardsView({ groups }: { groups: ReleaseGroup[] }) {
 export default function UpgradesClientPage({
   groups,
 }: UpgradesClientPageProps) {
+  const t = useTranslations("upgrades.listing");
+  const tReleaseStatus = useTranslations("upgrades.releaseStatus");
   const [view, setView] = useState<View>("table");
   const [selectedRelease, setSelectedRelease] = useState("all");
 
@@ -258,9 +275,14 @@ export default function UpgradesClientPage({
         .filter((group) => group.status !== null)
         .map((group) => ({
           key: group.key,
-          label: `${group.name} — ${group.status === "planned" ? "Planned" : "Shipped"}`,
+          label: t("releaseOption", {
+            name: group.name,
+            status: tReleaseStatus(
+              group.status === "planned" ? "planned" : "shipped",
+            ),
+          }),
         })),
-    [groups],
+    [groups, t, tReleaseStatus],
   );
 
   const visibleGroups =
@@ -271,7 +293,7 @@ export default function UpgradesClientPage({
   if (groups.length === 0) {
     return (
       <div className="py-20 text-center text-lg tracking-[-0.18px] text-white/60">
-        No published upgrades found.
+        {t("empty")}
       </div>
     );
   }
@@ -284,7 +306,7 @@ export default function UpgradesClientPage({
             htmlFor="release-select"
             className="text-[11px] font-semibold uppercase tracking-[0.08em] text-white/50"
           >
-            Release
+            {t("releaseLabel")}
           </label>
           <Select value={selectedRelease} onValueChange={setSelectedRelease}>
             <SelectTrigger
@@ -298,7 +320,7 @@ export default function UpgradesClientPage({
                 value="all"
                 className="text-[14.5px] focus:bg-white/10 focus:text-white"
               >
-                All releases
+                {t("allReleases")}
               </SelectItem>
               {releaseOptions.map((option) => (
                 <SelectItem
@@ -322,7 +344,7 @@ export default function UpgradesClientPage({
               view === "table" ? "bg-white text-black" : "text-white/70",
             )}
           >
-            List
+            {t("viewList")}
           </button>
           <button
             type="button"
@@ -333,7 +355,7 @@ export default function UpgradesClientPage({
               view === "cards" ? "bg-white text-black" : "text-white/70",
             )}
           >
-            Grid
+            {t("viewGrid")}
           </button>
         </div>
       </div>

--- a/apps/media/app/[locale]/upgrades/page.tsx
+++ b/apps/media/app/[locale]/upgrades/page.tsx
@@ -1,10 +1,7 @@
 import type { Metadata } from "next";
+import { getTranslations } from "@workspace/i18n/server";
 import { reader } from "@/lib/reader";
-import {
-  UPGRADES_SEO_DESCRIPTION,
-  UPGRADES_SEO_TITLE,
-  upgradesListingMetadata,
-} from "@/lib/metadata";
+import { upgradesListingMetadata } from "@/lib/metadata";
 import { JsonLd } from "@/components/seo/json-ld";
 import { buildUpgradeCollectionJsonLd } from "@/lib/content-structured-data";
 import { isPublishedUpgrade } from "@/lib/keystatic/upgrade-status";
@@ -124,6 +121,7 @@ export default async function UpgradesPage({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "upgrades" });
   const [upgrades, releases] = await Promise.all([
     getPublishedUpgrades(),
     getReleases(),
@@ -149,8 +147,8 @@ export default async function UpgradesPage({
         publishedAt: upgrade.publishedAt,
       })),
     locale,
-    title: UPGRADES_SEO_TITLE,
-    description: UPGRADES_SEO_DESCRIPTION,
+    title: t("metadata.title"),
+    description: t("metadata.description"),
   });
 
   return (
@@ -159,14 +157,13 @@ export default async function UpgradesPage({
       <div className="mx-auto w-full max-w-[1440px] px-[20px] md:px-[32px] xl:px-[40px]">
         <div className="flex max-w-3xl flex-col gap-2 py-8 md:py-10">
           <span className="text-xs font-medium uppercase tracking-[0.28em] text-[#14F195]">
-            Network upgrade notifications
+            {t("listing.kicker")}
           </span>
           <h1 className="m-0 text-[28px] font-medium leading-[1.15] tracking-[-0.5px] md:text-[34px] md:tracking-[-0.6px]">
-            Solana Upgrades
+            {t("listing.title")}
           </h1>
           <p className="m-0 max-w-2xl text-base leading-[1.4] text-[#ABABBA] md:text-lg">
-            Track network changes, validator actions, client support, and
-            rollout status for Solana protocol and performance upgrades.
+            {t("listing.description")}
           </p>
         </div>
       </div>

--- a/apps/media/components/upgrades/feature-activation-status.tsx
+++ b/apps/media/components/upgrades/feature-activation-status.tsx
@@ -1,4 +1,5 @@
 import { unstable_cache } from "next/cache";
+import { getTranslations } from "next-intl/server";
 import {
   getFeatureActivationStatus,
   LARGER_TRANSACTIONS_FEATURE_ADDRESS,
@@ -30,7 +31,8 @@ const getCachedFeatureActivationStatus = unstable_cache(
 );
 
 async function FeatureActivationStatusRow({ cluster }: { cluster: Cluster }) {
-  let status: ActivationStatus | "Unavailable";
+  const t = await getTranslations("upgrades.featureActivation");
+  let status: ActivationStatus | null;
   try {
     status = await getCachedFeatureActivationStatus(cluster);
   } catch (error) {
@@ -38,28 +40,38 @@ async function FeatureActivationStatusRow({ cluster }: { cluster: Cluster }) {
       `Failed to fetch ${cluster} feature activation status:`,
       error,
     );
-    status = "Unavailable";
+    status = null;
+  }
+
+  function statusLabel(): string {
+    if (status === null) return t("unavailable");
+    if (status.state === "not-activated") return t("notActivated");
+    if (status.state === "active") return t("active");
+
+    return t("liveInEpoch", { epoch: status.epoch });
   }
 
   return (
     <tr className="border-b border-white/10">
       <td className="px-6 py-4 text-base text-gray-300">{cluster}</td>
-      <td className="px-6 py-4 text-base text-gray-300">{status}</td>
+      <td className="px-6 py-4 text-base text-gray-300">{statusLabel()}</td>
     </tr>
   );
 }
 
-export function FeatureActivationStatus() {
+export async function FeatureActivationStatus() {
+  const t = await getTranslations("upgrades.featureActivation");
+
   return (
     <div className="overflow-x-auto mb-8">
       <table className="w-full border-collapse border border-white/10 rounded-lg">
         <thead className="bg-gray-900">
           <tr className="border-b border-white/10">
             <th className="px-6 py-4 text-left text-sm font-semibold text-white">
-              Cluster
+              {t("columnCluster")}
             </th>
             <th className="px-6 py-4 text-left text-sm font-semibold text-white">
-              Activation status
+              {t("columnStatus")}
             </th>
           </tr>
         </thead>

--- a/apps/media/components/upgrades/upgrade-social-image.tsx
+++ b/apps/media/components/upgrades/upgrade-social-image.tsx
@@ -2,7 +2,7 @@ import {
   formatUpgradePublishedDate,
   getUpgradeTitleFontSize,
 } from "@/lib/upgrades/social-image";
-import { STAGE_LABELS, type UpgradeStage } from "@/lib/upgrades/stage";
+import type { UpgradeStage } from "@/lib/upgrades/stage";
 
 type UpgradeMetric = {
   value: string;
@@ -15,6 +15,8 @@ type UpgradeSocialImageProps = {
   publishedAt?: string | null;
   authorName: string;
   stage: UpgradeStage;
+  stageLabel: string;
+  locale?: string;
   metrics: UpgradeMetric[];
 };
 
@@ -50,9 +52,11 @@ export function UpgradeSocialImage({
   publishedAt,
   authorName,
   stage,
+  stageLabel,
+  locale,
   metrics,
 }: UpgradeSocialImageProps) {
-  const publishedDate = formatUpgradePublishedDate(publishedAt);
+  const publishedDate = formatUpgradePublishedDate(publishedAt, locale);
   const palette = stageColorMap[stage];
 
   return (
@@ -114,7 +118,7 @@ export function UpgradeSocialImage({
                 lineHeight: 1,
               }}
             >
-              {STAGE_LABELS[stage]}
+              {stageLabel}
             </span>
           </div>
 

--- a/apps/media/lib/metadata.ts
+++ b/apps/media/lib/metadata.ts
@@ -48,7 +48,7 @@ function getPublicPageUrls(path: string, locale: string) {
   };
 }
 
-async function getNewsMetadataMessages(locale?: string) {
+async function getMetadataMessages(prefix: string[], locale?: string) {
   const resolvedLocale = resolveLocale(locale);
   const messages = await loadMergedMessages({
     app: "media",
@@ -56,7 +56,7 @@ async function getNewsMetadataMessages(locale?: string) {
   });
 
   function t(key: string, values: Record<string, string> = {}) {
-    const path = ["news", "metadata", ...key.split(".")];
+    const path = [...prefix, ...key.split(".")];
     const template = path.reduce<unknown>((value, part) => {
       if (value && typeof value === "object" && part in value) {
         return (value as Record<string, unknown>)[part];
@@ -76,6 +76,14 @@ async function getNewsMetadataMessages(locale?: string) {
   }
 
   return { locale: resolvedLocale, t };
+}
+
+function getNewsMetadataMessages(locale?: string) {
+  return getMetadataMessages(["news", "metadata"], locale);
+}
+
+function getUpgradesMetadataMessages(locale?: string) {
+  return getMetadataMessages(["upgrades", "metadata"], locale);
 }
 
 // ---------------------------------------------------------------------------
@@ -657,14 +665,13 @@ export async function podcastEpisodeMetadata(
 // Upgrades listing  /upgrades
 // ---------------------------------------------------------------------------
 
-export const UPGRADES_SEO_TITLE = "Solana Network Upgrades";
-export const UPGRADES_SEO_DESCRIPTION =
-  "Track Solana network upgrades, client support, protocol changes, rollout status, and performance improvements across the ecosystem.";
-
-export function upgradesListingMetadata(locale?: string): Metadata {
-  const resolvedLocale = resolveLocale(locale);
-  const title = UPGRADES_SEO_TITLE;
-  const description = UPGRADES_SEO_DESCRIPTION;
+export async function upgradesListingMetadata(
+  locale?: string,
+): Promise<Metadata> {
+  const { locale: resolvedLocale, t } =
+    await getUpgradesMetadataMessages(locale);
+  const title = t("title");
+  const description = t("description");
   const { alternates, canonicalUrl } = getPublicPageUrls(
     "/upgrades",
     resolvedLocale,
@@ -701,11 +708,12 @@ export async function upgradeMetadata(
   slug: string,
   locale?: string,
 ): Promise<Metadata> {
-  const resolvedLocale = resolveLocale(locale);
+  const { locale: resolvedLocale, t } =
+    await getUpgradesMetadataMessages(locale);
   const entry = await reader.collections.upgrades.read(slug);
 
   if (!isPublishedUpgrade(entry)) {
-    return notFoundMetadata("Upgrade Not Found");
+    return notFoundMetadata(t("notFound"));
   }
 
   const title = String(entry.title);

--- a/apps/media/lib/upgrades/feature-activation.ts
+++ b/apps/media/lib/upgrades/feature-activation.ts
@@ -19,9 +19,9 @@ type FeatureAccount = {
 };
 
 export type FeatureActivationStatus =
-  | "Not activated"
-  | `Live in Epoch ${number}`
-  | "Active";
+  | { state: "not-activated" }
+  | { state: "pending"; epoch: number }
+  | { state: "active" };
 
 export function readFeatureAccountState(
   account: FeatureAccount | null,
@@ -55,11 +55,11 @@ export async function getFeatureActivationStatus(
     .send({ abortSignal });
   const state = readFeatureAccountState(account);
 
-  if (state === "not-set") return "Not activated";
-  if (state === "active") return "Active";
+  if (state === "not-set") return { state: "not-activated" };
+  if (state === "active") return { state: "active" };
 
   const { epoch } = await rpc
     .getEpochInfo({ commitment: "confirmed" })
     .send({ abortSignal });
-  return `Live in Epoch ${Number(epoch) + 1}`;
+  return { state: "pending", epoch: Number(epoch) + 1 };
 }

--- a/apps/media/lib/upgrades/social-image.ts
+++ b/apps/media/lib/upgrades/social-image.ts
@@ -31,13 +31,14 @@ export function createUpgradeSocialImage(
 
 export function formatUpgradePublishedDate(
   publishedAt: string | null | undefined,
+  locale = "en",
 ): string | null {
   if (!publishedAt) return null;
 
   const date = new Date(publishedAt);
   if (Number.isNaN(date.getTime())) return null;
 
-  return new Intl.DateTimeFormat("en-US", {
+  return new Intl.DateTimeFormat(locale, {
     month: "long",
     year: "numeric",
     timeZone: "UTC",

--- a/apps/media/lib/upgrades/stage.ts
+++ b/apps/media/lib/upgrades/stage.ts
@@ -2,13 +2,6 @@ import type { UpgradeStage } from "./group-by-release";
 
 export type { UpgradeStage };
 
-export const STAGE_LABELS: Record<UpgradeStage, string> = {
-  planned: "Planned",
-  in_development: "In Development",
-  pending_activation: "Pending Feature Activation",
-  live: "Live on Mainnet",
-};
-
 export const STAGE_BADGE_CLASSES: Record<UpgradeStage, string> = {
   planned: "border-white/25 bg-white/5 text-white/70",
   in_development: "border-yellow-500/30 bg-yellow-500/10 text-yellow-300",

--- a/packages/i18n/messages/media/en/common.json
+++ b/packages/i18n/messages/media/en/common.json
@@ -77,5 +77,57 @@
         "imageAlt": "Breakpoint 2026 wordmark over a purple London skyline"
       }
     }
+  },
+  "upgrades": {
+    "metadata": {
+      "title": "Solana Network Upgrades",
+      "description": "Track Solana network upgrades, client support, protocol changes, rollout status, and performance improvements across the ecosystem.",
+      "notFound": "Upgrade Not Found"
+    },
+    "listing": {
+      "kicker": "Network upgrade notifications",
+      "title": "Solana Upgrades",
+      "description": "Track network changes, validator actions, client support, and rollout status for Solana protocol and performance upgrades.",
+      "empty": "No published upgrades found.",
+      "releaseLabel": "Release",
+      "allReleases": "All releases",
+      "releaseOption": "{name} — {status}",
+      "expectedDate": "Expected {date}",
+      "releaseOverview": "Release overview",
+      "viewDetails": "View details",
+      "viewList": "List",
+      "viewGrid": "Grid",
+      "columnUpgrade": "Upgrade",
+      "columnKeyMetric": "Key metric",
+      "columnStatus": "Status"
+    },
+    "releaseStatus": {
+      "planned": "Planned",
+      "shipped": "Shipped"
+    },
+    "stage": {
+      "planned": "Planned",
+      "in_development": "In Development",
+      "pending_activation": "Pending Feature Activation",
+      "live": "Live on Mainnet"
+    },
+    "detail": {
+      "back": "Back to Upgrades",
+      "share": "Share:",
+      "shareOnTwitter": "Share on Twitter",
+      "shareOnFacebook": "Share on Facebook",
+      "shareOnLinkedin": "Share on LinkedIn",
+      "shareOnTelegram": "Share on Telegram",
+      "bylineWithDate": "{date}, by {author}",
+      "byline": "By {author}"
+    },
+    "featureActivation": {
+      "columnCluster": "Cluster",
+      "columnStatus": "Activation status",
+      "notActivated": "Not activated",
+      "active": "Active",
+      "liveInEpoch": "Live in Epoch {epoch}",
+      "unavailable": "Unavailable"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Adds translation support to `/upgrades` — listing, detail page, feature-activation table, and OG card strings now render through next-intl instead of hardcoded English.
- Dates use the locale formatter rather than `en-US`.
- Rewords the `kit-plugin` docs frontmatter to drop a code-shaped token, which has been failing the docs frontmatter guard and discarding every Lingo run since Aug 7.

Article bodies in `content/upgrades/*.mdx` stay English — that content isn't locale-partitioned the way `apps/docs/content` is.
