### PR TITLE
fix: repair flaky i18n test and patch 2 high-severity CVEs

### DIFF
--- a/packages/i18n/src/messages.test.ts
+++ b/packages/i18n/src/messages.test.ts
@@ -118,19 +118,24 @@ describe("@workspace/i18n messages", () => {
     expect(messages).toHaveProperty("cookie-consent");
   });
 
-  it("falls back to English for new Breakpoint route messages", async () => {
-    const messages = await loadMergedMessages({
-      app: "breakpoint",
-      locale: "es",
-    });
+  it("falls back to English for new Breakpoint route messages", () => {
+    // Uses synthetic data rather than the live breakpoint catalog: a key
+    // that's still untranslated today has no guarantee of staying that way
+    // as translators catch up, which would make this test flaky over time.
+    const messages = deepMergeMessages(
+      {
+        breakpoint: {
+          travel: {
+            visas: { checkRequirements: "Check visa or ETA requirements" },
+          },
+        },
+      },
+      { breakpoint: { travel: { visas: {} } } },
+    );
 
     expect(messages).toHaveProperty(
       "breakpoint.travel.visas.checkRequirements",
       "Check visa or ETA requirements",
-    );
-    expect(messages).toHaveProperty(
-      "breakpoint.pages.registration.heroTitle",
-      "Snag Breakpoint 2026 tickets",
     );
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,8 @@ overrides:
   glob@9.3.5>minimatch: 9.0.7
   sharp@<0.35.0: 0.35.3
   thrift@0.23.0>uuid: 11.1.1
+  browserslist@<=4.28.6: 4.28.8
+  jsondiffpatch@<0.7.6: 0.7.6
 
 importers:
   .:
@@ -3206,6 +3208,12 @@ packages:
         integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==,
       }
     engines: { node: ">=10.0.0" }
+
+  "@dmsnell/diff-match-patch@1.1.0":
+    resolution:
+      {
+        integrity: sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==,
+      }
 
   "@emnapi/runtime@1.11.2":
     resolution:
@@ -9405,12 +9413,6 @@ packages:
         integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
       }
 
-  "@types/diff-match-patch@1.0.36":
-    resolution:
-      {
-        integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==,
-      }
-
   "@types/eslint-scope@3.7.7":
     resolution:
       {
@@ -10673,10 +10675,10 @@ packages:
         integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
       }
 
-  baseline-browser-mapping@2.10.43:
+  baseline-browser-mapping@2.11.20:
     resolution:
       {
-        integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==,
+        integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==,
       }
     engines: { node: ">=6.0.0" }
     hasBin: true
@@ -10778,18 +10780,10 @@ packages:
         integrity: sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==,
       }
 
-  browserslist@4.25.4:
+  browserslist@4.28.8:
     resolution:
       {
-        integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==,
-      }
-    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
-    hasBin: true
-
-  browserslist@4.28.6:
-    resolution:
-      {
-        integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==,
+        integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==,
       }
     engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
@@ -10912,6 +10906,12 @@ packages:
     resolution:
       {
         integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==,
+      }
+
+  caniuse-lite@1.0.30001810:
+    resolution:
+      {
+        integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==,
       }
 
   ccount@2.0.1:
@@ -12008,12 +12008,6 @@ packages:
         integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==,
       }
 
-  diff-match-patch@1.0.5:
-    resolution:
-      {
-        integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==,
-      }
-
   diff@4.0.2:
     resolution:
       {
@@ -12142,16 +12136,10 @@ packages:
         integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==,
       }
 
-  electron-to-chromium@1.5.215:
+  electron-to-chromium@1.5.418:
     resolution:
       {
-        integrity: sha512-TIvGp57UpeNetj/wV/xpFNpWGb0b/ROw372lHPx5Aafx02gjTBtWnEEcaSX3W2dLM3OSdGGyHX/cHl01JQsLaQ==,
-      }
-
-  electron-to-chromium@1.5.393:
-    resolution:
-      {
-        integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==,
+        integrity: sha512-UzS26r3AEbG5wSoGVpJKqwHIU9zwQN7LHdVIThDrJpS0I5KdlXFMEb8543fhc9dVnIIAST6ar8rhwa00AL5MlA==,
       }
 
   emery@1.4.4:
@@ -14295,10 +14283,10 @@ packages:
     engines: { node: ">=6" }
     hasBin: true
 
-  jsondiffpatch@0.6.0:
+  jsondiffpatch@0.7.6:
     resolution:
       {
-        integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==,
+        integrity: sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==,
       }
     engines: { node: ^18.0.0 || >=20.0.0 }
     hasBin: true
@@ -15509,16 +15497,10 @@ packages:
         integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==,
       }
 
