### PR TITLE
fix(content) Updated reduced rent feat activation schedule

### DIFF
--- a/apps/media/__tests__/upgrade-stage.test.ts
+++ b/apps/media/__tests__/upgrade-stage.test.ts
@@ -14,11 +14,12 @@ const messages = JSON.parse(
 );
 
 describe("upgrade stage helper", () => {
-  it("has a translated label and badge class for all four stages", () => {
+  it("has a translated label and badge class for all stages", () => {
     const stages = [
       "planned",
       "in_development",
       "pending_activation",
+      "partially_active",
       "live",
     ] as const;
     for (const stage of stages) {
@@ -30,6 +31,7 @@ describe("upgrade stage helper", () => {
   it("validates stage values from untrusted content data", () => {
     expect(isUpgradeStage("live")).toBe(true);
     expect(isUpgradeStage("pending_activation")).toBe(true);
+    expect(isUpgradeStage("partially_active")).toBe(true);
     expect(isUpgradeStage("mainnet-live")).toBe(false);
     expect(isUpgradeStage("action_required")).toBe(false);
     expect(isUpgradeStage(undefined)).toBe(false);

--- a/apps/media/components/upgrades/upgrade-social-image.tsx
+++ b/apps/media/components/upgrades/upgrade-social-image.tsx
@@ -39,6 +39,11 @@ const stageColorMap: Record<
     borderColor: "rgba(96, 165, 250, 0.35)",
     color: "#93C5FD",
   },
+  partially_active: {
+    backgroundColor: "rgba(45, 212, 191, 0.08)",
+    borderColor: "rgba(45, 212, 191, 0.35)",
+    color: "#5EEAD4",
+  },
   live: {
     backgroundColor: "rgba(20, 241, 149, 0.08)",
     borderColor: "rgba(20, 241, 149, 0.35)",

--- a/apps/media/content/upgrades/reduced-rent.mdx
+++ b/apps/media/content/upgrades/reduced-rent.mdx
@@ -8,7 +8,7 @@ subtitle: Cutting the cost of on-chain storage by 90%
 publishedAt: 2026-07-24T00:00:00.000Z
 status: published
 author: solana-foundation
-stage: pending_activation
+stage: partially_active
 release: agave-4-2
 order: 2
 metrics:
@@ -24,7 +24,7 @@ tags:
 
 # Reduced Rent
 
-Phased Rollout • Solana Foundation
+**Updated September 2026** • Solana Foundation
 
 "Rent" is a misleading name. Rent is not a fee. Rent is a fully refundable bond
 that pays for the storage an account occupies on every validator. Solana

--- a/apps/media/content/upgrades/reduced-rent.mdx
+++ b/apps/media/content/upgrades/reduced-rent.mdx
@@ -91,15 +91,15 @@ reduction across five independent feature gates. Each step activates
 separately. Core developers will determine if they can proceed with the next
 feature activation or if they need to gather more data on state demand.
 
-|                                                                                                                                    |             |                     |
-| ---------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------- |
-| [`4a6f7o7iTcA8hRDCrPLkSatnt5Ykxiu36wo5p1Tt12wC`](https://explorer.solana.com/address/4a6f7o7iTcA8hRDCrPLkSatnt5Ykxiu36wo5p1Tt12wC) | SIMD-0437-1 | 6,960 → 6,333 (9%)  |
-| [`61BtM7BkDEE8Yq5fskEVAQT9mYA8qCejJWoLe5apqg81`](https://explorer.solana.com/address/61BtM7BkDEE8Yq5fskEVAQT9mYA8qCejJWoLe5apqg81) | SIMD-0437-2 | 6,960 → 5,080 (27%) |
-| [`Ftxb3ZKq7aNqgxDBbP7EonvR2RszZk9ctjdsTX38kQaz`](https://explorer.solana.com/address/Ftxb3ZKq7aNqgxDBbP7EonvR2RszZk9ctjdsTX38kQaz) | SIMD-0437-3 | 6,960 → 2,575 (63%) |
-| [`GsUBNYNDPdMLHPD37TToHzrzcNcjpC9w5n1EcJk5iTaM`](https://explorer.solana.com/address/GsUBNYNDPdMLHPD37TToHzrzcNcjpC9w5n1EcJk5iTaM) | SIMD-0437-4 | 6,960 → 1,322 (81%) |
-| [`mZdnRh9T2EbDNvqKjkCR3bvo5c816tJaojtE9Xs7iuY`](https://explorer.solana.com/address/mZdnRh9T2EbDNvqKjkCR3bvo5c816tJaojtE9Xs7iuY)   | SIMD-0437-5 | 6,960 → 696 (90%)   |
+| Feature Gate                                                                                                                       | SIMD        | Reduction           | Status                |
+| ---------------------------------------------------------------------------------------------------------------------------------- | ----------- | ------------------- | --------------------- |
+| [`4a6f7o7iTcA8hRDCrPLkSatnt5Ykxiu36wo5p1Tt12wC`](https://explorer.solana.com/address/4a6f7o7iTcA8hRDCrPLkSatnt5Ykxiu36wo5p1Tt12wC) | SIMD-0437-1 | 6,960 → 6,333 (9%)  | Live on Mainnet       |
+| [`61BtM7BkDEE8Yq5fskEVAQT9mYA8qCejJWoLe5apqg81`](https://explorer.solana.com/address/61BtM7BkDEE8Yq5fskEVAQT9mYA8qCejJWoLe5apqg81) | SIMD-0437-2 | 6,960 → 5,080 (27%) | Live on Testnet       |
+| [`Ftxb3ZKq7aNqgxDBbP7EonvR2RszZk9ctjdsTX38kQaz`](https://explorer.solana.com/address/Ftxb3ZKq7aNqgxDBbP7EonvR2RszZk9ctjdsTX38kQaz) | SIMD-0437-3 | 6,960 → 2,575 (63%) | Expected in Agave 4.4 |
+| [`GsUBNYNDPdMLHPD37TToHzrzcNcjpC9w5n1EcJk5iTaM`](https://explorer.solana.com/address/GsUBNYNDPdMLHPD37TToHzrzcNcjpC9w5n1EcJk5iTaM) | SIMD-0437-4 | 6,960 → 1,322 (81%) | Expected in Agave 4.4 |
+| [`mZdnRh9T2EbDNvqKjkCR3bvo5c816tJaojtE9Xs7iuY`](https://explorer.solana.com/address/mZdnRh9T2EbDNvqKjkCR3bvo5c816tJaojtE9Xs7iuY)   | SIMD-0437-5 | 6,960 → 696 (90%)   | Expected in Agave 4.4 |
 
-Each feature gate is independent. The activations can put on hold if the data
+Each feature gate is independent. The activations can be put on hold if the data
 doesn't support moving forward.
 
 ### Rollout Status
@@ -116,7 +116,8 @@ The rollout is underway:
 The remaining three steps, SIMD-0437-3 through SIMD-0437-5, are delayed until
 Agave 4.4, expected in November 2026. This means the full 90% reduction, and
 the $0.0159 SPL token account deposit that comes with it, won't land until
-late 2026. However, accounts will get 27% cheaper in September.
+late 2026. However, accounts will get 27% cheaper than their original rent
+levels in September.
 
 ### Fallback Safeguard
 

--- a/apps/media/content/upgrades/reduced-rent.mdx
+++ b/apps/media/content/upgrades/reduced-rent.mdx
@@ -26,21 +26,20 @@ tags:
 
 Phased Rollout • Solana Foundation
 
-"Rent" is a misleading name. It isn't a fee. Rent is a fully refundable bond
+"Rent" is a misleading name. Rent is not a fee. Rent is a fully refundable bond
 that pays for the storage an account occupies on every validator. Solana
 requires accounts to hold a minimum balance sized to their data, and when
 that account is closed, the lamports are returned in full to whoever closes
 it. [SIMD-0437](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0437-incremental-rent-reduction.md)
 reduces the constant behind that bond, `lamports_per_byte`, from 6,960 down to
-696 — a 90% cut — rolled out in five separate feature-gated steps rather than
-a single change.
+696 — a 90% cut — rolled out in five separate feature-gated steps.
 
-|                                  |                              |
-| -------------------------------- | ---------------------------- |
-| Expected Mainnet Activation Date | Agave 4.2 - August 2026      |
-| Devnet Activation                | August 2026                  |
-| Breaking Change?                 | No                           |
-| Indexing Changes Required?       | No, state growth is possible |
+|                                  |                                                                 |
+| -------------------------------- | --------------------------------------------------------------- |
+| Expected Mainnet Activation Date | Steps 1-2: September 2026; Steps 3-5: Agave 4.4 (November 2026) |
+| Devnet Activation                | August 2026                                                     |
+| Breaking Change?                 | No                                                              |
+| Indexing Changes Required?       | No, state growth is possible                                    |
 
 ## Technical Details
 
@@ -61,23 +60,27 @@ min_balance = (128 + data_size) * lamports_per_byte
 ```
 
 The `128` is a fixed account storage overhead, and `data_size` is the size of
-the account in bytes. `lamports_per_byte` is currently 6,960, a constant set
-years ago and never adjusted since. Because it was fixed in lamports rather
-than tied to any actual validator storage cost, its real-world cost has moved
-independently of what storage actually costs to provide. Additionally, there has
-been concern that cheaper storage costs for accounts would lead to a large
-demand spike in on-chain storage space.
+the account in bytes. `lamports_per_byte` was 6,960. The constant was set years
+ago and never adjusted until the first rent-reduction step cut it to 6,333 at
+the start of mainnet epoch 1028 on September 3 2026. Because rent was fixed in
+lamports rather than tied to any actual validator storage cost, its real-world
+cost has moved independently of what storage actually costs to provide.
+Additionally, there has been concern that cheaper storage costs for accounts
+would lead to a large demand spike in on-chain storage space.
 
 ### Rent Case Study
 
 Assuming a payments business wants to create one million token accounts for
-their users, the current on-chain cost of rent would be one million accounts times
-$0.159 for an SPL token account rent deposit. So a business would pay
-$159,000 at the time of this writing. However, once all five rent-reduction
+their users, the pre-reduction on-chain cost of rent would be one million
+accounts times $0.159 for an SPL token account rent deposit. So a business would
+have paid $159,000 before the rollout began. However, once all five rent-reduction
 feature gates are active on mainnet and assuming similar economics, the cost of
 an SPL token account's rent would be $0.0159, resulting in a total cost of
 $15,900. A reduction of this size could make it practical for many more
 businesses to cover rent on behalf of their users, making onboarding easier.
+The deposit math above comes from
+[Rent Reduction on Solana: A Data-Backed Analysis](https://solana.com/news/rent-reduction-deep-dive),
+a Solana Foundation study of rent economics.
 
 ### Five-Step Phased Rollout
 
@@ -96,28 +99,45 @@ feature activation or if they need to gather more data on state demand.
 | [`GsUBNYNDPdMLHPD37TToHzrzcNcjpC9w5n1EcJk5iTaM`](https://explorer.solana.com/address/GsUBNYNDPdMLHPD37TToHzrzcNcjpC9w5n1EcJk5iTaM) | SIMD-0437-4 | 6,960 → 1,322 (81%) |
 | [`mZdnRh9T2EbDNvqKjkCR3bvo5c816tJaojtE9Xs7iuY`](https://explorer.solana.com/address/mZdnRh9T2EbDNvqKjkCR3bvo5c816tJaojtE9Xs7iuY)   | SIMD-0437-5 | 6,960 → 696 (90%)   |
 
-All five feature gates are currently inactive. Each one is independent, so
-the network can stop advancing at any step if the data doesn't support moving
-forward.
+Each feature gate is independent. The activations can put on hold if the data
+doesn't support moving forward.
+
+### Rollout Status
+
+The rollout is underway:
+
+- **SIMD-0437-1** (6,960 → 6,333 lamports per byte) is active on mainnet as of
+  September 3, 2026. This first 9% cut is already reflected in the minimum
+  balance for new accounts.
+- **SIMD-0437-2** (6,960 → 5,080 lamports per byte) activates on testnet on
+  September 3, 2026. Based on the feature-gate queue, mainnet activation is
+  expected one to two weeks later, in mid-September 2026.
+
+The remaining three steps, SIMD-0437-3 through SIMD-0437-5, are delayed until
+Agave 4.4, expected in November 2026. This means the full 90% reduction, and
+the $0.0159 SPL token account deposit that comes with it, won't land until
+late 2026. However, accounts will get 27% cheaper in September.
 
 ### Fallback Safeguard
 
 A sixth feature gate exists specifically to reverse course: if a step causes
 unexpected state growth or other issues, this fallback resets
-`lamports_per_byte` back to 6,960, the current value, without disrupting
+`lamports_per_byte` back to 6,960, the original value, without disrupting
 existing accounts. This is paired with
 [SIMD-0392](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0392-rent-increase-adaptations.md),
 which allows rent to be raised again later if empirical state growth turns
 out to be a problem.
 
-Umberto, a data researcher at the Solana Foundation, has done an in-depth
-analysis of the potential state growth issue when rent is reduced by 90%. His
+Umberto Natale, a data researcher at the Solana Foundation, has done an
+[in-depth analysis](https://solana.com/news/rent-reduction-deep-dive) of the
+potential state growth issue when rent is reduced by 90%. His model estimates
+that even after the full reduction, a state-bloat attack would still require
+roughly $17 million of locked capital to consume the network's current storage
+headroom. The data also shows most newly allocated account state is transient —
+in the cohort analyzed, 75.5% of account-creation events close within the same
+transaction — and net state growth is currently around 0.3 GB per day. His
 research suggests that the 90% reduction will not cause systemic risk to the
-cluster. The payoff for users is substantial: the rent deposit for a standard SPL
-token account falls from about $0.159 to $0.0159, a tenfold drop that makes
-account creation dramatically cheaper. Lowering rent by 90% puts
-Solana's onboarding costs in range of payment-specialized chains. Read more
-here: [Rent Reduction on Solana: A Data-Backed Analysis](https://solana.com/news/rent-reduction-deep-dive).
+cluster.
 
 ## About This Upgrade
 

--- a/apps/media/keystatic.config.tsx
+++ b/apps/media/keystatic.config.tsx
@@ -210,6 +210,7 @@ export default config({
               label: "Pending Feature Activation",
               value: "pending_activation",
             },
+            { label: "Partially Activated", value: "partially_active" },
             { label: "Live on Mainnet", value: "live" },
           ],
           defaultValue: "in_development",

--- a/apps/media/lib/upgrades/group-by-release.ts
+++ b/apps/media/lib/upgrades/group-by-release.ts
@@ -2,6 +2,7 @@ export type UpgradeStage =
   | "planned"
   | "in_development"
   | "pending_activation"
+  | "partially_active"
   | "live";
 
 export type UpgradeMetric = {

--- a/apps/media/lib/upgrades/stage.ts
+++ b/apps/media/lib/upgrades/stage.ts
@@ -6,6 +6,7 @@ export const STAGE_BADGE_CLASSES: Record<UpgradeStage, string> = {
   planned: "border-white/25 bg-white/5 text-white/70",
   in_development: "border-yellow-500/30 bg-yellow-500/10 text-yellow-300",
   pending_activation: "border-blue-400/30 bg-blue-400/10 text-blue-300",
+  partially_active: "border-teal-400/30 bg-teal-400/10 text-teal-300",
   live: "border-[#14F195]/30 bg-[#14F195]/10 text-[#14F195]",
 };
 
@@ -14,6 +15,7 @@ export function isUpgradeStage(value: unknown): value is UpgradeStage {
     value === "planned" ||
     value === "in_development" ||
     value === "pending_activation" ||
+    value === "partially_active" ||
     value === "live"
   );
 }

--- a/packages/i18n/messages/media/en/common.json
+++ b/packages/i18n/messages/media/en/common.json
@@ -109,6 +109,7 @@
       "planned": "Planned",
       "in_development": "In Development",
       "pending_activation": "Pending Feature Activation",
+      "partially_active": "Partially Activated",
       "live": "Live on Mainnet"
     },
     "detail": {


### PR DESCRIPTION
### Problem

The rent reduction page is out of date.

### Summary of Changes

Updating content. Rent reduction step 1 has been activated on mainnet. Step 2 will be active soon. The remaining steps will be activated in November.

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
