### PR TITLE
feat(ecosystem): add PurgeFi to ecosystem directory

### DIFF
--- a/packages/ecosystem-data/assets/companies/purgefi/logo.svg
+++ b/packages/ecosystem-data/assets/companies/purgefi/logo.svg
@@ -1,0 +1,12 @@
+<svg width="512" height="512" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="pGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#8B5CF6"/>
+      <stop offset="50%" stop-color="#5B9BD9"/>
+      <stop offset="100%" stop-color="#2DD4BF"/>
+    </linearGradient>
+  </defs>
+  <rect x="0" y="0" width="512" height="512" rx="72" fill="#0B0F19"/>
+  <text x="160" y="360" font-family="Arial, Helvetica, sans-serif" font-weight="800" font-size="290" fill="url(#pGradient)">P</text>
+  <circle cx="356" cy="374" r="34" fill="#22D3A0"/>
+</svg>

--- a/packages/ecosystem-data/src/companies/records/purgefi.ts
+++ b/packages/ecosystem-data/src/companies/records/purgefi.ts
@@ -13,7 +13,7 @@ export const purgefi = {
     description:
       "PurgeFi enables Solana users to safely recover locked rent SOL by identifying and burning zero-balance, spam, or abandoned token accounts. Built with user security as a top priority, PurgeFi is non-custodial, open-source, and requires zero sensitive wallet permissions. Users can batch-close accounts with transparent transaction simulation before signing.",
     sector: "Infrastructure",
-    type: "Tool",
+    type: "Platform",
     links: {
       website: "https://purgefi.com",
     },

--- a/packages/ecosystem-data/src/companies/records/purgefi.ts
+++ b/packages/ecosystem-data/src/companies/records/purgefi.ts
@@ -12,8 +12,8 @@ export const purgefi = {
       "PurgeFi is a non-custodial Solana utility tool that scans and closes empty or inactive token accounts to reclaim locked rent SOL directly to your wallet.",
     description:
       "PurgeFi enables Solana users to safely recover locked rent SOL by identifying and burning zero-balance, spam, or abandoned token accounts. Built with user security as a top priority, PurgeFi is non-custodial, open-source, and requires zero sensitive wallet permissions. Users can batch-close accounts with transparent transaction simulation before signing.",
-    sector: "Tools",
-    type: "Application",
+    sector: "Infrastructure",
+    type: "Tool",
     links: {
       website: "https://purgefi.com",
     },

--- a/packages/ecosystem-data/src/companies/records/purgefi.ts
+++ b/packages/ecosystem-data/src/companies/records/purgefi.ts
@@ -1,0 +1,33 @@
+import type { CompanyRecord } from "../../types";
+import purgefiLogo from "../../../assets/companies/purgefi/logo.svg";
+
+export const purgefi = {
+  id: "purgefi",
+  slug: "purgefi",
+  name: "PurgeFi",
+  legalName: "PurgeFi",
+  profile: {
+    tagline: "Reclaim locked rent SOL from empty token accounts",
+    summary:
+      "PurgeFi is a non-custodial Solana utility tool that scans and closes empty or inactive token accounts to reclaim locked rent SOL directly to your wallet.",
+    description:
+      "PurgeFi enables Solana users to safely recover locked rent SOL by identifying and burning zero-balance, spam, or abandoned token accounts. Built with user security as a top priority, PurgeFi is non-custodial, open-source, and requires zero sensitive wallet permissions. Users can batch-close accounts with transparent transaction simulation before signing.",
+    sector: "Tools",
+    type: "Application",
+    links: {
+      website: "https://purgefi.com",
+    },
+    socials: {
+      x: "https://x.com/PurgeFi_App",
+    },
+  },
+  defaultLogoId: "logo",
+  logos: [
+    {
+      id: "logo",
+      fileName: "logo.svg",
+      format: "svg",
+      source: purgefiLogo,
+    },
+  ],
+} satisfies CompanyRecord;

--- a/packages/ecosystem-data/src/companies/registry.ts
+++ b/packages/ecosystem-data/src/companies/registry.ts
@@ -71,6 +71,7 @@ import { phantom } from "./records/phantom";
 import { pipeNetwork } from "./records/pipe-network";
 import { playSolana } from "./records/play-solana";
 import { pyth } from "./records/pyth";
+import { purgefi } from "./records/purgefi";
 import { quicknode } from "./records/quicknode";
 import { raiku } from "./records/raiku";
 import { rain } from "./records/rain";
@@ -188,6 +189,7 @@ export const companies = [
   pipeNetwork,
   playSolana,
   pyth,
+  purgefi,
   quicknode,
   raiku,
   rain,


### PR DESCRIPTION
### Problem

PurgeFi was missing from the Solana ecosystem directory.

### Summary of Changes

Added PurgeFi company profile, logo asset, and registry entry to the ecosystem data package.
- Created `packages/ecosystem-data/src/companies/records/purgefi.ts`
- Added logo to `packages/ecosystem-data/assets/companies/purgefi/logo.svg`
- Registered `purgefi` in `packages/ecosystem-data/src/companies/registry.ts`

Fixes #

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":
none
-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":
n/a
-->