### PR TITLE
docs: update removed RPC migrations

### DIFF
--- a/apps/docs/content/docs/en/rpc/deprecated/confirmtransaction.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/confirmtransaction.mdx
@@ -27,4 +27,6 @@ failed transaction maps to the legacy `false` result.
 
 `getSignatureStatuses` does not accept a commitment parameter. Set
 `searchTransactionHistory: true` only when the signature may have left the
-recent status cache.
+recent status cache. Treat confirmation levels as ordered: `processed` <
+`confirmed` < `finalized`. A returned level satisfies an equal or weaker
+requested commitment.

--- a/apps/docs/content/docs/en/rpc/deprecated/confirmtransaction.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/confirmtransaction.mdx
@@ -1,13 +1,30 @@
 ---
-title: confirmTransaction
-hideTableOfContents: true
-h1: confirmTransaction RPC Method
+title: confirmTransaction (removed)
+description:
+  Migrate from the removed confirmTransaction RPC method to
+  getSignatureStatuses.
+url: /docs/rpc/deprecated/confirmtransaction
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getsignaturestatuses
 ---
 
-Fetch the current status of a transaction signature (processed, confirmed,
-finalized).
+`confirmTransaction` tested whether one transaction had succeeded at a requested
+commitment and returned an `RpcResponse<boolean>`.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getSignatureStatuses](/docs/rpc/http/getsignaturestatuses) instead.
+<Callout type="warn" title="Removed RPC method">
+  This JSON-RPC method was removed in Agave v2.0. Use
+  [getSignatureStatuses](/docs/rpc/http/getsignaturestatuses).
 </Callout>
+
+## Migration
+
+Wrap the legacy signature in an array: `[signature, commitment]` becomes
+`[[signature]]`. Read `result.value[0]`, compare its `confirmationStatus` with
+the required commitment, and require `err` to be `null`. A missing status or a
+failed transaction maps to the legacy `false` result.
+
+`getSignatureStatuses` does not accept a commitment parameter. Set
+`searchTransactionHistory: true` only when the signature may have left the
+recent status cache.

--- a/apps/docs/content/docs/en/rpc/deprecated/getconfirmedblock.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getconfirmedblock.mdx
@@ -1,13 +1,24 @@
 ---
-title: getConfirmedBlock
-hideTableOfContents: true
-h1: getConfirmedBlock RPC Method
+title: getConfirmedBlock (removed)
+description: Migrate from getConfirmedBlock to getBlock.
+url: /docs/rpc/deprecated/getconfirmedblock
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getblock
 ---
 
-Returns identity and transaction information about a confirmed block in the
-ledger
+`getConfirmedBlock` returned transaction and identity information for one
+confirmed block slot.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getBlock](/docs/rpc/http/getblock) instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0. Use
+  [getBlock](/docs/rpc/http/getblock).
 </Callout>
+
+## Migration
+
+Keep the slot as the first parameter. Move a legacy bare encoding into the
+configuration object and set `commitment: "confirmed"` to preserve the old
+method's commitment semantics. Set `maxSupportedTransactionVersion` when your
+client supports versioned transactions.

--- a/apps/docs/content/docs/en/rpc/deprecated/getconfirmedblocks.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getconfirmedblocks.mdx
@@ -1,12 +1,22 @@
 ---
-title: getConfirmedBlocks
-hideTableOfContents: true
-h1: getConfirmedBlocks RPC Method
+title: getConfirmedBlocks (removed)
+description: Migrate from getConfirmedBlocks to getBlocks.
+url: /docs/rpc/deprecated/getconfirmedblocks
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getblocks
 ---
 
-Returns a list of confirmed blocks between two slots
+`getConfirmedBlocks` returned confirmed block slots in an inclusive range.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getBlocks](/docs/rpc/http/getblocks) instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0. Use
+  [getBlocks](/docs/rpc/http/getblocks).
 </Callout>
