### PR TITLE
chore(env): remove stale app env key references

### DIFF
--- a/apps/docs/CLAUDE.md
+++ b/apps/docs/CLAUDE.md
@@ -159,12 +159,6 @@ documentation pages. Inkeep feedback uses a server action under
 - Sentry integration for error tracking
 - Fumadocs MDX processing runs on postinstall
 
-## Environment Variables
-
-- `DEVELOPER_CONTENT_API_KEY` - Content API access
-- `DEVELOPER_DATA_API_KEY` - Data API access
-- `DEVELOPER_DATA_API_URL` - Data API endpoint
-
 ## Content Conventions
 
 ### MDX Frontmatter

--- a/apps/templates/CLAUDE.md
+++ b/apps/templates/CLAUDE.md
@@ -115,7 +115,7 @@ Allowed remote image sources:
 
 ## Environment Variables
 
-- `TEMPLATES_APP_URL` - Base URL for the templates app
+- `NEXT_PUBLIC_TEMPLATES_APP_URL` - Base URL for the templates app
 - Standard shared env vars from root turbo.json
 
 ## Build Configuration

--- a/apps/web/apps-urls.ts
+++ b/apps/web/apps-urls.ts
@@ -31,7 +31,7 @@ const vercelTemplatesUrl = withRelatedProject({
 });
 const developmentTemplatesUrl = "http://localhost:3001";
 
-export const TEMPLATES_APP_URL =
+export const templatesAppUrl =
   process.env.NEXT_PUBLIC_TEMPLATES_APP_URL ||
   (process.env.NODE_ENV === "production"
     ? vercelTemplatesUrl
@@ -65,6 +65,6 @@ export const BREAKPOINT_APP_URL =
 
 console.log("MEDIA_APP_URL", MEDIA_APP_URL);
 console.log("DOCS_APP_URL", DOCS_APP_URL);
-console.log("TEMPLATES_APP_URL", TEMPLATES_APP_URL);
+console.log("templatesAppUrl", templatesAppUrl);
 console.log("ACCELERATE_APP_URL", ACCELERATE_APP_URL);
 console.log("BREAKPOINT_APP_URL", BREAKPOINT_APP_URL);

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -92,18 +92,6 @@ const nextConfig: NextConfig = {
       fallback: Rewrite[];
     };
 
-    // TODO: In production, add rewrite for /templates/* to templates app
-    // This allows the templates app to be deployed separately while maintaining
-    // the same domain for SEO and UX (prefetching, etc.)
-    // Example:
-    // if (process.env.TEMPLATES_APP_URL) {
-    //   baseRewrites.beforeFiles.push({
-    //     source: '/templates/:path*',
-    //     destination: `${process.env.TEMPLATES_APP_URL}/:path*`,
-    //     locale: false,
-    //   });
-    // }
-
     return baseRewrites;
   },
 

--- a/apps/web/rewrites-redirects.ts
+++ b/apps/web/rewrites-redirects.ts
@@ -1,7 +1,7 @@
 import {
   MEDIA_APP_URL,
   DOCS_APP_URL,
-  TEMPLATES_APP_URL,
+  templatesAppUrl,
   ACCELERATE_APP_URL,
   BREAKPOINT_APP_URL,
 } from "./apps-urls";
@@ -541,7 +541,7 @@ export default {
       // Templates app assets (required for static assets with assetPrefix: "/templates-assets")
       {
         source: "/templates-assets/:path+",
-        destination: `${TEMPLATES_APP_URL}/templates-assets/:path+`,
+        destination: `${templatesAppUrl}/templates-assets/:path+`,
         locale: false,
       },
       // Accelerate app rewrites
@@ -585,12 +585,12 @@ export default {
       // Templates app rewrites (must come before general /developers rewrites)
       {
         source: "/developers/templates",
-        destination: `${TEMPLATES_APP_URL}/developers/templates`,
+        destination: `${templatesAppUrl}/developers/templates`,
         locale: false,
       },
       {
         source: "/developers/templates/:path*",
-        destination: `${TEMPLATES_APP_URL}/developers/templates/:path*`,
+        destination: `${templatesAppUrl}/developers/templates/:path*`,
         locale: false,
       },
       // Docs app assets (required for static assets with assetPrefix: "/docs-assets")

--- a/apps/web/src/__tests__/routes/app-rewrites.test.ts
+++ b/apps/web/src/__tests__/routes/app-rewrites.test.ts
@@ -4,7 +4,7 @@ import {
   BREAKPOINT_APP_URL,
   DOCS_APP_URL,
   MEDIA_APP_URL,
-  TEMPLATES_APP_URL,
+  templatesAppUrl,
 } from "@@/apps-urls";
 import rewritesAndRedirects from "@@/rewrites-redirects";
 
@@ -62,7 +62,7 @@ describe("Cross-app rewrites", () => {
     );
     expectBeforeFileRewrite(
       "/developers/templates/:path*",
-      `${TEMPLATES_APP_URL}/developers/templates/:path*`,
+      `${templatesAppUrl}/developers/templates/:path*`,
     );
     expectBeforeFileRewrite(
       "/accelerate/:path*",
@@ -106,7 +106,7 @@ describe("Cross-app rewrites", () => {
     );
     expectBeforeFileRewrite(
       "/templates-assets/:path+",
-      `${TEMPLATES_APP_URL}/templates-assets/:path+`,
+      `${templatesAppUrl}/templates-assets/:path+`,
     );
     expectBeforeFileRewrite(
       "/accelerate-assets/_next/:path+",


### PR DESCRIPTION
## Problem
Some environment variable docs and comments still pointed to old or unused keys. That makes it harder to know which keys are actually needed.

## Solution
Removed stale docs app env key references, updated the templates app docs to use `NEXT_PUBLIC_TEMPLATES_APP_URL`, and renamed the web templates app URL export so it no longer looks like an env variable name.

## Testing
TODO: Not run.

### Summary of Changes

- Removed unused docs app environment variable references from `apps/docs/CLAUDE.md`.
- Updated templates app documentation from `TEMPLATES_APP_URL` to `NEXT_PUBLIC_TEMPLATES_APP_URL`.
- Renamed the web templates URL constant from `TEMPLATES_APP_URL` to `templatesAppUrl` and updated rewrites/tests that consume it.
- Removed a stale commented rewrite example that referenced `process.env.TEMPLATES_APP_URL`.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

none

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

n/a

-->