### PR TITLE
docs(rpc): shared Web3.js tab compatible with v3 (DEV-1040)

### DIFF
--- a/apps/docs/content/docs/en/rpc/http/getaccountinfo.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getaccountinfo.mdx
@@ -49,7 +49,7 @@ const accountInfo = await rpc.getAccountInfo(publicKey).send();
 console.log("Account Info:", accountInfo);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
@@ -57,7 +57,7 @@ const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
 const publicKey = new PublicKey("vines1vzrYbzLMRdu58ou5XTby4qAqVRLmqo36NKPTg");
 const accountInfo = await connection.getAccountInfo(publicKey);
 
-console.log("Account Info:", JSON.stringify(accountInfo, null, 2));
+console.log("Account Info:", accountInfo);
 ```
 
 ```rs !!request title="Rust"

--- a/apps/docs/content/docs/en/rpc/http/getbalance.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getbalance.mdx
@@ -47,7 +47,7 @@ const balance = await rpc.getBalance(publicKey).send();
 console.log("Account Balance:", balance);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
@@ -55,7 +55,7 @@ const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
 const publicKey = new PublicKey("83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri");
 const balance = await connection.getBalance(publicKey);
 
-console.log("Account Balance:", JSON.stringify(balance, null, 2));
+console.log("Account Balance:", balance);
 ```
 
 ```rs !!request title="Rust"

--- a/apps/docs/content/docs/en/rpc/http/getblock.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getblock.mdx
@@ -73,7 +73,7 @@ let block = await rpc
 console.log("block:", block);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getblockheight.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getblockheight.mdx
@@ -41,7 +41,7 @@ let blockHeight = await rpc.getBlockHeight().send();
 console.log("block height:", blockHeight);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getblockproduction.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getblockproduction.mdx
@@ -45,7 +45,7 @@ let blockProduction = await rpc.getBlockProduction().send();
 console.log("block production:", blockProduction);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getblocks.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getblocks.mdx
@@ -51,7 +51,7 @@ let blocks = await rpc.getBlocks(startSlot, endSlot).send();
 console.log("Blocks produced:", blocks);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getblocktime.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getblocktime.mdx
@@ -47,7 +47,7 @@ let blockTime = await rpc.getBlockTime(slotNumber).send();
 console.log("Block time:", blockTime);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getclusternodes.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getclusternodes.mdx
@@ -36,7 +36,7 @@ let nodes = await rpc.getClusterNodes().send();
 console.log(nodes);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getepochinfo.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getepochinfo.mdx
@@ -43,7 +43,7 @@ let epochInfo = await rpc.getEpochInfo().send();
 console.log(epochInfo);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getepochschedule.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getepochschedule.mdx
@@ -34,7 +34,7 @@ let epochSchedule = await rpc.getEpochSchedule().send();
 console.log(epochSchedule);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getfeeformessage.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getfeeformessage.mdx
@@ -55,7 +55,7 @@ let fee = await rpc
 console.log(fee);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, Message, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getfirstavailableblock.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getfirstavailableblock.mdx
@@ -34,7 +34,7 @@ let firstAvailableBlock = await rpc.getFirstAvailableBlock().send();
 console.log(firstAvailableBlock);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getgenesishash.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getgenesishash.mdx
@@ -34,7 +34,7 @@ let genesisHash = await rpc.getGenesisHash().send();
 console.log(genesisHash);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getinflationgovernor.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getinflationgovernor.mdx
@@ -43,7 +43,7 @@ let inflationGovener = await rpc.getInflationGovernor({ commitment }).send();
 console.log(inflationGovener);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getinflationrate.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getinflationrate.mdx
@@ -34,7 +34,7 @@ let inflationRate = await rpc.getInflationRate().send();
 console.log(inflationRate);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getinflationreward.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getinflationreward.mdx
@@ -61,7 +61,7 @@ let inflationReward = await rpc.getInflationReward(addresses, { epoch }).send();
 console.log(inflationReward);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getlargestaccounts.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getlargestaccounts.mdx
@@ -45,7 +45,7 @@ let largestAccounts = await rpc.getLargestAccounts().send();
 console.log(largestAccounts);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import {
   Connection,
   clusterApiUrl,

--- a/apps/docs/content/docs/en/rpc/http/getlatestblockhash.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getlatestblockhash.mdx
@@ -43,7 +43,7 @@ let latestBlockhash = await rpc.getLatestBlockhash({ commitment }).send();
 console.log(latestBlockhash);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl, type Commitment } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getleaderschedule.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getleaderschedule.mdx
@@ -57,7 +57,7 @@ let leaderSchedule = await rpc
 console.log(leaderSchedule);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getminimumbalanceforrentexemption.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getminimumbalanceforrentexemption.mdx
@@ -49,7 +49,7 @@ let minBalForRentExemption = await rpc
 console.log(minBalForRentExemption);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getmultipleaccounts.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getmultipleaccounts.mdx