-  node-releases@2.0.20:
+  node-releases@2.0.54:
     resolution:
       {
-        integrity: sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==,
-      }
-
-  node-releases@2.0.51:
-    resolution:
-      {
-        integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==,
+        integrity: sha512-YHs7BmmcsdAI5Ozuf8JZo6PT0mv2GIWC9vMfvUC3dp65M8hn7Ux8CPL+2oBI7juNuj9d0ndhTcznq2ODBps9cQ==,
       }
     engines: { node: ">=18" }
 
@@ -18813,23 +18795,14 @@ packages:
         integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==,
       }
 
-  update-browserslist-db@1.1.3:
+  update-browserslist-db@1.3.2:
     resolution:
       {
-        integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==,
+        integrity: sha512-UQ+MSxlhRm1bzjhU+DcuXfjFO1FzNtqhK5+9Yvlp90ItDLk5vT932A0rFu619nf7RVS+Y/VeaUW1jaRDqZ8VJw==,
       }
     hasBin: true
     peerDependencies:
-      browserslist: ">= 4.21.0"
-
-  update-browserslist-db@1.2.3:
-    resolution:
-      {
-        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
-      }
-    hasBin: true
-    peerDependencies:
-      browserslist: ">= 4.21.0"
+      browserslist: 4.28.8
 
   uri-js@4.4.1:
     resolution:
@@ -19792,7 +19765,7 @@ snapshots:
     dependencies:
       "@babel/compat-data": 7.28.4
       "@babel/helper-validator-option": 7.27.1
-      browserslist: 4.25.4
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -20896,6 +20869,8 @@ snapshots:
       unist-util-visit: 5.1.0
 
   "@discoveryjs/json-ext@0.5.7": {}
+
+  "@dmsnell/diff-match-patch@1.1.0": {}
 
   "@emnapi/runtime@1.11.2":
     dependencies:
@@ -25594,8 +25569,6 @@ snapshots:
 
   "@types/deep-eql@4.0.2": {}
 
-  "@types/diff-match-patch@1.0.36": {}
-
   "@types/eslint-scope@3.7.7":
     dependencies:
       "@types/eslint": 9.6.1
@@ -26267,7 +26240,7 @@ snapshots:
       "@ai-sdk/react": 1.2.12(react@19.2.6)(zod@4.4.3)
       "@ai-sdk/ui-utils": 1.2.11(zod@4.4.3)
       "@opentelemetry/api": 1.9.0
-      jsondiffpatch: 0.6.0
+      jsondiffpatch: 0.7.6
       zod: 4.4.3
     optionalDependencies:
       react: 19.2.6
@@ -26440,7 +26413,7 @@ snapshots:
 
   autoprefixer@10.5.0(postcss@8.5.18):
     dependencies:
-      browserslist: 4.28.6
+      browserslist: 4.28.8
       caniuse-lite: 1.0.30001793
       fraction.js: 5.3.4
       picocolors: 1.1.1
@@ -26499,7 +26472,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.43: {}
+  baseline-browser-mapping@2.11.20: {}
 
   basic-ftp@5.3.1: {}
 
@@ -26549,20 +26522,13 @@ snapshots:
 
   browser-or-node@1.3.0: {}
 
-  browserslist@4.25.4:
+  browserslist@4.28.8:
     dependencies:
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.215
-      node-releases: 2.0.20
-      update-browserslist-db: 1.1.3(browserslist@4.25.4)
-
-  browserslist@4.28.6:
-    dependencies:
-      baseline-browser-mapping: 2.10.43
-      caniuse-lite: 1.0.30001806
-      electron-to-chromium: 1.5.393
-      node-releases: 2.0.51
-      update-browserslist-db: 1.2.3(browserslist@4.28.6)
+      baseline-browser-mapping: 2.11.20
+      caniuse-lite: 1.0.30001810
+      electron-to-chromium: 1.5.418
+      node-releases: 2.0.54
+      update-browserslist-db: 1.3.2(browserslist@4.28.8)
 
   bs58@4.0.1:
     dependencies:
@@ -26634,6 +26600,8 @@ snapshots:
   caniuse-lite@1.0.30001793: {}
 
   caniuse-lite@1.0.30001806: {}
+
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -26846,7 +26814,7 @@ snapshots:
 
   core-js-compat@3.45.1:
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.28.8
 
   core-js@3.45.1: {}
 
@@ -27247,8 +27215,6 @@ snapshots:
 
   didyoumean@1.2.2: {}
 
-  diff-match-patch@1.0.5: {}
-
   diff@4.0.2: {}
 
   diff@5.2.0: {}
@@ -27314,9 +27280,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  electron-to-chromium@1.5.215: {}
-
-  electron-to-chromium@1.5.393: {}
+  electron-to-chromium@1.5.418: {}
 
   emery@1.4.4: {}
 
