### PR TITLE
feat(breakpoint): add lazy speaker headshot videos

### DIFF
--- a/apps/breakpoint/src/components/ImageTreatment.tsx
+++ b/apps/breakpoint/src/components/ImageTreatment.tsx
@@ -3,8 +3,19 @@
 import React, { useEffect, useRef, useState } from "react";
 import { publicAssetPath } from "@/config";
 
+/**
+ * Selects the kind of distortion applied to the source image.
+ *
+ * `none` keeps the image clean, `p1` creates tears and smears without the
+ * thresholded displacement effect, and `p2` adds thresholded displacement
+ * for a more aggressive, poster-like glitch.
+ */
 export type GlitchPattern = "none" | "p1" | "p2";
+
+/** Selects the exposure and contrast adjustment applied before tinting. */
 export type Lighting = "even" | "contrast" | "exposure";
+
+/** Selects the tint applied to the source image's luminance. */
 export type TreatmentColor =
   | "none"
   | "white"
@@ -14,18 +25,42 @@ export type TreatmentColor =
   | "yellow"
   | "pink";
 
+/** Fine-grained overrides for a glitch preset. */
 export interface TreatmentOverrides {
+  /** Number of horizontal tear slices generated for each frame. */
   iframes?: number;
+
+  /** Number of stretched smear slices generated for each frame. */
   pframes?: number;
+
+  /** Maximum displacement used by tears and smears. */
   shift?: number;
+
+  /** Base height/width of the generated glitch blocks. */
   block?: number;
+
+  /** Luminance cutoff used by the thresholded `p2` effect. */
   threshold?: number;
+
+  /** Initial horizontal displacement used by the thresholded effect. */
   xShift?: number;
+
+  /** Initial vertical displacement used by the thresholded effect. */
   yShift?: number;
+
+  /** Whether the thresholded displacement effect is enabled. */
   showEffect?: boolean;
+
+  /** Whether thresholding uses the distorted image or the base image. */
   preprocess?: "distortion" | "base";
+
+  /** Multiplier applied to source luminance before contrast. */
   exposure?: number;
+
+  /** Contrast adjustment applied to each source pixel. */
   contrast?: number;
+
+  /** Speed multiplier for animated glitch movement and re-seeding. */
   animSpeed?: number;
 }
 
@@ -33,18 +68,43 @@ export interface ImageTreatmentProps extends Omit<
   React.HTMLAttributes<HTMLDivElement>,
   "color"
 > {
+  /** Image URL used as the canvas source. It must be readable by the canvas. */
   src: string;
+
+  /** Accessible label for the treated image. */
   alt?: string;
+
+  /** Distortion preset used to build the glitch slices. */
   glitchPattern?: GlitchPattern;
+
+  /** Preset strength from 0 to 100; scales the number and size of glitches. */
   intensity?: number;
+
+  /** Exposure/contrast preset applied before the color treatment. */
   lighting?: Lighting;
+
+  /** Color used to tint the source's luminance; `none` keeps its original color. */
   color?: TreatmentColor;
+
+  /** Continuously animate the distortion while the image is in view. */
   motion?: boolean;
+
+  /** Periodically switch between clean and glitched frames; disabled for reduced motion. */
   flicker?: boolean;
+
+  /** Move glitch regions toward the pointer while the image is hovered. */
   mouseReactive?: boolean;
+
+  /** Radius, in rendered pixels, used by the pointer-localized glitch effect. */
   mouseRadius?: number;
+
+  /** Optional secondary image composited over the treated source. */
   foregroundSrc?: string;
+
+  /** Fine-tune the selected preset without defining a new preset. */
   overrides?: TreatmentOverrides;
+
+  /** How the source is fitted inside the treatment canvas. */
   objectFit?: "cover" | "contain";
 }
 
@@ -60,6 +120,7 @@ type Preset = {
   yShift: number;
 };
 
