### PR TITLE
fix(deps): patch production audit findings

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ catalogs:
       specifier: ^12.23.28
       version: 12.40.0
     next:
-      specifier: 15.5.21
-      version: 15.5.21
+      specifier: 15.5.24
+      version: 15.5.24
     next-intl:
       specifier: 4.13.4
       version: 4.13.4
@@ -52,7 +52,7 @@ overrides:
   postcss@<=8.5.17: 8.5.18
   nanoid@<3.3.18: 3.3.18
   glob@9.3.5>minimatch: 9.0.7
-  sharp@<0.35.0: 0.35.3
+  sharp@<0.35.0: 0.35.4
   thrift@0.23.0>uuid: 11.1.1
   ai>jsondiffpatch: 0.7.6
 
@@ -103,7 +103,7 @@ importers:
         version: 15.5.9(@mdx-js/loader@3.1.1(webpack@5.101.3(postcss@8.5.18)))(@mdx-js/react@3.1.1(@types/react@19.1.12)(react@19.2.6))
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.18))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.18))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -133,10 +133,10 @@ importers:
         version: 12.40.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -200,7 +200,7 @@ importers:
     dependencies:
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -224,10 +224,10 @@ importers:
         version: 12.40.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -297,7 +297,7 @@ importers:
         version: 0.1.2(unified@11.0.5)
       "@fumadocs/mdx-remote":
         specifier: ^1.4.10
-        version: 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+        version: 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       "@mdx-js/react":
         specifier: ^3.1.1
         version: 3.1.1(@types/react@19.1.12)(react@19.2.6)
@@ -333,7 +333,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -342,7 +342,7 @@ importers:
         version: link:../../packages/ui-chrome
       "@solana-foundation/solana-lib":
         specifier: ^2.40.3
-        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@solana/addresses":
         specifier: ^6.9.0
         version: 6.9.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.8.3)
@@ -381,25 +381,25 @@ importers:
         version: 3.2.0(date-fns@4.1.0)
       fumadocs-core:
         specifier: 15.6.12
-        version: 15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       fumadocs-mdx:
         specifier: ^12.0.3
-        version: 12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1))
+        version: 12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1))
       fumadocs-ui:
         specifier: 14.7.7
-        version: 14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1))
+        version: 14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1))
       mermaid:
         specifier: ^11.16.0
         version: 11.16.0
       next:
         specifier: "catalog:"
-        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-seo:
         specifier: ^6.6.0