+
+## Migration
+
+Pass the same `startSlot` and optional inclusive `endSlot` to `getBlocks`, then
+set `commitment: "confirmed"` in its configuration object. The replacement still
+omits skipped slots from the returned array.

--- a/apps/docs/content/docs/en/rpc/deprecated/getconfirmedblockswithlimit.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getconfirmedblockswithlimit.mdx
@@ -1,12 +1,23 @@
 ---
-title: getConfirmedBlocksWithLimit
-hideTableOfContents: true
-h1: getConfirmedBlocksWithLimit RPC Method
+title: getConfirmedBlocksWithLimit (removed)
+description: Migrate from getConfirmedBlocksWithLimit to getBlocksWithLimit.
+url: /docs/rpc/deprecated/getconfirmedblockswithlimit
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getblockswithlimit
 ---
 
-Returns a list of confirmed blocks starting at the given slot
+`getConfirmedBlocksWithLimit` returned up to a requested number of confirmed
+block slots, starting at one slot.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getBlocksWithLimit](/docs/rpc/http/getblockswithlimit) instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0. Use
+  [getBlocksWithLimit](/docs/rpc/http/getblockswithlimit).
 </Callout>
+
+## Migration
+
+Pass the same `startSlot` and `limit` as the first two parameters, then set
+`commitment: "confirmed"` in the optional configuration object. The limit counts
+returned, non-skipped block slots rather than the width of a slot range.

--- a/apps/docs/content/docs/en/rpc/deprecated/getconfirmedsignaturesforaddress2.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getconfirmedsignaturesforaddress2.mdx
@@ -1,14 +1,25 @@
 ---
-title: getConfirmedSignaturesForAddress2
-hideTableOfContents: true
-h1: getConfirmedSignaturesForAddress2 RPC Method
+title: getConfirmedSignaturesForAddress2 (removed)
+description:
+  Migrate from getConfirmedSignaturesForAddress2 to getSignaturesForAddress.
+url: /docs/rpc/deprecated/getconfirmedsignaturesforaddress2
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getsignaturesforaddress
 ---
 
-Returns signatures for confirmed transactions that include the given address in
-their `accountKeys` list. Returns signatures backwards in time from the provided
-signature or most recent confirmed block
+`getConfirmedSignaturesForAddress2` returned confirmed transaction signatures
+that referenced an address, ordered from newest to oldest.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getSignaturesForAddress](/docs/rpc/http/getsignaturesforaddress) instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0. Use
+  [getSignaturesForAddress](/docs/rpc/http/getsignaturesforaddress).
 </Callout>
+
+## Migration
+
+The address remains the first parameter. The `before`, `until`, and `limit`
+cursor fields keep the same meaning in the replacement configuration object. Use
+`commitment: "confirmed"` to preserve the legacy method's minimum commitment, or
+`finalized` when your application requires finalized history.

--- a/apps/docs/content/docs/en/rpc/deprecated/getconfirmedtransaction.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getconfirmedtransaction.mdx
@@ -1,12 +1,25 @@
 ---
-title: getConfirmedTransaction
-hideTableOfContents: true
-h1: getConfirmedTransaction RPC Method
+title: getConfirmedTransaction (removed)
+description: Migrate from getConfirmedTransaction to getTransaction.
+url: /docs/rpc/deprecated/getconfirmedtransaction
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/gettransaction
 ---
 
-Returns transaction details for a confirmed transaction
+`getConfirmedTransaction` returned transaction details for one confirmed
+transaction signature.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getTransaction](/docs/rpc/http/gettransaction) instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0. Use
+  [getTransaction](/docs/rpc/http/gettransaction).
 </Callout>
+
+## Migration
+
+Keep the transaction signature as the first parameter. Use the object form for
+the second parameter, set `commitment: "confirmed"`, carry over the desired
+`encoding`, and set `maxSupportedTransactionVersion` when the client supports
+versioned transactions. The replacement returns `null` when the transaction is
+not found at that commitment.

