### PR TITLE
DEV-191 Add versioned transaction and ALT example

### DIFF
--- a/apps/docs/content/docs/en/core/transactions/versioned-transactions.mdx
+++ b/apps/docs/content/docs/en/core/transactions/versioned-transactions.mdx
@@ -134,6 +134,20 @@ lookups.
   (non-signer); they cannot be signers.
 </Callout>
 
+### Create and use an address lookup table
+
+This example creates a lookup table, adds an address, and uses the table to
+compile and send a v0 transaction.
+
+```ts !! title="Versioned transaction with an ALT" file=packages/docs-examples/cookbook/transactions/versioned-transaction-alt/legacy.ts#region=versioned-transaction-alt
+
+```
+
+Only non-signer accounts can be loaded from a lookup table. The fee payer and
+every required signer remain in the message's static account list. An address
+also cannot be looked up in the same slot in which it was added, so the example
+waits for the next confirmed slot before compiling the v0 message.
+
 ### Resource limits in v0
 
 Unchanged from legacy: ComputeBudget instructions, with the same defaults when

--- a/packages/docs-examples/cookbook/transactions/versioned-transaction-alt/legacy.test.ts
+++ b/packages/docs-examples/cookbook/transactions/versioned-transaction-alt/legacy.test.ts
@@ -1,0 +1,80 @@
+import { spawn } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "vitest";
+import { expectExampleLogsSignature } from "../../../test/assert-signature";
+
+describe("cookbook/transactions/versioned-transaction-alt/legacy", () => {
+  it("creates and uses an address lookup table", async () => {
+    const ledger = await mkdtemp(join(tmpdir(), "docs-alt-validator-"));
+    const rpcUrl = "http://127.0.0.1:18999";
+    const validator = spawn(
+      "solana-test-validator",
+      [
+        "--reset",
+        "--quiet",
+        "--ledger",
+        ledger,
+        "--rpc-port",
+        "18999",
+        "--faucet-port",
+        "19001",
+        "--gossip-port",
+        "19002",
+        "--dynamic-port-range",
+        "19003-19103",
+      ],
+      { stdio: "ignore" },
+    );
+
+    try {
+      await waitForRpc(rpcUrl, validator);
+      process.env.SOLANA_RPC_URL = rpcUrl;
+      await expectExampleLogsSignature(() => import("./legacy"));
+    } finally {
+      delete process.env.SOLANA_RPC_URL;
+      await stopValidator(validator);
+      await rm(ledger, { force: true, recursive: true });
+    }
+  }, 60_000);
+});
+
+async function waitForRpc(
+  rpcUrl: string,
+  validator: ReturnType<typeof spawn>,
+): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (validator.exitCode !== null) {
+      throw new Error(`test validator exited with code ${validator.exitCode}`);
+    }
+
+    try {
+      const response = await fetch(rpcUrl, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "getHealth",
+        }),
+      });
+      if (response.ok) return;
+    } catch {
+      // The validator is still starting.
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  throw new Error("test validator did not become ready");
+}
+
+function stopValidator(validator: ReturnType<typeof spawn>): Promise<void> {
+  if (validator.exitCode !== null) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    validator.once("exit", () => resolve());
+    validator.kill("SIGTERM");
+  });
+}

--- a/packages/docs-examples/cookbook/transactions/versioned-transaction-alt/legacy.ts
+++ b/packages/docs-examples/cookbook/transactions/versioned-transaction-alt/legacy.ts
@@ -11,7 +11,10 @@ import {
   VersionedTransaction,
 } from "@solana/web3.js";
 
-const connection = new Connection("http://localhost:8899", "confirmed");
+const connection = new Connection(
+  process.env.SOLANA_RPC_URL ?? "http://localhost:8899",
+  "confirmed",
+);
 const payer = Keypair.generate();
 const recipient = Keypair.generate();
 

