### PR TITLE
docs: Standardize confidential key derivation on the main wallet

### DIFF
--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
@@ -153,7 +153,7 @@ fn main() -> Result<()> {
     let (_mint, token_account) = setup_pending_balance_account(&rpc_client, &owner, amount, decimals)?;
 
     // Derive the owner's keys to decrypt the current balances.
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(&owner, &token_account.to_bytes())
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(&owner, b"")
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     let account_data = rpc_client.get_account(&token_account)?;
@@ -310,7 +310,7 @@ fn configure_confidential_token_account(
         &[ExtensionType::ConfidentialTransferAccount],
     )?;
 
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, &token_account.to_bytes())
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
     let decryptable_balance: PodAeCiphertext = aes_key.encrypt(0).into();
 
@@ -427,8 +427,8 @@ serde_json = "1.0"
 // !collapse(1:25) collapsed
 // Imports: dependencies used by this example.
 import {
-  deriveAeKeyForOwnerMint,
-  deriveElGamalKeypairForOwnerMint,
+  deriveAeKey,
+  deriveElGamalKeypair,
   getApplyConfidentialPendingBalanceInstructionFromToken,
   getCreateConfidentialTransferAccountInstructionPlan
 } from "@solana-program/token-2022/confidential";
@@ -472,7 +472,7 @@ await mintPublicTokens(client, owner, mint, token, amount);
 await depositTokens(client, owner, mint, token, amount, decimals);
 
 // Derive the owner's keys to decrypt the current balances.
-const { elgamalSecretKey, aesKey } = await deriveConfidentialKeys(owner, mint);
+const { elgamalSecretKey, aesKey } = await deriveConfidentialKeys(owner);
 
 // The helper decrypts the pending and available balances, re-encrypts the new
 // available balance, and builds the ApplyPendingBalance instruction. No proof
