### PR TITLE
chore: format Breakpoint 2026 post

### DIFF
--- a/apps/media/content/posts/breakpoint-2026-london-speakers.mdx
+++ b/apps/media/content/posts/breakpoint-2026-london-speakers.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'The Token Supercycle Is Here: Solana Brings Breakpoint 2026 to London'
+title: "The Token Supercycle Is Here: Solana Brings Breakpoint 2026 to London"
 status: published
 heroImage: /uploads/posts/breakpoint-2026-london-speakers/heroImage.png
 description: >-
@@ -19,6 +19,7 @@ tags:
   - tag: stablecoins
   - tag: ai
 ---
+
 **Solana Breakpoint 2026 will take place at Olympia London from November 15–17, marking the first time the annual forum has come to the UK.** More than 8,000 attendees from over 100 countries are expected to join institutions, investors, technology companies, builders and policymakers shaping internet capital markets.
 
 The event centers on the Token Supercycle: a period in which stablecoins, tokenized assets, payments and AI-driven economic activity increasingly move onchain. [Solana Breakpoint 2026](https://solana.com/breakpoint) will bring the people building and financing these markets together in London.
@@ -27,15 +28,15 @@ The event centers on the Token Supercycle: a period in which stablecoins, tokeni
 
 The first group of speakers spans payments, asset management, digital collectibles, technology and macroeconomics. Additional leaders from global institutions, allocators, payment companies, enterprise, technology companies and government will be announced before November.
 
-* Anthony Soohoo, CEO of MoneyGram
-* Tad Smith, CEO of Candy Digital
-* Annabel Spring, CEO of Allfunds
-* Balaji Srinivasan, founder of The Network State
-* Anatoly Yakovenko, co-founder of Solana and CEO of Solana Labs
-* Zach Abrams, CEO of Bridge & Open Standard
-* Lily Liu, President of Solana Foundation
-* Raoul Pal, co-founder and CEO of Real Vision
-* Peter Moore, owner of Wisla Krakow Football Club
+- Anthony Soohoo, CEO of MoneyGram
+- Tad Smith, CEO of Candy Digital
+- Annabel Spring, CEO of Allfunds
+- Balaji Srinivasan, founder of The Network State
+- Anatoly Yakovenko, co-founder of Solana and CEO of Solana Labs
+- Zach Abrams, CEO of Bridge & Open Standard
+- Lily Liu, President of Solana Foundation
+- Raoul Pal, co-founder and CEO of Real Vision
+- Peter Moore, owner of Wisla Krakow Football Club
 
 ## Why London
 
@@ -49,8 +50,8 @@ London was selected for 2026 for its long-standing role as a global hub for capi
 
 Breakpoint programming will examine the forces driving onchain financial infrastructure now, as well as the technologies and markets that could follow.
 
-* **Day 1: The Supercycle, Today** will examine stablecoins, payments, tokenized real-world assets and the macroeconomic forces accelerating the growth of onchain financial infrastructure.
-* **Day 2: The Supercycle, Tomorrow** will explore AI agents, prediction markets, consumer applications, new forms of ownership and new markets enabled by programmable capital.
+- **Day 1: The Supercycle, Today** will examine stablecoins, payments, tokenized real-world assets and the macroeconomic forces accelerating the growth of onchain financial infrastructure.
+- **Day 2: The Supercycle, Tomorrow** will explore AI agents, prediction markets, consumer applications, new forms of ownership and new markets enabled by programmable capital.
 
 ## Solana’s onchain activity
 


### PR DESCRIPTION
## Problem

The Breakpoint 2026 speaker post does not match the repository Prettier configuration, causing the repository-wide Format and media lint checks to fail for every newly opened pull request.

## Summary of changes

- Format the post with the repository Prettier configuration
- Restore repository-wide formatting and media lint checks

## Classification

Low risk. Formatting only; no content changes.

## Security checklist

- [x] No secrets or credentials added
- [x] No authentication or authorization changes
- [x] No new external dependencies

## Dependencies

None.

## Threat model

Not applicable for a formatting-only change.