### PR TITLE
Add blockchain.com explorer

### DIFF
--- a/apps/web/src/data/navigation-hubs.ts
+++ b/apps/web/src/data/navigation-hubs.ts
@@ -662,6 +662,10 @@ const navigationHubStaticConfigs = {
             external: true,
           },
           {
+            href: "https://www.blockchain.com/explorer/assets/sol",
+            external: true,
+          },
+          {
             href: "https://status.solana.com/",
             external: true,
           },

--- a/packages/i18n/messages/web/ar/common.json
+++ b/packages/i18n/messages/web/ar/common.json
@@ -2094,6 +2094,10 @@
               "description": "مستكشف بلوكتشين سولانا بواسطة OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "مستكشف بلوكتشين سولانا بواسطة Blockchain.com."
+            },
+            {
               "title": "الحالة",
               "description": "حالة الشبكة الحالية والأحداث الطارئة."
             }

--- a/packages/i18n/messages/web/de/common.json
+++ b/packages/i18n/messages/web/de/common.json
@@ -2094,6 +2094,10 @@
               "description": "Solana-Blockchain-Explorer von OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Solana-Blockchain-Explorer von Blockchain.com."
+            },
+            {
               "title": "Status",
               "description": "Aktueller Netzwerkstatus und Störungen."
             }

--- a/packages/i18n/messages/web/el/common.json
+++ b/packages/i18n/messages/web/el/common.json
@@ -2094,6 +2094,10 @@
               "description": "Εξερευνητής blockchain Solana από το OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Εξερευνητής blockchain Solana από το Blockchain.com."
+            },
+            {
               "title": "Κατάσταση",
               "description": "Τρέχουσα κατάσταση δικτύου και περιστατικά."
             }

--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -2094,6 +2094,10 @@
               "description": "Solana blockchain explorer by OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Solana blockchain explorer by Blockchain.com."
+            },
+            {
               "title": "Status",
               "description": "Current network status and incidents."
             }

--- a/packages/i18n/messages/web/es/common.json
+++ b/packages/i18n/messages/web/es/common.json
@@ -2094,6 +2094,10 @@
               "description": "Explorador de la blockchain de Solana por OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Explorador de la blockchain de Solana por Blockchain.com."
+            },
+            {
               "title": "Estado",
               "description": "Estado actual de la red e incidencias."
             }

--- a/packages/i18n/messages/web/fi/common.json
+++ b/packages/i18n/messages/web/fi/common.json
@@ -2094,6 +2094,10 @@
               "description": "OKX:n Solana-lohkoketjuselain."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Blockchain.comin Solana-lohkoketjuselain."
+            },
+            {
               "title": "Tila",
               "description": "Verkon nykyinen tila ja häiriöt."
             }

--- a/packages/i18n/messages/web/fr/common.json
+++ b/packages/i18n/messages/web/fr/common.json
@@ -2094,6 +2094,10 @@
               "description": "Explorateur de la blockchain Solana par OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Explorateur de la blockchain Solana par Blockchain.com."
+            },
+            {
               "title": "Statut",
               "description": "Statut actuel du réseau et incidents."
             }

--- a/packages/i18n/messages/web/id/common.json
+++ b/packages/i18n/messages/web/id/common.json
@@ -2094,6 +2094,10 @@
               "description": "Block explorer blockchain Solana oleh OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Block explorer blockchain Solana oleh Blockchain.com."
+            },
+            {
               "title": "Status",
               "description": "Status jaringan terkini dan insiden yang terjadi."
             }

--- a/packages/i18n/messages/web/it/common.json
+++ b/packages/i18n/messages/web/it/common.json
@@ -2094,6 +2094,10 @@
               "description": "Block explorer della blockchain Solana di OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Block explorer della blockchain Solana di Blockchain.com."
+            },
+            {
               "title": "Stato",
               "description": "Stato attuale della rete e segnalazioni di incidenti."
             }

--- a/packages/i18n/messages/web/ja/common.json
+++ b/packages/i18n/messages/web/ja/common.json
@@ -2094,6 +2094,10 @@
               "description": "OKXによるSolanaブロックチェーンエクスプローラー。"
             },
             {
+              "title": "Blockchain.info",
+              "description": "Blockchain.comによるSolanaブロックチェーンエクスプローラー。"
+            },
+            {
               "title": "ステータス",
               "description": "現在のネットワークステータスとインシデント。"
             }