@@ -501,11 +501,7 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  const auditor = await deriveElGamalKeypairForOwnerMint({
-    signer: payer,
-    owner: payer.address,
-    mint: mint.address
-  });
+  const auditor = await deriveElGamalKeypair({ signer: payer });
 
   const plan = getCreateMintInstructionPlan({
     payer,
@@ -537,10 +533,7 @@ async function createConfidentialTokenAccount(
     tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     mint
   });
-  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(
-    accountOwner,
-    mint
-  );
+  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(accountOwner);
 
   const plan = await getCreateConfidentialTransferAccountInstructionPlan({
     rpc: kitClient.rpc,
@@ -592,24 +585,13 @@ async function depositTokens(
   ]);
 }
 
-async function deriveConfidentialKeys(
-  accountOwner: typeof owner,
-  mint: Awaited<ReturnType<typeof createConfidentialMint>>
-) {
-  const derivedElGamal = await deriveElGamalKeypairForOwnerMint({
-    signer: accountOwner,
-    owner: accountOwner.address,
-    mint
+async function deriveConfidentialKeys(accountOwner: typeof owner) {
+  const derivedElGamal = await deriveElGamalKeypair({
+    signer: accountOwner
   });
   const elgamalSecretKey = ElGamalSecretKey.fromBytes(derivedElGamal.secretKey);
   const elgamalKeypair = ElGamalKeypair.fromSecretKey(elgamalSecretKey);
-  const aesKey = AeKey.fromBytes(
-    await deriveAeKeyForOwnerMint({
-      signer: accountOwner,
-      owner: accountOwner.address,
-      mint
-    })
-  );
+  const aesKey = AeKey.fromBytes(await deriveAeKey({ signer: accountOwner }));
 
   return { elgamalKeypair, elgamalSecretKey, aesKey };
 }

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
@@ -85,6 +85,15 @@ mainnet-forking local validator such as [Surfpool](https://surfpool.run) does.
 Run the example against one of those (the code uses devnet) with a funded payer,
 and replace the placeholder mint and account addresses with your own.
 
+<Callout type="warn">
+  This example derives keys with the standard wallet-only derivation. A token
+  account configured before that standard holds `(owner, mint)`-seeded keys, so
+  the standard keys will not decrypt its balance and any proof built from them
+  fails verification. Check [accounts configured with legacy owner-mint
+  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-owner-mint-keys)
+  before running this against an account you did not just create.
+</Callout>
+
 ### Rust
 
 <CodeTabs>
@@ -500,8 +509,13 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
+  // The auditor is a separate party with its own wallet. The standard
+  // derivation binds keys to the wallet alone, so deriving the auditor key
+  // from `payer` would hand the auditor the very key that decrypts every
+  // confidential balance that wallet owns, on every mint.
+  const auditorSigner = await generateKeyPairSigner();
   const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
-    signer: payer
+    signer: auditorSigner
   });
 
   const plan = getCreateMintInstructionPlan({

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
@@ -85,16 +85,6 @@ mainnet-forking local validator such as [Surfpool](https://surfpool.run) does.
 Run the example against one of those (the code uses devnet) with a funded payer,
 and replace the placeholder mint and account addresses with your own.
 
-<Callout type="warn">
-  This example derives keys with the standard wallet-only derivation. A token
-  account configured before that standard holds seeded keys, from either the
-  `(owner, mint)` pair or the token account address, so the standard keys will
-  not decrypt its balance and any proof built from them fails verification.
-  Check [accounts configured with legacy seeded
-  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-seeded-keys)
-  before running this against an account you did not just create.
-</Callout>
-
 ### Rust
 
 <CodeTabs>
@@ -510,15 +500,8 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  // This demo mint gets a throwaway auditor: nothing below decrypts as the
-  // auditor, and the secret is discarded when the process exits. A real auditor
-  // has to keep its wallet, since that wallet is the only way to recover the
-  // key that decrypts transfers. See create-mint for that setup.
-  //
-  // Note that the auditor is a separate party with its own wallet. The standard
-  // derivation binds keys to the wallet alone, so deriving the auditor key
-  // from `payer` would hand the auditor the very key that decrypts every
-  // confidential balance that wallet owns, on every mint.
+  // Demo-only auditor from a throwaway wallet; see create-mint for real
+  // auditor setup.
   const auditorSigner = await generateKeyPairSigner();
   const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
     signer: auditorSigner

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
@@ -87,10 +87,11 @@ and replace the placeholder mint and account addresses with your own.
 
 <Callout type="warn">
   This example derives keys with the standard wallet-only derivation. A token
-  account configured before that standard holds `(owner, mint)`-seeded keys, so
-  the standard keys will not decrypt its balance and any proof built from them
-  fails verification. Check [accounts configured with legacy owner-mint
-  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-owner-mint-keys)
+  account configured before that standard holds seeded keys, from either the
+  `(owner, mint)` pair or the token account address, so the standard keys will
+  not decrypt its balance and any proof built from them fails verification.
+  Check [accounts configured with legacy seeded
+  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-seeded-keys)
   before running this against an account you did not just create.
 </Callout>
 
@@ -509,7 +510,12 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  // The auditor is a separate party with its own wallet. The standard
+  // This demo mint gets a throwaway auditor: nothing below decrypts as the
+  // auditor, and the secret is discarded when the process exits. A real auditor
+  // has to keep its wallet, since that wallet is the only way to recover the
+  // key that decrypts transfers. See create-mint for that setup.
+  //
+  // Note that the auditor is a separate party with its own wallet. The standard
   // derivation binds keys to the wallet alone, so deriving the auditor key
   // from `payer` would hand the auditor the very key that decrypts every
   // confidential balance that wallet owns, on every mint.

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/apply-pending-balance.mdx
@@ -153,7 +153,7 @@ fn main() -> Result<()> {
     let (_mint, token_account) = setup_pending_balance_account(&rpc_client, &owner, amount, decimals)?;
 
     // Derive the owner's keys to decrypt the current balances.
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(&owner, b"")
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(&owner)
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     let account_data = rpc_client.get_account(&token_account)?;
@@ -310,7 +310,7 @@ fn configure_confidential_token_account(
         &[ExtensionType::ConfidentialTransferAccount],
     )?;
 
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner)
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
     let decryptable_balance: PodAeCiphertext = aes_key.encrypt(0).into();
 
@@ -424,11 +424,10 @@ serde_json = "1.0"
 <CodeTabs>
 
 ```ts !! title="index.ts"
-// !collapse(1:25) collapsed
+// !collapse(1:24) collapsed
 // Imports: dependencies used by this example.
 import {
-  deriveAeKey,
-  deriveElGamalKeypair,
+  deriveConfidentialKeys,
   getApplyConfidentialPendingBalanceInstructionFromToken,
   getCreateConfidentialTransferAccountInstructionPlan
 } from "@solana-program/token-2022/confidential";
@@ -472,7 +471,7 @@ await mintPublicTokens(client, owner, mint, token, amount);
 await depositTokens(client, owner, mint, token, amount, decimals);
 
 // Derive the owner's keys to decrypt the current balances.
-const { elgamalSecretKey, aesKey } = await deriveConfidentialKeys(owner);
+const { elgamalSecretKey, aesKey } = await deriveConfidentialWasmKeys(owner);
 
 // The helper decrypts the pending and available balances, re-encrypts the new
 // available balance, and builds the ApplyPendingBalance instruction. No proof
@@ -501,7 +500,9 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  const auditor = await deriveElGamalKeypair({ signer: payer });
+  const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
+    signer: payer
+  });
 
   const plan = getCreateMintInstructionPlan({
     payer,
@@ -533,7 +534,8 @@ async function createConfidentialTokenAccount(
     tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     mint
   });
-  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(accountOwner);
+  const { elgamalKeypair, aesKey } =
+    await deriveConfidentialWasmKeys(accountOwner);
 
   const plan = await getCreateConfidentialTransferAccountInstructionPlan({
     rpc: kitClient.rpc,
@@ -585,15 +587,19 @@ async function depositTokens(
   ]);
 }
 
-async function deriveConfidentialKeys(accountOwner: typeof owner) {
-  const derivedElGamal = await deriveElGamalKeypair({
+async function deriveConfidentialWasmKeys(accountOwner: typeof owner) {
+  // One signature over the constant solana-conf-bal/v1 message derives both
+  // keys, bound to the wallet alone.
+  const { aeKey, elgamalKeypair } = await deriveConfidentialKeys({
     signer: accountOwner
   });
-  const elgamalSecretKey = ElGamalSecretKey.fromBytes(derivedElGamal.secretKey);
-  const elgamalKeypair = ElGamalKeypair.fromSecretKey(elgamalSecretKey);
-  const aesKey = AeKey.fromBytes(await deriveAeKey({ signer: accountOwner }));
+  const elgamalSecretKey = ElGamalSecretKey.fromBytes(elgamalKeypair.secretKey);
 
-  return { elgamalKeypair, elgamalSecretKey, aesKey };
+  return {
+    elgamalKeypair: ElGamalKeypair.fromSecretKey(elgamalSecretKey),
+    elgamalSecretKey,
+    aesKey: AeKey.fromBytes(aeKey)
+  };
 }
 ```
 

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
@@ -236,7 +236,7 @@ serde_json = "1.0"
 // !collapse(1:8) collapsed
 // Imports: dependencies used by this example.
 import { getCreateMintInstructionPlan } from "@solana-program/token-2022";
-import { deriveElGamalKeypairForOwnerMint } from "@solana-program/token-2022/confidential";
+import { deriveElGamalKeypair } from "@solana-program/token-2022/confidential";
 import { createClient, generateKeyPairSigner, some } from "@solana/kit";
 import { solanaRpc } from "@solana/kit-plugin-rpc";
 import { signerFromFile } from "@solana/kit-plugin-signer";
@@ -257,11 +257,7 @@ const mint = await generateKeyPairSigner();
 // The auditor ElGamal key lets the issuer decrypt transfer amounts for
 // compliance. Persist it; omit `auditorElgamalPubkey` to create a mint with no
 // auditor.
-const auditor = await deriveElGamalKeypairForOwnerMint({
-  signer: payer,
-  owner: payer.address,
-  mint: mint.address
-});
+const auditor = await deriveElGamalKeypair({ signer: payer });
 
 const plan = getCreateMintInstructionPlan({
   payer,

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
@@ -145,20 +145,10 @@ fn main() -> Result<()> {
     let rent = rpc_client.get_minimum_balance_for_rent_exemption(space)?;
 
     // The auditor ElGamal key lets the issuer decrypt transfer amounts for
-    // compliance. Pass `None` to create a mint with no auditor.
-    //
-    // The auditor is a separate party with its own wallet, so derive from that
-    // wallet and not from `payer`: the standard derivation binds keys to the
-    // wallet alone, so an auditor key derived from `payer` would decrypt every
-    // confidential balance that wallet owns, on every mint.
-    //
-    // Only the public key goes on the mint, but the secret is what decrypts
-    // transfers, and it is recoverable only from the wallet it came from. So
-    // load that wallet from a file the auditor keeps: a key generated in memory
-    // is gone when the process exits, leaving a mint whose configured auditor
-    // can never decrypt anything. Create one with
-    // `solana-keygen new -o ~/.config/solana/auditor.json`. In production the
-    // auditor derives their own keys and sends you the public key alone.
+    // compliance. Pass `None` to create a mint with no auditor. Derive it from
+    // the auditor's own wallet (`solana-keygen new -o
+    // ~/.config/solana/auditor.json`); in production the auditor sends the
+    // public key alone.
     let auditor_wallet = load_keypair(".config/solana/auditor.json")?;
     let (auditor, _auditor_aes_key) = derive_confidential_keys(&auditor_wallet)
         .map_err(|e| anyhow::anyhow!("derive auditor keys: {e}"))?;
@@ -277,19 +267,9 @@ const mint = await generateKeyPairSigner();
 
 // The auditor ElGamal key lets the issuer decrypt transfer amounts for
 // compliance. Omit `auditorElgamalPubkey` to create a mint with no auditor.
-//
-// The auditor is a separate party with its own wallet: the standard derivation
-// binds keys to the wallet alone, so deriving this key from `payer` would hand
-// the auditor the very key that decrypts every confidential balance that wallet
-// owns, on every mint.
-//
-// Only the public key goes on the mint, but the secret is what decrypts
-// transfers, and it is recoverable only from the wallet it came from. So load
-// that wallet from a file the auditor keeps rather than generating one in
-// memory: a fresh in-memory keypair is gone when the process exits, leaving a
-// mint whose configured auditor can never decrypt anything. Create one with
-// `solana-keygen new -o ~/.config/solana/auditor.json`. In production the
-// auditor derives their own keys and sends you `elgamalPubkey` alone.
+// Derive it from the auditor's own wallet (`solana-keygen new -o
+// ~/.config/solana/auditor.json`); in production the auditor sends the
+// public key alone.
 const auditorSigner = await createKeyPairSignerFromBytes(
   new Uint8Array(
     JSON.parse(

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
@@ -256,9 +256,13 @@ const mint = await generateKeyPairSigner();
 
 // The auditor ElGamal key lets the issuer decrypt transfer amounts for
 // compliance. Persist it; omit `auditorElgamalPubkey` to create a mint with no
-// auditor.
+// auditor. The auditor is a separate party with its own wallet: the standard
+// derivation binds keys to the wallet alone, so deriving this key from `payer`
+// would hand the auditor the very key that decrypts every confidential balance
+// that wallet owns, on every mint.
+const auditorSigner = await generateKeyPairSigner();
 const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
-  signer: payer
+  signer: auditorSigner
 });
 
 const plan = getCreateMintInstructionPlan({

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
@@ -236,7 +236,7 @@ serde_json = "1.0"
 // !collapse(1:8) collapsed
 // Imports: dependencies used by this example.
 import { getCreateMintInstructionPlan } from "@solana-program/token-2022";
-import { deriveElGamalKeypair } from "@solana-program/token-2022/confidential";
+import { deriveConfidentialKeys } from "@solana-program/token-2022/confidential";
 import { createClient, generateKeyPairSigner, some } from "@solana/kit";
 import { solanaRpc } from "@solana/kit-plugin-rpc";
 import { signerFromFile } from "@solana/kit-plugin-signer";
@@ -257,7 +257,9 @@ const mint = await generateKeyPairSigner();
 // The auditor ElGamal key lets the issuer decrypt transfer amounts for
 // compliance. Persist it; omit `auditorElgamalPubkey` to create a mint with no
 // auditor.
-const auditor = await deriveElGamalKeypair({ signer: payer });
+const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
+  signer: payer
+});
 
 const plan = getCreateMintInstructionPlan({
   payer,

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-mint.mdx
@@ -117,7 +117,7 @@ use solana_keypair::Keypair;
 use solana_signer::Signer;
 use solana_system_interface::instruction as system_instruction;
 use solana_transaction::Transaction;
-use solana_zk_sdk::encryption::elgamal::ElGamalKeypair;
+use solana_zk_sdk::encryption::derivation::derive_confidential_keys;
 use solana_zk_sdk_pod::encryption::elgamal::PodElGamalPubkey;
 use spl_token_2022::{
     extension::{
@@ -134,7 +134,7 @@ fn main() -> Result<()> {
         CommitmentConfig::confirmed(),
     );
 
-    let payer = load_keypair()?;
+    let payer = load_keypair(".config/solana/id.json")?;
     let mint = Keypair::new();
     let decimals: u8 = 2;
 
@@ -145,8 +145,23 @@ fn main() -> Result<()> {
     let rent = rpc_client.get_minimum_balance_for_rent_exemption(space)?;
 
     // The auditor ElGamal key lets the issuer decrypt transfer amounts for
-    // compliance. Persist this key. Pass `None` to create a mint with no auditor.
-    let auditor = ElGamalKeypair::new_rand();
+    // compliance. Pass `None` to create a mint with no auditor.
+    //
+    // The auditor is a separate party with its own wallet, so derive from that
+    // wallet and not from `payer`: the standard derivation binds keys to the
+    // wallet alone, so an auditor key derived from `payer` would decrypt every
+    // confidential balance that wallet owns, on every mint.
+    //
+    // Only the public key goes on the mint, but the secret is what decrypts
+    // transfers, and it is recoverable only from the wallet it came from. So
+    // load that wallet from a file the auditor keeps: a key generated in memory
+    // is gone when the process exits, leaving a mint whose configured auditor
+    // can never decrypt anything. Create one with
+    // `solana-keygen new -o ~/.config/solana/auditor.json`. In production the
+    // auditor derives their own keys and sends you the public key alone.
+    let auditor_wallet = load_keypair(".config/solana/auditor.json")?;
+    let (auditor, _auditor_aes_key) = derive_confidential_keys(&auditor_wallet)
+        .map_err(|e| anyhow::anyhow!("derive auditor keys: {e}"))?;
     let auditor_pubkey: PodElGamalPubkey = (*auditor.pubkey()).into();
 
     let create_account_ix = system_instruction::create_account(
@@ -187,10 +202,10 @@ fn main() -> Result<()> {
     Ok(())
 }
 
-fn load_keypair() -> Result<Keypair> {
+fn load_keypair(relative_path: &str) -> Result<Keypair> {
     let keypair_path = dirs::home_dir()
         .context("could not find home directory")?
-        .join(".config/solana/id.json");
+        .join(relative_path);
     let bytes: Vec<u8> = serde_json::from_reader(std::fs::File::open(keypair_path)?)?;
     let mut secret = [0u8; 32];
     secret.copy_from_slice(&bytes[0..32]);
@@ -233,13 +248,19 @@ serde_json = "1.0"
 <CodeTabs>
 
 ```ts !! title="index.ts"
-// !collapse(1:8) collapsed
+// !collapse(1:14) collapsed
 // Imports: dependencies used by this example.
 import { getCreateMintInstructionPlan } from "@solana-program/token-2022";
 import { deriveConfidentialKeys } from "@solana-program/token-2022/confidential";
-import { createClient, generateKeyPairSigner, some } from "@solana/kit";
+import {
+  createClient,
+  createKeyPairSignerFromBytes,
+  generateKeyPairSigner,
+  some
+} from "@solana/kit";
 import { solanaRpc } from "@solana/kit-plugin-rpc";
 import { signerFromFile } from "@solana/kit-plugin-signer";
+import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -255,12 +276,27 @@ const payer = client.payer;
 const mint = await generateKeyPairSigner();
 
 // The auditor ElGamal key lets the issuer decrypt transfer amounts for
-// compliance. Persist it; omit `auditorElgamalPubkey` to create a mint with no
-// auditor. The auditor is a separate party with its own wallet: the standard
-// derivation binds keys to the wallet alone, so deriving this key from `payer`
-// would hand the auditor the very key that decrypts every confidential balance
-// that wallet owns, on every mint.
-const auditorSigner = await generateKeyPairSigner();
+// compliance. Omit `auditorElgamalPubkey` to create a mint with no auditor.
+//
+// The auditor is a separate party with its own wallet: the standard derivation
+// binds keys to the wallet alone, so deriving this key from `payer` would hand
+// the auditor the very key that decrypts every confidential balance that wallet
+// owns, on every mint.
+//
+// Only the public key goes on the mint, but the secret is what decrypts
+// transfers, and it is recoverable only from the wallet it came from. So load
+// that wallet from a file the auditor keeps rather than generating one in
+// memory: a fresh in-memory keypair is gone when the process exits, leaving a
+// mint whose configured auditor can never decrypt anything. Create one with
+// `solana-keygen new -o ~/.config/solana/auditor.json`. In production the
+// auditor derives their own keys and sends you `elgamalPubkey` alone.
+const auditorSigner = await createKeyPairSignerFromBytes(
+  new Uint8Array(
+    JSON.parse(
+      await readFile(join(homedir(), ".config/solana/auditor.json"), "utf8")
+    )
+  )
+);
 const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
   signer: auditorSigner
 });

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
@@ -362,10 +362,11 @@ fn main() -> Result<()> {
         &[ExtensionType::ConfidentialTransferAccount],
     )?;
 
-    // 3. Derive the owner's ElGamal keypair and AES key from a signature over
-    //    the token account address. The same signer and address always derive
-    //    the same keys, so the owner can recover them from their wallet.
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(&payer, &token_account.to_bytes())
+    // 3. Derive the owner's ElGamal keypair and AES key from a wallet
+    //    signature with the standard empty seed. The same signer always
+    //    derives the same keys, so the owner can recover them from their
+    //    wallet.
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(&payer, b"")
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     // Initial decryptable available balance of 0, encrypted with the AES key.
@@ -549,8 +550,8 @@ serde_json = "1.0"
 // !collapse(1:21) collapsed
 // Imports: dependencies used by this example.
 import {
-  deriveAeKeyForOwnerMint,
-  deriveElGamalKeypairForOwnerMint,
+  deriveAeKey,
+  deriveElGamalKeypair,
   getCreateConfidentialTransferAccountInstructionPlan
 } from "@solana-program/token-2022/confidential";
 import {
@@ -591,20 +592,14 @@ const [tokenAccount] = await findAssociatedTokenPda({
   mint
 });
 
-// Derive recoverable ElGamal and AES keys bound to (owner, mint). Re-deriving
+// Derive recoverable ElGamal and AES keys bound to the main wallet. Re-deriving
 // from the same wallet always yields the same keys, so the owner can recover
 // them rather than having to back up a separate secret.
-const derivedElGamal = await deriveElGamalKeypairForOwnerMint({
-  signer: owner,
-  owner: owner.address,
-  mint
-});
+const derivedElGamal = await deriveElGamalKeypair({ signer: owner });
 const elgamalKeypair = ElGamalKeypair.fromSecretKey(
   ElGamalSecretKey.fromBytes(derivedElGamal.secretKey)
 );
-const aesKey = AeKey.fromBytes(
-  await deriveAeKeyForOwnerMint({ signer: owner, owner: owner.address, mint })
-);
+const aesKey = AeKey.fromBytes(await deriveAeKey({ signer: owner }));
 
 // Build the create-ATA + reallocate + verify-proof + configure plan, then send.
 // The helper returns an instruction plan because the steps may span more than
@@ -631,11 +626,7 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  const auditor = await deriveElGamalKeypairForOwnerMint({
-    signer: payer,
-    owner: payer.address,
-    mint: mint.address
-  });
+  const auditor = await deriveElGamalKeypair({ signer: payer });
 
   const plan = getCreateMintInstructionPlan({
     payer,

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
@@ -626,8 +626,13 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
+  // The auditor is a separate party with its own wallet. The standard
+  // derivation binds keys to the wallet alone, so deriving the auditor key
+  // from `payer` would hand the auditor the very key that decrypts every
+  // confidential balance that wallet owns, on every mint.
+  const auditorSigner = await generateKeyPairSigner();
   const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
-    signer: payer
+    signer: auditorSigner
   });
 
   const plan = getCreateMintInstructionPlan({

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
@@ -626,7 +626,12 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  // The auditor is a separate party with its own wallet. The standard
+  // This demo mint gets a throwaway auditor: nothing below decrypts as the
+  // auditor, and the secret is discarded when the process exits. A real auditor
+  // has to keep its wallet, since that wallet is the only way to recover the
+  // key that decrypts transfers. See create-mint for that setup.
+  //
+  // Note that the auditor is a separate party with its own wallet. The standard
   // derivation binds keys to the wallet alone, so deriving the auditor key
   // from `payer` would hand the auditor the very key that decrypts every
   // confidential balance that wallet owns, on every mint.

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
@@ -626,15 +626,8 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  // This demo mint gets a throwaway auditor: nothing below decrypts as the
-  // auditor, and the secret is discarded when the process exits. A real auditor
-  // has to keep its wallet, since that wallet is the only way to recover the
-  // key that decrypts transfers. See create-mint for that setup.
-  //
-  // Note that the auditor is a separate party with its own wallet. The standard
-  // derivation binds keys to the wallet alone, so deriving the auditor key
-  // from `payer` would hand the auditor the very key that decrypts every
-  // confidential balance that wallet owns, on every mint.
+  // Demo-only auditor from a throwaway wallet; see create-mint for real
+  // auditor setup.
   const auditorSigner = await generateKeyPairSigner();
   const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
     signer: auditorSigner

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/create-token-account.mdx
@@ -363,10 +363,10 @@ fn main() -> Result<()> {
     )?;
 
     // 3. Derive the owner's ElGamal keypair and AES key from a wallet
-    //    signature with the standard empty seed. The same signer always
-    //    derives the same keys, so the owner can recover them from their
-    //    wallet.
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(&payer, b"")
+    //    signature over the constant solana-conf-bal/v1 message. The standard
+    //    derivation takes no seed, so the same signer always derives the same
+    //    keys and the owner can recover them from their wallet.
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(&payer)
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     // Initial decryptable available balance of 0, encrypted with the AES key.
@@ -547,11 +547,10 @@ serde_json = "1.0"
 <CodeTabs>
 
 ```ts !! title="index.ts"
-// !collapse(1:21) collapsed
+// !collapse(1:20) collapsed
 // Imports: dependencies used by this example.
 import {
-  deriveAeKey,
-  deriveElGamalKeypair,
+  deriveConfidentialKeys,
   getCreateConfidentialTransferAccountInstructionPlan
 } from "@solana-program/token-2022/confidential";
 import {
@@ -592,14 +591,15 @@ const [tokenAccount] = await findAssociatedTokenPda({
   mint
 });
 
-// Derive recoverable ElGamal and AES keys bound to the main wallet. Re-deriving
-// from the same wallet always yields the same keys, so the owner can recover
-// them rather than having to back up a separate secret.
-const derivedElGamal = await deriveElGamalKeypair({ signer: owner });
+// Derive recoverable ElGamal and AES keys bound to the main wallet. One
+// signature over the constant solana-conf-bal/v1 message derives both keys, and
+// re-deriving from the same wallet always yields the same keys, so the owner
+// can recover them rather than having to back up a separate secret.
+const derivedKeys = await deriveConfidentialKeys({ signer: owner });
 const elgamalKeypair = ElGamalKeypair.fromSecretKey(
-  ElGamalSecretKey.fromBytes(derivedElGamal.secretKey)
+  ElGamalSecretKey.fromBytes(derivedKeys.elgamalKeypair.secretKey)
 );
-const aesKey = AeKey.fromBytes(await deriveAeKey({ signer: owner }));
+const aesKey = AeKey.fromBytes(derivedKeys.aeKey);
 
 // Build the create-ATA + reallocate + verify-proof + configure plan, then send.
 // The helper returns an instruction plan because the steps may span more than
@@ -626,7 +626,9 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  const auditor = await deriveElGamalKeypair({ signer: payer });
+  const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
+    signer: payer
+  });
 
   const plan = getCreateMintInstructionPlan({
     payer,

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
@@ -228,7 +228,7 @@ fn configure_confidential_token_account(
         &[ExtensionType::ConfidentialTransferAccount],
     )?;
 
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, &token_account.to_bytes())
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
     let decryptable_balance: PodAeCiphertext = aes_key.encrypt(0).into();
 
@@ -345,8 +345,8 @@ serde_json = "1.0"
 // !collapse(1:23) collapsed
 // Imports: dependencies used by this example.
 import {
-  deriveAeKeyForOwnerMint,
-  deriveElGamalKeypairForOwnerMint,
+  deriveAeKey,
+  deriveElGamalKeypair,
   getCreateConfidentialTransferAccountInstructionPlan
 } from "@solana-program/token-2022/confidential";
 import {
@@ -409,11 +409,7 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  const auditor = await deriveElGamalKeypairForOwnerMint({
-    signer: payer,
-    owner: payer.address,
-    mint: mint.address
-  });
+  const auditor = await deriveElGamalKeypair({ signer: payer });
 
   const plan = getCreateMintInstructionPlan({
     payer,
@@ -445,10 +441,7 @@ async function createConfidentialTokenAccount(
     tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     mint
   });
-  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(
-    accountOwner,
-    mint
-  );
+  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(accountOwner);
 
   const plan = await getCreateConfidentialTransferAccountInstructionPlan({
     rpc: kitClient.rpc,
@@ -481,24 +474,13 @@ async function mintPublicTokens(
   ]);
 }
 
-async function deriveConfidentialKeys(
-  accountOwner: typeof owner,
-  mint: Awaited<ReturnType<typeof createConfidentialMint>>
-) {
-  const derivedElGamal = await deriveElGamalKeypairForOwnerMint({
-    signer: accountOwner,
-    owner: accountOwner.address,
-    mint
+async function deriveConfidentialKeys(accountOwner: typeof owner) {
+  const derivedElGamal = await deriveElGamalKeypair({
+    signer: accountOwner
   });
   const elgamalSecretKey = ElGamalSecretKey.fromBytes(derivedElGamal.secretKey);
   const elgamalKeypair = ElGamalKeypair.fromSecretKey(elgamalSecretKey);
-  const aesKey = AeKey.fromBytes(
-    await deriveAeKeyForOwnerMint({
-      signer: accountOwner,
-      owner: accountOwner.address,
-      mint
-    })
-  );
+  const aesKey = AeKey.fromBytes(await deriveAeKey({ signer: accountOwner }));
 
   return { elgamalKeypair, elgamalSecretKey, aesKey };
 }

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
@@ -59,6 +59,15 @@ mainnet-forking local validator such as [Surfpool](https://surfpool.run) does.
 Run the example against one of those (the code uses devnet) with a funded payer,
 and replace the placeholder mint and account addresses with your own.
 
+<Callout type="warn">
+  This example derives keys with the standard wallet-only derivation. A token
+  account configured before that standard holds `(owner, mint)`-seeded keys, so
+  the standard keys will not decrypt its balance and any proof built from them
+  fails verification. Check [accounts configured with legacy owner-mint
+  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-owner-mint-keys)
+  before running this against an account you did not just create.
+</Callout>
+
 ### Rust
 
 <CodeTabs>
@@ -408,8 +417,13 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
+  // The auditor is a separate party with its own wallet. The standard
+  // derivation binds keys to the wallet alone, so deriving the auditor key
+  // from `payer` would hand the auditor the very key that decrypts every
+  // confidential balance that wallet owns, on every mint.
+  const auditorSigner = await generateKeyPairSigner();
   const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
-    signer: payer
+    signer: auditorSigner
   });
 
   const plan = getCreateMintInstructionPlan({

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
@@ -61,10 +61,11 @@ and replace the placeholder mint and account addresses with your own.
 
 <Callout type="warn">
   This example derives keys with the standard wallet-only derivation. A token
-  account configured before that standard holds `(owner, mint)`-seeded keys, so
-  the standard keys will not decrypt its balance and any proof built from them
-  fails verification. Check [accounts configured with legacy owner-mint
-  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-owner-mint-keys)
+  account configured before that standard holds seeded keys, from either the
+  `(owner, mint)` pair or the token account address, so the standard keys will
+  not decrypt its balance and any proof built from them fails verification.
+  Check [accounts configured with legacy seeded
+  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-seeded-keys)
   before running this against an account you did not just create.
 </Callout>
 
@@ -417,7 +418,12 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  // The auditor is a separate party with its own wallet. The standard
+  // This demo mint gets a throwaway auditor: nothing below decrypts as the
+  // auditor, and the secret is discarded when the process exits. A real auditor
+  // has to keep its wallet, since that wallet is the only way to recover the
+  // key that decrypts transfers. See create-mint for that setup.
+  //
+  // Note that the auditor is a separate party with its own wallet. The standard
   // derivation binds keys to the wallet alone, so deriving the auditor key
   // from `payer` would hand the auditor the very key that decrypts every
   // confidential balance that wallet owns, on every mint.

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
@@ -59,16 +59,6 @@ mainnet-forking local validator such as [Surfpool](https://surfpool.run) does.
 Run the example against one of those (the code uses devnet) with a funded payer,
 and replace the placeholder mint and account addresses with your own.
 
-<Callout type="warn">
-  This example derives keys with the standard wallet-only derivation. A token
-  account configured before that standard holds seeded keys, from either the
-  `(owner, mint)` pair or the token account address, so the standard keys will
-  not decrypt its balance and any proof built from them fails verification.
-  Check [accounts configured with legacy seeded
-  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-seeded-keys)
-  before running this against an account you did not just create.
-</Callout>
-
 ### Rust
 
 <CodeTabs>
@@ -418,15 +408,8 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  // This demo mint gets a throwaway auditor: nothing below decrypts as the
-  // auditor, and the secret is discarded when the process exits. A real auditor
-  // has to keep its wallet, since that wallet is the only way to recover the
-  // key that decrypts transfers. See create-mint for that setup.
-  //
-  // Note that the auditor is a separate party with its own wallet. The standard
-  // derivation binds keys to the wallet alone, so deriving the auditor key
-  // from `payer` would hand the auditor the very key that decrypts every
-  // confidential balance that wallet owns, on every mint.
+  // Demo-only auditor from a throwaway wallet; see create-mint for real
+  // auditor setup.
   const auditorSigner = await generateKeyPairSigner();
   const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
     signer: auditorSigner

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/deposit-tokens.mdx
@@ -228,7 +228,7 @@ fn configure_confidential_token_account(
         &[ExtensionType::ConfidentialTransferAccount],
     )?;
 
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner)
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
     let decryptable_balance: PodAeCiphertext = aes_key.encrypt(0).into();
 
@@ -342,11 +342,10 @@ serde_json = "1.0"
 <CodeTabs>
 
 ```ts !! title="index.ts"
-// !collapse(1:23) collapsed
+// !collapse(1:22) collapsed
 // Imports: dependencies used by this example.
 import {
-  deriveAeKey,
-  deriveElGamalKeypair,
+  deriveConfidentialKeys,
   getCreateConfidentialTransferAccountInstructionPlan
 } from "@solana-program/token-2022/confidential";
 import {
@@ -409,7 +408,9 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  const auditor = await deriveElGamalKeypair({ signer: payer });
+  const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
+    signer: payer
+  });
 
   const plan = getCreateMintInstructionPlan({
     payer,
@@ -441,7 +442,8 @@ async function createConfidentialTokenAccount(
     tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     mint
   });
-  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(accountOwner);
+  const { elgamalKeypair, aesKey } =
+    await deriveConfidentialWasmKeys(accountOwner);
 
   const plan = await getCreateConfidentialTransferAccountInstructionPlan({
     rpc: kitClient.rpc,
@@ -474,15 +476,19 @@ async function mintPublicTokens(
   ]);
 }
 
-async function deriveConfidentialKeys(accountOwner: typeof owner) {
-  const derivedElGamal = await deriveElGamalKeypair({
+async function deriveConfidentialWasmKeys(accountOwner: typeof owner) {
+  // One signature over the constant solana-conf-bal/v1 message derives both
+  // keys, bound to the wallet alone.
+  const { aeKey, elgamalKeypair } = await deriveConfidentialKeys({
     signer: accountOwner
   });
-  const elgamalSecretKey = ElGamalSecretKey.fromBytes(derivedElGamal.secretKey);
-  const elgamalKeypair = ElGamalKeypair.fromSecretKey(elgamalSecretKey);
-  const aesKey = AeKey.fromBytes(await deriveAeKey({ signer: accountOwner }));
+  const elgamalSecretKey = ElGamalSecretKey.fromBytes(elgamalKeypair.secretKey);
 
-  return { elgamalKeypair, elgamalSecretKey, aesKey };
+  return {
+    elgamalKeypair: ElGamalKeypair.fromSecretKey(elgamalSecretKey),
+    elgamalSecretKey,
+    aesKey: AeKey.fromBytes(aeKey)
+  };
 }
 ```
 

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
@@ -63,9 +63,9 @@ not anonymity.
 
 ## Terms
 
-- **ElGamal keypair**: per-account public-key keypair used to encrypt balances
-  and build ZK proofs. The public key is stored on the account.
-- **AES key**: per-account symmetric key used to encrypt the "decryptable
+- **ElGamal keypair**: the owner's public-key keypair used to encrypt balances
+  and build ZK proofs. The public key is stored on each configured account.
+- **AES key**: the owner's symmetric key used to encrypt the "decryptable
   available balance" so the owner can read their available balance in constant
   time, without solving a discrete log.
 - **Pending balance**: encrypted balance of funds received via deposits or
@@ -111,10 +111,12 @@ store those keys is an integration choice. A few common options:
 - **Derive from a wallet signature (recommended default).** The owner signs a
   canonical, domain-separated message and the keys are derived from that
   signature, so they are reproducible from the wallet alone and you do not have
-  to store them. The seed is deterministic per account: the JS helpers below
-  bind it to the `(owner, mint)` pair, while the Rust example seeds from the
-  token account address (for an associated token account these are equivalent,
-  since that address is itself derived from the owner and mint).
+  to store them. The standard derivation binds the keys to the main wallet only
+  (an empty public seed), so one wallet maps to one ElGamal keypair and one AES
+  key across all mints and token accounts. Earlier revisions of the helpers
+  seeded from the `(owner, mint)` pair or the token account address; those
+  variants are deprecated and should only be kept for decrypting balances that
+  were encrypted under them.
 - **Derive from independent key material.** For passkeys, secure enclaves, or
   MPC setups, derive the keys from a WebAuthn PRF output or other input key
   material so that the confidential keys are not tied to the account's signing
@@ -129,32 +131,25 @@ The `@solana-program/token-2022` client ships helpers for the recommended path:
 
 ```ts !! title="JS-derive-keys.ts"
 import {
-  deriveElGamalKeypairForOwnerMint,
-  deriveAeKeyForOwnerMint
-} from "@solana-program/token-2022";
+  deriveAeKey,
+  deriveElGamalKeypair
+} from "@solana-program/token-2022/confidential";
 
-// `owner` signs a domain-separated message; the keys are bound to (owner, mint).
-const { elgamalPubkey, secretKey } = await deriveElGamalKeypairForOwnerMint({
-  signer: owner,
-  owner: owner.address,
-  mint
+// `owner` signs a domain-separated message; the keys are bound to the wallet.
+const { elgamalPubkey, secretKey } = await deriveElGamalKeypair({
+  signer: owner
 });
-const aesKey = await deriveAeKeyForOwnerMint({
-  signer: owner,
-  owner: owner.address,
-  mint
-});
+const aesKey = await deriveAeKey({ signer: owner });
 ```
 
 ```rust !! title="rust-derive-keys.rs"
 use solana_zk_sdk::encryption::derivation::derive_confidential_keys;
 
-// `signer` is the account owner; the token account address is the public seed.
-// This is the canonical, domain-separated derivation that the JS helpers also
+// `signer` is the account owner; the standard derivation uses an empty public
+// seed. This is the same canonical, domain-separated derivation the JS helpers
 // use, so the keys match across clients.
-let (elgamal_keypair, aes_key) =
-    derive_confidential_keys(&signer, &token_account_pubkey.to_bytes())
-        .expect("Failed to derive confidential keys");
+let (elgamal_keypair, aes_key) = derive_confidential_keys(&signer, b"")
+    .expect("Failed to derive confidential keys");
 ```
 
 </CodeTabs>
@@ -510,7 +505,10 @@ from the mint config (the high-level helpers read it for you).
 If your product is the auditor (for example a regulated issuer or a compliance
 provider), you decrypt transfer amounts with the auditor secret key the same way
 an owner decrypts their own balance. Owners can also selectively share their
-per-account keys with a specific party without exposing them publicly.
+keys with a specific party without exposing them publicly — though under the
+standard wallet-bound derivation, the same keys cover all of the owner's
+confidential balances, so sharing them discloses every confidential account, not
+just one.
 
 ### Transaction monitoring (KYT)
 
@@ -604,4 +602,4 @@ is observable, not the overall model:
 | Address and graph screening   | Screen senders, recipients, mints, and owners and run counterparty graph analysis; these stay public.            | **P0**   |
 | Track public deposit/withdraw | Monitor cleartext deposit and withdraw amounts as the observable entry and exit points of the confidential pool. | **P0**   |
 | Auditor-key amount visibility | For auditor-enabled mints, decrypt transfer amounts using the auditor key to support amount-based detection.     | **P1**   |
-| Selective disclosure intake   | Support amount disclosures shared by users or issuers via per-account keys.                                      | **P2**   |
+| Selective disclosure intake   | Support amount disclosures shared by users or issuers via the owner's keys.                                      | **P2**   |

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
@@ -112,11 +112,12 @@ store those keys is an integration choice. A few common options:
   canonical, domain-separated message and the keys are derived from that
   signature, so they are reproducible from the wallet alone and you do not have
   to store them. The standard derivation binds the keys to the main wallet only
-  (an empty public seed), so one wallet maps to one ElGamal keypair and one AES
-  key across all mints and token accounts. Earlier revisions of the helpers
-  seeded from the `(owner, mint)` pair or the token account address; those
-  variants are deprecated and should only be kept for decrypting balances that
-  were encrypted under them.
+  and takes no seed at all, so clients cannot accidentally derive different
+  keys: one wallet maps to one ElGamal keypair and one AES key across all mints
+  and token accounts. Earlier revisions of the helpers seeded from the
+  `(owner, mint)` pair or the token account address; those variants are
+  deprecated and should only be kept for decrypting balances that were encrypted
+  under them.
 - **Derive from independent key material.** For passkeys, secure enclaves, or
   MPC setups, derive the keys from a WebAuthn PRF output or other input key
   material so that the confidential keys are not tied to the account's signing
@@ -130,25 +131,22 @@ The `@solana-program/token-2022` client ships helpers for the recommended path:
 <CodeTabs>
 
 ```ts !! title="JS-derive-keys.ts"
-import {
-  deriveAeKey,
-  deriveElGamalKeypair
-} from "@solana-program/token-2022/confidential";
+import { deriveConfidentialKeys } from "@solana-program/token-2022/confidential";
 
-// `owner` signs a domain-separated message; the keys are bound to the wallet.
-const { elgamalPubkey, secretKey } = await deriveElGamalKeypair({
+// `owner` signs the constant message "solana-conf-bal/v1" once; both keys are
+// derived from that single signature and bound to the wallet alone.
+const { aeKey, elgamalKeypair } = await deriveConfidentialKeys({
   signer: owner
 });
-const aesKey = await deriveAeKey({ signer: owner });
 ```
 
 ```rust !! title="rust-derive-keys.rs"
 use solana_zk_sdk::encryption::derivation::derive_confidential_keys;
 
-// `signer` is the account owner; the standard derivation uses an empty public
-// seed. This is the same canonical, domain-separated derivation the JS helpers
-// use, so the keys match across clients.
-let (elgamal_keypair, aes_key) = derive_confidential_keys(&signer, b"")
+// `signer` is the account owner. The standard derivation takes no seed: it
+// signs the constant message "solana-conf-bal/v1", so the keys match across
+// every standard client for the same wallet.
+let (elgamal_keypair, aes_key) = derive_confidential_keys(&signer)
     .expect("Failed to derive confidential keys");
 ```
 
@@ -158,7 +156,10 @@ let (elgamal_keypair, aes_key) = derive_confidential_keys(&signer, b"")
   Confidential keys are decryption keys. Treat a request to sign the derivation
   message like unlocking a private view of the user's balances. Prefer deriving
   on demand over storing them; if you do store them (for example in a custodial
-  service), protect them with the same rigor as signing keys.
+  service), protect them with the same rigor as signing keys. Wallets should
+  expose this signature through a dedicated derivation flow and refuse generic
+  signMessage requests for messages starting with `solana-conf-bal/v1`, since
+  that signature is the input key material for the user's decryption keys.
 </Callout>
 
 The derivation helpers return serialized key material. The high-level operation
@@ -172,10 +173,10 @@ import {
   AeKey
 } from "@solana/zk-sdk/bundler";
 
-const elgamalKeypair = ElGamalKeypair.fromSecretKey(
-  ElGamalSecretKey.fromBytes(secretKey)
+const elgamalKeypairObject = ElGamalKeypair.fromSecretKey(
+  ElGamalSecretKey.fromBytes(elgamalKeypair.secretKey)
 );
-const aesKeyObject = AeKey.fromBytes(aesKey);
+const aesKeyObject = AeKey.fromBytes(aeKey);
 ```
 
 ## Creating and configuring accounts

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
@@ -178,24 +178,37 @@ const elgamalKeypairObject = ElGamalKeypair.fromSecretKey(
 const aesKeyObject = AeKey.fromBytes(aeKey);
 ```
 
-### Accounts configured with legacy owner-mint keys
+### Accounts configured with legacy seeded keys
 
 Accounts configured before the wallet-only standard store an ElGamal public key
-derived from an `(owner, mint)` seed, and their `decryptable_available_balance`
-is encrypted under the matching AES key. The no-seed derivation cannot reproduce
+derived from a public seed, and their `decryptable_available_balance` is
+encrypted under the matching AES key. The no-seed derivation cannot reproduce
 either one, so on those accounts AES decryption yields garbage and any proof
-built from the standard keys fails verification. Detect the case by comparing
-the account's stored `elgamal_pubkey` against the standard key for the owner: if
-they differ, the account is on legacy keys and must keep using the deprecated
-seeded helpers (`deriveElGamalKeypairForOwnerMint` and `deriveAeKeyForOwnerMint`
-in JS, `derive_confidential_keys_with_seed` with the concatenated owner and mint
-bytes in Rust).
+built from the standard keys fails verification.
+
+Two seeds were in circulation, and a migration has to handle both:
+
+- **The `(owner, mint)` pair**, used by the deprecated JS helpers
+  `deriveElGamalKeypairForOwnerMint` and `deriveAeKeyForOwnerMint`. Reproduce it
+  with those same helpers, or in Rust with `derive_confidential_keys_with_seed`
+  over the concatenated owner and mint bytes.
+- **The token account address**, used by the earlier Rust examples on these
+  pages. Reproduce it with
+  `derive_confidential_keys_with_seed(&owner, &token_account.to_bytes())`.
+
+Detect which derivation an account is on by comparing its stored
+`elgamal_pubkey` against the standard key for the owner, then against each
+legacy candidate. Whichever matches is the derivation that account must keep
+using. If none match, the key came from somewhere else (a randomly generated
+keypair, an ElGamal registry entry, or a custom seed) and only its holder can
+supply it.
 
 There is no in-place rekey. `ConfigureAccount` fails with
 `ExtensionAlreadyInitialized` on an account that already has the extension, so
 moving an account onto the standard keys means draining and recreating it:
 
-1. Derive the legacy keys with the deprecated seeded helpers.
+1. Derive the legacy keys with whichever seed matched the account's stored
+   `elgamal_pubkey`.
 2. Apply any pending balance, then withdraw the full available balance to the
    public balance, using those legacy keys throughout.
 3. Empty the confidential balance and close the token account.

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
@@ -114,9 +114,7 @@ store those keys is an integration choice. A few common options:
   to store them. The standard derivation binds the keys to the main wallet only
   and takes no seed at all, so clients cannot accidentally derive different
   keys: one wallet maps to one ElGamal keypair and one AES key across all mints
-  and token accounts. The deprecated `ForOwnerMint` helpers derive
-  `(owner, mint)`-scoped keys; use them only to decrypt and migrate balances on
-  accounts configured with those keys.
+  and token accounts.
 - **Derive from independent key material.** For passkeys, secure enclaves, or
   MPC setups, derive the keys from a WebAuthn PRF output or other input key
   material so that the confidential keys are not tied to the account's signing
@@ -177,47 +175,6 @@ const elgamalKeypairObject = ElGamalKeypair.fromSecretKey(
 );
 const aesKeyObject = AeKey.fromBytes(aeKey);
 ```
-
-### Accounts configured with legacy seeded keys
-
-Accounts configured before the wallet-only standard store an ElGamal public key
-derived from a public seed, and their `decryptable_available_balance` is
-encrypted under the matching AES key. The no-seed derivation cannot reproduce
-either one, so on those accounts AES decryption yields garbage and any proof
-built from the standard keys fails verification.
-
-Two seeds were in circulation, and a migration has to handle both:
-
-- **The `(owner, mint)` pair**, used by the deprecated JS helpers
-  `deriveElGamalKeypairForOwnerMint` and `deriveAeKeyForOwnerMint`. Reproduce it
-  with those same helpers, or in Rust with `derive_confidential_keys_with_seed`
-  over the concatenated owner and mint bytes.
-- **The token account address**, used by the earlier Rust examples on these
-  pages. Reproduce it with
-  `derive_confidential_keys_with_seed(&owner, &token_account.to_bytes())`.
-
-Detect which derivation an account is on by comparing its stored
-`elgamal_pubkey` against the standard key for the owner, then against each
-legacy candidate. Whichever matches is the derivation that account must keep
-using. If none match, the key came from somewhere else (a randomly generated
-keypair, an ElGamal registry entry, or a custom seed) and only its holder can
-supply it.
-
-There is no in-place rekey. `ConfigureAccount` fails with
-`ExtensionAlreadyInitialized` on an account that already has the extension, so
-moving an account onto the standard keys means draining and recreating it:
-
-1. Derive the legacy keys with whichever seed matched the account's stored
-   `elgamal_pubkey`.
-2. Apply any pending balance, then withdraw the full available balance to the
-   public balance, using those legacy keys throughout.
-3. Empty the confidential balance and close the token account.
-4. Recreate the token account and configure it with the standard wallet-only
-   keys, then deposit and apply again.
-
-Retain the legacy keys afterwards if you need to read historical activity: past
-transfer ciphertexts stay encrypted under whichever key was active when they
-executed.
 
 ## Creating and configuring accounts
 

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
@@ -114,10 +114,9 @@ store those keys is an integration choice. A few common options:
   to store them. The standard derivation binds the keys to the main wallet only
   and takes no seed at all, so clients cannot accidentally derive different
   keys: one wallet maps to one ElGamal keypair and one AES key across all mints
-  and token accounts. Earlier revisions of the helpers seeded from the
-  `(owner, mint)` pair or the token account address; those variants are
-  deprecated and should only be kept for decrypting balances that were encrypted
-  under them.
+  and token accounts. The deprecated `ForOwnerMint` helpers derive
+  `(owner, mint)`-scoped keys; use them only to decrypt and migrate balances on
+  accounts configured with those keys.
 - **Derive from independent key material.** For passkeys, secure enclaves, or
   MPC setups, derive the keys from a WebAuthn PRF output or other input key
   material so that the confidential keys are not tied to the account's signing

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/integration-guide.mdx
@@ -178,6 +178,34 @@ const elgamalKeypairObject = ElGamalKeypair.fromSecretKey(
 const aesKeyObject = AeKey.fromBytes(aeKey);
 ```
 
+### Accounts configured with legacy owner-mint keys
+
+Accounts configured before the wallet-only standard store an ElGamal public key
+derived from an `(owner, mint)` seed, and their `decryptable_available_balance`
+is encrypted under the matching AES key. The no-seed derivation cannot reproduce
+either one, so on those accounts AES decryption yields garbage and any proof
+built from the standard keys fails verification. Detect the case by comparing
+the account's stored `elgamal_pubkey` against the standard key for the owner: if
+they differ, the account is on legacy keys and must keep using the deprecated
+seeded helpers (`deriveElGamalKeypairForOwnerMint` and `deriveAeKeyForOwnerMint`
+in JS, `derive_confidential_keys_with_seed` with the concatenated owner and mint
+bytes in Rust).
+
+There is no in-place rekey. `ConfigureAccount` fails with
+`ExtensionAlreadyInitialized` on an account that already has the extension, so
+moving an account onto the standard keys means draining and recreating it:
+
+1. Derive the legacy keys with the deprecated seeded helpers.
+2. Apply any pending balance, then withdraw the full available balance to the
+   public balance, using those legacy keys throughout.
+3. Empty the confidential balance and close the token account.
+4. Recreate the token account and configure it with the standard wallet-only
+   keys, then deposit and apply again.
+
+Retain the legacy keys afterwards if you need to read historical activity: past
+transfer ciphertexts stay encrypted under whichever key was active when they
+executed.
+
 ## Creating and configuring accounts
 
 Before an account can hold a confidential balance it needs the

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
@@ -210,9 +210,8 @@ fn main() -> Result<()> {
             .transpose()?;
 
     // Derive the sender's keys and read their current confidential balance.
-    let (sender_elgamal, sender_aes) =
-        derive_confidential_keys(&sender, &sender_token_account.to_bytes())
-            .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
+    let (sender_elgamal, sender_aes) = derive_confidential_keys(&sender, b"")
+        .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     let sender_acc = rpc_client.get_account(&sender_token_account)?;
     let sender_state = StateWithExtensions::<TokenAccount>::unpack(&sender_acc.data)?;
@@ -470,7 +469,7 @@ fn configure_confidential_token_account(
         &[ExtensionType::ConfidentialTransferAccount],
     )?;
 
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, &token_account.to_bytes())
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
     let decryptable_balance: PodAeCiphertext = aes_key.encrypt(0).into();
 
@@ -530,7 +529,7 @@ fn apply_pending_balance_for_account(
     owner: &Keypair,
     token_account: &Pubkey,
 ) -> Result<()> {
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, &token_account.to_bytes())
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     let account_data = rpc_client.get_account(token_account)?;
@@ -630,8 +629,8 @@ serde_json = "1.0"
 // !collapse(1:46) collapsed
 // Imports: dependencies used by this example.
 import {
-  deriveAeKeyForOwnerMint,
-  deriveElGamalKeypairForOwnerMint,
+  deriveAeKey,
+  deriveElGamalKeypair,
   getApplyConfidentialPendingBalanceInstructionFromToken,
   getConfidentialTransferInstructionPlan,
   getCreateConfidentialTransferAccountInstructionPlan
@@ -744,11 +743,11 @@ const destinationToken = await createConfidentialTokenAccount(
 );
 await mintPublicTokens(client, owner, mint, sourceToken, depositAmount);
 await depositTokens(client, owner, mint, sourceToken, depositAmount, decimals);
-await applyPendingBalance(client, owner, mint, sourceToken);
+await applyPendingBalance(client, owner, sourceToken);
 
-// Derive the sender's recoverable ElGamal and AES keys, bound to (owner, mint).
+// Derive the sender's recoverable ElGamal and AES keys, bound to the wallet.
 const { elgamalKeypair: sourceElgamalKeypair, aesKey } =
-  await deriveConfidentialKeys(owner, mint);
+  await deriveConfidentialKeys(owner);
 
 // The helper reads the recipient key from the destination account; pass the
 // configured auditor key so the proof matches the mint configuration.
@@ -810,11 +809,7 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  const auditor = await deriveElGamalKeypairForOwnerMint({
-    signer: payer,
-    owner: payer.address,
-    mint: mint.address
-  });
+  const auditor = await deriveElGamalKeypair({ signer: payer });
 
   const plan = getCreateMintInstructionPlan({
     payer,
@@ -847,10 +842,7 @@ async function createConfidentialTokenAccount(
     tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     mint
   });
-  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(
-    accountOwner,
-    mint
-  );
+  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(accountOwner);
 
   const plan = await getCreateConfidentialTransferAccountInstructionPlan({
     rpc: kitClient.rpc,
@@ -908,13 +900,10 @@ async function depositTokens(
 async function applyPendingBalance(
   kitClient: typeof client,
   accountOwner: typeof owner,
-  mint: Awaited<ReturnType<typeof createConfidentialMint>>,
   token: Awaited<ReturnType<typeof createConfidentialTokenAccount>>
 ) {
-  const { elgamalSecretKey, aesKey } = await deriveConfidentialKeys(
-    accountOwner,
-    mint
-  );
+  const { elgamalSecretKey, aesKey } =
+    await deriveConfidentialKeys(accountOwner);
   const tokenAccount = await fetchToken(kitClient.rpc, token);
   await kitClient.sendTransaction([
     getApplyConfidentialPendingBalanceInstructionFromToken({
@@ -928,24 +917,13 @@ async function applyPendingBalance(
   await pauseForPublicRpc();
 }
 
-async function deriveConfidentialKeys(
-  accountOwner: typeof owner,
-  mint: Awaited<ReturnType<typeof createConfidentialMint>>
-) {
-  const derivedElGamal = await deriveElGamalKeypairForOwnerMint({
-    signer: accountOwner,
-    owner: accountOwner.address,
-    mint
+async function deriveConfidentialKeys(accountOwner: typeof owner) {
+  const derivedElGamal = await deriveElGamalKeypair({
+    signer: accountOwner
   });
   const elgamalSecretKey = ElGamalSecretKey.fromBytes(derivedElGamal.secretKey);
   const elgamalKeypair = ElGamalKeypair.fromSecretKey(elgamalSecretKey);
-  const aesKey = AeKey.fromBytes(
-    await deriveAeKeyForOwnerMint({
-      signer: accountOwner,
-      owner: accountOwner.address,
-      mint
-    })
-  );
+  const aesKey = AeKey.fromBytes(await deriveAeKey({ signer: accountOwner }));
 
   return { elgamalKeypair, elgamalSecretKey, aesKey };
 }

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
@@ -112,6 +112,15 @@ Run the example against one of those (the code uses devnet) with a funded payer,
 and replace the placeholders with your mint and the sender and recipient
 accounts.
 
+<Callout type="warn">
+  This example derives keys with the standard wallet-only derivation. A token
+  account configured before that standard holds `(owner, mint)`-seeded keys, so
+  the standard keys will not decrypt its balance and any proof built from them
+  fails verification. Check [accounts configured with legacy owner-mint
+  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-owner-mint-keys)
+  before running this against an account you did not just create.
+</Callout>
+
 ### Rust
 
 <CodeTabs>
@@ -808,8 +817,13 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
+  // The auditor is a separate party with its own wallet. The standard
+  // derivation binds keys to the wallet alone, so deriving the auditor key
+  // from `payer` would hand the auditor the very key that decrypts every
+  // confidential balance that wallet owns, on every mint.
+  const auditorSigner = await generateKeyPairSigner();
   const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
-    signer: payer
+    signer: auditorSigner
   });
 
   const plan = getCreateMintInstructionPlan({

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
@@ -114,10 +114,11 @@ accounts.
 
 <Callout type="warn">
   This example derives keys with the standard wallet-only derivation. A token
-  account configured before that standard holds `(owner, mint)`-seeded keys, so
-  the standard keys will not decrypt its balance and any proof built from them
-  fails verification. Check [accounts configured with legacy owner-mint
-  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-owner-mint-keys)
+  account configured before that standard holds seeded keys, from either the
+  `(owner, mint)` pair or the token account address, so the standard keys will
+  not decrypt its balance and any proof built from them fails verification.
+  Check [accounts configured with legacy seeded
+  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-seeded-keys)
   before running this against an account you did not just create.
 </Callout>
 
@@ -817,7 +818,12 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  // The auditor is a separate party with its own wallet. The standard
+  // This demo mint gets a throwaway auditor: nothing below decrypts as the
+  // auditor, and the secret is discarded when the process exits. A real auditor
+  // has to keep its wallet, since that wallet is the only way to recover the
+  // key that decrypts transfers. See create-mint for that setup.
+  //
+  // Note that the auditor is a separate party with its own wallet. The standard
   // derivation binds keys to the wallet alone, so deriving the auditor key
   // from `payer` would hand the auditor the very key that decrypts every
   // confidential balance that wallet owns, on every mint.

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
@@ -210,7 +210,7 @@ fn main() -> Result<()> {
             .transpose()?;
 
     // Derive the sender's keys and read their current confidential balance.
-    let (sender_elgamal, sender_aes) = derive_confidential_keys(&sender, b"")
+    let (sender_elgamal, sender_aes) = derive_confidential_keys(&sender)
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     let sender_acc = rpc_client.get_account(&sender_token_account)?;
@@ -469,7 +469,7 @@ fn configure_confidential_token_account(
         &[ExtensionType::ConfidentialTransferAccount],
     )?;
 
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner)
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
     let decryptable_balance: PodAeCiphertext = aes_key.encrypt(0).into();
 
@@ -529,7 +529,7 @@ fn apply_pending_balance_for_account(
     owner: &Keypair,
     token_account: &Pubkey,
 ) -> Result<()> {
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner)
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     let account_data = rpc_client.get_account(token_account)?;
@@ -626,11 +626,10 @@ serde_json = "1.0"
 <CodeTabs>
 
 ```ts !! title="index.ts"
-// !collapse(1:46) collapsed
+// !collapse(1:45) collapsed
 // Imports: dependencies used by this example.
 import {
-  deriveAeKey,
-  deriveElGamalKeypair,
+  deriveConfidentialKeys,
   getApplyConfidentialPendingBalanceInstructionFromToken,
   getConfidentialTransferInstructionPlan,
   getCreateConfidentialTransferAccountInstructionPlan
@@ -747,7 +746,7 @@ await applyPendingBalance(client, owner, sourceToken);
 
 // Derive the sender's recoverable ElGamal and AES keys, bound to the wallet.
 const { elgamalKeypair: sourceElgamalKeypair, aesKey } =
-  await deriveConfidentialKeys(owner);
+  await deriveConfidentialWasmKeys(owner);
 
 // The helper reads the recipient key from the destination account; pass the
 // configured auditor key so the proof matches the mint configuration.
@@ -809,7 +808,9 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  const auditor = await deriveElGamalKeypair({ signer: payer });
+  const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
+    signer: payer
+  });
 
   const plan = getCreateMintInstructionPlan({
     payer,
@@ -842,7 +843,8 @@ async function createConfidentialTokenAccount(
     tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     mint
   });
-  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(accountOwner);
+  const { elgamalKeypair, aesKey } =
+    await deriveConfidentialWasmKeys(accountOwner);
 
   const plan = await getCreateConfidentialTransferAccountInstructionPlan({
     rpc: kitClient.rpc,
@@ -903,7 +905,7 @@ async function applyPendingBalance(
   token: Awaited<ReturnType<typeof createConfidentialTokenAccount>>
 ) {
   const { elgamalSecretKey, aesKey } =
-    await deriveConfidentialKeys(accountOwner);
+    await deriveConfidentialWasmKeys(accountOwner);
   const tokenAccount = await fetchToken(kitClient.rpc, token);
   await kitClient.sendTransaction([
     getApplyConfidentialPendingBalanceInstructionFromToken({
@@ -917,15 +919,19 @@ async function applyPendingBalance(
   await pauseForPublicRpc();
 }
 
-async function deriveConfidentialKeys(accountOwner: typeof owner) {
-  const derivedElGamal = await deriveElGamalKeypair({
+async function deriveConfidentialWasmKeys(accountOwner: typeof owner) {
+  // One signature over the constant solana-conf-bal/v1 message derives both
+  // keys, bound to the wallet alone.
+  const { aeKey, elgamalKeypair } = await deriveConfidentialKeys({
     signer: accountOwner
   });
-  const elgamalSecretKey = ElGamalSecretKey.fromBytes(derivedElGamal.secretKey);
-  const elgamalKeypair = ElGamalKeypair.fromSecretKey(elgamalSecretKey);
-  const aesKey = AeKey.fromBytes(await deriveAeKey({ signer: accountOwner }));
+  const elgamalSecretKey = ElGamalSecretKey.fromBytes(elgamalKeypair.secretKey);
 
-  return { elgamalKeypair, elgamalSecretKey, aesKey };
+  return {
+    elgamalKeypair: ElGamalKeypair.fromSecretKey(elgamalSecretKey),
+    elgamalSecretKey,
+    aesKey: AeKey.fromBytes(aeKey)
+  };
 }
 
 async function pauseForPublicRpc() {

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/transfer-tokens.mdx
@@ -112,16 +112,6 @@ Run the example against one of those (the code uses devnet) with a funded payer,
 and replace the placeholders with your mint and the sender and recipient
 accounts.
 
-<Callout type="warn">
-  This example derives keys with the standard wallet-only derivation. A token
-  account configured before that standard holds seeded keys, from either the
-  `(owner, mint)` pair or the token account address, so the standard keys will
-  not decrypt its balance and any proof built from them fails verification.
-  Check [accounts configured with legacy seeded
-  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-seeded-keys)
-  before running this against an account you did not just create.
-</Callout>
-
 ### Rust
 
 <CodeTabs>
@@ -818,15 +808,8 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  // This demo mint gets a throwaway auditor: nothing below decrypts as the
-  // auditor, and the secret is discarded when the process exits. A real auditor
-  // has to keep its wallet, since that wallet is the only way to recover the
-  // key that decrypts transfers. See create-mint for that setup.
-  //
-  // Note that the auditor is a separate party with its own wallet. The standard
-  // derivation binds keys to the wallet alone, so deriving the auditor key
-  // from `payer` would hand the auditor the very key that decrypts every
-  // confidential balance that wallet owns, on every mint.
+  // Demo-only auditor from a throwaway wallet; see create-mint for real
+  // auditor setup.
   const auditorSigner = await generateKeyPairSigner();
   const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
     signer: auditorSigner

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
@@ -172,7 +172,7 @@ fn main() -> Result<()> {
     let (mint, token_account) = setup_withdrawable_account(&rpc_client, &owner, amount, decimals)?;
 
     // Derive the owner's keys and read the current confidential available balance.
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(&owner, &token_account.to_bytes())
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(&owner, b"")
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     let account_data = rpc_client.get_account(&token_account)?;
@@ -387,7 +387,7 @@ fn configure_confidential_token_account(
         &[ExtensionType::ConfidentialTransferAccount],
     )?;
 
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, &token_account.to_bytes())
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
     let decryptable_balance: PodAeCiphertext = aes_key.encrypt(0).into();
 
@@ -447,7 +447,7 @@ fn apply_pending_balance_for_account(
     owner: &Keypair,
     token_account: &Pubkey,
 ) -> Result<()> {
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, &token_account.to_bytes())
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     let account_data = rpc_client.get_account(token_account)?;
@@ -547,8 +547,8 @@ serde_json = "1.0"
 // !collapse(1:31) collapsed
 // Imports: dependencies used by this example.
 import {
-  deriveAeKeyForOwnerMint,
-  deriveElGamalKeypairForOwnerMint,
+  deriveAeKey,
+  deriveElGamalKeypair,
   getApplyConfidentialPendingBalanceInstructionFromToken,
   getConfidentialWithdrawInstructionPlan,
   getCreateConfidentialTransferAccountInstructionPlan
@@ -598,10 +598,10 @@ const mint = await createConfidentialMint(client, owner, decimals);
 const token = await createConfidentialTokenAccount(client, owner, mint);
 await mintPublicTokens(client, owner, mint, token, depositAmount);
 await depositTokens(client, owner, mint, token, depositAmount, decimals);
-await applyPendingBalance(client, owner, mint, token);
+await applyPendingBalance(client, owner, token);
 
-// Derive the owner's recoverable ElGamal and AES keys, bound to (owner, mint).
-const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(owner, mint);
+// Derive the owner's recoverable ElGamal and AES keys, bound to the wallet.
+const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(owner);
 
 const tokenAccount = (await fetchToken(client.rpc, token)).data;
 
@@ -635,11 +635,7 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  const auditor = await deriveElGamalKeypairForOwnerMint({
-    signer: payer,
-    owner: payer.address,
-    mint: mint.address
-  });
+  const auditor = await deriveElGamalKeypair({ signer: payer });
 
   const plan = getCreateMintInstructionPlan({
     payer,
@@ -672,10 +668,7 @@ async function createConfidentialTokenAccount(
     tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     mint
   });
-  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(
-    accountOwner,
-    mint
-  );
+  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(accountOwner);
 
   const plan = await getCreateConfidentialTransferAccountInstructionPlan({
     rpc: kitClient.rpc,
@@ -733,13 +726,10 @@ async function depositTokens(
 async function applyPendingBalance(
   kitClient: typeof client,
   accountOwner: typeof owner,
-  mint: Awaited<ReturnType<typeof createConfidentialMint>>,
   token: Awaited<ReturnType<typeof createConfidentialTokenAccount>>
 ) {
-  const { elgamalSecretKey, aesKey } = await deriveConfidentialKeys(
-    accountOwner,
-    mint
-  );
+  const { elgamalSecretKey, aesKey } =
+    await deriveConfidentialKeys(accountOwner);
   const tokenAccount = await fetchToken(kitClient.rpc, token);
   await kitClient.sendTransaction([
     getApplyConfidentialPendingBalanceInstructionFromToken({
@@ -753,24 +743,13 @@ async function applyPendingBalance(
   await pauseForPublicRpc();
 }
 
-async function deriveConfidentialKeys(
-  accountOwner: typeof owner,
-  mint: Awaited<ReturnType<typeof createConfidentialMint>>
-) {
-  const derivedElGamal = await deriveElGamalKeypairForOwnerMint({
-    signer: accountOwner,
-    owner: accountOwner.address,
-    mint
+async function deriveConfidentialKeys(accountOwner: typeof owner) {
+  const derivedElGamal = await deriveElGamalKeypair({
+    signer: accountOwner
   });
   const elgamalSecretKey = ElGamalSecretKey.fromBytes(derivedElGamal.secretKey);
   const elgamalKeypair = ElGamalKeypair.fromSecretKey(elgamalSecretKey);
-  const aesKey = AeKey.fromBytes(
-    await deriveAeKeyForOwnerMint({
-      signer: accountOwner,
-      owner: accountOwner.address,
-      mint
-    })
-  );
+  const aesKey = AeKey.fromBytes(await deriveAeKey({ signer: accountOwner }));
 
   return { elgamalKeypair, elgamalSecretKey, aesKey };
 }

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
@@ -172,7 +172,7 @@ fn main() -> Result<()> {
     let (mint, token_account) = setup_withdrawable_account(&rpc_client, &owner, amount, decimals)?;
 
     // Derive the owner's keys and read the current confidential available balance.
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(&owner, b"")
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(&owner)
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     let account_data = rpc_client.get_account(&token_account)?;
@@ -387,7 +387,7 @@ fn configure_confidential_token_account(
         &[ExtensionType::ConfidentialTransferAccount],
     )?;
 
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner)
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
     let decryptable_balance: PodAeCiphertext = aes_key.encrypt(0).into();
 
@@ -447,7 +447,7 @@ fn apply_pending_balance_for_account(
     owner: &Keypair,
     token_account: &Pubkey,
 ) -> Result<()> {
-    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner, b"")
+    let (elgamal_keypair, aes_key) = derive_confidential_keys(owner)
         .map_err(|e| anyhow::anyhow!("derive confidential keys: {e}"))?;
 
     let account_data = rpc_client.get_account(token_account)?;
@@ -544,11 +544,10 @@ serde_json = "1.0"
 <CodeTabs>
 
 ```ts !! title="index.ts"
-// !collapse(1:31) collapsed
+// !collapse(1:30) collapsed
 // Imports: dependencies used by this example.
 import {
-  deriveAeKey,
-  deriveElGamalKeypair,
+  deriveConfidentialKeys,
   getApplyConfidentialPendingBalanceInstructionFromToken,
   getConfidentialWithdrawInstructionPlan,
   getCreateConfidentialTransferAccountInstructionPlan
@@ -601,7 +600,7 @@ await depositTokens(client, owner, mint, token, depositAmount, decimals);
 await applyPendingBalance(client, owner, token);
 
 // Derive the owner's recoverable ElGamal and AES keys, bound to the wallet.
-const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(owner);
+const { elgamalKeypair, aesKey } = await deriveConfidentialWasmKeys(owner);
 
 const tokenAccount = (await fetchToken(client.rpc, token)).data;
 
@@ -635,7 +634,9 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  const auditor = await deriveElGamalKeypair({ signer: payer });
+  const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
+    signer: payer
+  });
 
   const plan = getCreateMintInstructionPlan({
     payer,
@@ -668,7 +669,8 @@ async function createConfidentialTokenAccount(
     tokenProgram: TOKEN_2022_PROGRAM_ADDRESS,
     mint
   });
-  const { elgamalKeypair, aesKey } = await deriveConfidentialKeys(accountOwner);
+  const { elgamalKeypair, aesKey } =
+    await deriveConfidentialWasmKeys(accountOwner);
 
   const plan = await getCreateConfidentialTransferAccountInstructionPlan({
     rpc: kitClient.rpc,
@@ -729,7 +731,7 @@ async function applyPendingBalance(
   token: Awaited<ReturnType<typeof createConfidentialTokenAccount>>
 ) {
   const { elgamalSecretKey, aesKey } =
-    await deriveConfidentialKeys(accountOwner);
+    await deriveConfidentialWasmKeys(accountOwner);
   const tokenAccount = await fetchToken(kitClient.rpc, token);
   await kitClient.sendTransaction([
     getApplyConfidentialPendingBalanceInstructionFromToken({
@@ -743,15 +745,19 @@ async function applyPendingBalance(
   await pauseForPublicRpc();
 }
 
-async function deriveConfidentialKeys(accountOwner: typeof owner) {
-  const derivedElGamal = await deriveElGamalKeypair({
+async function deriveConfidentialWasmKeys(accountOwner: typeof owner) {
+  // One signature over the constant solana-conf-bal/v1 message derives both
+  // keys, bound to the wallet alone.
+  const { aeKey, elgamalKeypair } = await deriveConfidentialKeys({
     signer: accountOwner
   });
-  const elgamalSecretKey = ElGamalSecretKey.fromBytes(derivedElGamal.secretKey);
-  const elgamalKeypair = ElGamalKeypair.fromSecretKey(elgamalSecretKey);
-  const aesKey = AeKey.fromBytes(await deriveAeKey({ signer: accountOwner }));
+  const elgamalSecretKey = ElGamalSecretKey.fromBytes(elgamalKeypair.secretKey);
 
-  return { elgamalKeypair, elgamalSecretKey, aesKey };
+  return {
+    elgamalKeypair: ElGamalKeypair.fromSecretKey(elgamalSecretKey),
+    elgamalSecretKey,
+    aesKey: AeKey.fromBytes(aeKey)
+  };
 }
 
 async function pauseForPublicRpc() {

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
@@ -96,16 +96,6 @@ mainnet-forking local validator such as [Surfpool](https://surfpool.run) does.
 Run the example against one of those (the code uses devnet) with a funded payer,
 and replace the placeholders with your mint and token account.
 
-<Callout type="warn">
-  This example derives keys with the standard wallet-only derivation. A token
-  account configured before that standard holds seeded keys, from either the
-  `(owner, mint)` pair or the token account address, so the standard keys will
-  not decrypt its balance and any proof built from them fails verification.
-  Check [accounts configured with legacy seeded
-  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-seeded-keys)
-  before running this against an account you did not just create.
-</Callout>
-
 ### Rust
 
 <CodeTabs>
@@ -644,15 +634,8 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  // This demo mint gets a throwaway auditor: nothing below decrypts as the
-  // auditor, and the secret is discarded when the process exits. A real auditor
-  // has to keep its wallet, since that wallet is the only way to recover the
-  // key that decrypts transfers. See create-mint for that setup.
-  //
-  // Note that the auditor is a separate party with its own wallet. The standard
-  // derivation binds keys to the wallet alone, so deriving the auditor key
-  // from `payer` would hand the auditor the very key that decrypts every
-  // confidential balance that wallet owns, on every mint.
+  // Demo-only auditor from a throwaway wallet; see create-mint for real
+  // auditor setup.
   const auditorSigner = await generateKeyPairSigner();
   const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
     signer: auditorSigner

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
@@ -98,10 +98,11 @@ and replace the placeholders with your mint and token account.
 
 <Callout type="warn">
   This example derives keys with the standard wallet-only derivation. A token
-  account configured before that standard holds `(owner, mint)`-seeded keys, so
-  the standard keys will not decrypt its balance and any proof built from them
-  fails verification. Check [accounts configured with legacy owner-mint
-  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-owner-mint-keys)
+  account configured before that standard holds seeded keys, from either the
+  `(owner, mint)` pair or the token account address, so the standard keys will
+  not decrypt its balance and any proof built from them fails verification.
+  Check [accounts configured with legacy seeded
+  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-seeded-keys)
   before running this against an account you did not just create.
 </Callout>
 
@@ -643,7 +644,12 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
-  // The auditor is a separate party with its own wallet. The standard
+  // This demo mint gets a throwaway auditor: nothing below decrypts as the
+  // auditor, and the secret is discarded when the process exits. A real auditor
+  // has to keep its wallet, since that wallet is the only way to recover the
+  // key that decrypts transfers. See create-mint for that setup.
+  //
+  // Note that the auditor is a separate party with its own wallet. The standard
   // derivation binds keys to the wallet alone, so deriving the auditor key
   // from `payer` would hand the auditor the very key that decrypts every
   // confidential balance that wallet owns, on every mint.

--- a/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/confidential-transfer/withdraw-tokens.mdx
@@ -96,6 +96,15 @@ mainnet-forking local validator such as [Surfpool](https://surfpool.run) does.
 Run the example against one of those (the code uses devnet) with a funded payer,
 and replace the placeholders with your mint and token account.
 
+<Callout type="warn">
+  This example derives keys with the standard wallet-only derivation. A token
+  account configured before that standard holds `(owner, mint)`-seeded keys, so
+  the standard keys will not decrypt its balance and any proof built from them
+  fails verification. Check [accounts configured with legacy owner-mint
+  keys](/docs/tokens/extensions/confidential-transfer/integration-guide#accounts-configured-with-legacy-owner-mint-keys)
+  before running this against an account you did not just create.
+</Callout>
+
 ### Rust
 
 <CodeTabs>
@@ -634,8 +643,13 @@ async function createConfidentialMint(
   decimals: number
 ) {
   const mint = await generateKeyPairSigner();
+  // The auditor is a separate party with its own wallet. The standard
+  // derivation binds keys to the wallet alone, so deriving the auditor key
+  // from `payer` would hand the auditor the very key that decrypts every
+  // confidential balance that wallet owns, on every mint.
+  const auditorSigner = await generateKeyPairSigner();
   const { elgamalKeypair: auditor } = await deriveConfidentialKeys({
-    signer: payer
+    signer: auditorSigner
   });
 
   const plan = getCreateMintInstructionPlan({


### PR DESCRIPTION
## Summary

Updates the confidential-transfer docs to the wallet-only key derivation standard, now matching the enforced no-seed SDK APIs: one wallet maps to one ElGamal keypair and one AES key across all mints and token accounts, and the standard functions take no seed at all so clients cannot accidentally derive different keys.

- JS snippets use the new sign-once deriveConfidentialKeys({ signer }) from @solana-program/token-2022/confidential (one signature over the constant solana-conf-bal/v1 message derives both keys). The local WASM-wrapping helper in the examples is renamed deriveConfidentialWasmKeys so it doesn't shadow the import. Tracks solana-program/token-2022#1432.
- Rust snippets use the no-seed derive_confidential_keys(&signer). Tracks solana-program/zk-elgamal-proof#533.
- The integration guide's key-management section explains the no-seed standard, keeps the note that sharing wallet-bound keys discloses all of an owner's confidential balances, and adds the wallet-side guidance: expose derivation through a dedicated flow and refuse generic signMessage requests for messages starting with solana-conf-bal/v1.
- Also fixes the integration guide importing the derivation helpers from the package root: they only exist on the /confidential subpath.

Merge ordering: this should land after the SDK PRs above ship in releases (@solana-program/token-2022 with deriveConfidentialKeys, solana-zk-sdk with the no-seed derive_confidential_keys), so the docs never reference unpublished APIs.

Localized mirrors (pl, vi, ja, etc.) are intentionally untouched: they flow through the lingo i18n pipeline.

Refs: ECO-504