### PR TITLE
fix(docs): update ai audit patches

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -32,7 +32,7 @@
     "@vercel/og": "^0.8.6",
     "@workspace/i18n": "workspace:*",
     "@workspace/sentry": "workspace:*",
-    "ai": "^4.1.66",
+    "ai": "^4.3.19",
     "cheerio": "^1.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,7 @@ overrides:
   glob@9.3.5>minimatch: 9.0.7
   sharp@<0.35.0: 0.35.3
   thrift@0.23.0>uuid: 11.1.1
+  ai>jsondiffpatch: 0.7.6
 
 importers:
   .:
@@ -358,7 +359,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/sentry
       ai:
-        specifier: ^4.1.66
+        specifier: ^4.3.19
         version: 4.3.19(react@19.2.6)(zod@4.4.3)
       cheerio:
         specifier: ^1.0.0
@@ -3206,6 +3207,12 @@ packages:
         integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==,
       }
     engines: { node: ">=10.0.0" }
+
+  "@dmsnell/diff-match-patch@1.1.0":
+    resolution:
+      {
+        integrity: sha512-yejLPmM5pjsGvxS9gXablUSbInW7H976c/FJ4iQxWIm7/38xBySRemTPDe34lhg1gVLbJntX0+sH0jYfU+PN9A==,
+      }
 
   "@emnapi/runtime@1.11.2":
     resolution:
@@ -9405,12 +9412,6 @@ packages:
         integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==,
       }
 
-  "@types/diff-match-patch@1.0.36":
-    resolution:
-      {
-        integrity: sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==,
-      }
-
   "@types/eslint-scope@3.7.7":
     resolution:
       {
@@ -10673,10 +10674,10 @@ packages:
         integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
       }
 
-  baseline-browser-mapping@2.10.43:
+  baseline-browser-mapping@2.11.20:
     resolution:
       {
-        integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==,
+        integrity: sha512-H0ulySigv6icDJ1F7SjtdCD6PrhTpdYCmP0CactWy1+ekh0AFd0o1Wn5T8b+hnTmdBx19u9yhL6wvCylXMY7zw==,
       }
     engines: { node: ">=6.0.0" }
     hasBin: true
@@ -10778,18 +10779,10 @@ packages:
         integrity: sha512-0F2z/VSnLbmEeBcUrSuDH5l0HxTXdQQzLjkmBR4cYfvg1zJrKSlmIZFqyFR8oX0NrwPhy3c3HQ6i3OxMbew4Tg==,
       }
 
-  browserslist@4.25.4:
+  browserslist@4.28.7:
     resolution:
       {
-        integrity: sha512-4jYpcjabC606xJ3kw2QwGEZKX0Aw7sgQdZCvIK9dhVSPh76BKo+C+btT1RRofH7B+8iNpEbgGNVWiLki5q93yg==,
-      }
-    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
-    hasBin: true
-
-  browserslist@4.28.6:
-    resolution:
-      {
-        integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==,
+        integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==,
       }
     engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
@@ -12008,12 +12001,6 @@ packages:
         integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==,
       }
 
-  diff-match-patch@1.0.5:
-    resolution:
-      {
-        integrity: sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==,
-      }
-
   diff@4.0.2:
     resolution:
       {
@@ -12140,12 +12127,6 @@ packages:
     resolution:
       {
         integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==,
-      }
-
-  electron-to-chromium@1.5.215:
-    resolution:
-      {
-        integrity: sha512-TIvGp57UpeNetj/wV/xpFNpWGb0b/ROw372lHPx5Aafx02gjTBtWnEEcaSX3W2dLM3OSdGGyHX/cHl01JQsLaQ==,
       }
 
   electron-to-chromium@1.5.393:
@@ -12743,10 +12724,10 @@ packages:
         integrity: sha512-wpYMUmFu5f00Sm0cj2pfivpmawLZ0NKdviQ4w9zJeR8JVtOpOxHmLaJuj0vxvGqMJQWyP/COUkF75/57OKyRag==,
       }
 
-  fast-uri@3.1.5:
+  fast-uri@3.1.6:
     resolution:
       {
-        integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==,
+        integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==,
       }
 
   fastestsmallesttextencoderdecoder@1.0.22:
@@ -14295,10 +14276,10 @@ packages:
     engines: { node: ">=6" }
     hasBin: true
 
