### PR TITLE
docs(breakpoint): update travel visa and ETA guidance

### DIFF
--- a/apps/breakpoint/src/components/FAQAnswer.tsx
+++ b/apps/breakpoint/src/components/FAQAnswer.tsx
@@ -1,5 +1,11 @@
 import type { FAQPageItem } from "@/content/faq-page";
-import { breakpointHref, getAnchorLinkProps } from "@/lib/links";
+import { localizedRoutePath } from "@/config";
+import { useLocale } from "@workspace/i18n/client";
+import {
+  breakpointHref,
+  getAnchorLinkProps,
+  isRelativeHref,
+} from "@/lib/links";
 
 type FAQAnswerProps = {
   className?: string;
@@ -10,8 +16,11 @@ export default function FAQAnswer({
   className = "type-paragraph text-white md:pr-2xl",
   item,
 }: FAQAnswerProps) {
+  const locale = useLocale();
   const resolvedHref = item.answerHref
-    ? breakpointHref(item.answerHref)
+    ? isRelativeHref(item.answerHref)
+      ? localizedRoutePath(locale, item.answerHref)
+      : breakpointHref(item.answerHref)
     : undefined;
 
   const answerText = item.answer?.trim() ?? "";

--- a/apps/breakpoint/src/components/pages/travel/TravelPage.tsx
+++ b/apps/breakpoint/src/components/pages/travel/TravelPage.tsx
@@ -15,6 +15,7 @@ import {
   HEATHROW_AIRPORT_HREF,
   IAS_HREF,
   LONDON_CITY_AIRPORT_HREF,
+  LOCUS_HREF,
   VISA_CHECK_HREF,
 } from "@/content/links";
 import { getAnchorLinkProps } from "@/lib/links";
@@ -45,6 +46,11 @@ const AIRPORTS = [
     href: GATWICK_AIRPORT_HREF,
     id: "lgw",
   },
+] as const;
+
+const VISA_SUPPORT_OPTIONS = [
+  { id: "locus", href: LOCUS_HREF },
+  { id: "ias", href: IAS_HREF },
 ] as const;
 
 function FlightsSection() {
@@ -116,7 +122,7 @@ function VisaSection() {
           </div>
           <div className="type-paragraph flex flex-col gap-8 text-white md:col-span-8 md:col-start-9">
             <div className="flex flex-col gap-4">
-              <h3 className="type-p-large text-white">{t("firstStep")}</h3>
+              <h3 className="type-p-large text-white">{t("checkVisaOrEta")}</h3>
               <p>
                 <a
                   href={VISA_CHECK_HREF}
@@ -124,24 +130,34 @@ function VisaSection() {
                   {...getAnchorLinkProps({ href: VISA_CHECK_HREF })}
                 >
                   {t("officialRequirements")}
-                </a>{" "}
-                {t("entrySuffix")}
+                </a>
               </p>
             </div>
             <div className="flex flex-col gap-4">
-              <h3 className="type-p-large text-white">{t("secondStep")}</h3>
-              <p>
-                {t("supportPrefix")}{" "}
-                <a
-                  href={IAS_HREF}
-                  className="text-purple underline decoration-purple underline-offset-4 transition-opacity hover:opacity-80"
-                  {...getAnchorLinkProps({ href: IAS_HREF })}
+              <h3 className="type-p-large text-white">{t("supportHeading")}</h3>
+              {VISA_SUPPORT_OPTIONS.map((option) => (
+                <div
+                  key={option.id}
+                  className="flex flex-col items-start gap-4 border-t border-neutral-700 pb-3 pt-6"
                 >
-                  {t("supportLink")}
-                </a>{" "}
-                {t("supportSuffix")}
-              </p>
+                  <h4 className="type-p-large-bold text-white">
+                    {t(`supportOptions.${option.id}.name`)}
+                  </h4>
+                  <p>{t(`supportOptions.${option.id}.description`)}</p>
+                  <Button
+                    arrow
+                    href={option.href}
+                    label={t(`supportOptions.${option.id}.ctaLabel`)}
+                    variant="inline"
+                  />
+                </div>
+              ))}
               <p>{t("fees")}</p>
+            </div>
+            <div className="flex flex-col gap-4 border-t border-neutral-700 pt-6">
+              <h3 className="type-p-large text-white">
+                {t("invitationHeading")}
+              </h3>
               <p>
                 {t("invitationPrefix")}{" "}
                 <a

--- a/apps/breakpoint/src/content/faq-page.ts
+++ b/apps/breakpoint/src/content/faq-page.ts
@@ -2,6 +2,7 @@ import {
   APPLY_TO_SPEAK_HREF,
   SPONSOR_FORM_HREF,
   TICKET_TRANSFER_HREF,
+  VISA_CHECK_HREF,
 } from "@/content/links";
 
 export type FAQPageItem = {
@@ -138,9 +139,10 @@ export const faqPageSections = [
       },
       {
         id: "travel-visa",
-        question: "Do I need a visa to attend?",
-        answer:
-          "Entry requirements depend on your passport and travel plans. Review the official UK visa checker before booking travel.",
+        question: "Do I need a visa or ETA to attend?",
+        answer: "",
+        answerHref: VISA_CHECK_HREF,
+        answerLinkLabel: "Check the official UK visa requirements for entry",
       },
       {
         id: "travel-invitation-letter",
@@ -157,9 +159,11 @@ export const faqPageSections = [
       },
       {
         id: "travel-visa-support",
-        question: "Can Solana Foundation help with visas?",
+        question: "How can I get visa or ETA application support?",
         answer:
-          "Attendees are responsible for their own visa process. Solana Foundation has engaged Immigration Advice Service for attendees who need paid visa support.",
+          "Locus can help attendees apply for a visa or ETA and pay by crypto or card. Solana Foundation has also engaged Immigration Advice Service (IAS) to assist with visa applications. Attendees are responsible for the cost of these services.",
+        answerHref: "/travel#visas",
+        answerLinkLabel: "View visa and ETA support options",
       },
     ],
   },

--- a/apps/breakpoint/src/content/links.ts
+++ b/apps/breakpoint/src/content/links.ts
@@ -28,5 +28,6 @@ export const HEATHROW_AIRPORT_HREF = "https://www.heathrow.com/";
 export const GATWICK_AIRPORT_HREF = "https://www.gatwickairport.com/";
 export const BREAKPOINT_EMAIL_HREF = "mailto:breakpoint@solana.org";
 export const VISA_CHECK_HREF = "https://www.gov.uk/check-uk-visa";
+export const LOCUS_HREF = "https://breakpoint.golocus.xyz/uk-entry";
 export const IAS_HREF =
   "https://iasservices.org.uk/breakpoint-priority-visa-application-centre/";

--- a/apps/breakpoint/src/content/page.ts
+++ b/apps/breakpoint/src/content/page.ts
@@ -154,14 +154,19 @@ export type BreakpointMessages = {
       headline: string;
       summary: string;
       checkRequirements: string;
-      firstStep: string;
+      checkVisaOrEta: string;
       officialRequirements: string;
-      entrySuffix: string;
-      secondStep: string;
-      supportPrefix: string;
-      supportLink: string;
-      supportSuffix: string;
+      supportHeading: string;
+      supportOptions: Record<
+        string,
+        {
+          name: string;
+          description: string;
+          ctaLabel: string;
+        }
+      >;
       fees: string;
+      invitationHeading: string;
       invitationPrefix: string;
       invitationLink: string;
       invitationSuffix: string;

--- a/apps/breakpoint/src/tests/FAQAnswer.test.tsx
+++ b/apps/breakpoint/src/tests/FAQAnswer.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { NextIntlClientProvider } from "@workspace/i18n/client";
+import { describe, expect, it } from "vitest";
+import FAQAnswer from "@/components/FAQAnswer";
+import messages from "../../../../packages/i18n/messages/breakpoint/en/breakpoint.json";
+
+describe("FAQAnswer", () => {
+  it("preserves the active locale for relative links", () => {
+    render(
+      <NextIntlClientProvider locale="es" messages={messages}>
+        <FAQAnswer
+          item={{
+            answer: "",
+            answerHref: "/travel#visas",
+            answerLinkLabel: "View visa and ETA support options",
+          }}
+        />
+      </NextIntlClientProvider>,
+    );
+
+    expect(
+      screen.getByRole("link", {
+        name: "View visa and ETA support options",
+      }),
+    ).toHaveAttribute("href", "/es/breakpoint/travel#visas");
+  });
+});

--- a/packages/i18n/messages/breakpoint/en/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/en/breakpoint.json
@@ -284,16 +284,25 @@
       "visas": {
         "headline": "Visas for London",
         "summary": "Attendees are responsible for reviewing entry requirements and arranging their own visas.",
-        "checkRequirements": "Check visa requirements",
-        "firstStep": "First, check if you need a visa",
-        "officialRequirements": "Check the official UK visa requirements",
-        "entrySuffix": "for entry.",
-        "secondStep": "Then, if you need support with a visa",
-        "supportPrefix": "Solana Foundation has engaged Immigration Advice Service (IAS) to assist you in this process. If you’re ready to apply, click",
-        "supportLink": "here",
-        "supportSuffix": "to get started.",
+        "checkRequirements": "Check visa or ETA requirements",
+        "checkVisaOrEta": "Check if you need a visa or ETA",
+        "officialRequirements": "Check the official UK visa requirements for entry.",
+        "supportHeading": "If you need support with your visa or ETA application",
+        "supportOptions": {
+          "locus": {
+            "name": "Locus",
+            "description": "Attendees can apply for a visa or ETA and pay by crypto or card.",
+            "ctaLabel": "Apply with Locus"
+          },
+          "ias": {
+            "name": "Immigration Advice Service (IAS)",
+            "description": "Solana Foundation has engaged IAS to assist attendees with the visa application process.",
+            "ctaLabel": "Apply for a visa here"
+          }
+        },
         "fees": "Please note Solana Foundation does not cover the cost of visa support and it’s up to the individual to pay for these services.",
-        "invitationPrefix": "Need an invitation letter? Please email",
+        "invitationHeading": "Need an invitation letter?",
+        "invitationPrefix": "Please email",
         "invitationLink": "breakpoint@solana.org",
         "invitationSuffix": "."
       },

--- a/packages/i18n/messages/breakpoint/en/breakpoint.json
+++ b/packages/i18n/messages/breakpoint/en/breakpoint.json
@@ -192,7 +192,7 @@
     "travel": {
       "metadata": {
         "title": "Travel",
-        "description": "Plan travel to Breakpoint 2026 in London with airport, hotel, visa, and local recommendations."
+        "description": "Plan travel to Breakpoint 2026 in London with airport, hotel, visa and ETA, and local recommendations."
       },
       "title": "Travel",
       "cta": "Get tickets",
@@ -200,7 +200,7 @@
         "label": "Travel sections",
         "flights": "Airports",
         "hotels": "Hotels",
-        "visas": "Visas"
+        "visas": "Visas & ETAs"
       },
       "flights": {
         "eyebrow": "Nearby airports",
@@ -282,8 +282,8 @@
         }
       },
       "visas": {
-        "headline": "Visas for London",
-        "summary": "Attendees are responsible for reviewing entry requirements and arranging their own visas.",
+        "headline": "Visas & ETAs for London",
+        "summary": "Attendees are responsible for reviewing entry requirements and arranging their own visas or ETAs.",
         "checkRequirements": "Check visa or ETA requirements",
         "checkVisaOrEta": "Check if you need a visa or ETA",
         "officialRequirements": "Check the official UK visa requirements for entry.",
@@ -476,8 +476,10 @@
               },
               {
                 "id": "travel-visa",
-                "question": "Do I need a visa to attend?",
-                "answer": "Entry requirements depend on your passport and travel plans. Review the official UK visa checker before booking travel."
+                "question": "Do I need a visa or ETA to attend?",
+                "answer": "",
+                "answerHref": "https://www.gov.uk/check-uk-visa",
+                "answerLinkLabel": "Check the official UK visa requirements for entry"
               },
               {
                 "id": "travel-invitation-letter",
@@ -493,8 +495,10 @@
               },
               {
                 "id": "travel-visa-support",
-                "question": "Can Solana Foundation help with visas?",
-                "answer": "Attendees are responsible for their own visa process. Solana Foundation has engaged Immigration Advice Service for attendees who need paid visa support."
+                "question": "How can I get visa or ETA application support?",
+                "answer": "Locus can help attendees apply for a visa or ETA and pay by crypto or card. Solana Foundation has also engaged Immigration Advice Service (IAS) to assist with visa applications. Attendees are responsible for the cost of these services.",
+                "answerHref": "/travel#visas",
+                "answerLinkLabel": "View visa and ETA support options"
               }
             ]
           }

--- a/packages/i18n/src/messages.test.ts
+++ b/packages/i18n/src/messages.test.ts
@@ -126,7 +126,7 @@ describe("@workspace/i18n messages", () => {
 
     expect(messages).toHaveProperty(
       "breakpoint.travel.visas.checkRequirements",
-      "Check visa requirements",
+      "Check visa or ETA requirements",
     );
     expect(messages).toHaveProperty(
       "breakpoint.pages.registration.heroTitle",


### PR DESCRIPTION
## Problem

Breakpoint attendees need clearer travel guidance because UK entry may require either a visa or an ETA, and the old copy only talked about visas.

## Solution

Update the Breakpoint travel and FAQ content to say “visa or ETA,” link to the official UK checker, and add Locus as another paid support option alongside IAS.

## Testing

TODO: Not run.

### Summary of Changes

- Updated Breakpoint travel page visa copy to include ETAs.
- Added Locus as a visa and ETA support option.
- Updated FAQ entries and localized Breakpoint messages.
- Added the Locus support link constant.

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

none

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

n/a

-->