### PR TITLE
feat(analytics): standardize GA4 event tracking

### DIFF
--- a/apps/accelerate/src/app/[locale]/layout.tsx
+++ b/apps/accelerate/src/app/[locale]/layout.tsx
@@ -1,11 +1,9 @@
 import { ReactNode } from "react";
-import Script from "next/script";
 import type { AbstractIntlMessages } from "next-intl";
 import { NextIntlClientProvider } from "@workspace/i18n/client";
 import {
   CookieConsentBanner,
-  getCookieConsentBootstrapScript,
-  getCookieConsentDefaultScript,
+  GoogleAnalyticsTag,
   PersistentPodcastPlayer,
   ThemeProvider,
 } from "@solana-com/ui-chrome";
@@ -124,19 +122,7 @@ export default async function RootLayout({ children, params }: Props) {
       suppressHydrationWarning
     >
       <body className={spaceGrotesk.className} suppressHydrationWarning>
-        <Script strategy="beforeInteractive" id="consent-default">
-          {getCookieConsentDefaultScript()}
-        </Script>
-        {/* Google tag (gtag.js) */}
-        <Script
-          src="https://www.googletagmanager.com/gtag/js?id=G-1YDTXXYYQ4"
-          strategy="afterInteractive"
-        />
-        <Script id="google-analytics" strategy="afterInteractive">
-          {getCookieConsentBootstrapScript({
-            gaMeasurementId: "G-1YDTXXYYQ4",
-          })}
-        </Script>
+        <GoogleAnalyticsTag measurementId="G-1YDTXXYYQ4" />
         <NextIntlClientProvider messages={messages} locale={locale}>
           <ThemeProvider>
             <main className="min-h-screen">{children}</main>

--- a/apps/accelerate/src/components/homepage/StayUpdated.tsx
+++ b/apps/accelerate/src/components/homepage/StayUpdated.tsx
@@ -8,6 +8,7 @@ import {
   sendIterableFormRequest,
   SOLANA_NEWSLETTER_FORM_ID,
 } from "@solana-com/ui-chrome/iterable";
+import { trackLead } from "@solana-com/ui-chrome/analytics";
 import { getImagePath } from "@/config";
 import { useTranslations } from "@workspace/i18n/client";
 
@@ -50,6 +51,12 @@ export function StayUpdated() {
 
         setStatus("success");
         setEmail("");
+        trackLead({
+          appName: "accelerate",
+          leadType: "newsletter",
+          formId: "solana_newsletter",
+          placement: "homepage_stay_updated",
+        });
       } catch {
         setStatus("error");
         setErrorMsg(t("stayUpdated.error"));

--- a/apps/breakpoint/src/app/layout.tsx
+++ b/apps/breakpoint/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from "react";
 import "@/app/globals.css";
 import { config, publicAssetPath } from "@/config";
 import GTMTrackingSnippet from "@/components/GTMTrackingSnippet";
+import { isProductionAnalyticsEnabled } from "@solana-com/ui-chrome";
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   const googleTagManagerID = config.siteMetadata.googleTagManagerID;
@@ -17,14 +18,16 @@ export default function AppLayout({ children }: { children: ReactNode }) {
         />
       </head>
       <body>
-        <noscript>
-          <iframe
-            src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
-            height="0"
-            width="0"
-            style={{ display: "none", visibility: "hidden" }}
-          ></iframe>
-        </noscript>
+        {isProductionAnalyticsEnabled() && (
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
+              height="0"
+              width="0"
+              style={{ display: "none", visibility: "hidden" }}
+            ></iframe>
+          </noscript>
+        )}
         <GTMTrackingSnippet />
         {children}
       </body>

--- a/apps/breakpoint/src/app/layout.tsx
+++ b/apps/breakpoint/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from "react";
 import "@/app/globals.css";
 import { config, publicAssetPath } from "@/config";
 import GTMTrackingSnippet from "@/components/GTMTrackingSnippet";
-import { isProductionAnalyticsEnabled } from "@solana-com/ui-chrome";
+import { GoogleTagManagerNoScript } from "@solana-com/ui-chrome";
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   const googleTagManagerID = config.siteMetadata.googleTagManagerID;
@@ -18,16 +18,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
         />
       </head>
       <body>
-        {isProductionAnalyticsEnabled() && (
-          <noscript>
-            <iframe
-              src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
-              height="0"
-              width="0"
-              style={{ display: "none", visibility: "hidden" }}
-            ></iframe>
-          </noscript>
-        )}
+        <GoogleTagManagerNoScript containerId={googleTagManagerID} />
         <GTMTrackingSnippet />
         {children}
       </body>

--- a/apps/breakpoint/src/components/EmailSubscribeDialog.tsx
+++ b/apps/breakpoint/src/components/EmailSubscribeDialog.tsx
@@ -5,6 +5,7 @@ import {
   getIterableActionUrl,
   sendIterableFormRequest,
 } from "@solana-com/ui-chrome/iterable";
+import { trackLead } from "@solana-com/ui-chrome/analytics";
 import { useTranslations } from "@workspace/i18n/client";
 import Button from "@/components/Button";
 
@@ -97,6 +98,12 @@ export default function EmailSubscribeDialog({ open, onClose }: Props) {
 
       setEmail("");
       setStatus("done");
+      trackLead({
+        appName: "breakpoint",
+        leadType: "newsletter",
+        formId: "breakpoint_newsletter",
+        placement: "subscribe_dialog",
+      });
     } catch {
       setStatus("error");
     }

--- a/apps/breakpoint/src/components/GTMTrackingSnippet.tsx
+++ b/apps/breakpoint/src/components/GTMTrackingSnippet.tsx
@@ -4,10 +4,13 @@ import Script from "next/script";
 import {
   getCookieConsentBootstrapScript,
   getCookieConsentDefaultScript,
+  isProductionAnalyticsEnabled,
 } from "@solana-com/ui-chrome";
 import { config } from "@/config";
 
 export default function GTMTrackingSnippet() {
+  if (!isProductionAnalyticsEnabled()) return null;
+
   const id = config.siteMetadata.googleTagManagerID;
 
   return (

--- a/apps/docs/src/app/[locale]/layout.tsx
+++ b/apps/docs/src/app/[locale]/layout.tsx
@@ -17,7 +17,7 @@ import {
   PersistentPodcastPlayer,
   ThemeProvider,
   SitewideTopAlert,
-  isProductionAnalyticsEnabled,
+  GoogleTagManagerNoScript,
 } from "@solana-com/ui-chrome";
 import { loadMergedMessages } from "@workspace/i18n/messages";
 
@@ -34,18 +34,7 @@ export default async function RootLayout({ children, params }: Props) {
   return (
     <html lang={locale} dir={direction} suppressHydrationWarning>
       <body suppressHydrationWarning>
-        {/* Google Tag Manager (noscript) */}
-        {isProductionAnalyticsEnabled() && (
-          <noscript>
-            <iframe
-              src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
-              height="0"
-              width="0"
-              style={{ display: "none", visibility: "hidden" }}
-            ></iframe>
-          </noscript>
-        )}
-        {/* End Google Tag Manager (noscript) */}
+        <GoogleTagManagerNoScript containerId={googleTagManagerID} />
         <NextIntlClientProvider messages={messages} locale={locale}>
           <NextProvider>
             <PostHogProvider>

--- a/apps/docs/src/app/[locale]/layout.tsx
+++ b/apps/docs/src/app/[locale]/layout.tsx
@@ -17,6 +17,7 @@ import {
   PersistentPodcastPlayer,
   ThemeProvider,
   SitewideTopAlert,
+  isProductionAnalyticsEnabled,
 } from "@solana-com/ui-chrome";
 import { loadMergedMessages } from "@workspace/i18n/messages";
 
@@ -34,14 +35,16 @@ export default async function RootLayout({ children, params }: Props) {
     <html lang={locale} dir={direction} suppressHydrationWarning>
       <body suppressHydrationWarning>
         {/* Google Tag Manager (noscript) */}
-        <noscript>
-          <iframe
-            src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
-            height="0"
-            width="0"
-            style={{ display: "none", visibility: "hidden" }}
-          ></iframe>
-        </noscript>
+        {isProductionAnalyticsEnabled() && (
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
+              height="0"
+              width="0"
+              style={{ display: "none", visibility: "hidden" }}
+            ></iframe>
+          </noscript>
+        )}
         {/* End Google Tag Manager (noscript) */}
         <NextIntlClientProvider messages={messages} locale={locale}>
           <NextProvider>

--- a/apps/docs/src/components/GTMTrackingSnippet.tsx
+++ b/apps/docs/src/components/GTMTrackingSnippet.tsx
@@ -4,10 +4,13 @@ import Script from "next/script";
 import {
   getCookieConsentBootstrapScript,
   getCookieConsentDefaultScript,
+  isProductionAnalyticsEnabled,
 } from "@solana-com/ui-chrome";
 import { config } from "src/config";
 
 const GTMTrackingSnippet = () => {
+  if (!isProductionAnalyticsEnabled()) return null;
+
   const id = config.siteMetadata.googleTagManagerID;
 
   return (
@@ -16,7 +19,6 @@ const GTMTrackingSnippet = () => {
       <Script strategy="beforeInteractive" id="consent-default">
         {getCookieConsentDefaultScript()}
       </Script>
-
       <Script strategy="afterInteractive" id="gtm-invocation">
         {`
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -26,7 +28,6 @@ const GTMTrackingSnippet = () => {
         })(window,document,'script','dataLayer','${id}');
       `}
       </Script>
-      {/* The consent */}
       <Script strategy="afterInteractive" id="gtag-invocation">
         {getCookieConsentBootstrapScript()}
       </Script>

--- a/apps/docs/src/components/shared/EmailSubscribeForm/IterableEmailSubscribeForm.tsx
+++ b/apps/docs/src/components/shared/EmailSubscribeForm/IterableEmailSubscribeForm.tsx
@@ -85,6 +85,11 @@ export default function IterableEmailSubscribeForm({
     formId,
     schema,
     initialValues,
+    analytics: {
+      appName: "docs",
+      leadType: "newsletter",
+      placement: "email_subscribe_form",
+    },
   });
 
   const isInvalid = useMemo(() => {

--- a/apps/media/app/[locale]/layout.tsx
+++ b/apps/media/app/[locale]/layout.tsx
@@ -9,7 +9,7 @@ import {
   Footer,
   PersistentPodcastPlayer,
   ThemeProvider,
-  isProductionAnalyticsEnabled,
+  GoogleTagManagerNoScript,
 } from "@solana-com/ui-chrome";
 import appleTouchIcon from "@solana-com/ui-chrome/assets/apple-touch-icon.png";
 import { createDefaultSocialImage } from "@solana-com/ui-chrome/social-image";
@@ -104,18 +104,7 @@ export default async function LocaleLayout({ children, params }: Props) {
 
   return (
     <div dir={direction} suppressHydrationWarning>
-      {/* Google Tag Manager (noscript) */}
-      {isProductionAnalyticsEnabled() && (
-        <noscript>
-          <iframe
-            src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
-            height="0"
-            width="0"
-            style={{ display: "none", visibility: "hidden" }}
-          ></iframe>
-        </noscript>
-      )}
-      {/* End Google Tag Manager (noscript) */}
+      <GoogleTagManagerNoScript containerId={googleTagManagerID} />
       <NextIntlClientProvider messages={messages} locale={locale}>
         <ThemeProvider>
           <GTMTrackingSnippet />

--- a/apps/media/app/[locale]/layout.tsx
+++ b/apps/media/app/[locale]/layout.tsx
@@ -9,6 +9,7 @@ import {
   Footer,
   PersistentPodcastPlayer,
   ThemeProvider,
+  isProductionAnalyticsEnabled,
 } from "@solana-com/ui-chrome";
 import appleTouchIcon from "@solana-com/ui-chrome/assets/apple-touch-icon.png";
 import { createDefaultSocialImage } from "@solana-com/ui-chrome/social-image";
@@ -104,14 +105,16 @@ export default async function LocaleLayout({ children, params }: Props) {
   return (
     <div dir={direction} suppressHydrationWarning>
       {/* Google Tag Manager (noscript) */}
-      <noscript>
-        <iframe
-          src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
-          height="0"
-          width="0"
-          style={{ display: "none", visibility: "hidden" }}
-        ></iframe>
-      </noscript>
+      {isProductionAnalyticsEnabled() && (
+        <noscript>
+          <iframe
+            src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
+            height="0"
+            width="0"
+            style={{ display: "none", visibility: "hidden" }}
+          ></iframe>
+        </noscript>
+      )}
       {/* End Google Tag Manager (noscript) */}
       <NextIntlClientProvider messages={messages} locale={locale}>
         <ThemeProvider>

--- a/apps/media/components/GTMTrackingSnippet.tsx
+++ b/apps/media/components/GTMTrackingSnippet.tsx
@@ -4,18 +4,19 @@ import Script from "next/script";
 import {
   getCookieConsentBootstrapScript,
   getCookieConsentDefaultScript,
+  isProductionAnalyticsEnabled,
 } from "@solana-com/ui-chrome";
 import { config } from "@/lib/config";
 
 export const GTMTrackingSnippet = () => {
-  const id = config.siteMetadata.googleTagManagerID;
+  if (!isProductionAnalyticsEnabled()) return null;
 
+  const id = config.siteMetadata.googleTagManagerID;
   return (
     <>
       <Script strategy="beforeInteractive" id="consent-default">
         {getCookieConsentDefaultScript()}
       </Script>
-
       <Script strategy="afterInteractive" id="gtm-invocation">
         {`
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
@@ -25,7 +26,6 @@ export const GTMTrackingSnippet = () => {
         })(window,document,'script','dataLayer','${id}');
       `}
       </Script>
-      {/* Default consent configuration */}
       <Script strategy="afterInteractive" id="gtag-invocation">
         {getCookieConsentBootstrapScript()}
       </Script>

--- a/apps/media/components/podcast/audio-player.tsx
+++ b/apps/media/components/podcast/audio-player.tsx
@@ -9,7 +9,7 @@ import { SkipPrevious as SkipBack } from "@boxicons/react/SkipPrevious";
 import { SkipNext as SkipForward } from "@boxicons/react/SkipNext";
 import { Button } from "@/components/ui/button";
 import { usePlayerOptional } from "./player-context";
-import { trackPodcastPlay, trackPodcastPause } from "@/lib/podcast-analytics";
+import { trackPodcastPlay } from "@/lib/podcast-analytics";
 import { cn } from "@/lib/utils";
 import type { PodcastEpisode } from "@/lib/podcast-types";
 
@@ -69,9 +69,7 @@ export const AudioPlayer = ({
       };
 
       if (isGlobalEpisode) {
-        if (isPlaying) {
-          trackPodcastPause(eventParams);
-        } else {
+        if (!isPlaying) {
           trackPodcastPlay(eventParams);
         }
         globalPlayer.togglePlayPause();

--- a/apps/media/components/podcast/episode-card.tsx
+++ b/apps/media/components/podcast/episode-card.tsx
@@ -8,7 +8,6 @@ import { Badge } from "@/components/ui/badge";
 import { formatDuration, formatEpisodeDate } from "@/lib/podcast-utils";
 import {
   trackPodcastPlay,
-  trackPodcastPause,
   trackPodcastEpisodeClick,
 } from "@/lib/podcast-analytics";
 import { usePlayerOptional } from "./player-context";
@@ -42,9 +41,7 @@ export const EpisodeCard = ({
     };
 
     if (isCurrentEpisode) {
-      if (isPlaying) {
-        trackPodcastPause(eventParams);
-      } else {
+      if (!isPlaying) {
         trackPodcastPlay(eventParams);
       }
       player.togglePlayPause();

--- a/apps/media/lib/podcast-analytics.ts
+++ b/apps/media/lib/podcast-analytics.ts
@@ -1,22 +1,13 @@
 /**
  * Google Analytics event tracking for podcast interactions.
  *
- * Events are pushed to the dataLayer via gtag() which is initialized
- * by GTMTrackingSnippet. These events can be used in GA4 to build
- * reports around podcast engagement.
+ * These use the shared Solana.com GA4 contract. Do not add a pause event:
+ * pausing is noisy and does not represent a meaningful marketing outcome.
  */
-
-declare global {
-  interface Window {
-    gtag?: (..._args: unknown[]) => void;
-  }
-}
-
-function gtag(...args: unknown[]) {
-  if (typeof window !== "undefined" && window.gtag) {
-    window.gtag(...args);
-  }
-}
+import {
+  trackAnalyticsEvent,
+  trackContentSelection,
+} from "@solana-com/ui-chrome/analytics";
 
 export function trackPodcastPlay(params: {
   episode_title: string;
@@ -24,16 +15,14 @@ export function trackPodcastPlay(params: {
   podcast_title?: string;
   podcast_slug?: string;
 }) {
-  gtag("event", "podcast_play", params);
-}
-
-export function trackPodcastPause(params: {
-  episode_title: string;
-  episode_id?: string;
-  podcast_title?: string;
-  podcast_slug?: string;
-}) {
-  gtag("event", "podcast_pause", params);
+  trackAnalyticsEvent("podcast_play", {
+    app_name: "media",
+    content_type: "podcast_episode",
+    content_id: params.episode_id,
+    content_name: params.episode_title,
+    podcast_name: params.podcast_title,
+    podcast_slug: params.podcast_slug,
+  });
 }
 
 export function trackPodcastSubscribe(params: {
@@ -41,7 +30,13 @@ export function trackPodcastSubscribe(params: {
   podcast_slug?: string;
   platform: string;
 }) {
-  gtag("event", "podcast_subscribe", params);
+  trackAnalyticsEvent("podcast_subscribe", {
+    app_name: "media",
+    content_type: "podcast",
+    content_name: params.podcast_title,
+    podcast_slug: params.podcast_slug,
+    platform: params.platform,
+  });
 }
 
 export function trackPodcastEpisodeClick(params: {
@@ -50,5 +45,11 @@ export function trackPodcastEpisodeClick(params: {
   podcast_title?: string;
   podcast_slug?: string;
 }) {
-  gtag("event", "podcast_episode_click", params);
+  trackContentSelection({
+    appName: "media",
+    contentType: "podcast_episode",
+    contentId: params.episode_id,
+    contentName: params.episode_title,
+    placement: "podcast_card",
+  });
 }

--- a/apps/templates/src/app/layout.tsx
+++ b/apps/templates/src/app/layout.tsx
@@ -6,7 +6,7 @@ import {
   Footer,
   PersistentPodcastPlayer,
   ThemeProvider,
-  isProductionAnalyticsEnabled,
+  GoogleTagManagerNoScript,
 } from "@solana-com/ui-chrome";
 import { loadMergedMessages } from "@workspace/i18n/messages";
 import { getLangDir } from "rtl-detect";
@@ -52,16 +52,7 @@ export default async function RootLayout({ children }: Props) {
       suppressHydrationWarning
     >
       <body suppressHydrationWarning>
-        {isProductionAnalyticsEnabled() && (
-          <noscript>
-            <iframe
-              src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
-              height="0"
-              width="0"
-              style={{ display: "none", visibility: "hidden" }}
-            ></iframe>
-          </noscript>
-        )}
+        <GoogleTagManagerNoScript containerId={googleTagManagerID} />
         <NextIntlClientProvider messages={messages} locale={locale}>
           <ThemeProvider>
             <GTMTrackingSnippet />

--- a/apps/templates/src/app/layout.tsx
+++ b/apps/templates/src/app/layout.tsx
@@ -6,6 +6,7 @@ import {
   Footer,
   PersistentPodcastPlayer,
   ThemeProvider,
+  isProductionAnalyticsEnabled,
 } from "@solana-com/ui-chrome";
 import { loadMergedMessages } from "@workspace/i18n/messages";
 import { getLangDir } from "rtl-detect";
@@ -51,14 +52,16 @@ export default async function RootLayout({ children }: Props) {
       suppressHydrationWarning
     >
       <body suppressHydrationWarning>
-        <noscript>
-          <iframe
-            src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
-            height="0"
-            width="0"
-            style={{ display: "none", visibility: "hidden" }}
-          ></iframe>
-        </noscript>
+        {isProductionAnalyticsEnabled() && (
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
+              height="0"
+              width="0"
+              style={{ display: "none", visibility: "hidden" }}
+            ></iframe>
+          </noscript>
+        )}
         <NextIntlClientProvider messages={messages} locale={locale}>
           <ThemeProvider>
             <GTMTrackingSnippet />

--- a/apps/templates/src/components/gtm-tracking-snippet.tsx
+++ b/apps/templates/src/components/gtm-tracking-snippet.tsx
@@ -4,10 +4,13 @@ import Script from "next/script";
 import {
   getCookieConsentBootstrapScript,
   getCookieConsentDefaultScript,
+  isProductionAnalyticsEnabled,
 } from "@solana-com/ui-chrome";
 import { config } from "@/config";
 
 export const GTMTrackingSnippet = () => {
+  if (!isProductionAnalyticsEnabled()) return null;
+
   const id = config.siteMetadata.googleTagManagerID;
 
   return (
@@ -15,7 +18,6 @@ export const GTMTrackingSnippet = () => {
       <Script strategy="beforeInteractive" id="consent-default">
         {getCookieConsentDefaultScript()}
       </Script>
-
       <Script strategy="afterInteractive" id="gtm-invocation">
         {`
         (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':

--- a/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
+++ b/apps/web/src/app/[locale]/data/solana-data-dashboard.tsx
@@ -25,6 +25,10 @@ import {
 } from "react";
 import useSWR from "swr";
 import { Link } from "@solana-com/ui-chrome/link";
+import {
+  trackAnalyticsEvent,
+  trackContentSelection,
+} from "@solana-com/ui-chrome/analytics";
 import { useLocale, useTranslations } from "@workspace/i18n/client";
 import { usePathname, useRouter } from "@workspace/i18n/routing";
 
@@ -1311,7 +1315,7 @@ function DataResourceCard({
         className="relative inline-flex min-h-[31px] items-center justify-center border border-white/55 px-3 py-2 font-brand-mono text-[11px] leading-none font-bold uppercase text-nd-high-em-text transition-colors hover:border-white hover:bg-white/[0.08] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/40"
         href={href}
         onClick={() =>
-          trackDataResourceEvent("data_resource_click", {
+          trackDataResourceEvent("click", {
             destinationUrl: href,
             resourceId: card.analyticsId,
             resourceTitle: title,
@@ -1358,7 +1362,7 @@ function useDataResourceImpression(
 
     if (!("IntersectionObserver" in window)) {
       hasTrackedRef.current = true;
-      trackDataResourceEvent("data_resource_view", {
+      trackDataResourceEvent("view", {
         destinationUrl,
         resourceId,
         resourceTitle,
@@ -1373,7 +1377,7 @@ function useDataResourceImpression(
         }
 
         hasTrackedRef.current = true;
-        trackDataResourceEvent("data_resource_view", {
+        trackDataResourceEvent("view", {
           destinationUrl,
           resourceId,
           resourceTitle,
@@ -1392,7 +1396,7 @@ function useDataResourceImpression(
 }
 
 function trackDataResourceEvent(
-  eventName: "data_resource_click" | "data_resource_view",
+  eventName: "click" | "view",
   {
     destinationUrl,
     resourceId,
@@ -1403,17 +1407,24 @@ function trackDataResourceEvent(
     resourceTitle: string;
   },
 ) {
-  if (typeof window === "undefined" || typeof window.gtag === "undefined") {
+  if (eventName === "click") {
+    trackContentSelection({
+      appName: "web",
+      contentType: "data_resource",
+      contentId: resourceId,
+      contentName: resourceTitle,
+      placement: "solana_data_dashboard",
+      linkUrl: destinationUrl,
+    });
     return;
   }
 
-  window.gtag("event", eventName, {
-    destination_url: destinationUrl,
-    event_category: "Solana Data",
-    event_label: resourceTitle,
-    origin_path: `${window.location.pathname}${window.location.search}`,
-    resource_id: resourceId,
-    resource_title: resourceTitle,
+  trackAnalyticsEvent("view_item", {
+    app_name: "web",
+    content_type: "data_resource",
+    content_id: resourceId,
+    content_name: resourceTitle,
+    placement: "solana_data_dashboard",
   });
 }
 

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -17,6 +17,7 @@ import {
   SitewideTopAlert,
   InkeepChatButton,
   PersistentPodcastPlayer,
+  isProductionAnalyticsEnabled,
 } from "@solana-com/ui-chrome";
 import { ChromeWrapper } from "@/components/ChromeWrapper";
 import Script from "next/script";
@@ -41,14 +42,16 @@ export default async function RootLayout({ children, params }: Props) {
     <html lang={locale} dir={direction} suppressHydrationWarning>
       <body suppressHydrationWarning>
         {/* Google Tag Manager (noscript) */}
-        <noscript>
-          <iframe
-            src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
-            height="0"
-            width="0"
-            style={{ display: "none", visibility: "hidden" }}
-          ></iframe>
-        </noscript>
+        {isProductionAnalyticsEnabled() && (
+          <noscript>
+            <iframe
+              src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
+              height="0"
+              width="0"
+              style={{ display: "none", visibility: "hidden" }}
+            ></iframe>
+          </noscript>
+        )}
         {/* End Google Tag Manager (noscript) */}
         <NextIntlClientProvider messages={messages} locale={locale}>
           <PostHogProvider>

--- a/apps/web/src/app/[locale]/layout.tsx
+++ b/apps/web/src/app/[locale]/layout.tsx
@@ -17,7 +17,7 @@ import {
   SitewideTopAlert,
   InkeepChatButton,
   PersistentPodcastPlayer,
-  isProductionAnalyticsEnabled,
+  GoogleTagManagerNoScript,
 } from "@solana-com/ui-chrome";
 import { ChromeWrapper } from "@/components/ChromeWrapper";
 import Script from "next/script";
@@ -41,18 +41,7 @@ export default async function RootLayout({ children, params }: Props) {
   return (
     <html lang={locale} dir={direction} suppressHydrationWarning>
       <body suppressHydrationWarning>
-        {/* Google Tag Manager (noscript) */}
-        {isProductionAnalyticsEnabled() && (
-          <noscript>
-            <iframe
-              src={`https://www.googletagmanager.com/ns.html?id=${googleTagManagerID}`}
-              height="0"
-              width="0"
-              style={{ display: "none", visibility: "hidden" }}
-            ></iframe>
-          </noscript>
-        )}
-        {/* End Google Tag Manager (noscript) */}
+        <GoogleTagManagerNoScript containerId={googleTagManagerID} />
         <NextIntlClientProvider messages={messages} locale={locale}>
           <PostHogProvider>
             <ThemeProvider>

--- a/apps/web/src/components/GTMTrackingSnippet.tsx
+++ b/apps/web/src/components/GTMTrackingSnippet.tsx
@@ -4,10 +4,13 @@ import Script from "next/script";
 import {
   getCookieConsentBootstrapScript,
   getCookieConsentDefaultScript,
+  isProductionAnalyticsEnabled,
 } from "@solana-com/ui-chrome";
 import { config } from "src/config";
 
 const GTMTrackingSnippet = () => {
+  if (!isProductionAnalyticsEnabled()) return null;
+
   const id = config.siteMetadata.googleTagManagerID;
 
   return (
@@ -25,7 +28,6 @@ const GTMTrackingSnippet = () => {
         })(window,document,'script','dataLayer','${id}');
       `}
       </Script>
-      {/* The consent */}
       <Script strategy="afterInteractive" id="gtag-invocation">
         {getCookieConsentBootstrapScript()}
       </Script>

--- a/apps/web/src/components/ModalLauncher/ModalLauncher.tsx
+++ b/apps/web/src/components/ModalLauncher/ModalLauncher.tsx
@@ -11,6 +11,7 @@ import {
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Dialog, DialogContent } from "@workspace/ui";
 import ArtistsAndCreatorsNewsletter from "../newsletter/artistsAndCreators";
+import { trackContentSelection } from "@solana-com/ui-chrome/analytics";
 
 type ModalProps = {
   modalCloseHandler: (() => void) | null;
@@ -37,15 +38,6 @@ const ModalLauncher = () => {
   );
 
   const modalCloseHandler = useCallback(() => {
-    // if the modal action is not complete, track bounce
-    if (!modalActionCompleted.current && typeof window.gtag !== "undefined") {
-      window.gtag("event", "modal_bounce", {
-        event_category: "engagement",
-        event_action: "Closed Without Submission",
-        event_label: modalLaunchId,
-      });
-    }
-
     // Update the URL
     const currentPath = pathname;
     const currentQuery: Record<string, string> = {};
@@ -73,14 +65,12 @@ const ModalLauncher = () => {
       setShowModal(true);
       setModalLaunchId(modalLaunchIdParam);
 
-      // track modal launch
-      if (typeof window.gtag !== "undefined") {
-        window.gtag("event", "modal_launch", {
-          event_category: "engagement",
-          event_action: "Opened",
-          event_label: modalLaunchIdParam,
-        });
-      }
+      trackContentSelection({
+        appName: "web",
+        contentType: "modal",
+        contentId: modalLaunchIdParam,
+        placement: "query_param",
+      });
     } else {
       setShowModal(false);
       setModalComponent(null);

--- a/apps/web/src/components/ecdr/ECDRHero.tsx
+++ b/apps/web/src/components/ecdr/ECDRHero.tsx
@@ -6,6 +6,7 @@ import TypeformModal from "../shared/TypeformModal";
 import styles from "./ECDRHero.module.scss";
 import IndexBtn from "../index/IndexBtn";
 import SolanaRing from "../../../public/src/img/ecdr/solana-ring.png";
+import { trackContentSelection } from "@solana-com/ui-chrome/analytics";
 
 const ECDRHero = () => {
   const t = useTranslations();
@@ -51,9 +52,11 @@ const ECDRHero = () => {
             size="large"
             onClick={() => {
               setShowTypeformModal(true);
-              gtag("event", "Button click", {
-                event_category: "Open modal",
-                event_label: "EC Developers Report - Get in touch modal ",
+              trackContentSelection({
+                appName: "web",
+                contentType: "contact_cta",
+                contentName: "EC Developers Report - Get in touch",
+                placement: "ecdr_hero",
               });
             }}
           >

--- a/apps/web/src/components/ecdr/ECDRStats.tsx
+++ b/apps/web/src/components/ecdr/ECDRStats.tsx
@@ -4,6 +4,7 @@ import Link from "../../utils/Link";
 import { FormattedNumber } from "../SolFormattedMessage";
 import styles from "./ECDRStats.module.scss";
 import { Clipboard as ClipboardIcon } from "@boxicons/react/Clipboard";
+import { trackContentSelection } from "@solana-com/ui-chrome/analytics";
 
 type StatCardProps = {
   value: string | number;
@@ -61,9 +62,13 @@ const ECDRStats = () => {
                   <Link
                     to="/news/the-values-that-got-us-here-solana-2023"
                     onClick={() => {
-                      gtag("event", "Link click", {
-                        event_category: "Open blog link",
-                        event_label: "EC Developers Report - Blog link",
+                      trackContentSelection({
+                        appName: "web",
+                        contentType: "article",
+                        contentName: "The values that got us here",
+                        placement: "ecdr_stats",
+                        linkUrl:
+                          "/news/the-values-that-got-us-here-solana-2023",
                       });
                     }}
                   >

--- a/apps/web/src/components/newsletter/artistsAndCreators/index.tsx
+++ b/apps/web/src/components/newsletter/artistsAndCreators/index.tsx
@@ -4,6 +4,7 @@ import {
   getIterableActionUrl,
   sendIterableFormRequest,
 } from "@solana-com/ui-chrome/iterable";
+import { trackLead } from "@solana-com/ui-chrome/analytics";
 import { useTranslations } from "next-intl";
 import { DialogTitle, DialogDescription } from "@radix-ui/react-dialog";
 
@@ -108,14 +109,12 @@ const ArtistsAndCreatorsNewsletter = ({
         setIsSuccess(true);
         modalActionCompleted.current = true;
 
-        // track form submission
-        if (typeof window.gtag !== "undefined") {
-          window.gtag("event", "newsletter_sign_up", {
-            event_category: "engagement",
-            event_action: "Submitted",
-            event_label: "artistsAndCreatorsNewsletter",
-          });
-        }
+        trackLead({
+          appName: "web",
+          leadType: "newsletter",
+          formId: "artists_and_creators_newsletter",
+          placement: "modal",
+        });
       } catch (err) {
         console.error(err);
         setError("Something went wrong, please try again.");

--- a/apps/web/src/components/sdp/podcasts.tsx
+++ b/apps/web/src/components/sdp/podcasts.tsx
@@ -5,6 +5,7 @@ import Carousel, { CarouselControls } from "@/component-library/carousel";
 import { useMediaQuery } from "@/hooks/useMediaQuery";
 import { useRef } from "react";
 import FormattedDate from "../shared/FormattedDate";
+import { trackContentSelection } from "@solana-com/ui-chrome/analytics";
 
 export interface PodcastItem {
   title: string;
@@ -39,13 +40,12 @@ const PlayIcon = () => (
 );
 
 const trackSdpPodcastClick = (title: string) => {
-  if (typeof window !== "undefined" && window.gtag) {
-    window.gtag("event", "podcast_episode_click", {
-      episode_title: title,
-      podcast_slug: "sdp",
-      platform: "youtube",
-    });
-  }
+  trackContentSelection({
+    appName: "web",
+    contentType: "podcast_episode",
+    contentName: title,
+    placement: "solana_data_podcasts",
+  });
 };
 
 const PodcastCard = ({ title, img, href, date, duration }: PodcastItem) => {

--- a/apps/web/src/components/shared/EmailSubscribeForm/IterableEmailSubscribeForm.tsx
+++ b/apps/web/src/components/shared/EmailSubscribeForm/IterableEmailSubscribeForm.tsx
@@ -86,6 +86,11 @@ export default function IterableEmailSubscribeForm({
     formId,
     schema,
     initialValues,
+    analytics: {
+      appName: "web",
+      leadType: "newsletter",
+      placement: "email_subscribe_form",
+    },
   });
 
   const isInvalid = useMemo(() => {

--- a/docs/analytics/ga4-event-taxonomy.md
+++ b/docs/analytics/ga4-event-taxonomy.md
@@ -1,0 +1,59 @@
+# Solana.com GA4 event taxonomy
+
+This is the shared contract for the marketing surface: Web, Docs, Media,
+Templates, Accelerate, and Breakpoint. Application code emits these events via
+`@solana-com/ui-chrome/analytics`; GTM forwards them to the appropriate GA4
+Google tag.
+
+## Events
+
+| Event               | Use                                                                  | Required parameters                        |
+| ------------------- | -------------------------------------------------------------------- | ------------------------------------------ |
+| `generate_lead`     | A newsletter, contact, application, or registration request succeeds | `app_name`, `lead_type`, `form_id`         |
+| `select_content`    | A meaningful CTA, resource, card, episode, or modal is selected      | `app_name`, `content_type`                 |
+| `view_item`         | An important resource or other intent-bearing item becomes visible   | `app_name`, `content_type`, `content_id`   |
+| `podcast_play`      | A visitor starts or resumes an episode                               | `app_name`, `content_type`, `content_name` |
+| `podcast_subscribe` | A visitor chooses a podcast platform                                 | `app_name`, `content_type`, `platform`     |
+
+Optional common parameters are `content_id`, `content_name`, `placement`, and
+`link_url`. URLs exclude query strings. Values are trimmed and capped at 100
+characters. Never send email addresses, form values, user identifiers, or raw
+search terms.
+
+## GA4 enhanced measurement
+
+Keep GA4-generated `page_view`, `session_start`, `first_visit`,
+`user_engagement`, `scroll`, `file_download`, `view_search_results`, and video
+events. Retain the existing custom scroll-depth tags as requested.
+
+Disable GTM triggers that emit generic `click`, `navigation_click`,
+`button_click`, `tab_click`, and `speaker_expand`. They lack a stable business
+meaning and should be replaced only where a specific interaction maps to an
+event above.
+
+Avoid duplicate `form_start` and `form_submit`: retain GA4 enhanced measurement
+or GTM form triggers, but not both. Use `generate_lead` as the conversion event,
+because it means the request actually succeeded.
+
+## GTM configuration checklist
+
+1. In each app's container, create or retain exactly one Google tag with the
+   intended GA4 measurement ID and an All Pages trigger.
+2. Do not load a second direct `gtag.js` implementation when that Google tag is
+   present in GTM; two implementations duplicate automatic page views.
+3. Ensure the Google tag observes the consent default before it fires. The apps
+   already initialize Consent Mode before GTM loads.
+4. Forward the five custom events above. Register only useful dimensions:
+   `app_name`, `lead_type`, `content_type`, `content_id`, `placement`, and
+   `platform`.
+5. Mark `generate_lead` as a key event. Mark `podcast_subscribe` only if it is a
+   marketing KPI. Do not mark clicks, scrolls, opens, or views as key events.
+6. In Google tag settings, configure all first-party Solana domains and verify
+   the cross-domain list. Use Preview/Tag Assistant on every app route before
+   publishing.
+
+## Container ownership
+
+Container IDs must be maintained per application. Do not infer that a tag
+installed on `solana.com` also covers a separately deployed app behind a route
+rewrite. The final mapping is required before changing an ID in source or GTM.

--- a/docs/analytics/ga4-event-taxonomy.md
+++ b/docs/analytics/ga4-event-taxonomy.md
@@ -5,6 +5,10 @@ Templates, Accelerate, and Breakpoint. Application code emits these events via
 `@solana-com/ui-chrome/analytics`; GTM forwards them to the appropriate GA4
 Google tag.
 
+Analytics scripts and event emission are disabled for local development, preview
+deployments, and non-production builds. Production remains subject to the
+existing Consent Mode gate.
+
 ## Events
 
 | Event               | Use                                                                  | Required parameters                        |
@@ -37,8 +41,9 @@ because it means the request actually succeeded.
 
 ## GTM configuration checklist
 
-1. In each app's container, create or retain exactly one Google tag with the
-   intended GA4 measurement ID and an All Pages trigger.
+1. In each app's implementation, use exactly one Google tag with the intended
+   GA4 measurement ID and an All Pages trigger. The primary property may use a
+   direct Google tag; Breakpoint uses its separate GTM container.
 2. Do not load a second direct `gtag.js` implementation when that Google tag is
    present in GTM; two implementations duplicate automatic page views.
 3. Ensure the Google tag observes the consent default before it fires. The apps
@@ -54,6 +59,11 @@ because it means the request actually succeeded.
 
 ## Container ownership
 
-Container IDs must be maintained per application. Do not infer that a tag
-installed on `solana.com` also covers a separately deployed app behind a route
-rewrite. The final mapping is required before changing an ID in source or GTM.
+Container IDs must be maintained per application. Breakpoint uses the existing
+live container `GTM-TNX63HZ`; do not infer that a tag installed on `solana.com`
+also covers a separately deployed app behind a route rewrite.
+
+Configure the vendor's Meta, LinkedIn, and X tags in `GTM-TNX63HZ`, alongside
+the existing GA4 and scroll-depth triggers. Test with GTM Preview on
+`/breakpoint` before publishing. This preserves the established measurement
+history and avoids duplicate vendor tags.

--- a/packages/ui-chrome/README.md
+++ b/packages/ui-chrome/README.md
@@ -66,8 +66,10 @@ and full-width styling.
 
 ### NewsletterModal
 
-Modal for newsletter sign-up (e.g. Iterable). Props: `formId`, `children`
-(trigger).
+Modal for newsletter sign-up (e.g. Iterable). Props: `formId`,
+`analyticsAppName`, and `children` (trigger). `analyticsAppName` is required so
+a successful subscription can be attributed consistently; use one of `web`,
+`docs`, `media`, `templates`, `accelerate`, or `breakpoint`.
 
 ### DocsSidebarToggleIcon / DOCS_SIDEBAR_TOGGLE_SLOT_ID
 

--- a/packages/ui-chrome/package.json
+++ b/packages/ui-chrome/package.json
@@ -24,6 +24,9 @@
     "./iterable-signup": {
       "import": "./src/iterable-signup.tsx"
     },
+    "./analytics": {
+      "import": "./src/analytics.ts"
+    },
     "./icons": {
       "import": "./src/assets/icons/index.ts"
     },

--- a/packages/ui-chrome/src/analytics.ts
+++ b/packages/ui-chrome/src/analytics.ts
@@ -30,6 +30,14 @@ declare global {
 
 const MAX_VALUE_LENGTH = 100;
 
+/** Production is the only environment permitted to send analytics. */
+export function isProductionAnalyticsEnabled() {
+  return (
+    process.env.NODE_ENV === "production" &&
+    process.env.NEXT_PUBLIC_VERCEL_ENV === "production"
+  );
+}
+
 function sanitizeValue(value: AnalyticsValue) {
   if (typeof value !== "string") return value;
   return value.trim().slice(0, MAX_VALUE_LENGTH);
@@ -48,7 +56,13 @@ export function trackAnalyticsEvent(
   eventName: AnalyticsEventName,
   parameters: AnalyticsParameters & { app_name: AnalyticsAppName },
 ) {
-  if (typeof window === "undefined" || !window.gtag) return;
+  if (
+    !isProductionAnalyticsEnabled() ||
+    typeof window === "undefined" ||
+    !window.gtag
+  ) {
+    return;
+  }
 
   window.gtag("event", eventName, sanitizeParameters(parameters));
 }

--- a/packages/ui-chrome/src/analytics.ts
+++ b/packages/ui-chrome/src/analytics.ts
@@ -1,0 +1,98 @@
+/**
+ * Small, shared GA4 event contract for Solana.com properties.
+ *
+ * Do not pass email addresses, form field values, full search terms, or URL
+ * query strings. GA4 prohibits sending personally identifiable information.
+ */
+export type AnalyticsAppName =
+  | "web"
+  | "docs"
+  | "media"
+  | "templates"
+  | "accelerate"
+  | "breakpoint";
+
+export type AnalyticsEventName =
+  | "generate_lead"
+  | "select_content"
+  | "view_item"
+  | "podcast_play"
+  | "podcast_subscribe";
+
+type AnalyticsValue = string | number | boolean | undefined;
+type AnalyticsParameters = Record<string, AnalyticsValue>;
+
+declare global {
+  interface Window {
+    gtag?: (command: string, ...args: unknown[]) => void;
+  }
+}
+
+const MAX_VALUE_LENGTH = 100;
+
+function sanitizeValue(value: AnalyticsValue) {
+  if (typeof value !== "string") return value;
+  return value.trim().slice(0, MAX_VALUE_LENGTH);
+}
+
+function sanitizeParameters(parameters: AnalyticsParameters) {
+  return Object.fromEntries(
+    Object.entries(parameters)
+      .filter(([, value]) => value !== undefined)
+      .map(([key, value]) => [key, sanitizeValue(value)]),
+  ) as Record<string, string | number | boolean>;
+}
+
+/** Emits a GA4 event only after the site's consent-aware gtag bootstrap exists. */
+export function trackAnalyticsEvent(
+  eventName: AnalyticsEventName,
+  parameters: AnalyticsParameters & { app_name: AnalyticsAppName },
+) {
+  if (typeof window === "undefined" || !window.gtag) return;
+
+  window.gtag("event", eventName, sanitizeParameters(parameters));
+}
+
+export function trackLead({
+  appName,
+  leadType,
+  formId,
+  placement,
+}: {
+  appName: AnalyticsAppName;
+  leadType: "newsletter" | "contact" | "application" | "registration";
+  formId: string;
+  placement?: string;
+}) {
+  trackAnalyticsEvent("generate_lead", {
+    app_name: appName,
+    lead_type: leadType,
+    form_id: formId,
+    placement,
+  });
+}
+
+export function trackContentSelection({
+  appName,
+  contentType,
+  contentId,
+  contentName,
+  placement,
+  linkUrl,
+}: {
+  appName: AnalyticsAppName;
+  contentType: string;
+  contentId?: string;
+  contentName?: string;
+  placement?: string;
+  linkUrl?: string;
+}) {
+  trackAnalyticsEvent("select_content", {
+    app_name: appName,
+    content_type: contentType,
+    content_id: contentId,
+    content_name: contentName,
+    placement,
+    link_url: linkUrl ? linkUrl.split("?")[0] : undefined,
+  });
+}

--- a/packages/ui-chrome/src/google-analytics-tag.tsx
+++ b/packages/ui-chrome/src/google-analytics-tag.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import Script from "next/script";
+import {
+  getCookieConsentBootstrapScript,
+  getCookieConsentDefaultScript,
+} from "./cookie-consent";
+import { isProductionAnalyticsEnabled } from "./analytics";
+
+/**
+ * The direct Google tag used by the primary Solana.com GA4 property.
+ * Keep this separate from GTM containers: installing both for one destination
+ * causes duplicate automatic page views.
+ */
+export function GoogleAnalyticsTag({
+  measurementId,
+}: {
+  measurementId: string;
+}) {
+  if (!isProductionAnalyticsEnabled()) return null;
+
+  return (
+    <>
+      <Script strategy="beforeInteractive" id="consent-default">
+        {getCookieConsentDefaultScript()}
+      </Script>
+      <Script
+        async
+        src={`https://www.googletagmanager.com/gtag/js?id=${measurementId}`}
+        strategy="afterInteractive"
+      />
+      <Script strategy="afterInteractive" id="google-analytics-config">
+        {getCookieConsentBootstrapScript({ gaMeasurementId: measurementId })}
+      </Script>
+    </>
+  );
+}

--- a/packages/ui-chrome/src/google-tag-manager-noscript.tsx
+++ b/packages/ui-chrome/src/google-tag-manager-noscript.tsx
@@ -1,0 +1,21 @@
+import { isProductionAnalyticsEnabled } from "./analytics";
+
+/** No-JavaScript fallback for an approved GTM container. */
+export function GoogleTagManagerNoScript({
+  containerId,
+}: {
+  containerId: string;
+}) {
+  if (!isProductionAnalyticsEnabled()) return null;
+
+  return (
+    <noscript>
+      <iframe
+        src={`https://www.googletagmanager.com/ns.html?id=${containerId}`}
+        height="0"
+        width="0"
+        style={{ display: "none", visibility: "hidden" }}
+      />
+    </noscript>
+  );
+}

--- a/packages/ui-chrome/src/index.ts
+++ b/packages/ui-chrome/src/index.ts
@@ -21,6 +21,8 @@ export { InkeepChatButton } from "./inkeep-chat-button";
 export { InkeepSearchBar } from "./inkeep-searchbar";
 export { NewsletterModal } from "./newsletter-modal";
 export { CookieConsentBanner } from "./cookie-consent-banner";
+export { GoogleAnalyticsTag } from "./google-analytics-tag";
+export { isProductionAnalyticsEnabled } from "./analytics";
 export {
   getBrowserStorage,
   safeStorageGetItem,

--- a/packages/ui-chrome/src/index.ts
+++ b/packages/ui-chrome/src/index.ts
@@ -22,6 +22,7 @@ export { InkeepSearchBar } from "./inkeep-searchbar";
 export { NewsletterModal } from "./newsletter-modal";
 export { CookieConsentBanner } from "./cookie-consent-banner";
 export { GoogleAnalyticsTag } from "./google-analytics-tag";
+export { GoogleTagManagerNoScript } from "./google-tag-manager-noscript";
 export { isProductionAnalyticsEnabled } from "./analytics";
 export {
   getBrowserStorage,

--- a/packages/ui-chrome/src/iterable-signup.tsx
+++ b/packages/ui-chrome/src/iterable-signup.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { getIterableActionUrl, sendIterableFormRequest } from "./iterable";
+import { trackLead, type AnalyticsAppName } from "./analytics";
 
 export interface IterableSchema {
   isValidSync: (values: unknown) => boolean;
@@ -39,12 +40,18 @@ export interface UseIterableSignUpOptions {
   formId: string;
   schema: IterableSchema;
   initialValues: Record<string, string>;
+  analytics?: {
+    appName: AnalyticsAppName;
+    leadType: "newsletter" | "contact" | "application" | "registration";
+    placement?: string;
+  };
 }
 
 export function useIterableSignUp({
   formId,
   schema,
   initialValues,
+  analytics,
 }: UseIterableSignUpOptions) {
   const [state, setState] = useState<Record<string, string>>(initialValues);
   const [isDirty, setIsDirty] = useState(false);
@@ -88,6 +95,14 @@ export function useIterableSignUp({
         setIsLoading(true);
         await sendIterableFormRequest(actionUrl, state);
         setIsSuccess(true);
+        if (analytics) {
+          trackLead({
+            appName: analytics.appName,
+            leadType: analytics.leadType,
+            formId,
+            placement: analytics.placement,
+          });
+        }
       } catch (submissionError) {
         setError(
           submissionError instanceof Error
@@ -98,7 +113,7 @@ export function useIterableSignUp({
         setIsLoading(false);
       }
     },
-    [actionUrl, schema, state],
+    [actionUrl, analytics, formId, schema, state],
   );
 
   return {

--- a/packages/ui-chrome/src/newsletter-modal.tsx
+++ b/packages/ui-chrome/src/newsletter-modal.tsx
@@ -7,6 +7,7 @@ import { useTranslations } from "next-intl";
 import { X } from "@boxicons/react/X";
 import { useTheme } from "./theme-provider";
 import { getIterableActionUrl, sendIterableFormRequest } from "./iterable";
+import { trackLead, type AnalyticsAppName } from "./analytics";
 
 const Status = {
   Idle: "idle",
@@ -19,10 +20,15 @@ type StatusType = (typeof Status)[keyof typeof Status];
 
 interface NewsletterModalProps {
   formId: string;
+  analyticsAppName: AnalyticsAppName;
   children: React.ReactNode;
 }
 
-export function NewsletterModal({ formId, children }: NewsletterModalProps) {
+export function NewsletterModal({
+  formId,
+  analyticsAppName,
+  children,
+}: NewsletterModalProps) {
   const t = useTranslations();
   const { theme } = useTheme();
   const isDark = theme === "dark";
@@ -48,6 +54,12 @@ export function NewsletterModal({ formId, children }: NewsletterModalProps) {
 
       setStatus(Status.Success);
       setEmail("");
+      trackLead({
+        appName: analyticsAppName,
+        leadType: "newsletter",
+        formId,
+        placement: "newsletter_modal",
+      });
     } catch {
       setStatus(Status.Error);
     }


### PR DESCRIPTION
## Problem

Analytics events were inconsistent across Solana.com apps. Some events used old or noisy names, some scripts could run outside production, and each app copied its own Google Tag Manager fallback markup.

## Solution

Add a shared GA4 event contract in `@solana-com/ui-chrome`, route newsletter, podcast, modal, CTA, and data-resource tracking through it, and document the approved taxonomy. Analytics scripts and fallback tags now use shared helpers and only load in production.

## Testing

TODO

### Summary of Changes

- Added shared analytics helpers for `generate_lead`, `select_content`, `view_item`, podcast play, and podcast subscribe events.
- Gated GA4/GTM script loading and event emission to production deployments.
- Replaced duplicated GTM noscript iframe markup with a shared `GoogleTagManagerNoScript` component.
- Added a shared direct `GoogleAnalyticsTag` component for the Accelerate GA4 tag.
- Updated newsletter, podcast, modal, ECDR, SDP, and data dashboard interactions to use the shared event contract.
- Added `docs/analytics/ga4-event-taxonomy.md` with the event taxonomy and GTM configuration guidance.
- Removed noisy podcast pause and modal bounce tracking.

---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [x] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [ ] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [ ] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [ ] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

none

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

n/a

-->