### PR TITLE
docs: add spl token cli reference

### DIFF
--- a/apps/docs/content/docs/en/references/meta.json
+++ b/apps/docs/content/docs/en/references/meta.json
@@ -1,5 +1,11 @@
 {
   "title": "References",
-  "pages": ["clusters", "staking", "feature-gates", "terminology"],
+  "pages": [
+    "clusters",
+    "spl-token-cli",
+    "staking",
+    "feature-gates",
+    "terminology"
+  ],
   "defaultOpen": false
 }

--- a/apps/docs/content/docs/en/references/spl-token-cli.mdx
+++ b/apps/docs/content/docs/en/references/spl-token-cli.mdx
@@ -1,0 +1,318 @@
+---
+title: SPL Token CLI Reference
+description:
+  Complete command index and practical examples for creating and managing SPL
+  Token and Token-2022 mints and accounts.
+url: /docs/references/spl-token-cli
+type: reference
+prerequisites:
+  - /docs/intro/installation
+  - /docs/tokens
+related:
+  - /docs/tokens/quickstart
+  - /docs/tokens/extensions
+  - /docs/references/clusters
+---
+
+The `spl-token` command-line interface creates and manages mints, token
+accounts, authorities, transfers, and Token-2022 extensions.
+
+This reference follows
+[`spl-token-cli` v5.6.1](https://github.com/solana-program/token-2022/releases/tag/cli%40v5.6.1),
+the version bundled with Agave v4.2.1. Run `spl-token --version` and use
+`<command> --help` for the exact options available in your installed version.
+
+<Callout type="warn">
+  Mint creation, transfers, authority changes, burns, freezes, and account
+  closure submit transactions. Confirm the cluster, token program, signer, and
+  addresses before running a command. Mainnet changes use real assets.
+</Callout>
+
+## Install and get help
+
+The Agave CLI release bundle includes `spl-token`. If it is not installed, use
+the published Rust crate:
+
+```shell
+cargo install spl-token-cli --version 5.6.1
+spl-token --version
+```
+
+Inspect help at the root or command level:
+
+```shell
+spl-token --help
+spl-token create-token --help
+spl-token transfer --help
+```
+
+## Global options
+
+Place global options before the command.
+
+| Option                                       | Purpose                                                                   |
+| -------------------------------------------- | ------------------------------------------------------------------------- |
+| `-u, --url <URL_OR_MONIKER>`                 | Select an RPC URL or `mainnet-beta`, `testnet`, `devnet`, or `localhost`. |
+| `-C, --config <PATH>`                        | Use a different Solana CLI configuration file.                            |
+| `--fee-payer <KEYPAIR>`                      | Select the account that pays transaction fees.                            |
+| `-p, --program-id <ADDRESS>`                 | Use an explicit Token Program ID.                                         |
+| `--program-2022`                             | Use Token-2022 (`TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb`).           |
+| `--output <FORMAT>`                          | Return `json` or `json-compact` where supported.                          |
+| `--with-compute-unit-limit <UNITS>`          | Set the transaction compute unit limit.                                   |
+| `--with-compute-unit-price <MICRO_LAMPORTS>` | Set the priority price per compute unit.                                  |
+| `-v, --verbose`                              | Show additional output.                                                   |
+| `-V, --version`                              | Print the installed CLI version.                                          |
+
+The default program is the original Token Program. Use `--program-2022` for a
+Token-2022 mint or account, including when reading it. A command fails if the
+selected program does not own the supplied address.
+
+## Create and use a token
+
+The commands print created addresses. Save the mint address returned by
+`create-token` for the following commands.
+
+```shell
+# Create a six-decimal mint under the original Token Program.
+spl-token --url devnet create-token --decimals 6
+
+# Create the default signer's associated token account for the mint.
+spl-token --url devnet create-account <MINT_ADDRESS>
+
+# Mint 100 tokens to that associated token account.
+spl-token --url devnet mint <MINT_ADDRESS> 100
+
+# Read supply, balance, and complete mint or account details.
+spl-token --url devnet supply <MINT_ADDRESS>
+spl-token --url devnet balance <MINT_ADDRESS>
+spl-token --url devnet display <MINT_OR_TOKEN_ACCOUNT_ADDRESS>
+
+# Transfer tokens to a wallet and create its associated account if needed.
+spl-token --url devnet transfer \
+  <MINT_ADDRESS> \
+  10 \
+  <RECIPIENT_WALLET_ADDRESS> \
+  --fund-recipient
+```
+
+Amounts are UI token amounts, adjusted for the mint's decimals. Commands such as
+`transfer`, `burn`, and `unwrap-sol` accept `ALL` where shown in their help.
+
+## Create a Token-2022 mint
+
+Extensions allocate extra mint or account state and usually must be chosen when
+the mint is created. This example creates a six-decimal mint with embedded
+metadata support:
+
+```shell
+spl-token --program-2022 create-token \
+  --decimals 6 \
+  --enable-metadata
+
+spl-token --program-2022 initialize-metadata \
+  <MINT_ADDRESS> \
+  "Example Token" \
+  EXAMPLE \
+  https://example.com/token.json
+```
+
+Common `create-token` extension options include:
+
+- `--enable-close`
+- `--enable-confidential-transfers auto|manual`
+- `--enable-freeze`
+- `--enable-group` and `--enable-member`
+- `--enable-metadata`
+- `--enable-non-transferable`
+- `--enable-pause`
+- `--enable-permanent-delegate`
+- `--enable-permissioned-burn`
+- `--enable-transfer-hook` or `--transfer-hook <PROGRAM_ID>`
+- `--interest-rate <BASIS_POINTS>`
+- `--transfer-fee-basis-points <BASIS_POINTS>` with
+  `--transfer-fee-maximum-fee <AMOUNT>`
+- `--ui-amount-multiplier <MULTIPLIER>`
+
+Only combine extensions that the Token-2022 program permits together. Review the
+relevant [Token-2022 extension guide](/docs/tokens/extensions) before creating
+an irreversible mint configuration.
+
+## Manage authorities and delegates
+
+```shell
+# Change the mint authority.
+spl-token authorize <MINT_ADDRESS> mint <NEW_AUTHORITY_ADDRESS>
+
+# Permanently remove the mint authority.
+spl-token authorize <MINT_ADDRESS> mint --disable
+
+# Let a delegate spend up to 25 tokens from one token account.
+spl-token approve \
+  <TOKEN_ACCOUNT_ADDRESS> \
+  25 \
+  <DELEGATE_ADDRESS>
+
+# Remove the current delegate.
+spl-token revoke <TOKEN_ACCOUNT_ADDRESS>
+```
+
+`authorize` supports mint, freeze, owner, close, and extension-specific
+authority types. Removing an authority with `--disable` is permanent when no
+other program mechanism can restore it.
+
+## Freeze, burn, and close
+
+```shell
+spl-token freeze <TOKEN_ACCOUNT_ADDRESS>
+spl-token thaw <TOKEN_ACCOUNT_ADDRESS>
+
+spl-token burn <TOKEN_ACCOUNT_ADDRESS> 5
+
+# A token account must normally have a zero token balance before closing.
+spl-token close --address <TOKEN_ACCOUNT_ADDRESS>
+```
+
+`burn` reduces both the account balance and total supply. `close` returns the
+account's remaining lamports to the configured recipient; it does not recover
+burned tokens.
+
+## Wrap and unwrap SOL
+
+```shell
+# Create or fund the owner's wrapped SOL token account.
+spl-token wrap 1
+
+# Unwrap part of the wrapped SOL balance.
+spl-token unwrap-sol 0.25
+
+# Close the wrapped SOL account and return its full lamport balance.
+spl-token unwrap
+```
+
+Use `sync-native` after transferring lamports directly into a wrapped SOL token
+account so its token amount matches the underlying lamports.
+
+## Multisig signing
+
+Create an M-of-N Token Program multisig with up to 11 members:
+
+```shell
+spl-token create-multisig \
+  2 \
+  <MEMBER_1_ADDRESS> \
+  <MEMBER_2_ADDRESS> \
+  <MEMBER_3_ADDRESS>
+```
+
+For a transaction controlled by that multisig, pass the multisig address as the
+relevant authority and provide member keypairs through repeated
+`--multisig-signer` values. Check the target command's help because its primary
+authority flag varies by operation.
+
+## Confidential balances
+
+Confidential balance commands require a Token-2022 mint configured for
+confidential transfers and a configured recipient account.
+
+```shell
+spl-token --program-2022 configure-confidential-transfer-account \
+  <MINT_ADDRESS>
+
+spl-token --program-2022 deposit-confidential-tokens \
+  <MINT_ADDRESS> \
+  10
+
+spl-token --program-2022 apply-pending-balance <MINT_ADDRESS>
+
+spl-token --program-2022 withdraw-confidential-tokens \
+  <MINT_ADDRESS> \
+  5
+
+spl-token --program-2022 transfer \
+  <MINT_ADDRESS> \
+  1 \
+  <RECIPIENT_ADDRESS> \
+  --confidential
+```
+
+Use `enable-confidential-credits`, `disable-confidential-credits`,
+`enable-non-confidential-credits`, and `disable-non-confidential-credits` to
+control which deposits the account accepts. These settings affect account
+privacy and payment compatibility; inspect the account before changing them.
+
+## Complete command index
+
+The following index includes every top-level command in `spl-token-cli` v5.6.1.
+
+| Command                                   | Description                                                                   |
+| ----------------------------------------- | ----------------------------------------------------------------------------- |
+| `accounts`                                | List token accounts owned by a wallet, optionally filtered by mint.           |
+| `address`                                 | Print the selected wallet address or its associated token address.            |
+| `apply-pending-balance`                   | Move pending confidential tokens into the available confidential balance.     |
+| `approve`                                 | Approve a delegate and spending allowance for a token account.                |
+| `authorize`                               | Change or disable a mint, account, or extension authority.                    |
+| `balance`                                 | Show a token account balance.                                                 |
+| `bench`                                   | Run token benchmarking commands.                                              |
+| `burn`                                    | Destroy tokens from an account and reduce mint supply.                        |
+| `close`                                   | Close an eligible token account and recover its lamports.                     |
+| `close-mint`                              | Close a Token-2022 mint configured with the close-mint extension.             |
+| `configure-confidential-transfer-account` | Configure an account to use confidential transfers.                           |
+| `create-account`                          | Create an associated or auxiliary token account.                              |
+| `create-multisig`                         | Create an M-of-N Token Program multisig.                                      |
+| `create-token`                            | Create a mint, optionally with Token-2022 extensions.                         |
+| `deposit-confidential-tokens`             | Move non-confidential tokens into a pending confidential balance.             |
+| `disable-confidential-credits`            | Reject incoming confidential transfers for an account.                        |
+| `disable-cpi-guard`                       | Disable CPI Guard for an account.                                             |
+| `disable-non-confidential-credits`        | Reject incoming non-confidential transfers for a confidential account.        |
+| `disable-required-transfer-memos`         | Stop requiring incoming transfers to include memos.                           |
+| `display`                                 | Show complete mint, token account, or multisig details.                       |
+| `enable-confidential-credits`             | Accept incoming confidential transfers for a configured account.              |
+| `enable-cpi-guard`                        | Restrict selected token operations when invoked through CPI.                  |
+| `enable-non-confidential-credits`         | Accept incoming non-confidential transfers for a confidential account.        |
+| `enable-required-transfer-memos`          | Require incoming transfers to include memos.                                  |
+| `freeze`                                  | Freeze a token account using the mint's freeze authority.                     |
+| `gc`                                      | Close unnecessary token accounts and consolidate balances where possible.     |
+| `help`                                    | Print root or command help.                                                   |
+| `initialize-group`                        | Initialize the Token-2022 group configuration for a mint.                     |
+| `initialize-member`                       | Add a Token-2022 mint as a group member.                                      |
+| `initialize-metadata`                     | Initialize embedded Token-2022 metadata.                                      |
+| `mint`                                    | Create new token units using the mint authority.                              |
+| `pause`                                   | Pause mint, burn, and transfer for a pausable Token-2022 mint.                |
+| `resume`                                  | Resume operations for a paused Token-2022 mint.                               |
+| `revoke`                                  | Remove a token account delegate.                                              |
+| `set-interest-rate`                       | Update an interest-bearing mint's rate.                                       |
+| `set-transfer-fee`                        | Schedule new transfer fee parameters.                                         |
+| `set-transfer-hook`                       | Change a mint's transfer hook program ID.                                     |
+| `supply`                                  | Show a mint's total supply.                                                   |
+| `sync-native`                             | Synchronize a wrapped SOL account amount with its lamports.                   |
+| `thaw`                                    | Thaw a frozen token account.                                                  |
+| `transfer`                                | Transfer tokens to a token account or wallet.                                 |
+| `unwrap`                                  | Close a wrapped SOL account and recover all lamports.                         |
+| `unwrap-sol`                              | Remove some or all SOL from a wrapped SOL account.                            |
+| `update-confidential-transfer-settings`   | Update confidential transfer approval or auditor settings for a mint.         |
+| `update-default-account-state`            | Change a mint's default state for new token accounts.                         |
+| `update-group-address`                    | Change a mint's group pointer address.                                        |
+| `update-group-max-size`                   | Change a token group's maximum member count.                                  |
+| `update-member-address`                   | Change a mint's group member pointer address.                                 |
+| `update-metadata`                         | Change or remove embedded metadata fields.                                    |
+| `update-metadata-address`                 | Change a mint's metadata pointer address.                                     |
+| `update-ui-amount-multiplier`             | Schedule a new scaled UI amount multiplier.                                   |
+| `withdraw-confidential-tokens`            | Move confidential tokens back to the non-confidential balance.                |
+| `withdraw-excess-lamports`                | Withdraw lamports above the rent-exempt balance from a Token Program account. |
+| `withdraw-withheld-tokens`                | Collect transfer fees withheld in token accounts or the mint.                 |
+| `wrap`                                    | Wrap SOL in a native mint token account.                                      |
+
+## Structured and offline signing
+
+Use structured output rather than parsing display text:
+
+```shell
+spl-token accounts --output json
+spl-token display <MINT_ADDRESS> --output json-compact
+```
+
+Transaction-producing commands commonly support `--sign-only`, `--blockhash`,
+`--signer <PUBKEY=SIGNATURE>`, `--nonce`, and `--nonce-authority`. The exact
+offline inputs depend on the command, mint decimals, and authority arrangement,
+so generate the unsigned message from that command's `--help` instructions and
+verify every address before collecting signatures.

--- a/apps/docs/content/docs/en/references/spl-token-cli.mdx
+++ b/apps/docs/content/docs/en/references/spl-token-cli.mdx
@@ -216,17 +216,22 @@ confidential transfers and a configured recipient account.
 
 ```shell
 spl-token --program-2022 configure-confidential-transfer-account \
-  <MINT_ADDRESS>
+  <MINT_ADDRESS> \
+  --address <TOKEN_ACCOUNT_ADDRESS>
 
 spl-token --program-2022 deposit-confidential-tokens \
   <MINT_ADDRESS> \
-  10
+  10 \
+  --address <TOKEN_ACCOUNT_ADDRESS>
 
-spl-token --program-2022 apply-pending-balance <MINT_ADDRESS>
+spl-token --program-2022 apply-pending-balance \
+  <MINT_ADDRESS> \
+  --address <TOKEN_ACCOUNT_ADDRESS>
 
 spl-token --program-2022 withdraw-confidential-tokens \
   <MINT_ADDRESS> \
-  5
+  5 \
+  --address <TOKEN_ACCOUNT_ADDRESS>
 
 spl-token --program-2022 transfer \
   <MINT_ADDRESS> \
@@ -234,6 +239,10 @@ spl-token --program-2022 transfer \
   <RECIPIENT_ADDRESS> \
   --confidential
 ```
+
+The account-specific commands use `--address` above to keep their target
+explicit. If you omit it, the CLI uses the owner's associated token account for
+the mint.
 
 Use `enable-confidential-credits`, `disable-confidential-credits`,
 `enable-non-confidential-credits`, and `disable-non-confidential-credits` to

--- a/apps/docs/content/docs/en/references/spl-token-cli.mdx
+++ b/apps/docs/content/docs/en/references/spl-token-cli.mdx
@@ -238,9 +238,11 @@ spl-token --program-2022 transfer \
   --confidential
 ```
 
-The account-specific commands use `--address` above to keep their target
-explicit. If you omit it, the CLI uses the owner's associated token account for
-the mint.
+For `configure-confidential-transfer-account` and `apply-pending-balance`, pass
+either `--address <TOKEN_ACCOUNT_ADDRESS>` or a positional `<MINT_ADDRESS>`, not
+both. The positional form uses the owner's associated token account. Deposit and
+withdrawal always take the mint and accept `--address` to override that default
+account.
 
 Use `enable-confidential-credits`, `disable-confidential-credits`,
 `enable-non-confidential-credits`, and `disable-non-confidential-credits` to

--- a/apps/docs/content/docs/en/references/spl-token-cli.mdx
+++ b/apps/docs/content/docs/en/references/spl-token-cli.mdx
@@ -216,7 +216,6 @@ confidential transfers and a configured recipient account.
 
 ```shell
 spl-token --program-2022 configure-confidential-transfer-account \
-  <MINT_ADDRESS> \
   --address <TOKEN_ACCOUNT_ADDRESS>
 
 spl-token --program-2022 deposit-confidential-tokens \
@@ -225,7 +224,6 @@ spl-token --program-2022 deposit-confidential-tokens \
   --address <TOKEN_ACCOUNT_ADDRESS>
 
 spl-token --program-2022 apply-pending-balance \
-  <MINT_ADDRESS> \
   --address <TOKEN_ACCOUNT_ADDRESS>
 
 spl-token --program-2022 withdraw-confidential-tokens \


### PR DESCRIPTION
## Summary

- add practical spl token and token 2022 workflows for mints, accounts, transfers, authorities, wrapped sol, multisig, and confidential balances
- document the global options and extension creation flags from spl token cli 5.6.1
- include every top level spl token command with a concise description
- add the reference to docs navigation