+/** Baseline distortion settings for the public `glitchPattern` controls. */
 const PRESETS: Record<GlitchPattern, Preset> = {
   none: {
     iframes: 0,
@@ -96,6 +157,7 @@ const PRESETS: Record<GlitchPattern, Preset> = {
   },
 };
 
+/** Exposure/contrast pairs behind the public `lighting` control. */
 const LIGHTING_PRESETS: Record<
   Lighting,
   { exposure: number; contrast: number }
@@ -105,6 +167,7 @@ const LIGHTING_PRESETS: Record<
   exposure: { exposure: 1.1, contrast: -1 },
 };
 
+/** RGB values behind the public `color` control. */
 const COLOR_PRESETS: Record<TreatmentColor, [number, number, number] | null> = {
   none: null,
   white: [255, 255, 255],
@@ -115,12 +178,14 @@ const COLOR_PRESETS: Record<TreatmentColor, [number, number, number] | null> = {
   pink: [230, 93, 219],
 };
 
+/** Softer overlay colors used when a `foregroundSrc` is supplied. */
 const FG_OVERLAY: Partial<Record<TreatmentColor, [number, number, number]>> = {
   purple: [219, 190, 253],
   blue: [189, 217, 255],
   green: [192, 251, 227],
 };
 
+/** Cap canvas work so large source images do not dominate the render loop. */
 const MAX_DIMENSION = 800;
 
 type CanvasSize = {
@@ -384,6 +449,7 @@ export default function ImageTreatment({
       typeof window !== "undefined" &&
       window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     const animate = motion && !prefersReducedMotion;
+    const shouldFlicker = flicker && !prefersReducedMotion;
 
     const { w, h } = getRenderSize(image, containerSize);
     canvas.width = w;
@@ -714,7 +780,7 @@ export default function ImageTreatment({
       const el = wrapperRef.current;
       const state = mouseStateRef.current;
       state.hovering = false;
-      let autoGlitching = !flicker && animate;
+      let autoGlitching = !shouldFlicker && animate;
       let timeoutId: number | null = null;
 
       const resetGlitches = () => {
@@ -795,7 +861,7 @@ export default function ImageTreatment({
         }, dur);
       };
 
-      if (flicker) {
+      if (shouldFlicker) {
         autoGlitching = Math.random() < 0.4;
         if (autoGlitching) resetGlitches();
       } else if (autoGlitching) resetGlitches();
@@ -807,7 +873,7 @@ export default function ImageTreatment({
         } else drawClean();
       } else drawClean();
 
-      if (flicker) scheduleFlicker();
+      if (shouldFlicker) scheduleFlicker();
 
       if (animate) {
         const loop = () => {
@@ -846,7 +912,7 @@ export default function ImageTreatment({
       };
     }
 
-    if (flicker && hasGlitch) {
+    if (shouldFlicker && hasGlitch) {
       let timeoutId: number | null = null;
       let isGlitching = Math.random() < 0.4;
       const schedule = () => {

--- a/apps/breakpoint/src/components/ImageTreatment.tsx
+++ b/apps/breakpoint/src/components/ImageTreatment.tsx
@@ -372,6 +372,20 @@ export default function ImageTreatment({
   const [fgImage, setFgImage] = useState<HTMLImageElement | null>(null);
   const [inView, setInView] = useState(false);
   const [containerSize, setContainerSize] = useState<CanvasSize | null>(null);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  );
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    updatePreference();
+    mediaQuery.addEventListener("change", updatePreference);
+    return () => mediaQuery.removeEventListener("change", updatePreference);
+  }, []);
 
   useEffect(() => {
     const ctrl = new AbortController();
@@ -445,9 +459,6 @@ export default function ImageTreatment({
     const ctx = canvas.getContext("2d", { willReadFrequently: true });
     if (!ctx) return;
 
-    const prefersReducedMotion =
-      typeof window !== "undefined" &&
-      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
     const animate = motion && !prefersReducedMotion;
     const shouldFlicker = flicker && !prefersReducedMotion;
 
@@ -959,6 +970,7 @@ export default function ImageTreatment({
     mouseReactive,
     mouseRadius,
     objectFit,
+    prefersReducedMotion,
     containerSize?.width,
     containerSize?.height,
     overridesKey,

--- a/apps/breakpoint/src/components/sections/SpeakersCarousel.tsx
+++ b/apps/breakpoint/src/components/sections/SpeakersCarousel.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import Button from "@/components/Button";
 import CarouselControls from "@/components/CarouselControls";
-import ImageTreatment from "@/components/ImageTreatment";
 import SectionHeadline from "@/components/SectionHeadline";
 import { publicAssetPath } from "@/config";
 import type { BreakpointSpeaker } from "@/content/speakers/types";
@@ -46,6 +45,7 @@ function SpeakerMedia({ speaker }: { speaker: BreakpointSpeaker }) {
   const [loadVideo, setLoadVideo] = useState(false);
   const [videoReady, setVideoReady] = useState(false);
   const [videoFailed, setVideoFailed] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
   const imageSrc = speaker.headshotPng
     ? publicAssetPath(speaker.headshotPng)
     : undefined;
@@ -54,7 +54,20 @@ function SpeakerMedia({ speaker }: { speaker: BreakpointSpeaker }) {
     : undefined;
 
   useEffect(() => {
-    if (!webmSrc || shouldPreferStillImage()) return;
+    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const updatePreference = () => setPrefersReducedMotion(mediaQuery.matches);
+
+    updatePreference();
+    mediaQuery.addEventListener("change", updatePreference);
+    return () => mediaQuery.removeEventListener("change", updatePreference);
+  }, []);
+
+  useEffect(() => {
+    if (!webmSrc || prefersReducedMotion || shouldPreferStillImage()) {
+      setLoadVideo(false);
+      setVideoReady(false);
+      return;
+    }
 
     const element = mediaRef.current;
     if (!element || !("IntersectionObserver" in window)) {
@@ -73,9 +86,10 @@ function SpeakerMedia({ speaker }: { speaker: BreakpointSpeaker }) {
 
     observer.observe(element);
     return () => observer.disconnect();
-  }, [webmSrc]);
+  }, [prefersReducedMotion, webmSrc]);
 
-  const showVideo = loadVideo && !videoFailed && Boolean(webmSrc);
+  const showVideo =
+    !prefersReducedMotion && loadVideo && !videoFailed && Boolean(webmSrc);
 
   return (
     <div

--- a/apps/breakpoint/src/components/sections/SpeakersCarousel.tsx
+++ b/apps/breakpoint/src/components/sections/SpeakersCarousel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import Button from "@/components/Button";
 import CarouselControls from "@/components/CarouselControls";
+import ImageTreatment from "@/components/ImageTreatment";
 import SectionHeadline from "@/components/SectionHeadline";
 import { publicAssetPath } from "@/config";
 import type { BreakpointSpeaker } from "@/content/speakers/types";
@@ -23,11 +24,103 @@ function displayName(speaker: BreakpointSpeaker) {
     : speaker.name;
 }
 
-function SpeakerCard({ speaker }: { speaker: BreakpointSpeaker }) {
-  const name = displayName(speaker);
+type NetworkInformation = {
+  effectiveType?: string;
+  saveData?: boolean;
+};
+
+function shouldPreferStillImage() {
+  const connection = (
+    navigator as Navigator & { connection?: NetworkInformation }
+  ).connection;
+
+  return (
+    connection?.saveData === true ||
+    ["slow-2g", "2g"].includes(connection?.effectiveType ?? "") ||
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+function SpeakerMedia({ speaker }: { speaker: BreakpointSpeaker }) {
+  const mediaRef = useRef<HTMLDivElement>(null);
+  const [loadVideo, setLoadVideo] = useState(false);
+  const [videoReady, setVideoReady] = useState(false);
+  const [videoFailed, setVideoFailed] = useState(false);
   const imageSrc = speaker.headshotPng
     ? publicAssetPath(speaker.headshotPng)
     : undefined;
+  const webmSrc = speaker.headshotWebm
+    ? publicAssetPath(speaker.headshotWebm)
+    : undefined;
+
+  useEffect(() => {
+    if (!webmSrc || shouldPreferStillImage()) return;
+
+    const element = mediaRef.current;
+    if (!element || !("IntersectionObserver" in window)) {
+      setLoadVideo(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry?.isIntersecting) return;
+        setLoadVideo(true);
+        observer.disconnect();
+      },
+      { rootMargin: "160px 0px" },
+    );
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [webmSrc]);
+
+  const showVideo = loadVideo && !videoFailed && Boolean(webmSrc);
+
+  return (
+    <div
+      ref={mediaRef}
+      className="relative aspect-square overflow-hidden bg-neutral-800"
+    >
+      {imageSrc ? (
+        <img
+          src={imageSrc}
+          alt=""
+          width={460}
+          height={460}
+          loading="lazy"
+          decoding="async"
+          className={[
+            "absolute inset-0 h-full w-full object-cover transition-opacity duration-500 motion-reduce:transition-none",
+            videoReady && !videoFailed ? "opacity-0" : "opacity-100",
+          ].join(" ")}
+        />
+      ) : (
+        <div aria-hidden="true" className="absolute inset-0 bg-neutral-800" />
+      )}
+
+      {showVideo && (
+        <video
+          autoPlay
+          muted
+          loop
+          playsInline
+          preload="none"
+          poster={imageSrc}
+          aria-hidden="true"
+          onCanPlay={() => setVideoReady(true)}
+          onError={() => setVideoFailed(true)}
+          className="absolute inset-0 h-full w-full object-cover"
+        >
+          <source src={webmSrc} type="video/webm" />
+        </video>
+      )}
+    </div>
+  );
+}
+
+function SpeakerCard({ speaker }: { speaker: BreakpointSpeaker }) {
+  const name = displayName(speaker);
 
   return (
     <li
@@ -35,24 +128,10 @@ function SpeakerCard({ speaker }: { speaker: BreakpointSpeaker }) {
       className="w-[calc(100%-20px)] shrink-0 snap-start md:w-[calc((100%-48px)/3)]"
     >
       <article>
-        <div className="relative aspect-square overflow-hidden bg-neutral-800">
-          {imageSrc ? (
-            <img
-              src={imageSrc}
-              alt=""
-              width={460}
-              height={460}
-              loading="lazy"
-              decoding="async"
-              className="h-full w-full object-cover"
-            />
-          ) : (
-            <div aria-hidden="true" className="absolute inset-0" />
-          )}
-        </div>
+        <SpeakerMedia speaker={speaker} />
 
-        <div className="flex h-[106px] flex-col items-start gap-3xs py-xs text-white">
-          <h3 className="text-lg font-bold leading-[1.45]">{name}</h3>
+        <div className="flex min-h-[106px] flex-col items-start gap-3xs py-xs text-white">
+          <h3 className="type-p-large text-white">{name}</h3>
           <div className="flex flex-col gap-4xs">
             {speaker.company && (
               <p className="type-eyebrow text-white">{speaker.company}</p>


### PR DESCRIPTION
## Problem

Speaker cards only showed still headshots, so the Breakpoint homepage could not use the new animated speaker media. Loading animation everywhere by default could also waste bandwidth or ignore reduced-motion preferences.

## Solution

Add a speaker media component that keeps the still image as the fallback, lazy-loads WebM headshot videos when cards are near the viewport, and skips video for reduced motion, data saver, or very slow connections. Also update the image treatment flicker logic so reduced-motion users do not get flicker animation.

## Testing

TODO

### Summary of Changes

- Added lazy speaker headshot video support to the Breakpoint speakers carousel.
- Preserved still PNG headshots as posters and fallbacks.
- Avoided loading videos for reduced-motion, data-saver, and slow network users.
- Updated speaker card typography and height handling.
- Documented `ImageTreatment` public props and preset types.

---

### Change classification (SDLC §2)

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

New dependencies: none

Threat-model note for Critical changes: n/a