### PR TITLE
fix(content) Updating txv1 activation to the start of epoch 1035

### DIFF
--- a/apps/media/content/upgrades/larger-transaction-sizes.mdx
+++ b/apps/media/content/upgrades/larger-transaction-sizes.mdx
@@ -14,8 +14,8 @@ stage: pending_activation
 release: agave-4-2
 order: 3
 metrics:
-  - value: Sept 15
-    label: Mainnet activation, at the start of epoch 1035
+  - value: Epoch 1035
+    label: Mainnet activation, Sept 15 @ 01:20 UTC
   - value: "4096"
     label: Bytes per transaction, up from 1232
   - value: 3.3x

--- a/apps/media/content/upgrades/larger-transaction-sizes.mdx
+++ b/apps/media/content/upgrades/larger-transaction-sizes.mdx
@@ -3,7 +3,7 @@ title: Larger Transaction Sizes
 description: >-
   Solana raises the maximum transaction size from 1232 bytes to 4096 bytes at
   the start of mainnet epoch 1035, expected September 15, 2026 at approximately
-  01:00 UTC. SIMD-0296 and the v1 transaction format unlock ZK proofs, large
+  01:20 UTC. SIMD-0296 and the v1 transaction format unlock ZK proofs, large
   multisigs, and onchain signature schemes in a single atomic transaction. v1 is
   opt-in for sending but mandatory for reading transactions.
 subtitle: Raising the maximum transaction size from 1232 to 4096 bytes

--- a/apps/media/content/upgrades/larger-transaction-sizes.mdx
+++ b/apps/media/content/upgrades/larger-transaction-sizes.mdx
@@ -1,8 +1,9 @@
 ---
 title: Larger Transaction Sizes
 description: >-
-  Solana is raising the maximum transaction size from 1232 bytes to 4096 bytes
-  via SIMD-0296 and the v1 transaction format, unlocking ZK proofs, large
+  Solana raises the maximum transaction size from 1232 bytes to 4096 bytes at
+  the start of mainnet epoch 1035, expected September 15, 2026 at approximately
+  01:00 UTC. SIMD-0296 and the v1 transaction format unlock ZK proofs, large
   multisigs, and onchain signature schemes in a single atomic transaction. v1 is
   opt-in for sending but mandatory for reading transactions.
 subtitle: Raising the maximum transaction size from 1232 to 4096 bytes
@@ -13,6 +14,8 @@ stage: pending_activation
 release: agave-4-2
 order: 3
 metrics:
+  - value: Sept 15
+    label: Mainnet activation, at the start of epoch 1035
   - value: "4096"
     label: Bytes per transaction, up from 1232
   - value: 3.3x
@@ -23,10 +26,13 @@ tags:
   - tag: announcements
 ---
 
-**Updated August 2026** • Solana Foundation
+**Updated September 2026** • Solana Foundation
 
 A major upcoming upgrade to Solana raises the maximum transaction size from 1232
-bytes to 4096 bytes. The size increase is defined in
+-bytes to 4096 bytes. The feature has been activated on Testnet and Devnet and
+will be activated on Mainnet at the **start of mainnet epoch 1035**,
+expected on **September 15, 2026 at approximately 01:20 UTC**. The size
+increase is defined in
 [SIMD-0296](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0296-larger-transactions.md)
 and delivered through the v1 transaction format introduced in
 [SIMD-0385](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md).
@@ -47,12 +53,18 @@ to `v1` transactions.
 | **Sends** transactions                                   | No (opt-in) | If using v1 you MUST set the compute unit and data size limits explicitly (both default to zero). [Learn more](#sending-v1-transactions)                                            |
 | **Sponsors** fees or co-signs someone else's transaction | **Yes**     | Caps that scan ComputeBudget instructions stop binding. Read the limits you gate on from `transactionConfig`. [Learn more](#breaking-change-sponsoring-and-co-signing-transactions) |
 
-**Expected Mainnet Activation Date:**
+## Mainnet Activation: Epoch 1035
 
-Anza's [Agave v4.2 release schedule](https://github.com/anza-xyz/agave/wiki/v4.2-Release-Schedule)
-targets mainnet feature activation in **Agave v4.2**. This lands alongside the
-first stage of [reduced slot times](/upgrades/reduced-slot-times) and a rent
-reduction. Anza's schedule is explicitly tentative and subject to change.
+The `txv1` feature gate activates at the **start of mainnet epoch 1035**,
+expected on **September 15, 2026 at approximately 01:20 UTC**.
+
+|                                  |                                                             |
+| -------------------------------- | ----------------------------------------------------------- |
+| Expected Mainnet Activation Date | Start of epoch 1035 — September 15, 2026, approx. 01:20 UTC |
+| Devnet Activation                | Live                                                        |
+| Breaking Change?                 | Yes, for reading, indexing, and sponsoring transactions     |
+| Indexing Changes Required?       | Yes, read limits from `transactionConfig`                   |
+| Feature Gate                     | `txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL`               |
 
 Current feature gate activation status:
 
@@ -65,8 +77,10 @@ you can do so with the Solana CLI (use `-u d` or `-u t` for devnet or testnet):
 solana -u m feature status txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL
 ```
 
-Local testing is available today. V1 Transactions are enabled in:
+You can test v1 transactions today, ahead of epoch 1035. They are
+enabled on:
 
+- **Devnet**, where the feature gate is already active
 - Local test validator in the [Solana CLI](https://solana.com/docs/intro/installation)
   (v4.2+)
 - [Surfpool](https://www.surfpool.run/) (v1.5+)
@@ -479,7 +493,9 @@ and one single confirmation rather than several chained transactions.
 
 This upgrade addresses a practical ceiling that application teams have had to
 design around since the early days of Solana, and brings a whole new class of
-capabilities that we're looking forward to support.
+capabilities that we're looking forward to support. It goes live on mainnet at
+the start of epoch 1035, expected on September 15, 2026 at approximately
+01:20 UTC.
 
 The format details are specified in
 [SIMD-0385](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md)

--- a/apps/media/content/upgrades/larger-transaction-sizes.mdx
+++ b/apps/media/content/upgrades/larger-transaction-sizes.mdx
@@ -29,7 +29,7 @@ tags:
 **Updated September 2026** • Solana Foundation
 
 A major upcoming upgrade to Solana raises the maximum transaction size from 1232
--bytes to 4096 bytes. The feature has been activated on Testnet and Devnet and
+bytes to 4096 bytes. The feature has been activated on Testnet and Devnet and
 will be activated on Mainnet at the **start of mainnet epoch 1035**,
 expected on **September 15, 2026 at approximately 01:20 UTC**. The size
 increase is defined in


### PR DESCRIPTION
### Problem
The activation date for txv1 has moved back requiring an update to the /upgrades page

### Summary of Changes

Tx v1 will be activated on mainnet at the start of epoch 1035 on Sept 15 at 01:20 UTC 

Fixes #

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