@@ -28790,11 +28754,9 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsondiffpatch@0.6.0:
+  jsondiffpatch@0.7.6:
     dependencies:
-      "@types/diff-match-patch": 1.0.36
-      chalk: 5.6.2
-      diff-match-patch: 1.0.5
+      "@dmsnell/diff-match-patch": 1.1.0
 
   jsonp@0.2.1:
     dependencies:
@@ -29744,9 +29706,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.20: {}
-
-  node-releases@2.0.51: {}
+  node-releases@2.0.54: {}
 
   nopt@7.2.1:
     dependencies:
@@ -30300,7 +30260,7 @@ snapshots:
       "@csstools/postcss-trigonometric-functions": 4.0.9(postcss@8.5.18)
       "@csstools/postcss-unset-value": 4.0.0(postcss@8.5.18)
       autoprefixer: 10.5.0(postcss@8.5.18)
-      browserslist: 4.25.4
+      browserslist: 4.28.8
       css-blank-pseudo: 7.0.1(postcss@8.5.18)
       css-has-pseudo: 7.0.3(postcss@8.5.18)
       css-prefers-color-scheme: 10.0.0(postcss@8.5.18)
@@ -32047,15 +32007,9 @@ snapshots:
       webpack-sources: 3.3.3
       webpack-virtual-modules: 0.5.0
 
-  update-browserslist-db@1.1.3(browserslist@4.25.4):
+  update-browserslist-db@1.3.2(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.25.4
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.6):
-    dependencies:
-      browserslist: 4.28.6
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -32298,7 +32252,7 @@ snapshots:
       "@webassemblyjs/wasm-parser": 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.6
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.22.0
       es-module-lexer: 1.7.0
@@ -32339,7 +32293,7 @@ snapshots:
       "@webassemblyjs/wasm-parser": 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.6
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.22.0
       es-module-lexer: 1.7.0
@@ -32380,7 +32334,7 @@ snapshots:
       "@webassemblyjs/wasm-parser": 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.6
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.22.0
       es-module-lexer: 1.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,6 +51,13 @@ overrides:
   # @databricks/sql 2 requires Thrift's UUID dependency to remain CJS-compatible.
   # Package-level overrides are not inherited by pnpm consumers.
   "thrift@0.23.0>uuid": 11.1.1
+  # Keep transitive browserslist consumers (webpack, via @mdx-js/loader,
+  # @next/mdx, and @sentry/nextjs's webpack plugin) on the release patched for
+  # GHSA-c83g-rgw3-j3cx and GHSA-73wf-gq98-2v4g.
+  "browserslist@<=4.28.6": 4.28.8
+  # ai (a direct dependency of apps/docs) pulls jsondiffpatch 0.6.0; keep it
+  # on the release patched for GHSA-j4fx-xxwh-2485 (prototype pollution).
+  "jsondiffpatch@<0.7.6": 0.7.6
 
 auditConfig:
   ignoreGhsas:


### PR DESCRIPTION
## Summary

Two CI failures I found while verifying an unrelated PR, unrelated to any specific feature work:

- **`@workspace/i18n`'s flaky test**: "falls back to English for new Breakpoint route messages" asserted hardcoded English strings against the live Breakpoint content catalog for two keys that, when the test was written, hadn't been translated into Spanish yet. Both have since been fully translated (Spanish now has 100% parity with English for Breakpoint), so the test's fixture assumption went stale and started failing correctly, since the real message is now the Spanish string rather than the English fallback. Rewrote it to use synthetic data via `deepMergeMessages` directly, matching the pattern the two sibling tests in this same file already use, so it verifies the same fallback mechanism without depending on the live catalog's translation completeness at any given time (which will only keep changing as translators catch up).
- **`pnpm audit --audit-level high --prod`** (the exact command CI runs) was failing on:
  - `GHSA-c83g-rgw3-j3cx` / `GHSA-73wf-gq98-2v4g` (`browserslist`, transitive via webpack in every app)
  - `GHSA-j4fx-xxwh-2485` (`jsondiffpatch`, a direct dependency of the `ai` package `apps/docs` uses)

  Added `pnpm.overrides` entries pinning both to their patched releases, matching the existing pattern in this file for `esbuild`/`postcss`/`nanoid`/etc. Verified the resulting lockfile diff touches only these two packages' own dependency subtrees, no unrelated version bumps.

## Test plan

- [x] `pnpm audit --audit-level high --prod` exits 0 (was exit 1)
- [x] `pnpm exec turbo run test --filter='!@workspace/docs-examples'` is 9/9 green (was failing on `@workspace/i18n#test`)
- [x] Full monorepo `check-types`: 15/15 clean
- [x] Full monorepo `lint`: 13/13 clean (pre-existing warnings only, 0 errors)
- [x] Confirmed the lockfile diff is scoped to `browserslist`/`jsondiffpatch`'s own dependency trees only