### PR TITLE
fix(web): update SDP settlement copy

### DIFF
--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -11799,7 +11799,7 @@
     },
     "hero": {
       "title": "Launch and scale financial products on Solana with enterprise-ready APIs",
-      "description": "The institutional infrastructure for digital assets, built for compliant issuance, seamless payments, and efficient trading from a single platform on Solana.",
+      "description": "The institutional infrastructure for digital assets, built for compliant issuance, seamless payments, and efficient settlement from a single platform on Solana.",
       "primaryCta": "Join waitlist",
       "videoLabel": "VISION BEHIND SDP"
     },
@@ -11812,7 +11812,7 @@
       }
     },
     "cardGrid": {
-      "title": "A single, unified interface to issue, move and trade tokenized assets",
+      "title": "A single, unified interface to issue, move and settle tokenized assets",
       "columns": {
         "0": {
           "heading": "Issuance",
@@ -11823,9 +11823,9 @@
           "body": "Orchestrate fiat and stablecoin flows — on-ramp, off-ramp, and onchain transactions across B2B, B2C, and P2P use cases."
         },
         "2": {
-          "heading": "Trading",
+          "heading": "Settlement",
           "headingBadge": "Coming Soon",
-          "body": "Support financial flows including atomic swaps, vaults, onchain FX and more."
+          "body": "Support settlement flows for tokenized assets, including atomic delivery-versus-payment, onchain FX, and more."
         }
       }
     },
@@ -11852,7 +11852,7 @@
       "checklist": {
         "0": "Create assets",
         "1": "Move money",
-        "2": "Trade and settle"
+        "2": "Settlement"
       },
       "soonBadge": "Coming soon"
     },


### PR DESCRIPTION
## Problem
The SDP page still talks about trading in places where the product message should focus on settlement. That can make the feature sound broader or different from what is being positioned.

## Solution
Update the English web copy so the SDP hero, card grid, feature heading, and checklist consistently describe settlement instead of trading.

## Testing
TODO

### Summary of Changes

Updated SDP marketing copy in `packages/i18n/messages/web/en/common.json` to emphasize compliant issuance, payments, and settlement flows for tokenized assets.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->