--- a/packages/i18n/messages/web/ko/common.json
+++ b/packages/i18n/messages/web/ko/common.json
@@ -2094,6 +2094,10 @@
               "description": "OKX의 Solana 블록체인 탐색기."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Blockchain.com의 Solana 블록체인 탐색기."
+            },
+            {
               "title": "상태",
               "description": "현재 네트워크 상태 및 장애 현황."
             }

--- a/packages/i18n/messages/web/nl/common.json
+++ b/packages/i18n/messages/web/nl/common.json
@@ -2094,6 +2094,10 @@
               "description": "Solana-blokverkenner van OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Solana-blokverkenner van Blockchain.com."
+            },
+            {
               "title": "Status",
               "description": "Huidige netwerkstatus en incidenten."
             }

--- a/packages/i18n/messages/web/pl/common.json
+++ b/packages/i18n/messages/web/pl/common.json
@@ -2094,6 +2094,10 @@
               "description": "Eksplorator blockchainu Solana stworzony przez OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Eksplorator blockchainu Solana stworzony przez Blockchain.com."
+            },
+            {
               "title": "Status",
               "description": "Aktualny status sieci i zgłoszone incydenty."
             }

--- a/packages/i18n/messages/web/pt/common.json
+++ b/packages/i18n/messages/web/pt/common.json
@@ -2094,6 +2094,10 @@
               "description": "Explorador da blockchain Solana pela OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Explorador da blockchain Solana pela Blockchain.com."
+            },
+            {
               "title": "Status",
               "description": "Status atual da rede e incidentes."
             }

--- a/packages/i18n/messages/web/ru/common.json
+++ b/packages/i18n/messages/web/ru/common.json
@@ -2094,6 +2094,10 @@
               "description": "Обозреватель блокчейна Solana от OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Обозреватель блокчейна Solana от Blockchain.com."
+            },
+            {
               "title": "Статус",
               "description": "Текущий статус сети и инциденты."
             }

--- a/packages/i18n/messages/web/tr/common.json
+++ b/packages/i18n/messages/web/tr/common.json
@@ -2094,6 +2094,10 @@
               "description": "OKX tarafından sunulan Solana blok zinciri gezgini."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Blockchain.com tarafından sunulan Solana blok zinciri gezgini."
+            },
+            {
               "title": "Durum",
               "description": "Mevcut ağ durumu ve olaylar."
             }

--- a/packages/i18n/messages/web/uk/common.json
+++ b/packages/i18n/messages/web/uk/common.json
@@ -2094,6 +2094,10 @@
               "description": "Провідник блокчейну Solana від OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Провідник блокчейну Solana від Blockchain.com."
+            },
+            {
               "title": "Статус",
               "description": "Поточний статус мережі та інциденти."
             }

--- a/packages/i18n/messages/web/vi/common.json
+++ b/packages/i18n/messages/web/vi/common.json
@@ -2094,6 +2094,10 @@
               "description": "Trình khám phá blockchain Solana bởi OKX."
             },
             {
+              "title": "Blockchain.info",
+              "description": "Trình khám phá blockchain Solana bởi Blockchain.com."
+            },
+            {
               "title": "Trạng thái",
               "description": "Trạng thái mạng hiện tại và các sự cố."
             }

--- a/packages/i18n/messages/web/zh/common.json
+++ b/packages/i18n/messages/web/zh/common.json
@@ -2094,6 +2094,10 @@
               "description": "由 OKX 提供的 Solana 区块链浏览器。"
             },
             {
+              "title": "Blockchain.info",
+              "description": "由 Blockchain.com 提供的 Solana 区块链浏览器。"
+            },
+            {
               "title": "状态",
               "description": "当前网络状态与事件报告。"
             }


### PR DESCRIPTION
### Problem

Solana.com's `/network` page lists third-party block explorers under its
"Inspect" section (Solscan, Solana Explorer, Helius Orb, OKX Explorer), but
Blockchain.info — Blockchain.com's Solana block explorer — was missing from
that list, so users looking for explorer options on solana.com had no way to
discover it.

### Summary of Changes

- Added a "Blockchain.info" entry to the `/network` page's "Inspect" section,
  linking to `https://www.blockchain.com/explorer/assets/sol`
  (`apps/web/src/data/navigation-hubs.ts`).
- Added the matching title/description translation for this entry to all 19
  supported locales (`packages/i18n/messages/web/*/common.json`), matching
  the phrasing style of the existing OKX Explorer entry.

No security-relevant behavior changes — this is a static content/data
addition (a new outbound link and its translated label) to an existing list
of external explorer links.

Fixes #

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none": -->

none

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a": -->

n/a