--- a/packages/docs-examples/cookbook/transactions/versioned-transaction-alt/legacy.ts
+++ b/packages/docs-examples/cookbook/transactions/versioned-transaction-alt/legacy.ts
@@ -1,0 +1,96 @@
+// #region versioned-transaction-alt
+import {
+  AddressLookupTableProgram,
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  TransactionMessage,
+  VersionedTransaction,
+} from "@solana/web3.js";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const payer = Keypair.generate();
+const recipient = Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  payer.publicKey,
+  LAMPORTS_PER_SOL,
+);
+const { blockhash, lastValidBlockHeight } =
+  await connection.getLatestBlockhash();
+await connection.confirmTransaction({
+  blockhash,
+  lastValidBlockHeight,
+  signature: airdropSignature,
+});
+
+// Create the lookup table. Its address is derived from the authority and slot.
+const recentSlot = await connection.getSlot("finalized");
+const [createLookupTableInstruction, lookupTableAddress] =
+  AddressLookupTableProgram.createLookupTable({
+    authority: payer.publicKey,
+    payer: payer.publicKey,
+    recentSlot,
+  });
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(createLookupTableInstruction),
+  [payer],
+);
+
+// Store addresses that do not need to sign the v0 transaction in the table.
+const extendLookupTableInstruction =
+  AddressLookupTableProgram.extendLookupTable({
+    authority: payer.publicKey,
+    payer: payer.publicKey,
+    lookupTable: lookupTableAddress,
+    addresses: [recipient.publicKey],
+  });
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(extendLookupTableInstruction),
+  [payer],
+);
+
+const lookupTableAccount = (
+  await connection.getAddressLookupTable(lookupTableAddress)
+).value;
+if (!lookupTableAccount) {
+  throw new Error("Lookup table was not found");
+}
+
+// Addresses added to a table become usable in the slot after they are added.
+while (
+  (await connection.getSlot("confirmed")) <=
+  lookupTableAccount.state.lastExtendedSlot
+) {
+  await new Promise((resolve) => setTimeout(resolve, 400));
+}
+
+const transferInstruction = SystemProgram.transfer({
+  fromPubkey: payer.publicKey,
+  toPubkey: recipient.publicKey,
+  lamports: 1_000_000,
+});
+const transactionLifetime = await connection.getLatestBlockhash();
+
+// Passing the table to compileToV0Message replaces eligible 32-byte addresses
+// with 1-byte lookup indexes in the serialized transaction.
+const message = new TransactionMessage({
+  payerKey: payer.publicKey,
+  recentBlockhash: transactionLifetime.blockhash,
+  instructions: [transferInstruction],
+}).compileToV0Message([lookupTableAccount]);
+
+const transaction = new VersionedTransaction(message);
+transaction.sign([payer]);
+
+const signature = await connection.sendTransaction(transaction);
+await connection.confirmTransaction({ ...transactionLifetime, signature });
+console.log("Transaction signature:", signature);
+// #endregion versioned-transaction-alt

--- a/packages/docs-examples/test/assert-signature.ts
+++ b/packages/docs-examples/test/assert-signature.ts
@@ -4,8 +4,6 @@ import { createSolanaRpc, signature, type Signature } from "@solana/kit";
 // Base58 signatures are 87 or 88 chars; the alphabet excludes 0 O I l.
 const SIGNATURE_RE = /[1-9A-HJ-NP-Za-km-z]{87,88}/g;
 
-const rpc = createSolanaRpc("http://127.0.0.1:8899");
-
 /**
  * Run a cookbook example and assert every signature it logs is real.
  * Use this for any example that ends with `console.log("...:", signature)`.
@@ -51,6 +49,9 @@ export async function expectExampleLogsSignature(
 }
 
 async function fetchTxWithRetry(sig: Signature) {
+  const rpc = createSolanaRpc(
+    process.env.SOLANA_RPC_URL ?? "http://127.0.0.1:8899",
+  );
   for (let i = 0; i < 20; i++) {
     const tx = await rpc
       .getTransaction(sig, {


### PR DESCRIPTION
## Summary

- add a complete example that creates and extends an address lookup table
- use the table to compile, sign, send, and confirm a v0 transaction
- explain signer restrictions and the one slot activation delay