### PR TITLE
chore: bump version

### DIFF
--- a/apps/media/content/upgrades/larger-transaction-sizes.mdx
+++ b/apps/media/content/upgrades/larger-transaction-sizes.mdx
@@ -79,7 +79,7 @@ These are the first releases that handle v1 transactions. Upgrade your dependenc
 | ------------------------------------------------------------------------------------------------------------------- | ------------------------- | ------------------------------------------------------ |
 | [`@solana/kit`](https://www.npmjs.com/package/@solana/kit) (Typescript)                                             | 8.0.0                     | Read and send                                          |
 | [`@solana/web3.js`](https://www.npmjs.com/package/@solana/web3.js/v/3.0.0-rc.3) (Typescript) 3.x                    | 3.0.0-rc.3                | Read and send                                          |
-| [`@solana/web3.js`](https://www.npmjs.com/package/@solana/web3.js/v/1.99.0-beta.0) (Typescript) 1.x                 | 1.99.0-beta.0             | **Read only** — cannot build, sign, or send            |
+| [`@solana/web3.js`](https://www.npmjs.com/package/@solana/web3.js/v/1.99.0) (Typescript) 1.x                        | 1.99.0                    | **Read only** — cannot build, sign, or send            |
 | [`solana-*` crates](https://crates.io/users/anza-team?sort=recent-downloads) (Rust)                                 | 4.2.x                     | Read and send                                          |
 | [`solders`](https://pypi.org/project/solders/) (Python)                                                             | 0.29.0                    | Read and send                                          |
 | [`solana-foundation/solana-go`](https://github.com/solana-foundation/solana-go) (Go)                                | 1.23.0                    | Read and send — also in 2.0.0 on the `/v2` module path |


### PR DESCRIPTION
Bump min web3.js version to latest