@@ -62,7 +62,7 @@ let accounts = await rpc.getMultipleAccounts(addresses, config).send();
 console.log(accounts);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import {
   Connection,
   PublicKey,

--- a/apps/docs/content/docs/en/rpc/http/getprogramaccounts.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getprogramaccounts.mdx
@@ -99,7 +99,7 @@ let accounts = await rpc
 console.log(accounts);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import {
   Connection,
   PublicKey,

--- a/apps/docs/content/docs/en/rpc/http/getrecentperformancesamples.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getrecentperformancesamples.mdx
@@ -44,7 +44,7 @@ let performanceSamples = await rpc.getRecentPerformanceSamples(limit).send();
 console.log(performanceSamples);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getrecentprioritizationfees.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getrecentprioritizationfees.mdx
@@ -49,7 +49,7 @@ let prioritizationFees = await rpc
 console.log(prioritizationFees);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getsignaturesforaddress.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getsignaturesforaddress.mdx
@@ -58,7 +58,7 @@ let signatures = await rpc
 console.log(signatures);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import {
   Connection,
   PublicKey,

--- a/apps/docs/content/docs/en/rpc/http/getsignaturestatuses.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getsignaturestatuses.mdx
@@ -65,7 +65,7 @@ let signatureStatus = await rpc.getSignatureStatuses(signatures, config).send();
 console.log(signatureStatus);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import {
   Connection,
   clusterApiUrl,

--- a/apps/docs/content/docs/en/rpc/http/getslot.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getslot.mdx
@@ -41,7 +41,7 @@ let slot = await rpc.getSlot().send();
 console.log(slot);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl, type GetSlotConfig } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getslotleader.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getslotleader.mdx
@@ -43,7 +43,7 @@ let slotLeader = await rpc.getSlotLeader().send();
 console.log(slotLeader);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getslotleaders.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getslotleaders.mdx
@@ -45,7 +45,7 @@ let slotLeaders = await rpc.getSlotLeaders(startSlot, limit).send();
 console.log(slotLeaders);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getstakeminimumdelegation.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getstakeminimumdelegation.mdx
@@ -41,7 +41,7 @@ let stakeMinDelegation = await rpc.getStakeMinimumDelegation().send();
 console.log(stakeMinDelegation);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getsupply.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getsupply.mdx
@@ -41,7 +41,7 @@ let supply = await rpc.getSupply().send();
 console.log(supply);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/gettokenaccountbalance.mdx
+++ b/apps/docs/content/docs/en/rpc/http/gettokenaccountbalance.mdx
@@ -46,7 +46,7 @@ let tokenBalance = await rpc.getTokenAccountBalance(tokenAddress).send();
 console.log(tokenBalance);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/gettokenaccountsbyowner.mdx
+++ b/apps/docs/content/docs/en/rpc/http/gettokenaccountsbyowner.mdx
@@ -68,7 +68,7 @@ let tokenAccounts = await rpc
 console.log(tokenAccounts);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/gettokenlargestaccounts.mdx
+++ b/apps/docs/content/docs/en/rpc/http/gettokenlargestaccounts.mdx
@@ -46,7 +46,7 @@ let largestHolders = await rpc.getTokenLargestAccounts(mint).send();
 console.log(largestHolders);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/gettokensupply.mdx
+++ b/apps/docs/content/docs/en/rpc/http/gettokensupply.mdx
@@ -46,7 +46,7 @@ let tokenSupply = await rpc.getTokenSupply(mint).send();
 console.log(tokenSupply);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/gettransaction.mdx
+++ b/apps/docs/content/docs/en/rpc/http/gettransaction.mdx
@@ -53,7 +53,7 @@ let transaction = await rpc.getTransaction(signature as Signature).send();
 console.log(transaction);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import {
   Connection,
   PublicKey,

--- a/apps/docs/content/docs/en/rpc/http/gettransactioncount.mdx
+++ b/apps/docs/content/docs/en/rpc/http/gettransactioncount.mdx
@@ -42,7 +42,7 @@ let txCount = await rpc.getTransactionCount().send();
 console.log(txCount);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getversion.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getversion.mdx
@@ -35,7 +35,7 @@ let version = await rpc.getVersion().send();
 console.log(version);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/getvoteaccounts.mdx
+++ b/apps/docs/content/docs/en/rpc/http/getvoteaccounts.mdx
@@ -52,7 +52,7 @@ let voteAccounts = await rpc
 console.log(voteAccounts);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/isblockhashvalid.mdx
+++ b/apps/docs/content/docs/en/rpc/http/isblockhashvalid.mdx
@@ -46,7 +46,7 @@ let isValid = await rpc.isBlockhashValid(blockhash as Blockhash).send();
 console.log(isValid);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/minimumledgerslot.mdx
+++ b/apps/docs/content/docs/en/rpc/http/minimumledgerslot.mdx
@@ -39,7 +39,7 @@ let minLedgerSlot = await rpc.minimumLedgerSlot().send();
 console.log(minLedgerSlot);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/http/requestairdrop.mdx
+++ b/apps/docs/content/docs/en/rpc/http/requestairdrop.mdx
@@ -52,7 +52,7 @@ let signature = await rpc.requestAirdrop(receiver, airdropAmt).send();
 console.log(signature);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import {
   Connection,
   LAMPORTS_PER_SOL,

--- a/apps/docs/content/docs/en/rpc/http/sendtransaction.mdx
+++ b/apps/docs/content/docs/en/rpc/http/sendtransaction.mdx
@@ -89,7 +89,7 @@ const signature = await rpc
 console.log(signature);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import {
   Connection,
   VersionedTransaction,

--- a/apps/docs/content/docs/en/rpc/http/simulatetransaction.mdx
+++ b/apps/docs/content/docs/en/rpc/http/simulatetransaction.mdx
@@ -76,7 +76,7 @@ let simulateResult = await rpc
 console.log(simulateResult);
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import {
   Connection,
   VersionedTransaction,

--- a/apps/docs/content/docs/en/rpc/index.mdx
+++ b/apps/docs/content/docs/en/rpc/index.mdx
@@ -29,6 +29,13 @@ execution, and subscribe to live updates.
   </Card>
 </Cards>
 
+<Callout type="info">
+  Code samples on the HTTP and WebSocket reference pages run on both
+  `@solana/web3.js` v1 and v3. Note that v3 returns `bigint` for numeric fields
+  such as slots, lamports, and counts (v1 returns `number`), and returns
+  readonly arrays.
+</Callout>
+
 ## Cluster Endpoints
 
 Every RPC request goes to a specific cluster. The endpoint determines which

--- a/apps/docs/content/docs/en/rpc/websocket/accountsubscribe.mdx
+++ b/apps/docs/content/docs/en/rpc/websocket/accountsubscribe.mdx
@@ -54,7 +54,7 @@ for await (const notification of subscription) {
 }
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/websocket/logssubscribe.mdx
+++ b/apps/docs/content/docs/en/rpc/websocket/logssubscribe.mdx
@@ -50,7 +50,7 @@ for await (const notification of subscription) {
 }
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/websocket/programsubscribe.mdx
+++ b/apps/docs/content/docs/en/rpc/websocket/programsubscribe.mdx
@@ -50,7 +50,7 @@ for await (const notification of subscription) {
 }
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/websocket/rootsubscribe.mdx
+++ b/apps/docs/content/docs/en/rpc/websocket/rootsubscribe.mdx
@@ -36,7 +36,7 @@ for await (const notification of subscription) {
 }
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/websocket/signaturesubscribe.mdx
+++ b/apps/docs/content/docs/en/rpc/websocket/signaturesubscribe.mdx
@@ -62,7 +62,7 @@ for await (const notification of subscription) {
 }
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/websocket/slotsubscribe.mdx
+++ b/apps/docs/content/docs/en/rpc/websocket/slotsubscribe.mdx
@@ -36,7 +36,7 @@ for await (const notification of subscription) {
 }
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");

--- a/apps/docs/content/docs/en/rpc/websocket/slotsupdatessubscribe.mdx
+++ b/apps/docs/content/docs/en/rpc/websocket/slotsupdatessubscribe.mdx
@@ -28,7 +28,7 @@ Subscribe to a stream of tagged slot lifecycle updates emitted by the validator.
 }
 ```
 
-```ts !!request title="web3.js"
+```ts !!request title="Web3.js"
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");


### PR DESCRIPTION
## Problem

RPC HTTP/WebSocket reference pages label their web3.js sample tab `web3.js` (lowercase) and hold no shared identity with the rest of the docs. Two pages wrap RPC results in `JSON.stringify`, which throws on `bigint` under `@solana/web3.js` v3. The RPC overview page gives no heads-up that v3 changes result shapes.

## Changes

- Rename `title="web3.js"` to `title="Web3.js"` across all 51 `rpc/http/*.mdx` and `rpc/websocket/*.mdx` pages carrying a web3.js sample tab (single shared v1/v3 tab, per DEV-1040 decision).
- Drop `JSON.stringify(...)` around RPC results in `getaccountinfo.mdx` and `getbalance.mdx`, printing the value directly so the block works under v3's `bigint` return values.
- Scanned all `Web3.js` tab blocks for other v1/v3 incompatibilities (`Keypair.generate()`, `.toBuffer()`, `.sort()`/`.push()`, PDA sync calls) — none found; the `Connection` surface used in these blocks is unchanged in v3.
- Add a `<Callout type="info">` to `rpc/index.mdx` noting samples run on both v1 and v3, and that v3 returns `bigint` for numeric fields and readonly arrays.

Backfill of a `Web3.js` tab onto pages that currently only have `Kit` (8 http pages: getblockcommitment, getblockswithlimit, gethealth, gethighestsnapshotslot, getidentity, getmaxretransmitslot, getmaxshredinsertslot, gettokenaccountsbydelegate) and the 12 websocket `*unsubscribe`/`votesubscribe`/`index` pages with no web3.js tab at all is left out of scope per the ticket (optional, skip unless trivial).

Fixes DEV-1040