### PR TITLE
docs: add rpc provider selection guide

### DIFF
--- a/apps/docs/content/docs/en/references/clusters.mdx
+++ b/apps/docs/content/docs/en/references/clusters.mdx
@@ -24,6 +24,9 @@ users and developers to interact with the Solana blockchain.
 > Public endpoint rate limits are subject to change. The specific rate limits
 > listed on this document are not guaranteed to be the most up-to-date.
 
+For production infrastructure, use the [RPC provider guide](/docs/rpc/providers)
+to compare private services and find the maintained provider directory.
+
 ### Using explorers with different Clusters
 
 Many of the popular Solana blockchain explorers support selecting any of the

--- a/apps/docs/content/docs/en/rpc/index.mdx
+++ b/apps/docs/content/docs/en/rpc/index.mdx
@@ -6,6 +6,7 @@ description: >-
 url: /docs/rpc
 type: conceptual
 related:
+  - /docs/rpc/providers
   - /docs/rpc/http
   - /docs/rpc/websocket
   - /docs/rpc/json-structures
@@ -21,6 +22,9 @@ execution, and subscribe to live updates.
 />
 
 <Cards>
+  <Card title="Choose an RPC Provider" href="/docs/rpc/providers">
+    Compare production RPC infrastructure.
+  </Card>
   <Card title="HTTP Methods" href="/docs/rpc/http">
     Request-response RPC methods.
   </Card>
@@ -46,6 +50,9 @@ network you read from and where transactions are sent.
   production traffic. Shared public endpoints may return `429` when you exceed
   rate limits and `403` when traffic is blocked.
 </Callout>
+
+See [Choosing an RPC Provider](/docs/rpc/providers) for a production selection
+checklist and the maintained provider directory.
 
 For local development, Surfpool and `solana-test-validator` use these default
 localhost endpoints:

--- a/apps/docs/content/docs/en/rpc/meta.json
+++ b/apps/docs/content/docs/en/rpc/meta.json
@@ -1,6 +1,6 @@
 {
   "title": "Solana RPC Methods",
   "root": true,
-  "pages": ["json-structures", "http", "websocket", "deprecated"],
+  "pages": ["providers", "json-structures", "http", "websocket", "deprecated"],
   "defaultOpen": true
 }

