### PR TITLE
fix: blend image in the earth animation for safari

### DIFF
--- a/apps/web/src/app/[locale]/developers/migrate-to-solana/cosmos/developers-chain-migration-cosmos.tsx
+++ b/apps/web/src/app/[locale]/developers/migrate-to-solana/cosmos/developers-chain-migration-cosmos.tsx
@@ -154,7 +154,7 @@ export function DevelopersChainMigrationCosmosPage() {
 
       {/* Resources — identical to migrate-to-solana page */}
       <section className="relative overflow-hidden bg-nd-inverse text-nd-high-em-text text-left m-0 px-2">
-        <div className="max-w-[1828px] mx-auto rounded-xl overflow-hidden relative transform-gpu">
+        <div className="max-w-[1828px] mx-auto rounded-xl overflow-hidden relative">
           <UnicornScene
             projectId="cosmos-resources"
             className="!absolute inset-0 z-0"

--- a/apps/web/src/app/[locale]/developers/migrate-to-solana/developers-chain-migration.tsx
+++ b/apps/web/src/app/[locale]/developers/migrate-to-solana/developers-chain-migration.tsx
@@ -182,7 +182,7 @@ export function DevelopersChainMigrationPage() {
         id="resources"
         className="relative overflow-hidden bg-nd-inverse text-nd-high-em-text text-left m-0 px-2 scroll-mt-24"
       >
-        <div className="max-w-[1828px] mx-auto rounded-xl overflow-hidden relative transform-gpu">
+        <div className="max-w-[1828px] mx-auto rounded-xl overflow-hidden relative">
           <UnicornScene
             projectId="migration-resources"
             className="!absolute inset-0 z-0"

--- a/apps/web/src/app/[locale]/developers/migrate-to-solana/ethereum/developers-chain-migration-ethereum.tsx
+++ b/apps/web/src/app/[locale]/developers/migrate-to-solana/ethereum/developers-chain-migration-ethereum.tsx
@@ -188,7 +188,7 @@ export function DevelopersChainMigrationEthereumPage() {
       </div>
 
       <section className="relative overflow-hidden bg-nd-inverse text-nd-high-em-text text-left m-0 px-2">
-        <div className="max-w-[1828px] mx-auto rounded-xl overflow-hidden relative transform-gpu">
+        <div className="max-w-[1828px] mx-auto rounded-xl overflow-hidden relative">
           <UnicornScene
             projectId="ethereum-resources"
             className="!absolute inset-0 z-0"

--- a/apps/web/src/components/index/community.tsx
+++ b/apps/web/src/components/index/community.tsx
@@ -40,7 +40,7 @@ export const Community: React.FC<CommunityProps> = ({
 }) => {
   return (
     <section className="relative overflow-hidden bg-nd-inverse text-nd-high-em-text text-left m-0 px-2">
-      <div className="max-w-[1828px] mx-auto rounded-xl overflow-hidden relative transform-gpu">
+      <div className="max-w-[1828px] mx-auto rounded-xl overflow-hidden relative">
         {bgJsonFilePath && (
           <SafeUnicornScene
             projectId="community"


### PR DESCRIPTION
### Problem

<!-- What problem does this solve? Write enough that someone uninvolved can
     understand it six months from now — this feeds the auto-generated change
     log (SDLC §3.5.3). -->

Before

<img width="1312" height="590" alt="Screenshot 2026-08-28 at 16 26 07" src="https://github.com/user-attachments/assets/2bd6d67a-d621-41d0-843a-63f4e0bce7ad" />


After

<img width="1312" height="590" alt="Screenshot 2026-08-28 at 16 52 06" src="https://github.com/user-attachments/assets/c9ecc220-e3e1-4e7c-80ed-3b3496d0d129" />


### Summary of Changes

<!-- What changed and why. Call out anything security-relevant explicitly. -->

Fixed the blending of the earth lines with the background in Safari.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
