### PR TITLE
fix(accelerate): improve China roadshow mobile layout

### DIFF
--- a/apps/accelerate/src/app/globals.css
+++ b/apps/accelerate/src/app/globals.css
@@ -31,6 +31,15 @@ body {
     var(--font-space-grotesk), "Space Grotesk", system-ui, sans-serif;
 }
 
+/* Keep the FAB clear of the China hero's right-aligned actions on phones.
+   Consent UI has a higher stacking layer and takes priority while it is open. */
+@media (max-width: 767px) {
+  .accelerate-fab .sfab-button {
+    left: 24px;
+    right: auto;
+  }
+}
+
 /* ─── Accelerate gradient text ─── */
 .gradient-text {
   background: linear-gradient(135deg, #9945ff 0%, #19fb9b 50%, #00d4ff 100%);

--- a/apps/accelerate/src/app/globals.css
+++ b/apps/accelerate/src/app/globals.css
@@ -40,6 +40,16 @@ body {
   }
 }
 
+/* The closed button stays beneath site modals. Once opened, its scrim and
+   panel must sit above the page header while remaining below consent UI. */
+.accelerate-fab:has(.sfab-panel) .sfab-overlay {
+  z-index: 40;
+}
+
+.accelerate-fab:has(.sfab-panel) .sfab-panel {
+  z-index: 41;
+}
+
 /* ─── Accelerate gradient text ─── */
 .gradient-text {
   background: linear-gradient(135deg, #9945ff 0%, #19fb9b 50%, #00d4ff 100%);

--- a/apps/accelerate/src/components/FabMenu.tsx
+++ b/apps/accelerate/src/components/FabMenu.tsx
@@ -3,5 +3,9 @@
 import { SolanaFabMenu } from "@solana-foundation/fab-menu";
 
 export function FabMenu() {
-  return <SolanaFabMenu position="bottom-right" logoVariant="color" />;
+  return (
+    <div className="accelerate-fab">
+      <SolanaFabMenu position="bottom-right" logoVariant="color" zIndex={20} />
+    </div>
+  );
 }

--- a/apps/accelerate/src/components/china/ChinaRoadshow.tsx
+++ b/apps/accelerate/src/components/china/ChinaRoadshow.tsx
@@ -69,7 +69,7 @@ export function ChinaHeader() {
   ];
 
   return (
-    <header className="absolute inset-x-0 top-0 z-30 h-[88px] overflow-hidden bg-black/70 backdrop-blur-sm md:h-[138px]">
+    <header className="absolute inset-x-0 top-0 z-30 h-[88px] bg-black/70 md:h-[138px] lg:backdrop-blur-sm">
       <Image
         src={getImagePath("/images/china/header-bg.webp")}
         alt=""
@@ -245,7 +245,7 @@ function ChinaHero() {
   const t = useTranslations("accelerate.china");
 
   return (
-    <section className="relative h-[clamp(1040px,calc(72.34vw+217px),1389px)] overflow-hidden bg-black pt-[88px] text-white md:pt-[138px]">
+    <section className="relative h-[clamp(920px,calc(72.34vw+217px),1389px)] overflow-hidden bg-black pt-[88px] text-white md:pt-[138px]">
       <div className="pointer-events-none absolute left-1/2 top-0 aspect-[1920/1389] w-[clamp(1200px,calc(100vw+300px),1920px)] max-w-none -translate-x-1/2">
         <div className="absolute inset-0">
           {heroLayers.map((layer) => (


### PR DESCRIPTION
## Problem

On small screens, the China roadshow page had layout conflicts. The floating action button could sit too close to the hero actions, and the hero/header spacing was taller than needed on mobile.

## Solution

Move the Accelerate floating action button to the left on phones, lower its stacking level, reduce the China hero mobile height, and limit the header blur effect to larger screens.

## Testing

TODO

### Summary of Changes

- Updated the Accelerate FAB wrapper so the China page can adjust mobile positioning.
- Added mobile CSS to keep the FAB clear of right-aligned hero actions.
- Reduced the China hero minimum height on mobile.
- Removed mobile header overflow clipping and limited header backdrop blur to large screens.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [ ] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [ ] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [ ] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->