--- a/apps/docs/content/docs/en/rpc/deprecated/getfeecalculatorforblockhash.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getfeecalculatorforblockhash.mdx
@@ -1,14 +1,31 @@
 ---
-title: getFeeCalculatorForBlockhash
-hideTableOfContents: true
-h1: getFeeCalculatorForBlockhash RPC Method
+title: getFeeCalculatorForBlockhash (removed)
+description:
+  Replace getFeeCalculatorForBlockhash with isBlockhashValid and
+  getFeeForMessage.
+url: /docs/rpc/deprecated/getfeecalculatorforblockhash
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/isblockhashvalid
+  - /docs/rpc/http/getfeeformessage
 ---
 
-Returns the fee calculator associated with the query blockhash, or `null` if the
-blockhash has expired
+`getFeeCalculatorForBlockhash` combined a blockhash validity check with legacy
+fee-calculator data.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [isBlockhashValid](/docs/rpc/http/isblockhashvalid) or
-  [getFeeForMessage](/docs/rpc/http/getfeeformessage) instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0. Its two purposes now use separate RPC
+  methods.
 </Callout>
+
+## Migration
+
+- To check whether a blockhash is still usable, call
+  [isBlockhashValid](/docs/rpc/http/isblockhashvalid) with that blockhash.
+- To calculate the fee for a transaction, compile its message with a recent
+  blockhash and pass the base64-encoded message to
+  [getFeeForMessage](/docs/rpc/http/getfeeformessage).
+
+There is no one-to-one replacement that returns a fee from a blockhash alone.
+Fees depend on the complete transaction message.

--- a/apps/docs/content/docs/en/rpc/deprecated/getfeerategovernor.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getfeerategovernor.mdx
@@ -1,12 +1,27 @@
 ---
-title: getFeeRateGovernor
-hideTableOfContents: true
-h1: getFeeRateGovernor RPC Method
+title: getFeeRateGovernor (removed)
+description: Replace getFeeRateGovernor with message-specific fee calculation.
+url: /docs/rpc/deprecated/getfeerategovernor
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getfeeformessage
 ---
 
-Returns the fee rate governor information from the root bank
+`getFeeRateGovernor` exposed legacy fee-governor configuration from the root
+bank.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getFeeForMessage](/docs/rpc/http/getfeeformessage) instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0. There is no direct replacement for its
+  configuration response.
 </Callout>
+
+## Migration
+
+To estimate what the cluster will charge for a transaction, compile the
+transaction message and call
+[getFeeForMessage](/docs/rpc/http/getfeeformessage). To inspect the fee charged
+to a landed transaction, read `meta.fee` from
+[getTransaction](/docs/rpc/http/gettransaction).
+
+Do not try to derive a transaction fee from the removed governor fields.

--- a/apps/docs/content/docs/en/rpc/deprecated/getfees.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getfees.mdx
@@ -1,14 +1,29 @@
 ---
-title: getFees
-hideTableOfContents: true
-h1: getFees RPC Method
+title: getFees (removed)
+description: Replace getFees with getLatestBlockhash and getFeeForMessage.
+url: /docs/rpc/deprecated/getfees
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getlatestblockhash
+  - /docs/rpc/http/getfeeformessage
 ---
 
-Returns a recent block hash from the ledger, a fee schedule that can be used to
-compute the cost of submitting a transaction using it, and the last slot in
-which the blockhash will be valid.
+`getFees` combined a recent blockhash, its legacy fee calculator, and a last
+valid slot in one response.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getFeeForMessage](/docs/rpc/http/getfeeformessage) instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0. Replace its lifetime and fee fields
+  separately.
 </Callout>
+
+## Migration
+
+1. Call [getLatestBlockhash](/docs/rpc/http/getlatestblockhash) to obtain
+   `blockhash` and `lastValidBlockHeight`. The replacement reports a block
+   height, not the legacy `lastValidSlot`.
+2. Compile the transaction message with that blockhash, then pass the encoded
+   message to [getFeeForMessage](/docs/rpc/http/getfeeformessage).
+
+Use `lastValidBlockHeight` when tracking transaction expiration; do not convert
+it to a slot or fixed wall-clock deadline.

