### PR TITLE
refactor(web): use provider-neutral Solana RPC config

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -35,7 +35,7 @@ RPC_LATENCY_GRAFANA_API_TOKEN=
 # RWA.xyz API
 RWA_XYZ_API_TOKEN=
 
-HELIUS_API_KEY=
+# Full RPC endpoint; any provider is supported.
 SOLANA_RPC_URL=
 
 # University Ambassador application (empty sheets initialize response headers on first submission)

--- a/apps/web/scripts/build-validator-meta.mjs
+++ b/apps/web/scripts/build-validator-meta.mjs
@@ -7,7 +7,7 @@
 //
 // Run manually when the snapshot gets stale:
 //   node apps/web/scripts/build-validator-meta.mjs
-// Uses HELIUS_API_KEY when set, else the public mainnet RPC.
+// Uses SOLANA_RPC_URL when set, else the public mainnet RPC.
 import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -16,9 +16,7 @@ const OUT = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
   "../src/data/slot200/validator-meta.json",
 );
-const RPC = process.env.HELIUS_API_KEY
-  ? `https://mainnet.helius-rpc.com/?api-key=${process.env.HELIUS_API_KEY}`
-  : (process.env.SOLANA_RPC_URL ?? "https://api.mainnet-beta.solana.com");
+const RPC = process.env.SOLANA_RPC_URL ?? "https://api.mainnet-beta.solana.com";
 
 async function rpc(method, params = []) {
   const res = await fetch(RPC, {

--- a/apps/web/src/lib/epoch1000/solana.ts
+++ b/apps/web/src/lib/epoch1000/solana.ts
@@ -6,8 +6,6 @@ export const TARGET_EPOCH = 1000;
 export { isValidSolanaAddress };
 
 function rpcUrl(): string {
-  const key = process.env.HELIUS_API_KEY;
-  if (key) return `https://mainnet.helius-rpc.com/?api-key=${key}`;
   // Local/dev fallback — public RPC is rate-limited, fine for getEpochInfo
   return process.env.SOLANA_RPC_URL ?? "https://api.mainnet-beta.solana.com";
 }

--- a/apps/web/src/lib/slot200/rpc.ts
+++ b/apps/web/src/lib/slot200/rpc.ts
@@ -8,8 +8,9 @@ function rpcUrl(): string {
 
 /** WebSocket endpoint matching rpcUrl(), for slotSubscribe. */
 export function rpcWsUrl(): string {
-  const custom = process.env.SOLANA_RPC_URL;
-  if (custom) return custom.replace(/^http/, "ws");
+  // Most providers use the same endpoint for HTTP and WebSocket transport.
+  const rpcUrl = process.env.SOLANA_RPC_URL;
+  if (rpcUrl) return rpcUrl.replace(/^http/, "ws");
   return "wss://api.mainnet-beta.solana.com";
 }
 

--- a/apps/web/src/lib/slot200/rpc.ts
+++ b/apps/web/src/lib/slot200/rpc.ts
@@ -2,16 +2,12 @@ const DEFAULT_SLOT_MS = 400;
 const RPC_TIMEOUT_MS = 10_000;
 
 function rpcUrl(): string {
-  const key = process.env.HELIUS_API_KEY;
-  if (key) return `https://mainnet.helius-rpc.com/?api-key=${key}`;
   // Local/dev fallback — public RPC is rate-limited, fine for these light calls
   return process.env.SOLANA_RPC_URL ?? "https://api.mainnet-beta.solana.com";
 }
 
 /** WebSocket endpoint matching rpcUrl(), for slotSubscribe. */
 export function rpcWsUrl(): string {
-  const key = process.env.HELIUS_API_KEY;
-  if (key) return `wss://mainnet.helius-rpc.com/?api-key=${key}`;
   const custom = process.env.SOLANA_RPC_URL;
   if (custom) return custom.replace(/^http/, "ws");
   return "wss://api.mainnet-beta.solana.com";

--- a/turbo.json
+++ b/turbo.json
@@ -47,7 +47,6 @@
       "passThroughEnv": [
         "CI",
         "DATABRICKS_TOKEN",
-        "HELIUS_API_KEY",
         "INKEEP_API_KEY",
         "LUMA_PRIVATE_API_KEY",
         "RPC_LATENCY_GRAFANA_API_TOKEN",


### PR DESCRIPTION
## Problem

The web app had special handling for one branded RPC provider through `HELIUS_API_KEY`. That made RPC setup more confusing because the app also supports a full `SOLANA_RPC_URL`.

## Solution

Use `SOLANA_RPC_URL` as the single RPC configuration value for the affected web app code paths. The validator metadata script, epoch 1000 helper, Slot 200 HTTP RPC, and Slot 200 WebSocket RPC now use the provider-neutral URL setting with the public Solana mainnet RPC as the fallback.

Removed `HELIUS_API_KEY` from the example environment file and Turbo pass-through environment list.

## Testing

TODO

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->