-  jsondiffpatch@0.6.0:
+  jsondiffpatch@0.7.6:
     resolution:
       {
-        integrity: sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==,
+        integrity: sha512-zE9+AXFq+MkTolDor2Cw1nJzLC0aleqPkYf52Kb4Kn4mJcka/gFHpGI2JBVEJCfWOvBl0OoxZS+wuLdislQcqg==,
       }
     engines: { node: ^18.0.0 || >=20.0.0 }
     hasBin: true
@@ -15507,12 +15488,6 @@ packages:
     resolution:
       {
         integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==,
-      }
-
-  node-releases@2.0.20:
-    resolution:
-      {
-        integrity: sha512-7gK6zSXEH6neM212JgfYFXe+GmZQM+fia5SsusuBIUgnPheLFBmIPhtFoAQRj8/7wASYQnbDlHPVwY0BefoFgA==,
       }
 
   node-releases@2.0.51:
@@ -18813,15 +18788,6 @@ packages:
         integrity: sha512-aqrHaVBWW1JVKBHmGo33T5TxeL0qWzfvjWokObHA9bYmN7eNDkwOxmLjhioHl9878qDFMAaT51XNroRyuz7WxA==,
       }
 
-  update-browserslist-db@1.1.3:
-    resolution:
-      {
-        integrity: sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==,
-      }
-    hasBin: true
-    peerDependencies:
-      browserslist: ">= 4.21.0"
-
   update-browserslist-db@1.2.3:
     resolution:
       {
@@ -18829,7 +18795,7 @@ packages:
       }
     hasBin: true
     peerDependencies:
-      browserslist: ">= 4.21.0"
+      browserslist: 4.28.7
 
   uri-js@4.4.1:
     resolution:
@@ -19792,7 +19758,7 @@ snapshots:
     dependencies:
       "@babel/compat-data": 7.28.4
       "@babel/helper-validator-option": 7.27.1
-      browserslist: 4.25.4
+      browserslist: 4.28.7
       lru-cache: 5.1.1
       semver: 6.3.1
 
@@ -20896,6 +20862,8 @@ snapshots:
       unist-util-visit: 5.1.0
 
   "@discoveryjs/json-ext@0.5.7": {}
+
+  "@dmsnell/diff-match-patch@1.1.0": {}
 
   "@emnapi/runtime@1.11.2":
     dependencies:
@@ -25594,8 +25562,6 @@ snapshots:
 
   "@types/deep-eql@4.0.2": {}
 
-  "@types/diff-match-patch@1.0.36": {}
-
   "@types/eslint-scope@3.7.7":
     dependencies:
       "@types/eslint": 9.6.1
@@ -26267,7 +26233,7 @@ snapshots:
       "@ai-sdk/react": 1.2.12(react@19.2.6)(zod@4.4.3)
       "@ai-sdk/ui-utils": 1.2.11(zod@4.4.3)
       "@opentelemetry/api": 1.9.0
-      jsondiffpatch: 0.6.0
+      jsondiffpatch: 0.7.6
       zod: 4.4.3
     optionalDependencies:
       react: 19.2.6
@@ -26291,7 +26257,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -26440,7 +26406,7 @@ snapshots:
 
   autoprefixer@10.5.0(postcss@8.5.18):
     dependencies:
-      browserslist: 4.28.6
+      browserslist: 4.28.7
       caniuse-lite: 1.0.30001793
       fraction.js: 5.3.4
       picocolors: 1.1.1
@@ -26499,7 +26465,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.43: {}
+  baseline-browser-mapping@2.11.20: {}
 
   basic-ftp@5.3.1: {}
 
@@ -26549,20 +26515,13 @@ snapshots:
 
   browser-or-node@1.3.0: {}
 
-  browserslist@4.25.4:
+  browserslist@4.28.7:
     dependencies:
-      caniuse-lite: 1.0.30001793
-      electron-to-chromium: 1.5.215
-      node-releases: 2.0.20
-      update-browserslist-db: 1.1.3(browserslist@4.25.4)
-
-  browserslist@4.28.6:
-    dependencies:
-      baseline-browser-mapping: 2.10.43
+      baseline-browser-mapping: 2.11.20
       caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.393
       node-releases: 2.0.51
-      update-browserslist-db: 1.2.3(browserslist@4.28.6)
+      update-browserslist-db: 1.2.3(browserslist@4.28.7)
 
   bs58@4.0.1:
     dependencies:
@@ -26846,7 +26805,7 @@ snapshots:
 
   core-js-compat@3.45.1:
     dependencies:
-      browserslist: 4.25.4
+      browserslist: 4.28.7
 
   core-js@3.45.1: {}
 
