### PR TITLE
feat(web): rotate home hero promo banners

### DIFF
--- a/apps/web/src/app/[locale]/home.tsx
+++ b/apps/web/src/app/[locale]/home.tsx
@@ -67,11 +67,31 @@ const HERO_BANNERS = [
 
 type HeroBanner = (typeof HERO_BANNERS)[number];
 
-const getRandomHeroBanner = (): HeroBanner =>
-  HERO_BANNERS[Math.floor(Math.random() * HERO_BANNERS.length)] ??
-  HERO_BANNERS[0];
-
 const DEFAULT_HERO_BANNER = HERO_BANNERS[0];
+
+const isHeroBannerActive = (banner: HeroBanner, now = new Date()): boolean => {
+  const expiry =
+    "bannerExpiryDate" in banner ? banner.bannerExpiryDate : undefined;
+  if (!expiry) return true;
+
+  const today = new Date(now);
+  const expiryDate = new Date(expiry);
+  today.setHours(0, 0, 0, 0);
+  expiryDate.setHours(0, 0, 0, 0);
+
+  return today <= expiryDate;
+};
+
+const getRandomHeroBanner = (): HeroBanner => {
+  const activeBanners = HERO_BANNERS.filter((banner) =>
+    isHeroBannerActive(banner),
+  );
+
+  return (
+    activeBanners[Math.floor(Math.random() * activeBanners.length)] ??
+    DEFAULT_HERO_BANNER
+  );
+};
 
 interface HomePageProps {
   translations: {

--- a/apps/web/src/app/[locale]/home.tsx
+++ b/apps/web/src/app/[locale]/home.tsx
@@ -45,6 +45,34 @@ const TransactionsStat = dynamic(
   },
 );
 
+const HERO_BANNERS = [
+  {
+    bannerEyebrow: "200ms: Monitoring the situation",
+    bannerDescription:
+      "Watch Solana’s measured path to 200ms with live slot-time and network metrics.",
+    bannerImgSrc: "/src/img/index/slot-200ms-promo.webp",
+    bannerHref: "/200ms",
+    bannerLabel: "Open live monitor",
+  },
+  {
+    bannerEyebrow: "Breakpoint 2026",
+    bannerDescription:
+      "Solana's flagship gathering returns to London, November 15-17, 2026.",
+    bannerImgSrc: "/src/img/index/breakpoint-2026-promo.webp",
+    bannerHref: "/breakpoint",
+    bannerLabel: "Learn More",
+    bannerExpiryDate: "2026-11-17",
+  },
+] as const;
+
+type HeroBanner = (typeof HERO_BANNERS)[number];
+
+const getRandomHeroBanner = (): HeroBanner =>
+  HERO_BANNERS[Math.floor(Math.random() * HERO_BANNERS.length)] ??
+  HERO_BANNERS[0];
+
+const DEFAULT_HERO_BANNER = HERO_BANNERS[0];
+
 interface HomePageProps {
   translations: {
     heroTitle: React.ReactNode;
@@ -97,6 +125,11 @@ export function HomePage({
   activeCampaign,
 }: HomePageProps) {
   const [newsFallback, setNewsFallback] = useState<PostItem[] | null>(null);
+  const [heroBanner, setHeroBanner] = useState<HeroBanner>(DEFAULT_HERO_BANNER);
+
+  useEffect(() => {
+    setHeroBanner(getRandomHeroBanner());
+  }, []);
 
   // Workaround for Vercel preview mode
   // Fetch news fallback if news is empty
@@ -152,11 +185,7 @@ export function HomePage({
         <Hero
           title={translations.heroTitle}
           subtitle={translations.heroSubtitle}
-          bannerEyebrow="200ms: Monitoring the situation"
-          bannerDescription="Watch Solana’s measured path to 200ms with live slot-time and network metrics."
-          bannerImgSrc="/src/img/index/slot-200ms-promo.webp"
-          bannerHref="/200ms"
-          bannerLabel="Open live monitor"
+          {...heroBanner}
           cta={translations.heroCta}
           bgJsonFilePath="/src/img/index/hero-bg.json"
           bgImageSrc="/src/img/index/hero-bg.webp"

--- a/apps/web/src/app/[locale]/home.tsx
+++ b/apps/web/src/app/[locale]/home.tsx
@@ -74,12 +74,7 @@ const isHeroBannerActive = (banner: HeroBanner, now = new Date()): boolean => {
     "bannerExpiryDate" in banner ? banner.bannerExpiryDate : undefined;
   if (!expiry) return true;
 
-  const today = new Date(now);
-  const expiryDate = new Date(expiry);
-  today.setHours(0, 0, 0, 0);
-  expiryDate.setHours(0, 0, 0, 0);
-
-  return today <= expiryDate;
+  return now.toISOString().slice(0, 10) <= expiry;
 };
 
 const getRandomHeroBanner = (): HeroBanner => {

--- a/apps/web/src/components/index/hero.tsx
+++ b/apps/web/src/components/index/hero.tsx
@@ -69,13 +69,7 @@ export const Hero: React.FC<HeroProps> = ({
     if (!bannerHref || !bannerLabel) return false;
     if (!bannerExpiryDate) return true; // Show if no expiry date set
 
-    const expiryDate = new Date(bannerExpiryDate);
-    const today = new Date();
-    // Set time to start of day for comparison
-    today.setHours(0, 0, 0, 0);
-    expiryDate.setHours(0, 0, 0, 0);
-
-    return today <= expiryDate;
+    return new Date().toISOString().slice(0, 10) <= bannerExpiryDate;
   }, [bannerHref, bannerLabel, bannerExpiryDate]);
 
   return (


### PR DESCRIPTION
## Problem

The home page hero only showed the 200ms promo, so the Breakpoint 2026 promo was not visible there.

## Solution

Add a small list of hero promo banners and randomly pick one after the page loads. The list includes the existing 200ms promo and restores the Breakpoint 2026 promo.

## Testing

TODO

### Problem

<!-- What problem does this solve? Write enough that someone uninvolved can
     understand it six months from now — this feeds the auto-generated change
     log (SDLC §3.5.3). -->

### Summary of Changes

<!-- What changed and why. Call out anything security-relevant explicitly. -->

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->