### PR TITLE
docs: add solana cli reference

### DIFF
--- a/apps/docs/content/docs/en/references/meta.json
+++ b/apps/docs/content/docs/en/references/meta.json
@@ -1,5 +1,11 @@
 {
   "title": "References",
-  "pages": ["clusters", "staking", "feature-gates", "terminology"],
+  "pages": [
+    "clusters",
+    "solana-cli",
+    "staking",
+    "feature-gates",
+    "terminology"
+  ],
   "defaultOpen": false
 }

--- a/apps/docs/content/docs/en/references/solana-cli.mdx
+++ b/apps/docs/content/docs/en/references/solana-cli.mdx
@@ -1,0 +1,286 @@
+---
+title: Solana CLI Reference
+description:
+  Complete command index and practical examples for the Agave Solana
+  command-line interface.
+url: /docs/references/solana-cli
+type: reference
+prerequisites:
+  - /docs/intro/installation
+related:
+  - /docs/references/clusters
+  - /docs/core/transactions
+  - /docs/core/programs
+---
+
+The `solana` command-line interface configures a cluster connection, reads
+network state, sends SOL, manages durable nonces, deploys programs, and operates
+stake and vote accounts.
+
+This reference follows
+[Agave v4.2.1](https://github.com/anza-xyz/agave/releases/tag/v4.2.1). Run
+`solana --version` to check the installed release and use `--help` for the exact
+options available in that version.
+
+<Callout type="warn">
+  Commands that create, transfer, authorize, withdraw, or deploy submit
+  transactions. Confirm the configured cluster and signer before running them.
+  Devnet and Testnet tokens have no value; Mainnet commands use real SOL.
+</Callout>
+
+## Command structure
+
+```text
+solana [GLOBAL_OPTIONS] <COMMAND> [COMMAND_OPTIONS]
+```
+
+Get help at any level:
+
+```shell
+solana --help
+solana transfer --help
+solana address-lookup-table extend --help
+```
+
+## Global options
+
+Global options can be placed before the command. Command-specific help repeats
+the options that apply to that command.
+
+| Option                          | Purpose                                                                        |
+| ------------------------------- | ------------------------------------------------------------------------------ |
+| `-u, --url <URL_OR_MONIKER>`    | Select an RPC URL or `mainnet-beta`, `testnet`, `devnet`, or `localhost`.      |
+| `--ws <URL>`                    | Override the WebSocket endpoint.                                               |
+| `-k, --keypair <KEYPAIR>`       | Select a keypair file, `ASK`, stdin (`-`), or a supported signer URL.          |
+| `-C, --config <FILEPATH>`       | Use a different CLI configuration file.                                        |
+| `--commitment <LEVEL>`          | Read at `processed`, `confirmed`, or `finalized` commitment.                   |
+| `--output <FORMAT>`             | Return `json` or `json-compact` where supported.                               |
+| `--skip-preflight`              | Send without RPC simulation. Use only when the failure tradeoff is understood. |
+| `--use-tpu-client`              | Send transactions through the TPU client.                                      |
+| `--no-address-labels`           | Print addresses without local labels.                                          |
+| `--skip-seed-phrase-validation` | Permit a recovery phrase outside the BIP39 English list.                       |
+| `-v, --verbose`                 | Show additional command output.                                                |
+| `-V, --version`                 | Print the installed CLI version.                                               |
+
+## Configure the CLI
+
+```shell
+# Inspect the effective configuration.
+solana config get
+
+# Use Devnet and a specific signer by default.
+solana config set --url devnet
+solana config set --keypair ./devnet-keypair.json
+
+# Override defaults for one command.
+solana --url mainnet-beta --keypair usb://ledger address
+```
+
+The configuration contains an RPC URL, WebSocket URL, default signer, and
+commitment. A command-line option overrides the saved value for that invocation.
+
+## Common account and transaction workflows
+
+```shell
+# Print the default signer's address and balance.
+solana address
+solana balance
+
+# Read an account as JSON.
+solana account <ACCOUNT_ADDRESS> --output json
+
+# Request Devnet SOL.
+solana airdrop 1 --url devnet
+
+# Send SOL and then confirm the returned signature.
+solana transfer <RECIPIENT_ADDRESS> 0.1 --allow-unfunded-recipient
+solana confirm <TRANSACTION_SIGNATURE>
+
+# Inspect recent activity and stream logs mentioning an address.
+solana transaction-history <ADDRESS> --limit 20
+solana logs <ADDRESS>
+```
+
+`transfer` accepts SOL by default. Use `ALL` as the amount to move the available
+balance after fees. For token examples, see the
+[token quickstart](/docs/tokens/quickstart).
+
+## Program workflows
+
+```shell
+# Deploy or upgrade an SBF program.
+solana program deploy ./target/deploy/my_program.so
+
+# Inspect the deployed program and list programs controlled by the signer.
+solana program show <PROGRAM_ID>
+solana program show --programs
+
+# Close a program buffer and recover its lamports.
+solana program close <BUFFER_ADDRESS>
+```
+
+Pass `--program-id <KEYPAIR_OR_ADDRESS>` when a deployment must use a known
+program ID. `--final` makes a new deployment immutable; read its help carefully
+before using it because the upgrade authority cannot be restored.
+
+## Durable nonce workflows
+
+```shell
+solana-keygen new --outfile nonce-account.json
+solana create-nonce-account nonce-account.json 0.1
+solana nonce nonce-account.json
+solana new-nonce nonce-account.json
+solana withdraw-from-nonce-account nonce-account.json <RECIPIENT_ADDRESS> ALL
+```
+
+Use `authorize-nonce-account` to change the nonce authority and `nonce-account`
+to inspect the full account state. Transactions using a nonce also accept
+`--nonce` and `--nonce-authority` on supported commands.
+
+## Stake workflows
+
+```shell
+solana-keygen new --outfile stake-account.json
+solana create-stake-account stake-account.json 1
+solana delegate-stake stake-account.json <VOTE_ACCOUNT_ADDRESS>
+solana stake-account stake-account.json
+
+solana deactivate-stake stake-account.json
+solana withdraw-stake stake-account.json <RECIPIENT_ADDRESS> ALL
+```
+
+Deactivation completes at an epoch boundary and may take more than one epoch.
+Use `stakes`, `validators`, `stake-history`, and `stake-minimum-delegation` to
+inspect cluster and delegation state before submitting changes.
+
+## Address utilities
+
+```shell
+# Derive a PDA from typed seeds.
+solana find-program-derived-address \
+  <PROGRAM_ID> \
+  string:profile \
+  pubkey:<OWNER_ADDRESS>
+
+# Create and extend an address lookup table.
+solana address-lookup-table create
+solana address-lookup-table extend \
+  <LOOKUP_TABLE_ADDRESS> \
+  --addresses <ADDRESS_1>,<ADDRESS_2>
+```
+
+PDA seeds use `PREFIX:VALUE`. Supported prefixes include `string`, `pubkey`,
+`hex`, `u8`, and fixed-width signed or unsigned integer encodings such as
+`u64le`.
+
+## Off-chain messages and shell completion
+
+```shell
+solana sign-offchain-message "terms accepted"
+solana verify-offchain-signature \
+  "terms accepted" \
+  <SIGNATURE> \
+  --signer <SIGNER_ADDRESS>
+
+# Print a completion script for the current shell.
+solana completion --shell zsh
+```
+
+## Complete command index
+
+The following index includes every top-level command in Agave v4.2.1. Commands
+such as `program`, `config`, `feature`, and `address-lookup-table` contain
+nested commands; run `<command> --help` to list them.
+
+| Command                             | Description                                                                       |
+| ----------------------------------- | --------------------------------------------------------------------------------- |
+| `account`                           | Show an account's lamports, owner, data, and executable state.                    |
+| `address`                           | Print the selected signer's public key.                                           |
+| `address-lookup-table`              | Create, extend, freeze, deactivate, close, and inspect address lookup tables.     |
+| `airdrop`                           | Request SOL from a cluster faucet.                                                |
+| `alpenglow-genesis-info`            | Read information about the Alpenglow genesis certificate.                         |
+| `authorize-nonce-account`           | Assign a durable nonce account authority.                                         |
+| `balance`                           | Show an account's SOL balance.                                                    |
+| `block`                             | Fetch a confirmed block by slot.                                                  |
+| `block-height`                      | Show the current block height.                                                    |
+| `block-production`                  | Show leader block production for a slot range.                                    |
+| `block-time`                        | Estimate the production time of a block.                                          |
+| `catchup`                           | Wait for a validator to catch up with the cluster.                                |
+| `close-vote-account`                | Close a vote account and withdraw its remaining funds.                            |
+| `cluster-date`                      | Estimate the cluster date from genesis time and network time.                     |
+| `cluster-version`                   | Show the cluster entrypoint's software version.                                   |
+| `completion`                        | Generate a shell completion script.                                               |
+| `config`                            | Get or set CLI defaults.                                                          |
+| `confirm`                           | Check a transaction signature's confirmation status.                              |
+| `create-address-with-seed`          | Derive a system address from a base, seed, and program ID.                        |
+| `create-nonce-account`              | Create and initialize a durable nonce account.                                    |
+| `create-stake-account`              | Create a stake account.                                                           |
+| `create-stake-account-checked`      | Create a stake account while checking the withdraw authority as a signer.         |
+| `create-vote-account`               | Create a validator vote account.                                                  |
+| `deactivate-stake`                  | Begin deactivating delegated stake.                                               |
+| `decode-transaction`                | Decode a serialized transaction.                                                  |
+| `delegate-stake`                    | Delegate a stake account to a vote account.                                       |
+| `epoch`                             | Show the current epoch number.                                                    |
+| `epoch-info`                        | Show epoch, slot, block height, and transaction count information.                |
+| `feature`                           | Inspect and manage runtime feature accounts.                                      |
+| `find-program-derived-address`      | Derive a PDA and canonical bump from typed seeds.                                 |
+| `first-available-block`             | Show the first complete block retained by the RPC node.                           |
+| `genesis-hash`                      | Show the cluster genesis hash.                                                    |
+| `gossip`                            | List nodes visible through gossip.                                                |
+| `help`                              | Print root or command help.                                                       |
+| `inflation`                         | Show inflation governor, rate, or reward information.                             |
+| `largest-accounts`                  | List the cluster's largest accounts.                                              |
+| `leader-schedule`                   | Display the leader schedule.                                                      |
+| `live-slots`                        | Stream current slot progression.                                                  |
+| `logs`                              | Stream transaction logs, optionally filtered by address.                          |
+| `merge-stake`                       | Merge compatible stake accounts.                                                  |
+| `new-nonce`                         | Advance a durable nonce.                                                          |
+| `nonce`                             | Print a durable nonce value.                                                      |
+| `nonce-account`                     | Show complete durable nonce account state.                                        |
+| `program`                           | Deploy, upgrade, inspect, dump, set authority for, or close programs and buffers. |
+| `recent-prioritization-fees`        | Show recent prioritization fees for writable accounts.                            |
+| `rent`                              | Calculate the rent-exempt minimum for an account data size.                       |
+| `resolve-signer`                    | Resolve a general signer reference such as a Ledger URL to its specific path.     |
+| `sign-offchain-message`             | Sign a UTF-8 off-chain message.                                                   |
+| `slot`                              | Show the current slot.                                                            |
+| `split-stake`                       | Split lamports from one stake account into another.                               |
+| `stake-account`                     | Show a stake account's authorities, balance, and delegation state.                |
+| `stake-authorize`                   | Change a stake or withdraw authority.                                             |
+| `stake-authorize-checked`           | Change a stake authority while checking the new authority as a signer.            |
+| `stake-history`                     | Show cluster stake activation and deactivation history.                           |
+| `stake-minimum-delegation`          | Show the cluster's minimum stake delegation.                                      |
+| `stake-set-lockup`                  | Set a stake account lockup.                                                       |
+| `stake-set-lockup-checked`          | Set a lockup while checking the new custodian as a signer.                        |
+| `stakes`                            | List stake accounts, optionally filtered by validator or authority.               |
+| `supply`                            | Show circulating, non-circulating, and total SOL supply.                          |
+| `transaction-count`                 | Show the cluster transaction count.                                               |
+| `transaction-history`               | List transactions involving an address from newest to oldest.                     |
+| `transfer`                          | Transfer SOL between system accounts.                                             |
+| `upgrade-nonce-account`             | Idempotently upgrade a legacy nonce account.                                      |
+| `validator-info`                    | Publish or read validator information.                                            |
+| `validators`                        | Show validator stake, commission, skip rate, and version summary.                 |
+| `verify-offchain-signature`         | Verify a signed off-chain message.                                                |
+| `vote-account`                      | Show a vote account's authorities, commission, credits, and votes.                |
+| `vote-authorize-voter`              | Change a vote account's voter authority.                                          |
+| `vote-authorize-voter-checked`      | Change voter authority while checking the new authority as a signer.              |
+| `vote-authorize-withdrawer`         | Change a vote account's withdraw authority.                                       |
+| `vote-authorize-withdrawer-checked` | Change withdraw authority while checking the new authority as a signer.           |
+| `vote-update-commission`            | Change a vote account's commission.                                               |
+| `vote-update-validator`             | Change the validator identity assigned to a vote account.                         |
+| `withdraw-from-nonce-account`       | Withdraw some or all SOL from a durable nonce account.                            |
+| `withdraw-from-vote-account`        | Withdraw lamports from a vote account.                                            |
+| `withdraw-stake`                    | Withdraw inactive SOL from a stake account.                                       |
+
+## Script output
+
+Use `--output json` or `--output json-compact` where supported instead of
+parsing human-readable output:
+
+```shell
+solana epoch-info --output json
+solana account <ACCOUNT_ADDRESS> --output json-compact
+solana validators --output json > validators.json
+```
+
+Not every command supports structured output. Check the command's help before
+depending on it in automation, and treat nonzero exit status as failure.


### PR DESCRIPTION
## Summary

- add practical examples for configuration, transfers, programs, nonces, staking, address utilities, and automation
- document the global options exposed by agave 4.2.1
- include every top level solana command with a concise description
- add the reference to docs navigation