### PR TITLE
feat(media): add upgrade additional resources

### DIFF
--- a/apps/media/app/[locale]/upgrades/[slug]/page.tsx
+++ b/apps/media/app/[locale]/upgrades/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { Twitter } from "@boxicons/react/Twitter";
 import { Facebook } from "@boxicons/react/Facebook";
 import { Linkedin } from "@boxicons/react/Linkedin";
 import { Send } from "@boxicons/react/Send";
+import { Link as LinkIcon } from "@boxicons/react/Link";
 import type { Metadata } from "next";
 import { MDXRemote } from "next-mdx-remote/rsc";
 import remarkGfm from "remark-gfm";
@@ -163,6 +164,25 @@ export default async function Page({ params }: Props) {
               )}
             </div>
           )}
+          {entry.additionalResources &&
+            entry.additionalResources.length > 0 && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 mt-4">
+                {entry.additionalResources.map(
+                  (resource: { label: string; url: string }, i: number) => (
+                    <a
+                      key={`${resource.url}-${i}`}
+                      href={resource.url}
+                      className="group flex items-center gap-3 rounded-lg border border-white/10 bg-white/[0.02] px-4 py-3 text-sm font-medium text-white transition-colors hover:border-[#14F195]/50 hover:bg-white/[0.05] hover:text-[#14F195]"
+                    >
+                      <LinkIcon className="size-4 shrink-0 text-[#14F195]" />
+                      <span className="underline-offset-4 group-hover:underline">
+                        {resource.label}
+                      </span>
+                    </a>
+                  ),
+                )}
+              </div>
+            )}
         </div>
       </section>
 

--- a/apps/media/content/upgrades/agave-4-2-release-overview.mdx
+++ b/apps/media/content/upgrades/agave-4-2-release-overview.mdx
@@ -19,6 +19,9 @@ metrics:
     label: Slot times, down from 400ms
   - value: 150ms
     label: Alpenglow target finality, activating in 4.3
+additionalResources:
+  - label: Agave v4.2 Release Schedule
+    url: https://github.com/anza-xyz/agave/wiki/v4.2-Release-Schedule
 categories:
   - category: upgrades
 tags:

--- a/apps/media/keystatic.config.tsx
+++ b/apps/media/keystatic.config.tsx
@@ -231,6 +231,25 @@ export default config({
             itemLabel: (props) => props.fields.value.value || "Metric",
           },
         ),
+        additionalResources: fields.array(
+          fields.object({
+            label: fields.text({
+              label: "Label",
+              validation: { isRequired: true },
+            }),
+            url: fields.text({
+              label: "Link",
+              description: "A relative Solana.com path or an absolute URL.",
+              validation: { isRequired: true },
+            }),
+          }),
+          {
+            label: "Additional Resources",
+            description:
+              "Optional links to deep dives, announcements, and related material.",
+            itemLabel: (props) => props.fields.label.value || "Resource",
+          },
+        ),
         author: defaultAuthorRelationship(),
         publishedAt: fields.datetime({
           label: "Publish Date",


### PR DESCRIPTION
## Summary
- add optional `additionalResources` metadata to upgrade entries
- render compact linked resource cards below Key Metrics when resources are configured
- support relative Solana.com paths and absolute URLs

## Validation
- pre-commit ESLint and Prettier
- gitleaks
- `pnpm --filter solana-com-media check-types` *(blocked by existing missing `@solana/kit` in feature-activation files)*
- `pnpm --filter solana-com-media test -- __tests__/keystatic-config.test.ts` *(157 tests pass; suite is blocked by the same missing package)*