### PR TITLE
fix(web): rename settlement copy to markets

### DIFF
--- a/packages/i18n/messages/web/en/common.json
+++ b/packages/i18n/messages/web/en/common.json
@@ -11823,7 +11823,7 @@
           "body": "Orchestrate fiat and stablecoin flows — on-ramp, off-ramp, and onchain transactions across B2B, B2C, and P2P use cases."
         },
         "2": {
-          "heading": "Settlement",
+          "heading": "Markets",
           "headingBadge": "Coming Soon",
           "body": "Support settlement flows for tokenized assets, including atomic delivery-versus-payment, onchain FX, and more."
         }
@@ -11852,7 +11852,7 @@
       "checklist": {
         "0": "Create assets",
         "1": "Move money",
-        "2": "Settlement"
+        "2": "Markets"
       },
       "soonBadge": "Coming soon"
     },


### PR DESCRIPTION
## Problem
The SDP page still called the upcoming item "Settlement," but the intended label is "Markets." This could make the page copy inconsistent with the current product naming.

## Solution
Renamed the English web copy from "Settlement" to "Markets" in both the card heading and checklist item.

## Testing
Not run; copy-only change.

### Problem

<!-- What problem does this solve? Write enough that someone uninvolved can
     understand it six months from now — this feeds the auto-generated change
     log (SDLC §3.5.3). -->

### Summary of Changes

<!-- What changed and why. Call out anything security-relevant explicitly. -->

Fixes #

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->