### PR TITLE
docs(tools): add PLGRND, a visual Solana playground, to Developer Resources

### DIFF
--- a/apps/docs/content/docs/en/tools/index.mdx
+++ b/apps/docs/content/docs/en/tools/index.mdx
@@ -110,6 +110,10 @@ hidePageNavigation: true
     Test Solana programs in a fast in-process VM, without a validator, in Rust
     and TypeScript.
   </Card>
+  <Card title="PLGRND" href="/docs/tools/plgrnd">
+    Wire keypairs, PDAs, instructions and transactions on a visual canvas and
+    embed live examples in your docs.
+  </Card>
   <Card title="Actions and Blinks" href="/docs/tools/actions">
     Turn any Solana transaction into a shareable, metadata-rich link.
   </Card>

--- a/apps/docs/content/docs/en/tools/meta.json
+++ b/apps/docs/content/docs/en/tools/meta.json
@@ -16,6 +16,7 @@
     "private-channels",
     "surfpool",
     "litesvm",
+    "plgrnd",
     "actions",
     "ai",
     "---Documentation---",

--- a/apps/docs/content/docs/en/tools/plgrnd/index.mdx
+++ b/apps/docs/content/docs/en/tools/plgrnd/index.mdx
@@ -1,0 +1,109 @@
+---
+title: PLGRND
+description:
+  Visual, node-based playground for Solana. Wire keypairs, PDAs, instructions
+  and transactions on a canvas, run them against a live cluster, and embed the
+  result in your own docs.
+---
+
+PLGRND is an open-source (MIT) visual playground for Solana. Instead of writing
+a script to derive an address or build an instruction, you wire nodes together
+on a canvas: each node is a typed building block (keypair, PDA, associated token
+account, instruction, transaction, RPC call) and the graph re-evaluates live as
+you edit it. Every flow is encoded in its URL, so a working example is a link,
+and any flow can be embedded in a page as an interactive widget.
+
+The widgets below reproduce recipes from the [Cookbook](/developers/cookbook) as
+node graphs. They run in your browser against mainnet; edit any input and the
+result updates.
+
+## Calculate the rent-exempt minimum
+
+Mirrors
+[How to Calculate Account Creation Cost](/developers/cookbook/accounts/calculate-rent):
+`getMinimumBalanceForRentExemption(space)` for a 1,500-byte account. Change the
+number of bytes.
+
+<iframe
+  src="https://plgrnd.io/embed?theme=auto&ref=solana-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0pAByyAvvBQBDSjskhKaKZSIAlNAkpKTaALa1KAAnt4EeewFd7zgGZIAE7OOgghxMRIXtYAOghx5tw8zhwAGhysAArJxDoANnkYzgDmaJSs7p4+AEL5ocRoAGJBltYcUg5OYggAFBi0Og0AlM7izpQAFmjOGGh5aMTGKM7EeV4YxsGAKATjUzM69tOBaACOXpguOkWT05FIANYARkgPzsfEePQAdM6ME6GlXbTLgAVVY1Q45lGfmcj2oxgwXxAGi0+EIkBIACZ+DR6Ew2JxePxBMJROJDDJIEpoNB5CBFFTSJptHoDJBQMZTERAAmEMwGDWc7lh8Mwzh6pFgAFZZLIQkUhTc3gtPmghsjUSACEQEOQqHQGBjQeDIcShCJuhS5Ao5FoQLp9IYED5HmhAlBSNLNBqtRiEGUcfqiFwODwAOrMcwAaVNpIt7JAlLpDIAnMy7azHWUAO5Be5EVgAQQAklxg3wUbA0URArqjIGMYleAB9NIZbIx83k+OU2lJqC0232tnACtVjEoWu4g0gAAiRYAypkADIFgCaHbJEm7UElABY+4y00PDJyzBj1ZXNeiSNAA3iMSx2EkN3HpFAAOwANgPSkxR4z8anjyriVN4viPHUCANLAzh5AcgiBJQWCjleRAoNier3rOC7LmuL5dm+kB7ge6iDgBHImGeIAXmOJC7ne06PoSfDwCSnZboRX4Hu+-4OoBlHAYqGAHNMQrzswS40ahGLEJKDH4k+RKsWam6WpAB5-rxw5GAJGLVGgEzuMsipOvYLqBJAYqkJiqjCgi0LhJE0QuEgYCulMOjLAA1Hygyqs4ADrzhwLu6iwfBQRIc49DBHCxhKNQaA6MEQWYs4iXJYi6oALrwGgKClFgkC4NJCbULYBVoE2TY6kopnmUogR4MUEw2DWSj9H5SjzH4ZjwBgUSBA02q1gNXhDWgAASoQoPMI11c6rqNc1rU4slpRUTWa2BBt00ILN07tZ1DTdWgvXIpePplRVpTVX6Nj3TmgT3MtLVtaQdXZrmp3nf1g3Db6-p-eNDR7Qd2plJ9lBPS9TVvdtG3VpO61lGDc0Yu1j3fT1ZjeteUjlflt1Nu1cGOJFGCva1SgTko7i0F4Ng4-wY0TUjLP-VNM3oyApMRYhlNw6tVAo1RE4I6j3PTrT9OMz9uOXfjhOVdVR1IHkVM2OhdMIAzTNnX1ICswDvOjZzaOHR9A0a0Lhv6Dt-rjhhRiixbaGYjrevy8i2UaEAA"
+  title="Rent-exempt minimum in PLGRND"
+  width="100%"
+  height="480"
+  loading="lazy"
+  sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+  allow="clipboard-write"
+  referrerPolicy="strict-origin-when-cross-origin"
+  style={{ border: 0, borderRadius: "12px" }}
+/>
+
+## Sign and verify a message
+
+Mirrors
+[How to Sign and Verify a Message](/developers/cookbook/wallets/sign-message): a
+keypair signs the message, and the signature is verified with the public key
+alone. Press **Generate** for a new keypair or edit the message.
+
+<iframe
+  src="https://plgrnd.io/embed?theme=auto&ref=solana-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC00aLIC+8FAENK2ySEpoplIgGU8AcwQACbQhQ2waAE54AZtTs2AtpgzalmgAOgihZgCSAOJcNrQuqACuxJh2thwoAEwArNmkAJw2wta6iS5oNkjOLjaUABYVfhgBQTYA7iJ1tQ1xbmC6FQDWaNQA3DYAahwAShEAYgCaNpExAII8AKrTHDbEDcSDGDYi7Z3dFbSJAEYANnjENsNe4jdegCgE57tISINX34M2crEPD0WB2I7IdAYAB0NgACuVmjYomgEK4BjZ3EgatobGi2o8RrRtHgatibGgUCd6o1-IE0JBPsUEKVyrs6vYghgwRNtHdHBg9NQjpQXIk0NCQOpNPhCJAQINyFQ6Ax5QBpDgLOGrCLTfiCYSicQGGSQeQgRRmzQgHR6STS2CyogoWT8Gj0IgAEQiZjhABlVgt9UIRGIJJBpFBMgAWc2WpQADg0Wl0+gjhmMpnlUplIAIRGImTdKqYbE4vGDhrDJqg2QAbHHlPlkzbUwYjCYiIAEwji1zuDyeOcdeblJGgxY98pY7G4fHgBtDxvTppUagUUFIsettrToA7WZAPaaLQYDqd8soSsMJflPA4AA05wIQ0bw5GzevIKRsi2d+3M0QPA9AAjok9wAlcCRtLYWJSDYABWiQ+LQRxVK4nw3NoABeXgoEglhDueIAYFe7qqiAKxcJWi5viAppqI2kDNtubYRmeI7OqRN4gN6voBkG84vtWy61rGn5bimdrpvuRCERx8rENGE7kdO5ZPgur41pACYNp+agsVJe4AfKPbMqyaBglc2gYGg2QJnJ+bymAXGTiAUyzIsAD6lHrFsHDUZpImQNkYkWhuSYGbu7GOTaRbKq5vH+oGAXCe+ADsSafqQEWSbuGadtm0WjsQ2TKaWM4VoJVZLu+pCyPVWVpb+rFGQVh5OK4Hh4JSpz1J8ly3PchKKNKAC68CUlyOBEVI1BKJNaCeZ5ipKAN-ZqiMShuJYdSUEoLpKHgCCXHtNxoO4pjwBgSBlCkRCKvw123WgAAS9goGd92kKtfb3Btc3bbtbraC4QQHi6wOg2glBvQ4n3ygdR0nUoZ0XVKw4xbN80oEES0rfEeD9EY-1bVYu1KCRq19AMJOo5dxE3S4d3yg9V2MyksMfeR+PU8Tm2A-TehQweJGQ2DnPw8R30E0TaC0+dpi5pjc0LUtl5KPupM7XtlPHvSKMK497PkZeRvPRLJvfZrAti9DRCi1QIPi+9ku63SQQG2jSujljqueZTZmUGUaBa+TKDfUjiSnYbbPPfbV5PUzr0u+RAdWCyQflKHgtO3bCOkbnMMp5xh3HVHnuKxjPsqzji2eer1tk3tzlKHrHt02bSdEKbsdJxb3dW5m2e2wezkj-3TnfW3Icd97RC+7XS1pyUmchwLSgt4HwcV53zNS7vydw6n31b1nNuO8LRBjxfztH1fJ-p+ZO9z-KC+48t0u-cQJPry3a1-ZtDuvc96swZubYuLNP6DW-vzJuI977jwgeAKB61AGGxfnRGu78W54AwLyfk2d9qZFLsjIBYCu6TwPhPZBh08F8gIMPG+edYqILvgjYhkdo5e1GuoIAA"
+  title="Sign and verify a message in PLGRND"
+  width="100%"
+  height="480"
+  loading="lazy"
+  sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+  allow="clipboard-write"
+  referrerPolicy="strict-origin-when-cross-origin"
+  style={{ border: 0, borderRadius: "12px" }}
+/>
+
+## Derive an associated token account
+
+Mirrors
+[How to Get a Token Account](/developers/cookbook/tokens/get-token-account): the
+same owner and Token-2022 mint as the recipe. The ATA node derives the address
+the recipe then fetches; switch it to the classic Token program to see the
+address change.
+
+<iframe
+  src="https://plgrnd.io/embed?theme=auto&ref=solana-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0pAJyyAvvBQBDSjskhKaKZSIBBDBiTE8etCgAElJAGs0CRzuLEkAVwRKLxQUACdMDAAdBGjzHnNHAF5HADM8BBQAfVpQpABzUJ0AW0ydEPCrAApsJAB3BDRQ2Gc3D0cc-MKi5qL0ygBdZp0rGztjJxd3Tw6C4oBKADpHAGVitEc6htCvDMdewK8MZwALdfDbekdKnUceVoQlACZZR8e9vrmAbhP1uITkdCOPBHDC1ETEU4TJC3e5PF6PJaMY46BB5daUU4beqNDbbDHrfaUZpIbYpAA2eFoPxaU3auVmRQWIA0WnwhEgJEe-Bo9CYbE4vH4gmEonEhhkkCU0Gg8hAiklpE02j0BkgoGMpiIgATCLFbK46PwYkkiahAzz4xznSloObM1kgAhESjkKh0BgcngcAAafHgwpEYgkapAEtl8qVIF0+kMGrMHPMjAArAAlAAiKQAigAxIqp5akdAAdQAWkJVI9SAApFIARwwxC9KAAQtQUgAOJsAaQAEhhEwnCwArSiFrks2BsojEaDct189jcX0CIQBsXBiVSmUKKBtiNR1XqkxxkA6wlXO5TOGvW3jyccyhc128j3epf+0VB6RybeQdRaSMqjGR5EI8ABGpCuAAagAbKmrgAArmAgUgoImeBSCkyGMLQg5SEUna1DWg6DjoACaRSMMWKS9lmfiPAALAA4l6SB2hODrsiAOgukYc7xvEQorh+4pQNAzw-vRib-vuMb3PB9JdE6sLPK8bF3pGPE8u6ICpgAkss8EADLmKRgkioGImQIm0FhlAknSYBwaxkQjEpJB8EAF4AKpSKwqZgMcWaVqQXoYNBjCqHg9EAOxehmyarLQPAoG2hndrUiYFIxfg8DWfjUBmakcVO9Gzs+IAsAugp+kJFnrjuu4-tAUnKtGTnARyOrDNYtj2FCtLeL4ARmCygwgA4aJYJAuDFRyUjUEoE1oJkmTOkosZKKEeB5MclBKNxSibI0ShkmgKRmPA1h+KExDac6-BXTdaDdiiKCnU6pDrUem3bbt3I6KEaLHtx-2A2glAvRk70cgdR2hCdZ0jexjpzQtS0rQ+X2mD9O17QdhII+dD3+E9TqPiAj23ZDb13Y8WN7VtuOg0DRAg1QANA9T0NcZ9BOnUT9ooyGaMoGiK0HSqOO7UoKCfektCGoTF0UyTt2szxlPPa93MS-oUvK-oYPHrLzPg1z2my0o8uK-zI39BoQA"
+  title="Associated token account address in PLGRND"
+  width="100%"
+  height="480"
+  loading="lazy"
+  sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+  allow="clipboard-write"
+  referrerPolicy="strict-origin-when-cross-origin"
+  style={{ border: 0, borderRadius: "12px" }}
+/>
+
+## Build a transaction with a priority fee
+
+Mirrors [How to Send SOL](/developers/cookbook/transactions/send-sol) and
+[How to Add Priority Fees to a Transaction](/developers/cookbook/transactions/add-priority-fees):
+a compute unit limit, a compute unit price and a System transfer, appended to
+one transaction. The display shows the unsigned transaction — program ids,
+account metas and raw instruction data. Nothing is signed or sent.
+
+<iframe
+  src="https://plgrnd.io/embed?theme=auto&ref=solana-docs#flow=N4IgbiBcDMA0IDsD2ATApgZygbVASxShAGMBGEeAFwE8AHNIgYQHkBZVgUQDkAVCkWkgx5KeJAiigAHlAAM8alAC0AJgBssgL7wUAQ0q7JISmimUiAQQT6kAW2oACJADMHuh5QBOuhBl3FRcQcAdxEACzcHWk8xGJoHZzQ0AB0EVJ4ADQcAIQBVAEkAGQARDgAlBwwDT0oMNwQHNFtaeK8fPwCxBABuRv8I-K4AZR4y3MYefOZhh2R0N1p6BBQ68TQHPF8vAFdO8VgNhsow9c80Yjx6AHJVz3RPSAdiO1ptkwdthBEHABs8W2+AApSLBZGDQWCAJQHZ7NN7rT7faJ4YjrYEOAHETxIJQ-XTNJA1KJoTwORi5aEOIbUKpNDzeXyJUmA2QAOlkpCpzEKkNZDmK+SGAAVChYAJqVMJIYJ1Y4I3x4ADmCDQKHp7X8gQQj2iSEV3lsGxWB38z0+lAxaAMGAO3mChyqnl2WocegMfK4SGOm0VGzqwmVqqcpIwaAQlFZIE02nwhEgIAARuQqHQGPHRhZhhYJlMuAB9PJFUplfiCYRaowySDyECKavaEBuwyQYDR2CxojEFT8Gj0JhsTi8UtCERdSvKaDQGt10ikLQ6fTN0AmMxEQAJhE8XvCPl8LX8AeY2x34whk8ZU0QuLlWNlysPy2OWyAq9OoKQVPPG4ujAhtrYEySb5gsBWgxiABBEHgZ69mmICDCMYw5tMQz3qO4jjjAH4KHIDZNkYmyOs6j4kFuJi5LuhT-CIUZgRB8bENAPYXvGLDsNwfDwGWaESE+VZKJOr6QCoc64d+T4ruY8YbsiqIHJi2K4vigg1HU9CkuSNHtuBcaIN2KZ9vGV43nenEjhWvFyNhQkfqJBg-n+AGeG+R7aZBenngZcHDKM4yTMhqHmdIUAAOzgrWOELnZT4ETsew8SRcJkbuQoxKimnHiQAAsTGeaxg4cQIZmPkFkD8VOVnQCJkVLsYpiSSAG6hssgEuXRxjQcxIA8BwGQFVxgXPpZ4WYZ+eHiXVRBqAA1oqtDZAAVrYxDzWYXAYGUYRlJ4YooJlpA9UMAAcABSYphEKABirAAOoAGpDAAiqwABaioPQ9aAANKFGK6WufRACsOWwXl7EBcVg2lQJVmZWCtk1RJ64OGcFy0HgYaHrROmUO5MFEN1vXg+hFnVjDVVflFy4TfG2RipQACO2RIAmU3BQgtAXQAnMdzgYIdYQA5zpBSLYt1oLdmVlJ9ioABI8M4YTHboU2ZRYnNcGA9PFH9bXEGowP9mxQ6mQ+xMlWVgmZZzo1iVTq5SW4thIOaBxDNyOs6QgjH6bBRm3iWJvcRhgkA3D1X2f+gHVuypCtTpeDex5sHwT5SHDETPElXOh2CTblPgVsTpxUQGA0iYtg8AyGBMh7RAoB1nkCsKoq-YHA1VqQmUaFZSiw-DRiI-Gtf0cFBssQOYNtxDHdd4JSikFO-fjfbDUeCc6q+JqXQHDFRcugmji70R6HRgAuvAqqKpgOAZVI1BKJfaB5nmSZKG0m9xUoMSKmElBKFBb8q5b3EPkBAuI0DOHMPADAztPBpXjEmfgMDthwLQDLHwKAfiwVfu-DoWov5Kl-j2XQngr71SgsQ0hVp0HLCwZBUggCNRxVAeAyBUYtJtTvg-FAV9n6niUL+SOngCE-z-gA2ErwkoiAwKwqBIBkGoKIKeJBsDUQ0MwbBfhgjHIiKIVQEhZD6GULIeouh8ZxGkTQORaRsj2G33vo-Z+ADcHAIQMwN4uixEqEYR-LULCsFsOgao2CFCgkoLURgsx4EGEuLiu4v+389HGAMVaNyxjqGRJCd42JfiwEBMPBwnSXDHF5gQN47RJJPH-28fJJAhQlKElqLYsJiiTzuQURE2hmjykOUqYkuR1RDHmNxikygpislKFqfUgkKlbFYyIMUnhT88x4GyUAuJHj+n-2gD4vBXR-EQLkR0rJKjwloMyW5XZrj4mePSeQxOgyMldMgjsnJ+y8mHLsf9Z8DilnP0oDEuqVSE5KGcNiWwQptgszQPffJpzWntXhZ0jRRAAVvyBf0u5Ly7njJeaC8FkLoWws+fM+MizeF5hxuiswwLXlIEJVNGFzT5HBNRe04JuL4xUokrc-RVD7k4oueYulDKmVwtJT87hFKvYCN6cIrZIL8TO3DLkPAzLjlKMTsczliAdkVPlYQgZozsV8pMUK8COylXmlVXMwpCzfkUpBW88QNytn13-uzDxcKWnwItUi85zzhVXI2Qkw1WL4z10FYGxsDDNiSLmafTQQA"
+  title="Transaction anatomy with a priority fee in PLGRND"
+  width="100%"
+  height="480"
+  loading="lazy"
+  sandbox="allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+  allow="clipboard-write"
+  referrerPolicy="strict-origin-when-cross-origin"
+  style={{ border: 0, borderRadius: "12px" }}
+/>
+
+## Embed a flow in your own page
+
+Open any flow in PLGRND and use **Share → Embed** to get an `<iframe>` snippet.
+Query parameters select the theme and colors and the interaction level
+(read-only, interactive, or full editor); the flow itself stays in the URL hash.
+
+## Resources
+
+- [plgrnd.io](https://plgrnd.io) - The playground
+- [GitHub](https://github.com/RedDuckTeam/PLGRND) - Source code, MIT license
+- [Embedding guide](https://github.com/RedDuckTeam/PLGRND#embedding) - URL
+  parameters and interaction modes


### PR DESCRIPTION
### Problem

The docs explain Solana primitives (PDAs, associated token accounts, rent, transactions, priority fees) in prose and code, and the Cookbook gives copy-paste recipes. What's missing is a way to try those concepts in the browser without setting up a project: change a seed and see the PDA change, bump the account size and see the rent change, add a compute-budget instruction and see the serialized transaction. Readers who learn by poking at a working example have to leave the docs and set up local tooling first.

### Summary of Changes

This PR proposes adding PLGRND to the Tools section. PLGRND (https://plgrnd.io, MIT, source: https://github.com/RedDuckTeam/PLGRND) is an open-source visual playground where Solana primitives are nodes on a canvas that evaluate live.

- New page `apps/docs/content/docs/en/tools/plgrnd/index.mdx`, modelled on `tools/litesvm`: what PLGRND is, four embedded flows that mirror existing Cookbook recipes (calculate rent, sign and verify a message, derive an associated token account, build a transaction with a priority fee), embedding notes, links to the site and repo.
- `tools/meta.json`: `plgrnd` entry after `litesvm`.
- `tools/index.mdx`: a card under "Tools".

The embeds are plain sandboxed, lazy-loaded `<iframe>` tags pointing at `https://plgrnd.io/embed`, the same mechanism already used on the docs landing page, in the Surfpool video tutorials and in the Commerce Kit quickstart. Each flow is fully encoded in its URL. No new dependencies, no code changes, no Cookbook changes. Written as tool documentation: no comparisons, no recommendations, no RPC providers named.

I understand the Tools section has so far listed tools migrated by maintainers, so this is a proposal rather than an assumption that it belongs here. Happy to narrow the scope, e.g. a shorter page without embeds, or to close if it doesn't fit.

Fixes #

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [X] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [X] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [X] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [X] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [X] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

New dependencies: none

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->

Threat-model note: n/a