--- a/apps/docs/content/docs/en/rpc/deprecated/getrecentblockhash.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getrecentblockhash.mdx
@@ -1,13 +1,27 @@
 ---
-title: getRecentBlockhash
-hideTableOfContents: true
-h1: getRecentBlockhash RPC Method
+title: getRecentBlockhash (removed)
+description:
+  Replace getRecentBlockhash with getLatestBlockhash and getFeeForMessage.
+url: /docs/rpc/deprecated/getrecentblockhash
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getlatestblockhash
+  - /docs/rpc/http/getfeeformessage
 ---
 
-Returns a recent block hash from the ledger, and a fee schedule that can be used
-to compute the cost of submitting a transaction using it.
+`getRecentBlockhash` returned a recent blockhash together with a legacy fee
+calculator.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getLatestBlockhash](/docs/rpc/http/getlatestblockhash) instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0. Its blockhash and fee data now come
+  from separate methods.
 </Callout>
+
+## Migration
+
+Use [getLatestBlockhash](/docs/rpc/http/getlatestblockhash) for the current
+`blockhash` and `lastValidBlockHeight`. If you also need a fee estimate, compile
+the transaction message with that blockhash and call
+[getFeeForMessage](/docs/rpc/http/getfeeformessage). The old fee-calculator
+response does not have a supported equivalent.

--- a/apps/docs/content/docs/en/rpc/deprecated/getsignatureconfirmation.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getsignatureconfirmation.mdx
@@ -1,13 +1,29 @@
 ---
-title: getSignatureConfirmation
-hideTableOfContents: true
-h1: getSignatureConfirmation RPC Method
+title: getSignatureConfirmation (removed)
+description:
+  Migrate the confirmations and status fields from getSignatureConfirmation to
+  getSignatureStatuses.
+url: /docs/rpc/deprecated/getsignatureconfirmation
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getsignaturestatuses
 ---
 
-Fetch the current status of a transaction signature (processed, confirmed,
-finalized).
+`getSignatureConfirmation` accepted one signature and returned `null` or an
+object containing `confirmations` and `status`.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getSignatureStatuses](/docs/rpc/http/getsignaturestatuses) instead.
+<Callout type="warn" title="Removed RPC method">
+  This JSON-RPC method was removed in Agave v2.0. Use
+  [getSignatureStatuses](/docs/rpc/http/getsignaturestatuses).
 </Callout>
+
+## Migration
+
+Wrap the signature in an array and read `result.value[0]`. The replacement's
+`confirmations` field preserves the confirmation count. Prefer `err` for the
+transaction outcome: `null` means success and a non-null value is the execution
+error. The replacement also returns `slot` and `confirmationStatus`.
+
+If the legacy call supplied a commitment, compare `confirmationStatus` with that
+level because `getSignatureStatuses` does not accept a commitment option.

--- a/apps/docs/content/docs/en/rpc/deprecated/getsignatureconfirmation.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getsignatureconfirmation.mdx
@@ -26,4 +26,6 @@ transaction outcome: `null` means success and a non-null value is the execution
 error. The replacement also returns `slot` and `confirmationStatus`.
 
 If the legacy call supplied a commitment, compare `confirmationStatus` with that
-level because `getSignatureStatuses` does not accept a commitment option.
+level because `getSignatureStatuses` does not accept a commitment option. Treat
+the levels as `processed` < `confirmed` < `finalized`; an equal or stronger
+returned level satisfies the request.

--- a/apps/docs/content/docs/en/rpc/deprecated/getsignaturestatus.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getsignaturestatus.mdx
@@ -1,13 +1,30 @@
 ---
