### PR TITLE
docs: replace with new avm installation cli command

### DIFF
--- a/apps/docs/content/docs/en/intro/installation/dependencies.mdx
+++ b/apps/docs/content/docs/en/intro/installation/dependencies.mdx
@@ -396,7 +396,7 @@ To install Anchor using AVM, follow the steps below:
 1. Install AVM with the following command:
 
 ```terminal
-$ cargo install --git https://github.com/solana-foundation/anchor avm --force
+$ curl -sSfL https://raw.githubusercontent.com/otter-sec/anchor/master/avm/install | sh
 ```
 
 2.  Confirm that AVM installed successfully:


### PR DESCRIPTION
### Problem

<!-- What problem does this solve? Write enough that someone uninvolved can
     understand it six months from now — this feeds the auto-generated change
     log (SDLC §3.5.3). -->

The current avm installation CLI in our docs is broken:

```terminal
cargo install --git https://github.com/otter-sec/anchor avm --force
```

both `+stable` and `+nightly` give the error:

```
error: failed to compile `avm v1.1.2 (https://github.com/otter-sec/anchor#db4c9d64)`, intermediate artifacts can be found at `/var/folders/6t/8kzvt_t12jvbjyt2l5gv54bw0000gn/T/cargo-installgn8yoz`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_BUILD_BUILD_DIR` to that path.

Caused by:
  failed to run `rustc` to learn about target-specific information

Caused by:
  process didn't exit successfully: `$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc - --crate-name ___ --print=file-names --crate-type bin --crate-type rlib --crate-type dylib --crate-type cdylib --crate-type staticlib --crate-type proc-macro --print=sysroot --print=split-debuginfo --print=crate-name --print=cfg -Wwarnings` (signal: 11, SIGSEGV: invalid memory reference)
```

### Summary of Changes

<!-- What changed and why. Call out anything security-relevant explicitly. -->

Replace the link with the updated one from https://github.com/solana-foundation/anchor README.md:

```terminal
curl -sSfL https://raw.githubusercontent.com/otter-sec/anchor/master/avm/install | sh
```