### PR TITLE
docs: web3.js v3 reference and landing pages (DEV-1038)

### DIFF
--- a/apps/docs/content/docs/en/clients/index.mdx
+++ b/apps/docs/content/docs/en/clients/index.mdx
@@ -8,8 +8,7 @@ hideTableOfContents: true
 
 <Cards>
   <Card title="TypeScript" href="/docs/clients/official/javascript">
-    @solana/kit, @solana/client, and React hooks - plus the legacy
-    @solana/web3.js.
+    @solana/kit and React hooks - plus @solana/web3.js v3 and web3.js (legacy).
   </Card>
   <Card title="Rust" href="/docs/clients/official/rust">
     The solana_sdk crates for clients and onchain programs.

--- a/apps/docs/content/docs/en/clients/official/javascript.mdx
+++ b/apps/docs/content/docs/en/clients/official/javascript.mdx
@@ -50,10 +50,42 @@ See the [Keychain documentation](/docs/tools/keychain) and
 [Choosing a backend](/docs/tools/keychain/choosing-a-backend) for setup and
 custody-model guidance.
 
-## Solana Web3.js
+## Solana Web3.js v3
 
-`@solana/web3.js` is the legacy TypeScript SDK for Solana. New apps should use
-`@solana/kit`; see [Migrating to Kit](/docs/frontend/web3-compat).
+`@solana/web3.js` v3 rebuilds the classic class-based API — `Connection`,
+`Keypair`, `Transaction`, `PublicKey` — on top of `@solana/kit` internals. It is
+a bridge for existing `@solana/web3.js` (legacy) codebases, not a starting point
+for new projects; new apps should build directly on `@solana/kit`. Most methods
+that were synchronous in the legacy SDK, such as `Keypair.generate()` and
+`transaction.sign()`, are now async.
+
+```bash
+npm install @solana/web3.js@rc
+```
+
+| Package                        | Description                          | GitHub                                                                          |
+| ------------------------------ | ------------------------------------ | ------------------------------------------------------------------------------- |
+| @solana/web3.js                | Core SDK (release candidate)         | [Source](https://github.com/solana-foundation/solana-web3.js)                   |
+| @solana-program/system         | Interact with System program         | [Source](https://github.com/solana-program/system/tree/main/clients/js)         |
+| @solana-program/token          | Interact with Token program          | [Source](https://github.com/solana-program/token/tree/main/clients/js)          |
+| @solana-program/token-2022     | Interact with Token-2022 program     | [Source](https://github.com/solana-program/token-2022/tree/main/clients/js)     |
+| @solana-program/memo           | Interact with Memo program           | [Source](https://github.com/solana-program/memo/tree/main/clients/js)           |
+| @solana-program/compute-budget | Interact with Compute Budget program | [Source](https://github.com/solana-program/compute-budget/tree/main/clients/js) |
+
+`@solana/spl-token` depends on `@solana/web3.js` (legacy) and does not run on
+v3. Use `@solana-program/token` or `@solana-program/token-2022` instead; their
+generated instructions and instruction plans work directly with v3's
+`Transaction.add()`.
+
+- [web3.js v1 → v3 migration guide](https://github.com/solana-foundation/solana-web3.js/blob/v3.x/docs/web3js-v1-to-v3-migration.md)
+- [spl-token migration guide](https://github.com/solana-foundation/solana-web3.js/blob/v3.x/docs/web3js-spl-token-migration.md)
+
+## Solana Web3.js (legacy)
+
+`@solana/web3.js` (legacy, `1.x`) is the original TypeScript SDK for Solana. It
+is in maintenance mode. New apps should use `@solana/kit`, and existing
+codebases should plan a move to web3.js v3 or Kit; see
+[Migrating to Kit](/docs/frontend/web3-compat).
 
 | Package           | Description                                                    | GitHub                                                                             |
 | ----------------- | -------------------------------------------------------------- | ---------------------------------------------------------------------------------- |

--- a/apps/docs/content/docs/en/core/fees/fee-structure.mdx
+++ b/apps/docs/content/docs/en/core/fees/fee-structure.mdx
@@ -191,10 +191,11 @@ scheduler's buffer for execution.
 The examples below show how to set the CU limit and CU price on a transaction
 using Solana SDKs.
 
-| SDK                            | Source Code Reference                                                                                                            |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `@solana/web3.js` (Typescript) | [`ComputeBudgetProgram`](https://github.com/solana-foundation/solana-web3.js/blob/v1.98.0/src/programs/compute-budget.ts#L218)   |
-| `solana-sdk` (Rust)            | [`ComputeBudgetInstruction`](https://github.com/anza-xyz/solana-sdk/blob/clock%40v2.2.3/compute-budget-interface/src/lib.rs#L24) |
+| SDK                                    | Source Code Reference                                                                                                                   |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `@solana/web3.js` v3 (Typescript)      | [`ComputeBudgetProgram`](https://github.com/solana-foundation/solana-web3.js/blob/v3.x/packages/web3.js/src/programs/compute-budget.ts) |
+| `@solana/web3.js` (legacy, Typescript) | [`ComputeBudgetProgram`](https://github.com/solana-foundation/solana-web3.js/blob/v1.98.0/src/programs/compute-budget.ts#L218)          |
+| `solana-sdk` (Rust)                    | [`ComputeBudgetInstruction`](https://github.com/anza-xyz/solana-sdk/blob/clock%40v2.2.3/compute-budget-interface/src/lib.rs#L24)        |
 
 <CodeTabs storage="compute-budget">
 

--- a/apps/docs/content/docs/en/core/pda/pda-derivation.mdx
+++ b/apps/docs/content/docs/en/core/pda/pda-derivation.mdx
@@ -143,11 +143,12 @@ The Solana SDKs provide functions for PDA derivation. Each function takes:
 - **Optional seeds**: Predefined inputs such as strings, numbers, or other
   account addresses.
 
-| SDK                            | Function                                                                                                                         |
-| ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
-| `@solana/kit` (TypeScript)     | [`getProgramDerivedAddress`](https://github.com/anza-xyz/kit/blob/v2.1.0/packages/addresses/src/program-derived-address.ts#L157) |
-| `@solana/web3.js` (TypeScript) | [`findProgramAddressSync`](https://github.com/solana-foundation/solana-web3.js/blob/v1.98.0/src/publickey.ts#L212)               |
-| `solana_sdk` (Rust)            | [`find_program_address`](https://github.com/anza-xyz/solana-sdk/blob/clock%40v2.2.3/pubkey/src/lib.rs#L800)                      |
+| SDK                                    | Function                                                                                                                          |
+| -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| `@solana/kit` (TypeScript)             | [`getProgramDerivedAddress`](https://github.com/anza-xyz/kit/blob/v2.1.0/packages/addresses/src/program-derived-address.ts#L157)  |
+| `@solana/web3.js` v3 (TypeScript)      | [`PublicKey.findProgramAddress`](https://github.com/solana-foundation/solana-web3.js/blob/v3.x/packages/web3.js/src/publickey.ts) |
+| `@solana/web3.js` (legacy, TypeScript) | [`findProgramAddressSync`](https://github.com/solana-foundation/solana-web3.js/blob/v1.98.0/src/publickey.ts#L212)                |
+| `solana_sdk` (Rust)                    | [`find_program_address`](https://github.com/anza-xyz/solana-sdk/blob/clock%40v2.2.3/pubkey/src/lib.rs#L800)                       |
 
 The examples below derive a PDA using the Solana SDKs. Click **&#9655; Run** to
 execute the code.

--- a/apps/docs/content/docs/en/defi/exchange.mdx
+++ b/apps/docs/content/docs/en/defi/exchange.mdx
@@ -386,7 +386,8 @@ transfer of 1040000000 - 1030000000 = 10,000,000 lamports = 0.01 SOL
 If you need more information about the transaction type or other specifics, you
 can request the block from RPC in binary format, and parse it using either our
 [Rust SDK](https://github.com/solana-labs/solana) or
-[Javascript SDK](https://github.com/solana-labs/solana-web3.js).
+[Javascript SDK](https://github.com/solana-foundation/solana-web3.js)
+(`@solana/web3.js` v3 or legacy).
 
 ### Address History
 
@@ -565,10 +566,10 @@ by the cluster. If the transaction fails, it will report any transaction errors.
 solana transfer <USER_ADDRESS> <AMOUNT> --allow-unfunded-recipient --keypair <KEYPAIR> --url http://localhost:8899
 ```
 
-The [Solana Javascript SDK](https://github.com/solana-labs/solana-web3.js)
-offers a similar approach for the JS ecosystem. Use the `SystemProgram` to build
-a transfer transaction, and submit it using the `sendAndConfirmTransaction`
-method.
+The [Solana Javascript SDK](https://github.com/solana-foundation/solana-web3.js)
+(`@solana/web3.js` v3 or legacy) offers a similar approach for the JS ecosystem.
+Use the `SystemProgram` to build a transfer transaction, and submit it using the
+`sendAndConfirmTransaction` method.
 
 ### Asynchronous
 

--- a/apps/docs/content/docs/en/frontend/index.mdx
+++ b/apps/docs/content/docs/en/frontend/index.mdx
@@ -37,11 +37,14 @@ clients for the on-chain programs you call.
   </Card>
 </Cards>
 
-<Callout type="warn" title="web3.js v1 and wallet-adapter are legacy">
-  Many Solana projects still rely on the older `@solana/web3.js` (v1) and
+<Callout type="warn" title="web3.js (legacy) and wallet-adapter are legacy">
+  Many Solana projects still rely on the older `@solana/web3.js` (legacy) and
   `@solana/wallet-adapter-*`. For new work, prefer `@solana/kit` with the kit
   plugins below; Wallet Standard discovery (via `@solana/kit-plugin-wallet`)
-  replaces wallet-adapter for modern wallets.
+  replaces wallet-adapter for modern wallets. If you maintain a large
+  `@solana/web3.js` (legacy) codebase, see [Migrating to
+  Kit](/docs/frontend/web3-compat) for web3.js v3, a bridge that keeps the
+  classic `Connection`/`Keypair`/`Transaction` API on Kit internals.
 </Callout>
 
 - [Kit client guide](/docs/frontend/client): build a client from plugins for

--- a/apps/docs/content/docs/en/frontend/web3-compat.mdx
+++ b/apps/docs/content/docs/en/frontend/web3-compat.mdx
@@ -23,16 +23,20 @@ know onto their Kit equivalents.
 | `sendAndConfirmTransaction(...)`       | `client.sendTransaction([...])` (planner signs, sends, and confirms) |
 | `@solana/wallet-adapter-*`             | `@solana/kit-plugin-wallet` + Wallet Standard discovery              |
 
+web3.js v3 keeps the class-based names above — `Connection`, `Keypair`,
+`Transaction`, `PublicKey` — as thin wrappers over Kit internals, so the Kit
+column also describes what those classes do under the hood in v3.
+
 ## Coming from web3.js?
 
 If you maintain a large `@solana/web3.js` v1 codebase and a full rewrite to Kit
 isn't practical yet, web3.js v3 is the bridge. It currently ships as
 `@solana/web3.js@rc` (the `3.0.0-rc` line) and rebuilds the classic class-based
-API — `Connection`, `Keypair`, `Transaction` — on top of `@solana/kit`
-internals. Because it sits on Kit, interop is tight: `PublicKey` is a deprecated
-alias of `Address`, and a v3 `Keypair` structurally satisfies Kit's
-`KeyPairSigner`, so you can pass it directly to Kit APIs, plugins, and
-Codama-generated clients.
+API — `Connection`, `Keypair`, `Transaction`, `PublicKey` — on top of
+`@solana/kit` internals. Because it sits on Kit, interop is tight: `PublicKey`
+is the primary address type and its `.toBase58()` returns Kit's branded
+`Address` string, and a v3 `Keypair` implements Kit's `KeyPairSigner`, so you
+can pass it directly to Kit APIs, plugins, and Codama-generated clients.
 
 <Callout type="warn" title="v1 transactions and web3.js v1">
   web3.js v1 reads the [v1 transaction

--- a/apps/docs/content/docs/en/payments/agentic-payments/intro-to-x402.mdx
+++ b/apps/docs/content/docs/en/payments/agentic-payments/intro-to-x402.mdx
@@ -149,11 +149,16 @@ https://corbits.dev/
 Example that lets you pay for Solana RPC requests.
 
 ```bash
-npm install @faremeter/payment-solana @faremeter/fetch @faremeter/info
-@solana/web3.js
+npm install @faremeter/payment-solana @faremeter/fetch @faremeter/info @solana/web3.js
 ```
 
 Create a `payer-wallet.json` and fund it with some USDC and some mainnet sol.
+
+<Callout type="info" title="web3.js (legacy) example">
+  This example uses `@solana/web3.js` (legacy), which `@faremeter` currently
+  depends on. If you port it to web3.js v3, `Keypair.fromSecretKey` is async:
+  use `await Keypair.fromSecretKey(...)`.
+</Callout>
 
 ```ts filename=e2e.ts
 import {
@@ -620,6 +625,13 @@ app.listen(3001, () => console.log("x402 USDC server listening on :3001"));
 ```
 
 ### Minimal Client (Node)
+
+<Callout type="info" title="web3.js (legacy) example">
+  This example uses `@solana/web3.js` (legacy) and `@solana/spl-token`, which
+  does not run on web3.js v3; see
+  [`@solana-program/token`](/docs/clients/official/javascript) for the v3
+  equivalent. `Keypair.fromSecretKey` is also async on v3.
+</Callout>
 
 ```ts filename=client.ts
 import { Connection, Keypair, PublicKey, Transaction } from "@solana/web3.js";


### PR DESCRIPTION
## Problem

The docs describe `@solana/web3.js` only as the legacy SDK. With web3.js v3 (`3.0.0-rc.3`) shipping, readers need to know it exists, how it relates to Kit, and how to install it. `frontend/web3-compat.mdx` also claimed `PublicKey` is a deprecated alias of `Address`, which is no longer true in v3.

## Changes

- `clients/official/javascript.mdx`: split the Web3.js section into v3 (packages, install, async note, spl-token incompatibility, links to upstream migration guides) and legacy (maintenance-only).
- `clients/index.mdx`, `frontend/index.mdx`: point readers at v3 as the bridge for existing web3.js apps.
- `frontend/web3-compat.mdx`: fix the `PublicKey` / `Address` claim; add v3 note to the concept table.
- `core/fees/fee-structure.mdx`, `core/pda/pda-derivation.mdx`: add v3 rows to source-link tables.
- `defi/exchange.mdx`: fix stale `solana-labs` repo links.
- `payments/agentic-payments/intro-to-x402.mdx`: fix broken install command; note that third-party examples use legacy web3.js and that `Keypair.fromSecretKey` is async on v3.

Part of the web3.js v3 docs rollout tracked in DEV-17. Targets the `docs/DEV-17-web3js-v3` integration branch.

Fixes DEV-1038