### PR TITLE
fix(breakpoint): update hero registration CTA

### DIFF
--- a/apps/breakpoint/src/components/sections/HeroSection.tsx
+++ b/apps/breakpoint/src/components/sections/HeroSection.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useRef, useState } from "react";
 import { AnimatePresence, motion } from "motion/react";
 import { useTranslations } from "@workspace/i18n/client";
 import Button from "@/components/Button";
-import EmailSubscribeDialog from "@/components/EmailSubscribeDialog";
 import ImageTreatment from "@/components/ImageTreatment";
 import TextScramble from "@/components/TextScramble";
 import WordReveal from "@/components/WordReveal";
@@ -17,7 +16,6 @@ export default function HeroSection() {
   const [interacting, setInteracting] = useState(false);
   const [cursorY, setCursorY] = useState(50);
   const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const [subscribeOpen, setSubscribeOpen] = useState(false);
   const mediaRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -126,10 +124,10 @@ export default function HeroSection() {
               />
             ) : (
               <Button
-                label={t("hero.cta")}
+                label={t("menu.items.register")}
                 variant="primary"
                 arrow
-                onClick={() => setSubscribeOpen(true)}
+                href="/registration"
               />
             )}
           </div>
@@ -159,11 +157,6 @@ export default function HeroSection() {
         width={1440}
         height={146}
         className="pointer-events-none absolute bottom-0 left-0 z-0 h-[146px] w-full object-cover"
-      />
-
-      <EmailSubscribeDialog
-        open={subscribeOpen}
-        onClose={() => setSubscribeOpen(false)}
       />
     </section>
   );


### PR DESCRIPTION
## Problem
The Breakpoint hero button opened an email subscribe popup instead of taking visitors to the registration page. That makes it harder for someone to register from the main call-to-action.

## Solution
The hero button now says `Register` and links directly to `/registration`. The unused email subscribe dialog state and component were removed from the hero section.

## Testing
TODO: Not provided.

### Summary of Changes

Updated the Breakpoint hero registration CTA to navigate to the registration page instead of opening the email subscribe dialog.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

none

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

n/a

-->