-title: getSignatureStatus
-hideTableOfContents: true
-h1: getSignatureStatus RPC Method
+title: getSignatureStatus (removed)
+description:
+  Migrate the transaction result from getSignatureStatus to
+  getSignatureStatuses.
+url: /docs/rpc/deprecated/getsignaturestatus
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getsignaturestatuses
 ---
 
-Fetch the current status of a transaction signature (processed, confirmed,
-finalized).
+`getSignatureStatus` accepted one signature and returned `null`, a successful
+transaction result, or a transaction error once the requested commitment was
+reached.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getSignatureStatuses](/docs/rpc/http/getsignaturestatuses) instead.
+<Callout type="warn" title="Removed RPC method">
+  This JSON-RPC method was removed in Agave v2.0. Use
+  [getSignatureStatuses](/docs/rpc/http/getsignaturestatuses).
 </Callout>
+
+## Migration
+
+Wrap the signature in an array and inspect `result.value[0]`. A `null` entry
+means no status was found. For a non-null entry, `err: null` means the
+transaction succeeded and a non-null `err` is the transaction error.
+
+The replacement exposes a legacy `status` field, but new code should use `err`.
+If the old call supplied a commitment, separately compare `confirmationStatus`
+with that level.

--- a/apps/docs/content/docs/en/rpc/deprecated/getsignaturestatus.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getsignaturestatus.mdx
@@ -27,4 +27,5 @@ transaction succeeded and a non-null `err` is the transaction error.
 
 The replacement exposes a legacy `status` field, but new code should use `err`.
 If the old call supplied a commitment, separately compare `confirmationStatus`
-with that level.
+with that level. Treat the levels as `processed` < `confirmed` < `finalized`; an
+equal or stronger returned level satisfies the request.

--- a/apps/docs/content/docs/en/rpc/deprecated/getsnapshotslot.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getsnapshotslot.mdx
@@ -1,12 +1,23 @@
 ---
-title: getSnapshotSlot
-hideTableOfContents: true
-h1: getSnapshotSlot RPC Method
+title: getSnapshotSlot (removed)
+description: Migrate from getSnapshotSlot to getHighestSnapshotSlot.
+url: /docs/rpc/deprecated/getsnapshotslot
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/gethighestsnapshotslot
 ---
 
-Returns the highest slot that the node has a snapshot for
+`getSnapshotSlot` returned one number: the highest full snapshot slot available
+on the RPC node.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use
-  [getHighestSnapshotSlot](/docs/rpc/http/gethighestsnapshotslot) instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0. Use
+  [getHighestSnapshotSlot](/docs/rpc/http/gethighestsnapshotslot).
 </Callout>
+
+## Migration
+
+The replacement returns an object rather than a single slot. Read `full` for the
+highest full snapshot slot. The optional `incremental` field is the highest
+incremental snapshot based on that full snapshot.

--- a/apps/docs/content/docs/en/rpc/deprecated/getstakeactivation.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getstakeactivation.mdx
@@ -28,6 +28,20 @@ Fetch and decode both the stake account and the StakeHistory sysvar account at
 stake delegation and decoded stake-history entries. The calculation must account
 for warmup and cooldown rather than comparing activation epochs alone.
 
+To reproduce the legacy balances, keep the stake account's total lamports and
+the decoded `Meta.rent_exempt_reserve` in addition to the delegation. Set
+`active` to the effective stake returned by the activation calculation, then
+derive `inactive` with saturating subtraction:
+
+```text
+inactive = account lamports - active - rent-exempt reserve
+```
+
+This includes undelegated lamports while excluding the reserve. For an
+initialized stake account with no delegation, set `active` to zero and use the
+same subtraction. Do not calculate `inactive` as only delegated stake minus
+effective stake.
+
 If a legacy caller supplied `epoch`, require it to equal the current epoch; the
 final legacy RPC implementation rejected other values. Reconstructing activation
 at an older epoch requires archived stake-account and sysvar state from that

--- a/apps/docs/content/docs/en/rpc/deprecated/getstakeactivation.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getstakeactivation.mdx
@@ -1,14 +1,32 @@
 ---