--- a/apps/docs/content/docs/en/rpc/providers.mdx
+++ b/apps/docs/content/docs/en/rpc/providers.mdx
@@ -82,9 +82,10 @@ curl "$RPC_URL" \
 ```
 
 `minimumLedgerSlot` reports the lowest slot retained in the node's ledger, while
-`getFirstAvailableBlock` reports the first complete block available to the node.
-Neither alone guarantees that every historical method or transaction is
-available, so test a known old signature or block from your required range.
+`getFirstAvailableBlock` reports the lowest confirmed block slot that has not
+been purged. Neither alone guarantees that every historical method or
+transaction is available, so test a known old signature or block from your
+required range.
 
 Also test error responses. Confirm how the service reports rate limiting, method
 restrictions, oversized responses, timeouts, and invalid API keys.
@@ -119,9 +120,12 @@ rate-limited, stale, or unavailable.
    with HTTP after reconnecting.
 
 Do not retry every request blindly. Reads are generally safe to retry, but a
-timed-out transaction submission may already have reached the cluster. Reuse the
-same signed transaction and track its signature instead of creating a new
-payment or state change.
+timed-out transaction submission may already have reached the cluster. While its
+recent blockhash remains valid, reuse the same signed transaction and track its
+signature instead of creating a new payment or state change. After the blockhash
+expires, check whether the original signature or intended state change landed
+before rebuilding with a fresh blockhash. A rebuilt transaction has a new
+signature, so preserve application-level idempotency before sending it.
 
 ## Protect access credentials
 

--- a/apps/docs/content/docs/en/rpc/providers.mdx
+++ b/apps/docs/content/docs/en/rpc/providers.mdx
@@ -1,0 +1,151 @@
+---
+title: Choosing an RPC Provider
+description:
+  Compare Solana RPC providers by method coverage, history, limits, regions,
+  reliability, and operational fit.
+url: /docs/rpc/providers
+type: guide
+prerequisites:
+  - /docs/rpc
+related:
+  - /docs/references/clusters
+  - /docs/rpc/http
+  - /docs/rpc/websocket
+---
+
+An RPC provider gives your application an HTTP endpoint for requests and,
+usually, a WebSocket endpoint for subscriptions. The public Solana endpoints are
+useful for development, but production applications should use private RPC
+access with capacity and support that match their traffic.
+
+Use the [Solana RPC infrastructure directory](/rpc) to find current free,
+shared, and dedicated services. The directory changes as providers and their
+offerings change; this guide explains how to compare them.
+
+## Start with your workload
+
+Measure or estimate the workload before comparing plans:
+
+- clusters you need: Mainnet, Devnet, or Testnet
+- peak requests per second, not only the daily average
+- HTTP methods, WebSocket subscriptions, and concurrent connections
+- response size and bandwidth, especially for account and block queries
+- how far back you need transaction, signature, and block history
+- where your users and backend services run
+- whether you submit transactions, read data, or do both
+
+A wallet balance view, an indexer, and a transaction service have different
+bottlenecks. Test with representative requests and response sizes instead of a
+single lightweight method.
+
+## Compare provider capabilities
+
+| Area                 | Questions to ask                                                                                                                               |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Standard RPC         | Is every required [HTTP](/docs/rpc/http) and [WebSocket](/docs/rpc/websocket) method available? Are any methods disabled or priced separately? |
+| History              | What is the earliest available slot? Is full transaction history retained, and how are archival requests billed?                               |
+| Limits               | What are the request, method, response-size, bandwidth, batch, WebSocket, and concurrent-connection limits?                                    |
+| Freshness            | How far behind the cluster can reads be? Are `processed`, `confirmed`, and `finalized` commitments all supported consistently?                 |
+| Transaction delivery | Does the service only forward `sendTransaction`, or also provide routing, retries, staked connections, or status tracking?                     |
+| Regions              | Can traffic run near your users or backend? Is routing automatic, configurable, or tied to one region?                                         |
+| Reliability          | Is there a published SLA, status page, incident history, support path, and maintenance policy?                                                 |
+| Access               | Are browser requests allowed? How are API keys scoped, rotated, restricted, and observed?                                                      |
+| Portability          | Does the application depend on provider-specific APIs, parsed data, webhooks, or streams beyond standard Solana RPC?                           |
+| Cost                 | Which units are billed: requests, method weights, compute credits, response bytes, egress, or dedicated capacity?                              |
+
+Provider-specific APIs can be valuable, but keep the standard RPC boundary
+clear. That makes it easier to add a fallback or change providers later.
+
+## Check history and method support
+
+Run the exact methods your application needs against a trial endpoint. These
+standard calls provide a useful first check:
+
+```shell title="Inspect an RPC endpoint"
+RPC_URL="https://your-provider.example"
+
+curl "$RPC_URL" \
+  -H "content-type: application/json" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"getVersion"}'
+
+curl "$RPC_URL" \
+  -H "content-type: application/json" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"getHealth"}'
+
+curl "$RPC_URL" \
+  -H "content-type: application/json" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"minimumLedgerSlot"}'
+
+curl "$RPC_URL" \
+  -H "content-type: application/json" \
+  --data '{"jsonrpc":"2.0","id":1,"method":"getFirstAvailableBlock"}'
+```
+
+`minimumLedgerSlot` reports the lowest slot retained in the node's ledger, while
+`getFirstAvailableBlock` reports the first complete block available to the node.
+Neither alone guarantees that every historical method or transaction is
+available, so test a known old signature or block from your required range.
+
+Also test error responses. Confirm how the service reports rate limiting, method
+restrictions, oversized responses, timeouts, and invalid API keys.
+
+## Measure latency and freshness
+
+Latency includes network distance, provider routing, queueing, and the time
+needed to execute a method. Measure at least:
+
+- median and tail latency, such as p95 and p99
+- error and timeout rates at normal and peak load
+- returned slot compared with another healthy endpoint
+- time from sending a transaction to observing its signature status
+- WebSocket reconnect time and missed-notification recovery
+
+Run measurements from the same regions as the application. A fast response from
+a lagging node can still give users stale state.
+
+## Plan for failures
+
+For production traffic, decide what happens when an endpoint becomes slow,
+rate-limited, stale, or unavailable.
+
+1. Configure timeouts, bounded retries, and backoff with jitter.
+2. Maintain at least one separately operated fallback for critical paths.
+3. Health-check both availability and slot freshness before routing traffic.
+4. Keep related blockhash, simulation, send, and confirmation operations on a
+   healthy endpoint when possible; lag between endpoints can produce confusing
+   results.
+5. Re-establish WebSocket connections and subscriptions after disconnects.
+   Subscription notifications are not a durable event log, so reconcile state
+   with HTTP after reconnecting.
+
+Do not retry every request blindly. Reads are generally safe to retry, but a
+timed-out transaction submission may already have reached the cluster. Reuse the
+same signed transaction and track its signature instead of creating a new
+payment or state change.
+
+## Protect access credentials
+
+Treat paid RPC URLs and API keys as credentials. Keep unrestricted keys out of
+source control, logs, analytics, and public client bundles. If a browser or
+mobile client must call RPC directly, use a restricted public key or a backend
+proxy and enforce origin, method, and rate limits where the provider supports
+them.
+
+An RPC endpoint never needs a wallet's private key or seed phrase. Transactions
+sent through `sendTransaction` are already signed.
+
+## Selection checklist
+
+Before committing to a provider or architecture, confirm:
+
+- required clusters, methods, commitments, and historical range work
+- sustained and burst traffic fit documented limits
+- latency, freshness, and error rates meet targets from every required region
+- WebSocket reconnect and reconciliation behavior is tested
+- keys can be scoped, rotated, and monitored
+- pricing has been modeled with representative heavy methods and responses
+- alerts, support, status information, and escalation paths are documented
+- a fallback has been tested instead of only configured
+
+Re-run the evaluation as traffic and RPC usage change. The best provider fit is
+an operational decision, not a permanent property of an application.

--- a/apps/docs/content/docs/en/rpc/providers.mdx
+++ b/apps/docs/content/docs/en/rpc/providers.mdx
@@ -123,9 +123,12 @@ Do not retry every request blindly. Reads are generally safe to retry, but a
 timed-out transaction submission may already have reached the cluster. While its
 recent blockhash remains valid, reuse the same signed transaction and track its
 signature instead of creating a new payment or state change. After the blockhash
-expires, check whether the original signature or intended state change landed
-before rebuilding with a fresh blockhash. A rebuilt transaction has a new
-signature, so preserve application-level idempotency before sending it.
+expires, search transaction history for the original signature or verify the
+intended change against reliable application or onchain state. A `null` result
+from the recent signature-status cache is inconclusive. Only rebuild with a
+fresh blockhash after establishing that the original did not land. A rebuilt
+transaction has a new signature, so preserve application-level idempotency
+before sending it.
 
 ## Protect access credentials
 


### PR DESCRIPTION
## Summary

- add a vendor-neutral guide for evaluating production rpc providers
- cover method and history support, capacity, latency, failover, credentials, and cost
- link the maintained rpc directory instead of duplicating a changing vendor list
- surface the guide from the rpc overview and cluster reference