### PR TITLE
docs: add Private Channels readiness guidance

### DIFF
--- a/apps/docs/content/docs/en/tools/private-channels.mdx
+++ b/apps/docs/content/docs/en/tools/private-channels.mdx
@@ -10,5 +10,43 @@ transfers inside payment channels.
 ## Resources
 
 - **[Product page](https://launch.solana.com/products/private-channels)**
-- **[GitHub](https://github.com/solana-foundation/contra)**
+- **[GitHub](https://github.com/solana-foundation/solana-private-channels)**
 - **[Brochure](/assets/docs/tools/private-channels/Contra.pdf)**
+
+## Readiness checklist
+
+Treat the public implementation as evaluation software until your deployment has
+completed its own security and operational review. Before handling real funds:
+
+- Exercise deposits, private transfers, and withdrawals on localnet or devnet,
+  including failures and recovery paths.
+- Audit the escrow and withdrawal programs, operator services, gateway, and
+  optional authentication boundary for your configuration.
+- Define custody and rotation for admin keys, database and RPC network
+  boundaries, monitoring, backups, and incident response.
+- Verify the system invariants and repeat the review whenever you update a
+  pinned component.
+
+<Cards>
+  <Card
+    title="Devnet quick start"
+    href="https://github.com/solana-foundation/solana-private-channels/blob/main/docs/DEVNET_QUICKSTART.md"
+  >
+    Deploy the stack in an environment that does not put production funds at
+    risk.
+  </Card>
+  <Card
+    title="Architecture"
+    href="https://github.com/solana-foundation/solana-private-channels/blob/main/docs/ARCHITECTURE.md"
+  >
+    Review the trust boundaries between the channel, gateway, operator, indexer,
+    database, and Solana programs.
+  </Card>
+  <Card
+    title="System invariants"
+    href="https://github.com/solana-foundation/solana-private-channels/blob/main/docs/INVARIANTS.md"
+  >
+    Validate the safety and consistency properties your deployment must
+    preserve.
+  </Card>
+</Cards>


### PR DESCRIPTION
### Problem

The Private Channels page points to product materials but does not give teams a practical readiness boundary before they evaluate infrastructure that can custody and move funds.

### Summary of Changes

- Add a concrete pre-production checklist covering test environments, audits, trust boundaries, key custody, monitoring, backups, and incident response.
- Link directly to the maintained devnet quick start, architecture, and system-invariants references.
- Replace the redirected repository URL with its canonical location.

Fixes DEV-954

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs.
- [x] No user input or untrusted HTML handling changes are included.
- [x] No dependencies are added or updated.
- [x] No production error-handling paths are changed.
- [x] This is not a Critical change.

New dependencies: none.

Threat-model note: n/a.
