### PR TITLE
docs: label maturity of evolving features

### DIFF
--- a/apps/docs/content/docs/en/clients/official/rust.mdx
+++ b/apps/docs/content/docs/en/clients/official/rust.mdx
@@ -61,9 +61,10 @@ be used as a replacement for `solana-program` to write onchain programs.
 | --------- | -------------------------------- | --------------------------------- | ----------------------------------------------- |
 | pinocchio | Zero-dependency onchain programs | [View](https://docs.rs/pinocchio) | [Source](https://github.com/anza-xyz/pinocchio) |
 
-<Callout type="warn">
-  Pinocchio is still in development and will likely have breaking changes in the
-  near future.
+<Callout type="warn" title="Maturity: Active development">
+  Pinocchio is a pre-1.0 library under active development. Expect breaking API
+  changes between releases, pin exact versions, and test upgrades before using
+  them in production programs.
 </Callout>
 
 Pinocchio includes program-specific crates for interacting with Solana programs:

--- a/apps/docs/content/docs/en/tokenization/dvp.mdx
+++ b/apps/docs/content/docs/en/tokenization/dvp.mdx
@@ -64,7 +64,7 @@ This guide demonstrates how to implement a complete DvP workflow on Solana using
 SPL Token 2022 extensions for compliant bond issuance and standard USDC for
 settlement, all without writing custom Rust programs.
 
-<Callout type="info" title="Educational Reference Implementation">
+<Callout type="warn" title="Maturity: Educational reference">
 
 You can use the [source code](https://github.com/Woody4618/dvp) of this
 implementation to try an implementation of DvP locally.

--- a/apps/docs/content/docs/en/tools/commerce-kit/index.mdx
+++ b/apps/docs/content/docs/en/tools/commerce-kit/index.mdx
@@ -7,6 +7,13 @@ description: Commerce primitives for building Solana payment experiences
 Solana.** From drop-in payment buttons to headless primitives, Commerce Kit
 provides everything you need to accept crypto payments.
 
+<Callout type="warn" title="Maturity: Early release">
+  Commerce Kit packages are currently pre-1.0. Pin package versions and test
+  wallet, pricing, payment verification, and failure flows for your deployment
+  before accepting production payments. Follow changes in the [source
+  repository](https://github.com/solana-foundation/commerce-kit).
+</Callout>
+
 ## Why Commerce Kit?
 
 - **Drop-in Components**: Pre-built PaymentButton with wallet connection, token

--- a/apps/docs/content/docs/en/tools/kora/beta/index.mdx
+++ b/apps/docs/content/docs/en/tools/kora/beta/index.mdx
@@ -10,9 +10,11 @@ _Available on GitHub:
 Kora v2.2.0-beta introduces Jito bundle support, new RPC methods, Docker images,
 enhanced security features, and SDK improvements.
 
-> **This is a pre-release.** Features documented here are available in
-> `v2.2.0-beta.7` and may change before stable release. For stable
-> documentation, see the [main Kora docs](/docs/tools/kora).
+<Callout type="warn" title="Maturity: Beta">
+  This is a pre-release. Features documented here are available in
+  `v2.2.0-beta.7` and may change before stable release. For stable
+  documentation, see the [main Kora docs](/docs/tools/kora).
+</Callout>
 
 ## Highlights
 

--- a/apps/docs/content/docs/en/tools/private-channels.mdx
+++ b/apps/docs/content/docs/en/tools/private-channels.mdx
@@ -7,6 +7,13 @@ description: Enterprise layer for internet capital markets
 Solana.** It provides a configurable app-layer for private, instant, zero-fee
 transfers inside payment channels.
 
+<Callout type="warn" title="Maturity: Active development">
+  The reference implementation is under active development and has not been
+  audited. Do not use it with production funds without an independent security
+  review. Track the latest status in the [source
+  repository](https://github.com/solana-foundation/solana-private-channels).
+</Callout>
+
 ## Resources
 
 - **[Product page](https://launch.solana.com/products/private-channels)**


### PR DESCRIPTION
### Problem

Several fast-moving features appear alongside stable documentation without a consistent, prominent indication of their current maturity or the precautions integrators should take.

### Summary of Changes

- Add consistent maturity callouts for Pinocchio, Private Channels, Commerce Kit, the Kora beta channel, and the DvP reference guide.
- Preserve the existing status guidance while making it visible and actionable near each page's introduction.
- Include version-pinning, testing, audit, and stable-documentation guidance where appropriate.

Fixes DEV-970

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] No user input or untrusted HTML handling changes are included.
- [x] No dependencies are added or updated.
- [x] No production error-handling paths are changed.
- [x] This is not a Critical change.

New dependencies: none.

Threat-model note: n/a.
