### PR TITLE
Fix capitalization of Quicknode in data pages

### DIFF
--- a/apps/web/src/app/[locale]/data/data-config.ts
+++ b/apps/web/src/app/[locale]/data/data-config.ts
@@ -485,7 +485,7 @@ export const providerColors: Record<string, string> = {
   FluxRPC: "#F2C14E",
   Helius: "#E84125",
   Jito: "#A78BFA",
-  QuickNode: "#6CFF75",
+  Quicknode: "#6CFF75",
   RWA: "#A1B9E3",
   Stakewiz: "#f6b486",
   Stellium: "#FB7185",
@@ -509,8 +509,9 @@ const providerAliases: Record<string, ProviderName> = {
   fluxrpc: "FluxRPC",
   helius: "Helius",
   jito: "Jito",
-  Quicknode: "QuickNode",
-  quicknode: "QuickNode",
+  Quicknode: "Quicknode",
+  QuickNode: "Quicknode",
+  quicknode: "Quicknode",
   stellium: "Stellium",
   temporal: "Temporal",
   triton: "Triton",
@@ -922,7 +923,7 @@ export const chartDefinitions = [
           "Errored rpc_requests_total divided by successful and errored requests for the selected filters. Skipped outcomes are neutral. Hover the chart for error types.",
       },
       {
-        provider: "QuickNode",
+        provider: "Quicknode",
         description:
           "Errored rpc_requests_total divided by successful and errored requests for the selected filters. Skipped outcomes are neutral. Hover the chart for error types.",
       },
@@ -956,7 +957,7 @@ export const chartDefinitions = [
           "Prometheus rate over 5 minutes for the selected RPC method, region, and infrastructure filter.",
       },
       {
-        provider: "QuickNode",
+        provider: "Quicknode",
         description:
           "Prometheus rate over 5 minutes for the selected RPC method, region, and infrastructure filter.",
       },
@@ -989,7 +990,7 @@ export const chartDefinitions = [
           "Prometheus histogram p50 over 1 hour for the selected RPC method, region, and infrastructure filter.",
       },
       {
-        provider: "QuickNode",
+        provider: "Quicknode",
         description:
           "Prometheus histogram p50 over 1 hour for the selected RPC method, region, and infrastructure filter.",
       },
@@ -1022,7 +1023,7 @@ export const chartDefinitions = [
           "Prometheus histogram p95 over 1 hour for the selected RPC method, region, and infrastructure filter.",
       },
       {
-        provider: "QuickNode",
+        provider: "Quicknode",
         description:
           "Prometheus histogram p95 over 1 hour for the selected RPC method, region, and infrastructure filter.",
       },
@@ -1055,7 +1056,7 @@ export const chartDefinitions = [
           "Prometheus histogram p99 over 1 hour for the selected RPC method, region, and infrastructure filter.",
       },
       {
-        provider: "QuickNode",
+        provider: "Quicknode",
         description:
           "Prometheus histogram p99 over 1 hour for the selected RPC method, region, and infrastructure filter.",
       },


### PR DESCRIPTION
### Problem

Quicknode uses a lowercase N, the change was made a year ago. The Solana Data page still shows the uppercase N.

### Summary of Changes

Use `Quicknode` lowercase N and alias any `QuickNode` instances to Quicknode.

### Change classification (SDLC §2)

[*] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

[*] No secrets, tokens, or credentials in source, env files, or CI logs