-title: getStakeActivation
-hideTableOfContents: true
-h1: getStakeActivation RPC Method
+title: getStakeActivation (removed)
+description:
+  Replace getStakeActivation by decoding stake state and deriving activation
+  from current epoch data.
+url: /docs/rpc/deprecated/getstakeactivation
+type: reference
+related:
+  - /docs/rpc/deprecated
+  - /docs/rpc/http/getaccountinfo
+  - /docs/rpc/http/getepochinfo
 ---
 
-Returns epoch activation information for a stake account
+`getStakeActivation` calculated the active, inactive, and activating or
+deactivating stake for one stake account at an optional epoch.
 
-<Callout type="warn" title={"Deprecated Method"}>
-  This method is expected to be removed in `solana-core` v2.0. Please use [this
-  alternative
-  approach](https://github.com/solana-developers/solana-rpc-get-stake-activation)
-  instead.
+<Callout type="warn" title="Removed RPC method">
+  This method was removed in Agave v2.0 and has no single-method replacement.
 </Callout>
+
+## Migration
+
+Fetch and decode the stake account with
+[getAccountInfo](/docs/rpc/http/getaccountinfo), obtain the current epoch with
+[getEpochInfo](/docs/rpc/http/getepochinfo), and derive activation from the
+stake delegation and stake-history data. The calculation must account for warmup
+and cooldown rather than comparing activation epochs alone.
+
+The
+[stake activation reference implementation](https://github.com/solana-developers/solana-rpc-get-stake-activation)
+shows this multi-step replacement. If you expose the result through an API,
+cache epoch-level inputs rather than recomputing them for every account.

--- a/apps/docs/content/docs/en/rpc/deprecated/getstakeactivation.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/getstakeactivation.mdx
@@ -12,7 +12,8 @@ related:
 ---
 
 `getStakeActivation` calculated the active, inactive, and activating or
-deactivating stake for one stake account at an optional epoch.
+deactivating stake for one stake account. Its final implementation accepted an
+optional epoch field but supported only the current epoch.
 
 <Callout type="warn" title="Removed RPC method">
   This method was removed in Agave v2.0 and has no single-method replacement.
@@ -20,11 +21,17 @@ deactivating stake for one stake account at an optional epoch.
 
 ## Migration
 
-Fetch and decode the stake account with
-[getAccountInfo](/docs/rpc/http/getaccountinfo), obtain the current epoch with
-[getEpochInfo](/docs/rpc/http/getepochinfo), and derive activation from the
-stake delegation and stake-history data. The calculation must account for warmup
-and cooldown rather than comparing activation epochs alone.
+Fetch and decode both the stake account and the StakeHistory sysvar account at
+`SysvarStakeHistory1111111111111111111111111` with
+[getAccountInfo](/docs/rpc/http/getaccountinfo). Obtain the current epoch with
+[getEpochInfo](/docs/rpc/http/getepochinfo), then derive activation from the
+stake delegation and decoded stake-history entries. The calculation must account
+for warmup and cooldown rather than comparing activation epochs alone.
+
+If a legacy caller supplied `epoch`, require it to equal the current epoch; the
+final legacy RPC implementation rejected other values. Reconstructing activation
+at an older epoch requires archived stake-account and sysvar state from that
+epoch, which current `getAccountInfo` responses do not provide.
 
 The
 [stake activation reference implementation](https://github.com/solana-developers/solana-rpc-get-stake-activation)

--- a/apps/docs/content/docs/en/rpc/deprecated/index.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/index.mdx
@@ -42,4 +42,5 @@ version and falling back to these method names.
 
 The replacement signature-status method does not accept a commitment parameter.
 When migrating a legacy call that did, compare the returned `confirmationStatus`
-with the commitment your application requires.
+with the commitment your application requires. Treat the levels as ordered:
+`processed` < `confirmed` < `finalized`.

--- a/apps/docs/content/docs/en/rpc/deprecated/index.mdx
+++ b/apps/docs/content/docs/en/rpc/deprecated/index.mdx
@@ -1,0 +1,45 @@
+---
+title: Removed RPC Methods
+description:
+  Migrate from JSON-RPC methods removed in Agave v2.0 to supported Solana RPC
+  methods and response shapes.
+url: /docs/rpc/deprecated
+type: reference
+related:
+  - /docs/rpc/http
+  - /docs/rpc/websocket
+---
+
+The JSON-RPC methods in this section were removed in Agave v2.0 and are not
+available on current RPC nodes. Migrate calls instead of detecting a validator
+version and falling back to these method names.
+
+<Callout type="info">
+  An SDK may still expose a similarly named convenience function. For example, a
+  client-side `confirmTransaction` helper can use `getSignatureStatuses` and
+  subscriptions internally. That helper is different from the removed
+  `confirmTransaction` JSON-RPC method documented here.
+</Callout>
+
+## Migration Summary
+
+| Removed method                                                                                | Supported replacement                                                   |
+| --------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| [`confirmTransaction`](/docs/rpc/deprecated/confirmtransaction)                               | `getSignatureStatuses`; compare `confirmationStatus` and `err`          |
+| [`getConfirmedBlock`](/docs/rpc/deprecated/getconfirmedblock)                                 | `getBlock` with `commitment: "confirmed"`                               |
+| [`getConfirmedBlocks`](/docs/rpc/deprecated/getconfirmedblocks)                               | `getBlocks` with `commitment: "confirmed"`                              |
+| [`getConfirmedBlocksWithLimit`](/docs/rpc/deprecated/getconfirmedblockswithlimit)             | `getBlocksWithLimit` with `commitment: "confirmed"`                     |
+| [`getConfirmedSignaturesForAddress2`](/docs/rpc/deprecated/getconfirmedsignaturesforaddress2) | `getSignaturesForAddress`                                               |
+| [`getConfirmedTransaction`](/docs/rpc/deprecated/getconfirmedtransaction)                     | `getTransaction` with `commitment: "confirmed"`                         |
+| [`getFeeCalculatorForBlockhash`](/docs/rpc/deprecated/getfeecalculatorforblockhash)           | `isBlockhashValid` for validity; `getFeeForMessage` for cost            |
+| [`getFeeRateGovernor`](/docs/rpc/deprecated/getfeerategovernor)                               | No direct replacement; use `getFeeForMessage` for a transaction message |
+| [`getFees`](/docs/rpc/deprecated/getfees)                                                     | `getLatestBlockhash` plus `getFeeForMessage`                            |
+| [`getRecentBlockhash`](/docs/rpc/deprecated/getrecentblockhash)                               | `getLatestBlockhash` plus `getFeeForMessage` when a fee is needed       |
+| [`getSignatureConfirmation`](/docs/rpc/deprecated/getsignatureconfirmation)                   | `getSignatureStatuses`; read `confirmations` and `err`                  |
+| [`getSignatureStatus`](/docs/rpc/deprecated/getsignaturestatus)                               | `getSignatureStatuses`; read the first result's `err`                   |
+| [`getSnapshotSlot`](/docs/rpc/deprecated/getsnapshotslot)                                     | `getHighestSnapshotSlot`                                                |
+| [`getStakeActivation`](/docs/rpc/deprecated/getstakeactivation)                               | Decode the stake account and derive activation from epoch data          |
+
+The replacement signature-status method does not accept a commitment parameter.
+When migrating a legacy call that did, compare the returned `confirmationStatus`
+with the commitment your application requires.

--- a/apps/docs/content/docs/en/rpc/deprecated/meta.json
+++ b/apps/docs/content/docs/en/rpc/deprecated/meta.json
@@ -1,6 +1,7 @@
 {
-  "title": "Deprecated Methods",
+  "title": "Removed Methods",
   "pages": [
+    "index",
     "confirmtransaction",
     "getconfirmedblock",
     "getconfirmedblocks",

--- a/apps/media/content/posts/breakpoint-2026-london-speakers.mdx
+++ b/apps/media/content/posts/breakpoint-2026-london-speakers.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'The Token Supercycle Is Here: Solana Brings Breakpoint 2026 to London'
+title: "The Token Supercycle Is Here: Solana Brings Breakpoint 2026 to London"
 status: published
 heroImage: /uploads/posts/breakpoint-2026-london-speakers/heroImage.png
 description: >-
@@ -19,6 +19,7 @@ tags:
   - tag: stablecoins
   - tag: ai
 ---
+
 **Solana Breakpoint 2026 will take place at Olympia London from November 15–17, marking the first time the annual forum has come to the UK.** More than 8,000 attendees from over 100 countries are expected to join institutions, investors, technology companies, builders and policymakers shaping internet capital markets.
 
 The event centers on the Token Supercycle: a period in which stablecoins, tokenized assets, payments and AI-driven economic activity increasingly move onchain. [Solana Breakpoint 2026](https://solana.com/breakpoint) will bring the people building and financing these markets together in London.
@@ -27,15 +28,15 @@ The event centers on the Token Supercycle: a period in which stablecoins, tokeni
 
 The first group of speakers spans payments, asset management, digital collectibles, technology and macroeconomics. Additional leaders from global institutions, allocators, payment companies, enterprise, technology companies and government will be announced before November.
 
-* Anthony Soohoo, CEO of MoneyGram
-* Tad Smith, CEO of Candy Digital
-* Annabel Spring, CEO of Allfunds
-* Balaji Srinivasan, founder of The Network State
-* Anatoly Yakovenko, co-founder of Solana and CEO of Solana Labs
-* Zach Abrams, CEO of Bridge & Open Standard
-* Lily Liu, President of Solana Foundation
-* Raoul Pal, co-founder and CEO of Real Vision
-* Peter Moore, owner of Wisla Krakow Football Club
+- Anthony Soohoo, CEO of MoneyGram
+- Tad Smith, CEO of Candy Digital
+- Annabel Spring, CEO of Allfunds
+- Balaji Srinivasan, founder of The Network State
+- Anatoly Yakovenko, co-founder of Solana and CEO of Solana Labs
+- Zach Abrams, CEO of Bridge & Open Standard
+- Lily Liu, President of Solana Foundation
+- Raoul Pal, co-founder and CEO of Real Vision
+- Peter Moore, owner of Wisla Krakow Football Club
 
 ## Why London
 
@@ -49,8 +50,8 @@ London was selected for 2026 for its long-standing role as a global hub for capi
 
 Breakpoint programming will examine the forces driving onchain financial infrastructure now, as well as the technologies and markets that could follow.
 
-* **Day 1: The Supercycle, Today** will examine stablecoins, payments, tokenized real-world assets and the macroeconomic forces accelerating the growth of onchain financial infrastructure.
-* **Day 2: The Supercycle, Tomorrow** will explore AI agents, prediction markets, consumer applications, new forms of ownership and new markets enabled by programmable capital.
+- **Day 1: The Supercycle, Today** will examine stablecoins, payments, tokenized real-world assets and the macroeconomic forces accelerating the growth of onchain financial infrastructure.
+- **Day 2: The Supercycle, Tomorrow** will explore AI agents, prediction markets, consumer applications, new forms of ownership and new markets enabled by programmable capital.
 
 ## Solana’s onchain activity
 


### PR DESCRIPTION
## Problem

The deprecated RPC reference pages still describe these endpoints as pending removal from solana-core v2.0, and the three signature-status pages do not explain their distinct legacy response shapes.

## Summary

- add a migration index for all 14 removed JSON-RPC methods
- update the pages to current Agave v2.0 removal terminology
- document parameter and response-shape changes for each replacement
- distinguish the confirmation methods and the split fee/lifetime migrations
- identify methods without a direct replacement