@@ -27247,8 +27206,6 @@ snapshots:
 
   didyoumean@1.2.2: {}
 
-  diff-match-patch@1.0.5: {}
-
   diff@4.0.2: {}
 
   diff@5.2.0: {}
@@ -27313,8 +27270,6 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
-
-  electron-to-chromium@1.5.215: {}
 
   electron-to-chromium@1.5.393: {}
 
@@ -27798,7 +27753,7 @@ snapshots:
 
   fast-stable-stringify@1.0.0: {}
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fastestsmallesttextencoderdecoder@1.0.22: {}
 
@@ -28790,11 +28745,9 @@ snapshots:
 
   json5@2.2.3: {}
 
-  jsondiffpatch@0.6.0:
+  jsondiffpatch@0.7.6:
     dependencies:
-      "@types/diff-match-patch": 1.0.36
-      chalk: 5.6.2
-      diff-match-patch: 1.0.5
+      "@dmsnell/diff-match-patch": 1.1.0
 
   jsonp@0.2.1:
     dependencies:
@@ -29744,8 +29697,6 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.20: {}
-
   node-releases@2.0.51: {}
 
   nopt@7.2.1:
@@ -30300,7 +30251,7 @@ snapshots:
       "@csstools/postcss-trigonometric-functions": 4.0.9(postcss@8.5.18)
       "@csstools/postcss-unset-value": 4.0.0(postcss@8.5.18)
       autoprefixer: 10.5.0(postcss@8.5.18)
-      browserslist: 4.25.4
+      browserslist: 4.28.7
       css-blank-pseudo: 7.0.1(postcss@8.5.18)
       css-has-pseudo: 7.0.3(postcss@8.5.18)
       css-prefers-color-scheme: 10.0.0(postcss@8.5.18)
@@ -32047,15 +31998,9 @@ snapshots:
       webpack-sources: 3.3.3
       webpack-virtual-modules: 0.5.0
 
-  update-browserslist-db@1.1.3(browserslist@4.25.4):
+  update-browserslist-db@1.2.3(browserslist@4.28.7):
     dependencies:
-      browserslist: 4.25.4
-      escalade: 3.2.0
-      picocolors: 1.1.1
-
-  update-browserslist-db@1.2.3(browserslist@4.28.6):
-    dependencies:
-      browserslist: 4.28.6
+      browserslist: 4.28.7
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -32298,7 +32243,7 @@ snapshots:
       "@webassemblyjs/wasm-parser": 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.6
+      browserslist: 4.28.7
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.22.0
       es-module-lexer: 1.7.0
@@ -32339,7 +32284,7 @@ snapshots:
       "@webassemblyjs/wasm-parser": 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.6
+      browserslist: 4.28.7
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.22.0
       es-module-lexer: 1.7.0
@@ -32380,7 +32325,7 @@ snapshots:
       "@webassemblyjs/wasm-parser": 1.14.1
       acorn: 8.16.0
       acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.6
+      browserslist: 4.28.7
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.22.0
       es-module-lexer: 1.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -51,6 +51,9 @@ overrides:
   # @databricks/sql 2 requires Thrift's UUID dependency to remain CJS-compatible.
   # Package-level overrides are not inherited by pnpm consumers.
   "thrift@0.23.0>uuid": 11.1.1
+  # ai v4 pins jsondiffpatch 0.6, which is fixed only in a later compatible
+  # release; keep the direct ai update above while bridging that exact pin.
+  "ai>jsondiffpatch": 0.7.6
 
 auditConfig:
   ignoreGhsas:
@@ -71,3 +74,10 @@ allowBuilds:
   lz4: true
   sharp: true
   utf-8-validate: true
+
+# Allow the newly published security patches through the workspace's package
+# age policy while they age normally for future installs.
+minimumReleaseAgeExclude:
+  - jsondiffpatch@0.7.6
+  - browserslist@4.28.7
+  - fast-uri@3.1.6


### PR DESCRIPTION
## Problem

The docs app used an older `ai` package path that still pulled in audit-sensitive transitive versions. In simple terms: one package brought along smaller packages that needed security patch updates.

## Solution

Update the docs app `ai` dependency to `^4.3.19` and add a workspace override so `ai` uses `jsondiffpatch@0.7.6`. Refresh the lockfile so related patched transitive packages are resolved, and temporarily exclude the new patch versions from the workspace package age policy while they age normally.

## Testing

TODO: Validation not provided.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

Updated `ai` and overrode its `jsondiffpatch` transitive dependency to pick up security patches. No new direct dependencies.

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

n/a

-->