-        version: 6.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 6.8.0(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       node-fetch-cache:
         specifier: ^5.1.0
         version: 5.1.0
@@ -432,7 +432,7 @@ importers:
         version: 1.92.1
       sharp:
         specifier: ^0.35.0
-        version: 0.35.3(@types/node@24.13.3)
+        version: 0.35.4(@types/node@24.13.3)
       svg-pan-zoom:
         specifier: ^3.6.2
         version: 3.6.2
@@ -514,13 +514,13 @@ importers:
         version: 2.2.10(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@keystar/ui":
         specifier: 0.8.0
-        version: 0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
+        version: 0.8.0(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
       "@keystatic/core":
         specifier: ^0.6.0
-        version: 0.6.0(@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
+        version: 0.6.0(@keystar/ui@0.8.0(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
       "@keystatic/next":
         specifier: ^5.0.4
-        version: 5.0.4(@keystatic/core@0.6.0(@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 5.0.4(@keystatic/core@0.6.0(@keystar/ui@0.8.0(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@radix-ui/react-avatar":
         specifier: ^1.1.11
         version: 1.1.11(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -532,7 +532,7 @@ importers:
         version: 1.2.4(@types/react@19.1.12)(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -586,10 +586,10 @@ importers:
         version: 12.40.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -695,7 +695,7 @@ importers:
         version: 13.0.2(postcss@8.5.18)
       sharp:
         specifier: ^0.35.0
-        version: 0.35.3(@types/node@24.13.3)
+        version: 0.35.4(@types/node@24.13.3)
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -713,7 +713,7 @@ importers:
         version: 0.5.119(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@3.25.76)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
       "@solana-com/ui-chrome":
         specifier: workspace:*
         version: link:../../packages/ui-chrome
@@ -740,13 +740,13 @@ importers:
         version: 12.40.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       nuqs:
         specifier: ^2.4.3
-        version: 2.7.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6)
+        version: 2.7.2(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -855,7 +855,7 @@ importers:
         version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@sentry/nextjs":
         specifier: ^10.11.0
-        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))
+        version: 10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))
       "@sindresorhus/slugify":
         specifier: ^2.2.1
         version: 2.2.1
@@ -867,7 +867,7 @@ importers:
         version: link:../../packages/sitemap
       "@solana-foundation/solana-lib":
         specifier: ^2.40.3
-        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@typeform/embed":
         specifier: ^5.1.0
         version: 5.5.0
@@ -921,7 +921,7 @@ importers:
         version: link:../../packages/ui
       botid:
         specifier: ^1.5.11
-        version: 1.5.11(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)
+        version: 1.5.11(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)
       cheerio:
         specifier: ^1.0.0
         version: 1.1.2
@@ -954,10 +954,10 @@ importers:
         version: 12.40.0(@emotion/is-prop-valid@1.2.2)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       next:
         specifier: "catalog:"
-        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       next-mdx-remote:
         specifier: ^6.0.0
         version: 6.0.0(@types/react@19.1.12)(react@19.2.6)
@@ -1011,7 +1011,7 @@ importers:
         version: 1.92.1
       sharp:
         specifier: ^0.35.0
-        version: 0.35.3(@types/node@24.13.3)
+        version: 0.35.4(@types/node@24.13.3)
       slick-carousel:
         specifier: ^1.8.1
         version: 1.8.1(jquery@3.7.1)
@@ -1029,7 +1029,7 @@ importers:
         version: 3.4.1
       unicornstudio-react:
         specifier: ^1.4.33
-        version: 1.5.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.5.2(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       yup:
         specifier: ^1.4.0
         version: 1.7.0
@@ -1265,10 +1265,10 @@ importers:
     dependencies:
       next:
         specifier: "catalog:"
-        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -1357,7 +1357,7 @@ importers:
         version: 2.1.1
       next:
         specifier: "catalog:"
-        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -1418,10 +1418,10 @@ importers:
         version: 2.1.1
       next:
         specifier: "catalog:"
-        version: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+        version: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl:
         specifier: "catalog:"
-        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
+        version: 4.13.4(@swc/helpers@0.5.17)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3)
       react:
         specifier: "catalog:"
         version: 19.2.6
@@ -3773,237 +3773,237 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@img/sharp-darwin-arm64@0.35.3":
+  "@img/sharp-darwin-arm64@0.35.4":
     resolution:
       {
-        integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==,
+        integrity: sha512-Uhfl4V4lhP2nbUVF9+hyH1+luj86f1gUFeo8ALYxFoULoU+G87D43BfeMP8XHsk9boxAnCY/bf2EHwhA7MuGsA==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [darwin]
 
-  "@img/sharp-darwin-x64@0.35.3":
+  "@img/sharp-darwin-x64@0.35.4":
     resolution:
       {
-        integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==,
+        integrity: sha512-hWniXY3bG5qKpkKrAwPe4y+VTPmf086YQAnkxWh7uA1YrlRouWGa0M0Mxj3ZjnXFkv7/TD1bTy9lGUK26vRvWw==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [darwin]
 
-  "@img/sharp-freebsd-wasm32@0.35.3":
+  "@img/sharp-freebsd-wasm32@0.35.4":
     resolution:
       {
-        integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==,
+        integrity: sha512-lIsKw/BU+kjB4eZjxrYrZmwOJYi3Ajrv66iAlBmUPyKc3HpnloevB1g3wxGD9P/5BbQ1brBGl65VRRrCvQDEqA==,
       }
     engines: { node: ">=20.9.0" }
     os: [freebsd]
 
-  "@img/sharp-libvips-darwin-arm64@1.3.2":
+  "@img/sharp-libvips-darwin-arm64@1.3.3":
     resolution:
       {
-        integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==,
+        integrity: sha512-suTBPTDGrI9WodccaDdwZItTSaBYASlBk1NSfElSHrUfzu3szG6lvIF58+WiFvnfzuK8ZBFS5zE00PxqxnRiPg==,
       }
     cpu: [arm64]
     os: [darwin]
 
-  "@img/sharp-libvips-darwin-x64@1.3.2":
+  "@img/sharp-libvips-darwin-x64@1.3.3":
     resolution:
       {
-        integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==,
+        integrity: sha512-FVJZ5mITMobmXIz/hPDTw0EintTW5H3WfrxwLqEqjiIihlu+hVRyGrFQ60xl0Lxn7Bt3zdpevPaQi0HEzqz9fw==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@img/sharp-libvips-linux-arm64@1.3.2":
+  "@img/sharp-libvips-linux-arm64@1.3.3":
     resolution:
       {
-        integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==,
+        integrity: sha512-0DaL0A6Xu6sQSQFwe4iVCrKWU2cCTItnRsYsCdxAMm9NF6twAA9BKnoqy4hqz4+azQ0JHuA26qiUKsf1XJ/v5A==,
       }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-arm@1.3.2":
+  "@img/sharp-libvips-linux-arm@1.3.3":
     resolution:
       {
-        integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==,
+        integrity: sha512-3rbU4vqXXc3hY/OiXdl52xZvT0F1yEngWfvqudtPJg/KkyiaQw2DRsFrNzpmLvfavbwOq3qXn36GP8obHRULQA==,
       }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-ppc64@1.3.2":
+  "@img/sharp-libvips-linux-ppc64@1.3.3":
     resolution:
       {
-        integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==,
+        integrity: sha512-cdn1OvUBwsXhbC0zSzJnNzf5MZ/mTrobawDvNXBTxe8VtqKAm0sRuEY2Evzovb/w9JMk4TvRxqt1mekSuJz64w==,
       }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-riscv64@1.3.2":
+  "@img/sharp-libvips-linux-riscv64@1.3.3":
     resolution:
       {
-        integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==,
+        integrity: sha512-HjPVx7yKz+0lqdhDlTw1tt90wamBoxhiXpvl1XZpJLiHH4RCJ5yDTqH+VlYPv2fwFs89JFw4c1IexYOcQUi4IQ==,
       }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-s390x@1.3.2":
+  "@img/sharp-libvips-linux-s390x@1.3.3":
     resolution:
       {
-        integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==,
+        integrity: sha512-neWLh+3yCNThxnfy3c4BbVBeGgt9aftno+XbT56iK28RgeDs3UOFWviLWlUu0bArYVYJaFDK+RRohbicUNCm8Q==,
       }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-x64@1.3.2":
+  "@img/sharp-libvips-linux-x64@1.3.3":
     resolution:
       {
-        integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==,
+        integrity: sha512-4vKmvAst9nrowcqquKFAyZJUDolUaIp8uRiN0mWFguJ1IplC9/pitXtlnnlU4aa/eJw3J7i67V+pwUL+wZGdsA==,
       }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linuxmusl-arm64@1.3.2":
+  "@img/sharp-libvips-linuxmusl-arm64@1.3.3":
     resolution:
       {
-        integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==,
+        integrity: sha512-Y9kQaLMuNoB0bPYOOdcZMaseNrFpPodIWWMrx+CZyydf2xn68j9WYc6sWWRrDwNkzCQjKYfc68L7jKjGlHMibw==,
       }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-libvips-linuxmusl-x64@1.3.2":
+  "@img/sharp-libvips-linuxmusl-x64@1.3.3":
     resolution:
       {
-        integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==,
+        integrity: sha512-fj8Mv0HHfD1Rr+4I68+3agJynxDWtBFgicTbSOb9Bke6pIwzGcJ+RX/yHjmiEGFMCavY/dxvem7MyNaJF+wDiw==,
       }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-linux-arm64@0.35.3":
+  "@img/sharp-linux-arm64@0.35.4":
     resolution:
       {
-        integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==,
+        integrity: sha512-De4jpEnAU8Hd5oT0j1G3uL4ZvTuipVMn7YC6vPaJhy6/7EwEae0SVAoBrUMYQbkLGDm85taVWwuPc1a44LTzCQ==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-arm@0.35.3":
+  "@img/sharp-linux-arm@0.35.4":
     resolution:
       {
-        integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==,
+        integrity: sha512-7OAS8gI0EReKGVN2HssHlM6umJgxF5VI3xN0p9FA91p/YO+ou5hiNghLdZ5BEHztwaaK5+bLKRf8x/o2L2nk9A==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-ppc64@0.35.3":
+  "@img/sharp-linux-ppc64@0.35.4":
     resolution:
       {
-        integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==,
+        integrity: sha512-2oYZJeIl4kCcMGk4ouZVjnkCtFrpQFlNEtJ6GbxzhHQchwH0NH/qEb9ykmOl29dqwMq+JhFdZn+1ak2FKhI9fQ==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-riscv64@0.35.3":
+  "@img/sharp-linux-riscv64@0.35.4":
     resolution:
       {
-        integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==,
+        integrity: sha512-cPbNChoRURAWdebDIHSenxRpgEdy7JkPydSnUxRm9VvKD7m0/xVaR/8Fzlu81pk5nHEvHH87UZUA7cTtwnbJSA==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-s390x@0.35.3":
+  "@img/sharp-linux-s390x@0.35.4":
     resolution:
       {
-        integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==,
+        integrity: sha512-RY0JFY8Fd6RonCBtHz+DvadaPkXDSI1AUn6yWL9TipqkZ1vY8w8evqdgyDFnkm4/K1ve1TvZiaePP5oSd4+WVQ==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-x64@0.35.3":
+  "@img/sharp-linux-x64@0.35.4":
     resolution:
       {
-        integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==,
+        integrity: sha512-9qvvEAuk8k89TfWUoX2htWjbAMX8p+NxCppjpcg5k6xMsjhBQPTsoIh36h9Qde4WRuGpJeYnOjdosDn/cnv+OA==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linuxmusl-arm64@0.35.3":
+  "@img/sharp-linuxmusl-arm64@0.35.4":
     resolution:
       {
-        integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==,
+        integrity: sha512-KB5jxpfWQTr0nc3xdHtWChdbifHrBGsd2SM62Eyxrl8afikm+f5qGBU75SJIZBT/S1MC8XyacdlXBMSWq6OURA==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-linuxmusl-x64@0.35.3":
+  "@img/sharp-linuxmusl-x64@0.35.4":
     resolution:
       {
-        integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==,
+        integrity: sha512-f+eZJZIQNEEd26RPSW+76chwOf1XtA2Y/O+5ocVyLliHkeih3e+jhLVBdNTd2rS3IbNXK8+ug93Vf5ZXtF5Lxg==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-wasm32@0.35.3":
+  "@img/sharp-wasm32@0.35.4":
     resolution:
       {
-        integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==,
+        integrity: sha512-zQnl4Kwp7Q6NHsENtU2T/00Zi+w3AQNwz3+UaTyVBy2FpXrzXzGjndpK61onhZjRtRpQXxCTeqw19bVyXOh7jA==,
       }
     engines: { node: ">=20.9.0" }
 
-  "@img/sharp-webcontainers-wasm32@0.35.3":
+  "@img/sharp-webcontainers-wasm32@0.35.4":
     resolution:
       {
-        integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==,
+        integrity: sha512-ESfNkywmCfPNyaZjxooddJQiQ+l/nTpGEOGthxiLnIHXC/CmcBixnfwUleX9mCz9ovrUUvKMap/pm8RYbzfwaA==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [wasm32]
 
-  "@img/sharp-win32-arm64@0.35.3":
+  "@img/sharp-win32-arm64@0.35.4":
     resolution:
       {
-        integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==,
+        integrity: sha512-iNdlBX9gLVvqe2I3uIJSIKTq6wckP/DYxZtcqxm09x5Gi24DnFBmPAWZmr60ZyYMG0xlzo6goG3670ar+RXvRw==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [win32]
 
-  "@img/sharp-win32-ia32@0.35.3":
+  "@img/sharp-win32-ia32@0.35.4":
     resolution:
       {
-        integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==,
+        integrity: sha512-kqRsbaa5CS6KHlpxnN7WhE6vAAugXyZButpRdvDWetlv6Qv4N9WTcrWzF7tXfB9T7MsoadqdI8hmwLq6UlLvtw==,
       }
     engines: { node: ^20.9.0 }
     cpu: [ia32]
     os: [win32]
 
-  "@img/sharp-win32-x64@0.35.3":
+  "@img/sharp-win32-x64@0.35.4":
     resolution:
       {
-        integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==,
+        integrity: sha512-XtmnYhBcrORsJ4XJngyzr/EWP0hRZLAZRFaApdKuviyqF78+ylxh2y06ZmtULAMOnObJ3ucpN0AcwSWnMowTRg==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [x64]
@@ -4412,10 +4412,10 @@ packages:
         integrity: sha512-Egh7VRZktquGix3FdTiOtKhbz+67qYoAJyPyt2h0QEUBA1RA22fSDTCsihXtJvtKTYm2jom0cw8O3+BH4Xv4Aw==,
       }
 
-  "@next/env@15.5.21":
+  "@next/env@15.5.24":
     resolution:
       {
-        integrity: sha512-hjJI/GfrjWHgNguRIBzItjRRu0m3Nrz17GhxsjuHfjIvg9hyg3239REd2dpI+bpMTFuVrVprHzEQ19m++cDtbw==,
+        integrity: sha512-mBDF7T0XKZjs9SpUAl0buizVO+O02ULjOvWX8o/AZo/5AGw/UAS1Zzcylmd4pqbftzmKQi+L/nB4jgBYKEAl5Q==,
       }
 
   "@next/eslint-plugin-next@15.5.19":
@@ -4438,77 +4438,77 @@ packages:
       "@mdx-js/react":
         optional: true
 
-  "@next/swc-darwin-arm64@15.5.21":
+  "@next/swc-darwin-arm64@15.5.24":
     resolution:
       {
-        integrity: sha512-ZfjqPEdi6TRC/fWx7UDbwb1fbVgyh2uD5tVTRKIDZDlYM+UNuE/LafDG2fwuAoZilADpABh46OY/F5qf9JjqLQ==,
+        integrity: sha512-AGdNLvxZNY6eR2iSnV+6wUa8CiHTMr4F7g3uHH7fT4ICIJBE00R9u4tzN/Vuwsw0cOi8MTD2HJcTCb6siMH88Q==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [darwin]
 
-  "@next/swc-darwin-x64@15.5.21":
+  "@next/swc-darwin-x64@15.5.24":
     resolution:
       {
-        integrity: sha512-TlCf1NpxgQLzTrexuev75xwmNCJMd1/qkJpTVP1GRRcih93hlIBn1P72hkh8T0gnRFr6BmWksQtbyG3jT6jnww==,
+        integrity: sha512-9HrQajBMmGcrrrvDfRimiCrbAPh3E6uHJmwBovYr6Yrmi9p9PZqI876BrXX280wICh3o2XwUlp4blkB0NNBqFg==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
     os: [darwin]
 
-  "@next/swc-linux-arm64-gnu@15.5.21":
+  "@next/swc-linux-arm64-gnu@15.5.24":
     resolution:
       {
-        integrity: sha512-LXRsq1p+HvHSi7ygwNcSEEcK0zuo5jS75ZlqFHtOH+LF7qntXAJVJxah+1Pi/GyBm7EpkwU7m4EgbvIKrMqm9A==,
+        integrity: sha512-rl9LSfE75si0WT3cDgdUC1XYCKS+TgxC+/IjitmeycrAG18X/plIP1/vy8dd/HPycYcIvE688PD7FuvEAiEAew==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@next/swc-linux-arm64-musl@15.5.21":
+  "@next/swc-linux-arm64-musl@15.5.24":
     resolution:
       {
-        integrity: sha512-hyGixhFxpDKjqoev6l4KlcRBlt9AXWrGhDZwmwg49sMJM5tnKQPSi+SEj9+e5n+l/bthRGZUdh59GKIs6lQPRw==,
+        integrity: sha512-TlNAnpsjxSF3aAUtqnfmtXXf8m9sIDBlmF3c7bTAlnshUYu2U0OxN2uf5d0gcFwqHVEdivJNBcCaqNOwPGNimw==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@next/swc-linux-x64-gnu@15.5.21":
+  "@next/swc-linux-x64-gnu@15.5.24":
     resolution:
       {
-        integrity: sha512-qfE+YfOba6S2+13e8qn1/UozDVNZ2clBlrs8UtDoax4s8ediu6sq93z66OEHUYlb69Tffh5JTNkgtsAKiSuugg==,
+        integrity: sha512-7dwtlhr0SLndqTG1z9ncRkbJswDZiKWlxzFyXDvJ2RDZRDRHp8zyMJ4D9UH/FgnQeXxxB6gZy2pMcIUoNKQ4pA==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@next/swc-linux-x64-musl@15.5.21":
+  "@next/swc-linux-x64-musl@15.5.24":
     resolution:
       {
-        integrity: sha512-BXLGG+EvIwp/Rrgl6HY8sqvD6BOUOIRz8/naDbeLNX7mlA5H2XRcL6MW/0IGnJISfj5BA9gNhFyJj5yOoiIDJQ==,
+        integrity: sha512-kGZxM+WhkYs0276lFrMkj7PRtXT3Btp6cwvfSO/cCVLxJJttB5Ccnl2niaCgUja8HgSbEVnMHpg3FJWoOJ9e/g==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@next/swc-win32-arm64-msvc@15.5.21":
+  "@next/swc-win32-arm64-msvc@15.5.24":
     resolution:
       {
-        integrity: sha512-tNGNOlT0Wn7E4IMsSnufjXN/l2L2/AGdLLpa2vzS89SYCBuihgLn3ngLsIrvndAnWo9nAkus+4gZHTI/Ijx9HA==,
+        integrity: sha512-jBDDkZ/qKAqkWivWDMkJSXUzbzV0QKRBKJjEHUAvSB97Hzw7NLzJ6yV56Lts/wjir7s4P31GYgpbS6ZL+hasAA==,
       }
     engines: { node: ">= 10" }
     cpu: [arm64]
     os: [win32]
 
-  "@next/swc-win32-x64-msvc@15.5.21":
+  "@next/swc-win32-x64-msvc@15.5.24":
     resolution:
       {
-        integrity: sha512-DmIdWmC9p4rdNIiQqo8ap0+Cnj6kKtTZnuSCxoYydSc8sgpDgAg9wFhxplunak9imLV0pTvc5WVCOHwm5eHLtQ==,
+        integrity: sha512-JqtwjvvorjacQ0spgjmUJoxySoYgPwdT1sFdQ0/zmW4iMlP2hjYlCoJIyS7o6Epb4Fug8eco3HXFoBDUCDeH7Q==,
       }
     engines: { node: ">= 10" }
     cpu: [x64]
@@ -10901,10 +10901,10 @@ packages:
         integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==,
       }
 
-  caniuse-lite@1.0.30001806:
+  caniuse-lite@1.0.30001810:
     resolution:
       {
-        integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==,
+        integrity: sha512-TITQPUkaz+aVk5GL6NhOdwk1aEaNTSDPsGFWrTuhKGtjTF70jL/Oht2W4c6rXUe5fu7Ie19VIahAXHIIiWWNeg==,
       }
 
   ccount@2.0.1:
@@ -14158,17 +14158,17 @@ packages:
         integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
       }
 
-  js-yaml@3.15.1:
+  js-yaml@3.15.2:
     resolution:
       {
-        integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==,
+        integrity: sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==,
       }
     hasBin: true
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     resolution:
       {
-        integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==,
+        integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==,
       }
     hasBin: true
 
@@ -15407,10 +15407,10 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@15.5.21:
+  next@15.5.24:
     resolution:
       {
-        integrity: sha512-/TsdBtkWLhkl+NVL3Uqws2UphNd6IPzOtzSk1fHaf+0P7GQKLZDUytyhns/Ykbzdy9+YRjwG7ONvrHaaTDdFqQ==,
+        integrity: sha512-Y+xn8EQCoC3ZbsFPyzE+tE8XOdrWeUdUF7NeXbmg9DsgAxl5UYxlsrvgVESHTyTGigoTa1bCUrxn70F5bqt0Gw==,
       }
     engines: { node: ^18.18.0 || ^19.8.0 || >= 20.0.0 }
     hasBin: true
@@ -17470,10 +17470,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  sharp@0.35.3:
+  sharp@0.35.4:
     resolution:
       {
-        integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==,
+        integrity: sha512-n++8XWcj+jCOr2IOl7h8LbKnGBDY4aPbmprMONBNFdn0ImXqpGVv5zliDs0V9HbmbCQLpbuo2ej9rAoOQTvMDA==,
       }
     engines: { node: ">=20.9.0" }
     peerDependencies:
@@ -21043,7 +21043,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -21118,11 +21118,11 @@ snapshots:
     dependencies:
       "@formatjs/fast-memoize": 3.1.6
 
-  "@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)":
+  "@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@mdx-js/mdx": 3.1.1
-      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      js-yaml: 4.3.1
+      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      js-yaml: 4.3.2
       react: 19.2.6
       unified: 11.0.5
       vfile: 6.0.3
@@ -21167,108 +21167,108 @@ snapshots:
 
   "@img/colour@1.1.0": {}
 
-  "@img/sharp-darwin-arm64@0.35.3":
+  "@img/sharp-darwin-arm64@0.35.4":
     optionalDependencies:
-      "@img/sharp-libvips-darwin-arm64": 1.3.2
+      "@img/sharp-libvips-darwin-arm64": 1.3.3
     optional: true
 
-  "@img/sharp-darwin-x64@0.35.3":
+  "@img/sharp-darwin-x64@0.35.4":
     optionalDependencies:
-      "@img/sharp-libvips-darwin-x64": 1.3.2
+      "@img/sharp-libvips-darwin-x64": 1.3.3
     optional: true
 
-  "@img/sharp-freebsd-wasm32@0.35.3":
+  "@img/sharp-freebsd-wasm32@0.35.4":
     dependencies:
-      "@img/sharp-wasm32": 0.35.3
+      "@img/sharp-wasm32": 0.35.4
     optional: true
 
-  "@img/sharp-libvips-darwin-arm64@1.3.2":
+  "@img/sharp-libvips-darwin-arm64@1.3.3":
     optional: true
 
-  "@img/sharp-libvips-darwin-x64@1.3.2":
+  "@img/sharp-libvips-darwin-x64@1.3.3":
     optional: true
 
-  "@img/sharp-libvips-linux-arm64@1.3.2":
+  "@img/sharp-libvips-linux-arm64@1.3.3":
     optional: true
 
-  "@img/sharp-libvips-linux-arm@1.3.2":
+  "@img/sharp-libvips-linux-arm@1.3.3":
     optional: true
 
-  "@img/sharp-libvips-linux-ppc64@1.3.2":
+  "@img/sharp-libvips-linux-ppc64@1.3.3":
     optional: true
 
-  "@img/sharp-libvips-linux-riscv64@1.3.2":
+  "@img/sharp-libvips-linux-riscv64@1.3.3":
     optional: true
 
-  "@img/sharp-libvips-linux-s390x@1.3.2":
+  "@img/sharp-libvips-linux-s390x@1.3.3":
     optional: true
 
-  "@img/sharp-libvips-linux-x64@1.3.2":
+  "@img/sharp-libvips-linux-x64@1.3.3":
     optional: true
 
-  "@img/sharp-libvips-linuxmusl-arm64@1.3.2":
+  "@img/sharp-libvips-linuxmusl-arm64@1.3.3":
     optional: true
 
-  "@img/sharp-libvips-linuxmusl-x64@1.3.2":
+  "@img/sharp-libvips-linuxmusl-x64@1.3.3":
     optional: true
 
-  "@img/sharp-linux-arm64@0.35.3":
+  "@img/sharp-linux-arm64@0.35.4":
     optionalDependencies:
-      "@img/sharp-libvips-linux-arm64": 1.3.2
+      "@img/sharp-libvips-linux-arm64": 1.3.3
     optional: true
 
-  "@img/sharp-linux-arm@0.35.3":
+  "@img/sharp-linux-arm@0.35.4":
     optionalDependencies:
-      "@img/sharp-libvips-linux-arm": 1.3.2
+      "@img/sharp-libvips-linux-arm": 1.3.3
     optional: true
 
-  "@img/sharp-linux-ppc64@0.35.3":
+  "@img/sharp-linux-ppc64@0.35.4":
     optionalDependencies:
-      "@img/sharp-libvips-linux-ppc64": 1.3.2
+      "@img/sharp-libvips-linux-ppc64": 1.3.3
     optional: true
 
-  "@img/sharp-linux-riscv64@0.35.3":
+  "@img/sharp-linux-riscv64@0.35.4":
     optionalDependencies:
-      "@img/sharp-libvips-linux-riscv64": 1.3.2
+      "@img/sharp-libvips-linux-riscv64": 1.3.3
     optional: true
 
-  "@img/sharp-linux-s390x@0.35.3":
+  "@img/sharp-linux-s390x@0.35.4":
     optionalDependencies:
-      "@img/sharp-libvips-linux-s390x": 1.3.2
+      "@img/sharp-libvips-linux-s390x": 1.3.3
     optional: true
 
-  "@img/sharp-linux-x64@0.35.3":
+  "@img/sharp-linux-x64@0.35.4":
     optionalDependencies:
-      "@img/sharp-libvips-linux-x64": 1.3.2
+      "@img/sharp-libvips-linux-x64": 1.3.3
     optional: true
 
-  "@img/sharp-linuxmusl-arm64@0.35.3":
+  "@img/sharp-linuxmusl-arm64@0.35.4":
     optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-arm64": 1.3.2
+      "@img/sharp-libvips-linuxmusl-arm64": 1.3.3
     optional: true
 
-  "@img/sharp-linuxmusl-x64@0.35.3":
+  "@img/sharp-linuxmusl-x64@0.35.4":
     optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-x64": 1.3.2
+      "@img/sharp-libvips-linuxmusl-x64": 1.3.3
     optional: true
 
-  "@img/sharp-wasm32@0.35.3":
+  "@img/sharp-wasm32@0.35.4":
     dependencies:
       "@emnapi/runtime": 1.11.2
     optional: true
 
-  "@img/sharp-webcontainers-wasm32@0.35.3":
+  "@img/sharp-webcontainers-wasm32@0.35.4":
     dependencies:
-      "@img/sharp-wasm32": 0.35.3
+      "@img/sharp-wasm32": 0.35.4
     optional: true
 
-  "@img/sharp-win32-arm64@0.35.3":
+  "@img/sharp-win32-arm64@0.35.4":
     optional: true
 
-  "@img/sharp-win32-ia32@0.35.3":
+  "@img/sharp-win32-ia32@0.35.4":
     optional: true
 
-  "@img/sharp-win32-x64@0.35.3":
+  "@img/sharp-win32-x64@0.35.4":
     optional: true
 
   "@inkeep/cxkit-color-mode@0.5.119": {}
@@ -21548,7 +21548,7 @@ snapshots:
 
   "@juggle/resize-observer@3.4.0": {}
 
-  "@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)":
+  "@keystar/ui@0.8.0(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
       "@emotion/css": 11.13.5
@@ -21563,13 +21563,13 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-stately: 3.48.0(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
-  "@keystatic/core@0.6.0(@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)":
+  "@keystatic/core@0.6.0(@keystar/ui@0.8.0(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
       "@braintree/sanitize-url": 6.0.4
@@ -21596,7 +21596,7 @@ snapshots:
       idb-keyval: 6.2.2
       ignore: 5.3.2
       is-hotkey: 0.2.0
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       lib0: 0.2.117
       lru-cache: 10.4.3
       match-sorter: 6.3.4
@@ -21633,19 +21633,19 @@ snapshots:
       y-protocols: 1.0.7(yjs@13.6.29)
       yjs: 13.6.29
     optionalDependencies:
-      "@keystar/ui": 0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
+      "@keystar/ui": 0.8.0(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
       react-aria: 3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-stately: 3.48.0(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
-  "@keystatic/next@5.0.4(@keystatic/core@0.6.0(@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@keystatic/next@5.0.4(@keystatic/core@0.6.0(@keystar/ui@0.8.0(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@babel/runtime": 7.28.4
-      "@keystatic/core": 0.6.0(@keystar/ui@0.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
+      "@keystatic/core": 0.6.0(@keystar/ui@0.8.0(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6))(react-aria@3.50.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react-stately@3.48.0(react@19.2.6))(react@19.2.6)
       "@types/react": 19.1.12
       chokidar: 3.6.0
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       server-only: 0.0.1
@@ -21722,7 +21722,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  "@next/env@15.5.21": {}
+  "@next/env@15.5.24": {}
 
   "@next/eslint-plugin-next@15.5.19":
     dependencies:
@@ -21735,28 +21735,28 @@ snapshots:
       "@mdx-js/loader": 3.1.1(webpack@5.101.3(postcss@8.5.18))
       "@mdx-js/react": 3.1.1(@types/react@19.1.12)(react@19.2.6)
 
-  "@next/swc-darwin-arm64@15.5.21":
+  "@next/swc-darwin-arm64@15.5.24":
     optional: true
 
-  "@next/swc-darwin-x64@15.5.21":
+  "@next/swc-darwin-x64@15.5.24":
     optional: true
 
-  "@next/swc-linux-arm64-gnu@15.5.21":
+  "@next/swc-linux-arm64-gnu@15.5.24":
     optional: true
 
-  "@next/swc-linux-arm64-musl@15.5.21":
+  "@next/swc-linux-arm64-musl@15.5.24":
     optional: true
 
-  "@next/swc-linux-x64-gnu@15.5.21":
+  "@next/swc-linux-x64-gnu@15.5.24":
     optional: true
 
-  "@next/swc-linux-x64-musl@15.5.21":
+  "@next/swc-linux-x64-musl@15.5.24":
     optional: true
 
-  "@next/swc-win32-arm64-msvc@15.5.21":
+  "@next/swc-win32-arm64-msvc@15.5.24":
     optional: true
 
-  "@next/swc-win32-x64-msvc@15.5.21":
+  "@next/swc-win32-x64-msvc@15.5.24":
     optional: true
 
   "@noble/curves@1.9.7":
@@ -23299,7 +23299,7 @@ snapshots:
 
   "@sentry/core@10.11.0": {}
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.18))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(postcss@8.5.18))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -23313,7 +23313,7 @@ snapshots:
       "@sentry/vercel-edge": 10.11.0
       "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(postcss@8.5.18))
       chalk: 3.0.0
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -23326,7 +23326,7 @@ snapshots:
       - supports-color
       - webpack
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -23340,7 +23340,7 @@ snapshots:
       "@sentry/vercel-edge": 10.11.0
       "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(@swc/core@1.15.41(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.18))
       chalk: 3.0.0
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -23353,7 +23353,7 @@ snapshots:
       - supports-color
       - webpack
 
-  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))":
+  "@sentry/nextjs@10.11.0(@opentelemetry/context-async-hooks@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.1.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.1.0(@opentelemetry/api@1.9.0))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))":
     dependencies:
       "@opentelemetry/api": 1.9.0
       "@opentelemetry/semantic-conventions": 1.37.0
@@ -23367,7 +23367,7 @@ snapshots:
       "@sentry/vercel-edge": 10.11.0
       "@sentry/webpack-plugin": 4.3.0(webpack@5.101.3(lightningcss@1.32.0)(postcss@8.5.18))
       chalk: 3.0.0
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       resolve: 1.22.8
       rollup: 4.59.0
       stacktrace-parser: 0.1.11
@@ -23561,13 +23561,13 @@ snapshots:
       color: 5.0.3
       text-hex: 1.0.0
 
-  "@solana-foundation/solana-lib@2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
+  "@solana-foundation/solana-lib@2.41.0(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(jquery@3.7.1)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)":
     dependencies:
       "@radix-ui/react-tooltip": 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@types/react-slick": 0.23.13
       class-variance-authority: 0.7.1
       html-react-parser: 5.2.6(@types/react@19.1.12)(react@19.2.6)
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       prismjs: 1.30.0
       react: 19.2.6
       react-countup: 6.5.3(react@19.2.6)
@@ -26495,9 +26495,9 @@ snapshots:
       bs58: 4.0.1
       text-encoding-utf-8: 1.0.2
 
-  botid@1.5.11(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6):
+  botid@1.5.11(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6):
     optionalDependencies:
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
 
   brace-expansion@1.1.16:
@@ -26518,7 +26518,7 @@ snapshots:
   browserslist@4.28.7:
     dependencies:
       baseline-browser-mapping: 2.11.20
-      caniuse-lite: 1.0.30001806
+      caniuse-lite: 1.0.30001810
       electron-to-chromium: 1.5.393
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
@@ -26592,7 +26592,7 @@ snapshots:
 
   caniuse-lite@1.0.30001793: {}
 
-  caniuse-lite@1.0.30001806: {}
+  caniuse-lite@1.0.30001810: {}
 
   ccount@2.0.1: {}
 
@@ -26828,7 +26828,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.8.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -27874,7 +27874,7 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       "@formatjs/intl-localematcher": 0.6.1
       "@orama/orama": 3.1.14
@@ -27895,21 +27895,21 @@ snapshots:
       unist-util-visit: 5.1.0
     optionalDependencies:
       "@types/react": 19.1.12
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1)):
+  fumadocs-mdx@12.0.3(@fumadocs/mdx-remote@1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6))(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(vite@7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1)):
     dependencies:
       "@mdx-js/mdx": 3.1.1
       "@standard-schema/spec": 1.0.0
       chokidar: 4.0.3
       esbuild: 0.28.1
       estree-util-value-to-estree: 3.4.0
-      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      js-yaml: 4.3.1
+      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      js-yaml: 4.3.2
       lru-cache: 11.2.2
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -27921,14 +27921,14 @@ snapshots:
       unist-util-visit: 5.1.0
       zod: 4.4.3
     optionalDependencies:
-      "@fumadocs/mdx-remote": 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      "@fumadocs/mdx-remote": 1.4.10(@types/mdx@2.0.13)(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       vite: 7.3.5(@types/node@24.13.3)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.92.1)(terser@5.48.0)(tsx@4.22.4)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1)):
+  fumadocs-ui@14.7.7(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(fumadocs-core@15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.8.1)):
     dependencies:
       "@radix-ui/react-accordion": 1.2.12(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       "@radix-ui/react-collapsible": 1.1.12(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -27940,10 +27940,10 @@ snapshots:
       "@radix-ui/react-slot": 1.2.4(@types/react@19.1.12)(react@19.2.6)
       "@radix-ui/react-tabs": 1.1.13(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       class-variance-authority: 0.7.1
-      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      fumadocs-core: 15.6.12(@types/react@19.1.12)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       lodash.merge: 4.6.2
       lucide-react: 0.473.0(react@19.2.6)
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-themes: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       postcss-selector-parser: 7.1.0
       react: 19.2.6
@@ -28121,7 +28121,7 @@ snapshots:
 
   gray-matter@4.0.3:
     dependencies:
-      js-yaml: 3.15.1
+      js-yaml: 3.15.2
       kind-of: 6.0.3
       section-matter: 1.0.0
       strip-bom-string: 1.0.0
@@ -28677,12 +28677,12 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.1:
+  js-yaml@3.15.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.1:
+  js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
 
@@ -29597,14 +29597,14 @@ snapshots:
 
   next-intl-swc-plugin-extractor@4.13.4: {}
 
-  next-intl@4.13.4(@swc/helpers@0.5.17)(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
+  next-intl@4.13.4(@swc/helpers@0.5.17)(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react@19.2.6)(typescript@5.8.3):
     dependencies:
       "@formatjs/intl-localematcher": 0.8.10
       "@parcel/watcher": 2.5.1
       "@swc/core": 1.15.41(@swc/helpers@0.5.17)
       icu-minify: 4.13.4
       negotiator: 1.0.0
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       next-intl-swc-plugin-extractor: 4.13.4
       po-parser: 2.1.1
       react: 19.2.6
@@ -29628,9 +29628,9 @@ snapshots:
       - "@types/react"
       - supports-color
 
-  next-seo@6.8.0(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  next-seo@6.8.0(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
@@ -29639,28 +29639,28 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
-  next@15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1):
+  next@15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1):
     dependencies:
-      "@next/env": 15.5.21
+      "@next/env": 15.5.24
       "@swc/helpers": 0.5.15
-      caniuse-lite: 1.0.30001806
+      caniuse-lite: 1.0.30001810
       postcss: 8.5.18
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.6)
     optionalDependencies:
-      "@next/swc-darwin-arm64": 15.5.21
-      "@next/swc-darwin-x64": 15.5.21
-      "@next/swc-linux-arm64-gnu": 15.5.21
-      "@next/swc-linux-arm64-musl": 15.5.21
-      "@next/swc-linux-x64-gnu": 15.5.21
-      "@next/swc-linux-x64-musl": 15.5.21
-      "@next/swc-win32-arm64-msvc": 15.5.21
-      "@next/swc-win32-x64-msvc": 15.5.21
+      "@next/swc-darwin-arm64": 15.5.24
+      "@next/swc-darwin-x64": 15.5.24
+      "@next/swc-linux-arm64-gnu": 15.5.24
+      "@next/swc-linux-arm64-musl": 15.5.24
+      "@next/swc-linux-x64-gnu": 15.5.24
+      "@next/swc-linux-x64-musl": 15.5.24
+      "@next/swc-win32-arm64-msvc": 15.5.24
+      "@next/swc-win32-x64-msvc": 15.5.24
       "@opentelemetry/api": 1.9.0
       "@playwright/test": 1.58.2
       sass: 1.92.1
-      sharp: 0.35.3(@types/node@24.13.3)
+      sharp: 0.35.4(@types/node@24.13.3)
     transitivePeerDependencies:
       - "@babel/core"
       - "@types/node"
@@ -29745,12 +29745,12 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuqs@2.7.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6):
+  nuqs@2.7.2(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-router-dom@6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-router@6.3.0(react@19.2.6))(react@19.2.6):
     dependencies:
       "@standard-schema/spec": 1.0.0
       react: 19.2.6
     optionalDependencies:
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
       react-router: 6.3.0(react@19.2.6)
       react-router-dom: 6.3.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
@@ -31121,37 +31121,37 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
-  sharp@0.35.3(@types/node@24.13.3):
+  sharp@0.35.4(@types/node@24.13.3):
     dependencies:
       "@img/colour": 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      "@img/sharp-darwin-arm64": 0.35.3
-      "@img/sharp-darwin-x64": 0.35.3
-      "@img/sharp-freebsd-wasm32": 0.35.3
-      "@img/sharp-libvips-darwin-arm64": 1.3.2
-      "@img/sharp-libvips-darwin-x64": 1.3.2
-      "@img/sharp-libvips-linux-arm": 1.3.2
-      "@img/sharp-libvips-linux-arm64": 1.3.2
-      "@img/sharp-libvips-linux-ppc64": 1.3.2
-      "@img/sharp-libvips-linux-riscv64": 1.3.2
-      "@img/sharp-libvips-linux-s390x": 1.3.2
-      "@img/sharp-libvips-linux-x64": 1.3.2
-      "@img/sharp-libvips-linuxmusl-arm64": 1.3.2
-      "@img/sharp-libvips-linuxmusl-x64": 1.3.2
-      "@img/sharp-linux-arm": 0.35.3
-      "@img/sharp-linux-arm64": 0.35.3
-      "@img/sharp-linux-ppc64": 0.35.3
-      "@img/sharp-linux-riscv64": 0.35.3
-      "@img/sharp-linux-s390x": 0.35.3
-      "@img/sharp-linux-x64": 0.35.3
-      "@img/sharp-linuxmusl-arm64": 0.35.3
-      "@img/sharp-linuxmusl-x64": 0.35.3
-      "@img/sharp-webcontainers-wasm32": 0.35.3
-      "@img/sharp-win32-arm64": 0.35.3
-      "@img/sharp-win32-ia32": 0.35.3
-      "@img/sharp-win32-x64": 0.35.3
+      "@img/sharp-darwin-arm64": 0.35.4
+      "@img/sharp-darwin-x64": 0.35.4
+      "@img/sharp-freebsd-wasm32": 0.35.4
+      "@img/sharp-libvips-darwin-arm64": 1.3.3
+      "@img/sharp-libvips-darwin-x64": 1.3.3
+      "@img/sharp-libvips-linux-arm": 1.3.3
+      "@img/sharp-libvips-linux-arm64": 1.3.3
+      "@img/sharp-libvips-linux-ppc64": 1.3.3
+      "@img/sharp-libvips-linux-riscv64": 1.3.3
+      "@img/sharp-libvips-linux-s390x": 1.3.3
+      "@img/sharp-libvips-linux-x64": 1.3.3
+      "@img/sharp-libvips-linuxmusl-arm64": 1.3.3
+      "@img/sharp-libvips-linuxmusl-x64": 1.3.3
+      "@img/sharp-linux-arm": 0.35.4
+      "@img/sharp-linux-arm64": 0.35.4
+      "@img/sharp-linux-ppc64": 0.35.4
+      "@img/sharp-linux-riscv64": 0.35.4
+      "@img/sharp-linux-s390x": 0.35.4
+      "@img/sharp-linux-x64": 0.35.4
+      "@img/sharp-linuxmusl-arm64": 0.35.4
+      "@img/sharp-linuxmusl-x64": 0.35.4
+      "@img/sharp-webcontainers-wasm32": 0.35.4
+      "@img/sharp-win32-arm64": 0.35.4
+      "@img/sharp-win32-ia32": 0.35.4
+      "@img/sharp-win32-x64": 0.35.4
       "@types/node": 24.13.3
 
   shebang-command@2.0.0:
@@ -31904,12 +31904,12 @@ snapshots:
       pako: 0.2.9
       tiny-inflate: 1.0.3
 
-  unicornstudio-react@1.5.2(next@15.5.21(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  unicornstudio-react@1.5.2(next@15.5.24(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1))(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
-      next: 15.5.21(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
+      next: 15.5.24(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(@types/node@24.13.3)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(sass@1.92.1)
 
   unified-engine@11.2.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,7 +12,7 @@ catalog:
   date-fns: ^4.1.0
   lodash: ^4.17.23
   motion: ^12.23.28
-  next: 15.5.21
+  next: 15.5.24
   next-intl: 4.13.4
   react: 19.2.6
   react-dom: 19.2.6
@@ -47,7 +47,7 @@ overrides:
   "glob@9.3.5>minimatch": 9.0.7
   # Next.js 15 still requests Sharp 0.34, so force its optional dependency onto
   # the current patched release containing the updated libvips binaries.
-  "sharp@<0.35.0": 0.35.3
+  "sharp@<0.35.0": 0.35.4
   # @databricks/sql 2 requires Thrift's UUID dependency to remain CJS-compatible.
   # Package-level overrides are not inherited by pnpm consumers.
   "thrift@0.23.0>uuid": 11.1.1


### PR DESCRIPTION
## Summary

- Update the shared Next.js catalog from 15.5.21 to 15.5.24 for [GHSA-p293-qw3h-jr36](https://github.com/advisories/GHSA-p293-qw3h-jr36).
- Bump the existing Sharp override and resolved packages from 0.35.3 to 0.35.4.
- Update js-yaml 3.x and 4.x to the patched releases 3.15.2 and 4.3.2.

## Validation

- Scope: all 17 workspace projects
✓ Lockfile passes supply-chain policies (verified 3m ago)
Lockfile is up to date, resolution step is skipped
Already up to date

Done in 958ms using pnpm v11.13.1
- 54 vulnerabilities found
Severity: 14 low | 38 moderate | 2 high (2 ignored) (passes; the repository still reports 2 ignored high findings)
- 
- 
/Users/karambit/orca/workspaces/solana-com/mahimahi/apps/accelerate/src/lib/miami-speakers.ts
  62:12  warning  'value' is defined but never used. Allowed unused args must match /^_/u  no-unused-vars

✖ 1 problem (0 errors, 1 warning)

Checking formatting...
All matched files use Prettier code style! (0 errors; one existing warning)
-    ▲ Next.js 15.5.24
   - Experiments (use with caution):
     ✓ externalDir
     · clientTraceMetadata

   Creating an optimized production build ...
warn  - It seems like you don't have a global error handler set up. It is recommended that you add a global-error.js file with Sentry instrumentation so that React rendering errors are reported to Sentry. Read more: https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/#react-render-errors-in-app-router (you can suppress this warning by setting SENTRY_SUPPRESS_GLOBAL_ERROR_HANDLER_FILE_WARNING=1 as environment variable)
 ✓ Compiled successfully in 7.3s
   Linting and checking validity of types ...

./src/lib/miami-speakers.ts
62:12  Warning: 'value' is defined but never used. Allowed unused args must match /^_/u.  no-unused-vars

info  - Need to disable some ESLint rules? Learn more here: https://nextjs.org/docs/app/api-reference/config/eslint#disabling-rules
   Collecting page data ...
   Generating static pages (0/11) ...
   Generating static pages (2/11) 
   Generating static pages (5/11) 
   Generating static pages (8/11) 
 ✓ Generating static pages (11/11)
   Finalizing page optimization ...
   Collecting build traces ...

Route (app)                                 Size  First Load JS
┌ ○ /_not-found                             1 kB         182 kB
├ ● /[locale]                            15.6 kB         260 kB
├   └ /en
├ ● /[locale]/agenda                      1.7 kB         183 kB
├   └ /en/agenda
├ ● /[locale]/hong-kong                  2.28 kB         823 kB
├   └ /en/hong-kong
├ ● /[locale]/hong-kong/agenda           2.12 kB         344 kB
├   └ /en/hong-kong/agenda
├ ● /[locale]/miami                      2.76 kB         823 kB
├   └ /en/miami
├ ● /[locale]/miami/agenda               2.22 kB         344 kB
├   └ /en/miami/agenda
├ ○ /robots.txt                            128 B         181 kB
└ ○ /sitemap.xml                           128 B         181 kB
+ First Load JS shared by all             181 kB
  ├ chunks/600-3a69ab25b241c839.js        122 kB
  ├ chunks/8bb33555-2250cd1573c05e99.js  54.2 kB
  └ other shared chunks (total)          4.26 kB


ƒ Middleware                             52.9 kB

○  (Static)  prerendered as static content
●  (SSG)     prerendered as static HTML (uses generateStaticParams)
