### PR TITLE
chore(content): larger tx page suggest validator upgrades

### DIFF
--- a/apps/media/content/upgrades/larger-transaction-sizes.mdx
+++ b/apps/media/content/upgrades/larger-transaction-sizes.mdx
@@ -181,6 +181,27 @@ Sample code is available [here](https://github.com/solana-foundation/transaction
 
 </Audience>
 
+<Audience title="For Validator and RPC Operators" summary="Jito-Solana and RPC operators both need v4.2.2 before epoch 1035.">
+
+All v4.2.x validators support larger transactions at the consensus layer;
+however, there are two classes of nodes that need a specific release before
+epoch 1035.
+
+**Jito-Solana validators — v4.2.2 or later.** Earlier releases do not support v1
+transactions. This means a leader running an older jito-solana build will not
+build v1 transactions into its blocks. All jito-solana operators should upgrade
+to [v4.2.2](https://github.com/jito-foundation/jito-solana/releases/tag/v4.2.2-jito).
+
+**RPC nodes — Agave v4.2.2 or later.** Releases before v4.2.2
+downgrade v1 messages to v0 on the way into storage, because the conversion
+checks the `versioned` flag before the `config` field
+([fixed in v4.2.2](https://github.com/anza-xyz/agave/commit/d46ffdce1d9c4112e32fe12fbda6e04af1dceb3a)).
+The transaction still comes back, but as a v0 with its compute budget zeroed and
+its version misreported. To fix the issue, all RPC operators should upgrade
+their node to [Agave v4.2.2](https://github.com/anza-xyz/agave/releases/tag/v4.2.2).
+
+</Audience>
+
 </AudienceGroup>
 
 **[GitHub: Transaction V1 Example Code](https://github.com/solana-foundation/transaction-v1-examples)** has a runnable example in each of these languages — sending, decoding, reading blocks, and indexing over gRPC — against a local validator, plus a version matrix recording the first release of every dependency that handles v1, including the ones that drop the config silently rather than erroring. Details for all breaking changes are included below:


### PR DESCRIPTION
### Problem

jito < 4.2.2 does not support tx v1
RPC < 4.2.2 has a tx v1 bug

### Summary of Changes

Advise operators to upgrade.


---

### Change classification (SDLC §2)

<!-- Classify your own change. When in doubt, classify up. The reviewer
     validates this. -->

- [ ] **Critical** — auth, secrets/key handling, fund movement, deploy/CI
      security gates, or anything that changes who can do what
- [ ] **Standard** — production-facing, non-critical (features, API/route
      changes, dependency updates, monitoring/config)
- [x] **Low** — no security impact (docs, tests, dev tooling, content)

### Security checklist

- [x] No secrets, tokens, or credentials in source, env files, or CI logs
      (use Doppler / `NEXT_PUBLIC_*` only for values safe to ship to the
      browser).
- [x] Input from users or external services is validated before use; no
      `dangerouslySetInnerHTML` / unsanitized HTML on untrusted input.
- [x] New or updated dependencies are justified below, and `pnpm audit`
      passes (no new High/Critical advisories).
- [x] Errors are handled explicitly — no silent failures on production paths.
- [x] For **Critical** changes: a trust-boundary / threat-model note is
      included below, and a second reviewer has been requested.

<!-- New dependencies (name + why), or "none":

-->

<!-- Threat-model note for Critical changes (trust boundaries, worst-case
     impact if compromised, external dependency failure modes), or "n/a":

-->
