### PR TITLE
docs(core): add Web3.js v3 tabs to core concept pages (DEV-1039)

### DIFF
--- a/apps/docs/content/docs/en/core/accounts/account-structure.mdx
+++ b/apps/docs/content/docs/en/core/accounts/account-structure.mdx
@@ -50,7 +50,15 @@ const keypairSigner = await generateKeyPairSigner();
 console.log(keypairSigner);
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
+import { Keypair } from "@solana/web3.js";
+
+const keypair = await Keypair.generate();
+console.log(`Public Key: ${keypair.publicKey}`);
+console.log(`Secret Key: ${keypair.secretKey}`);
+```
+
+```ts !! title="Web3.js (legacy)"
 import { Keypair } from "@solana/web3.js";
 
 const keypair = Keypair.generate();
@@ -95,16 +103,25 @@ console.log(`PDA: ${pda}`);
 console.log(`Bump: ${bump}`);
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
 import { PublicKey } from "@solana/web3.js";
 
 const programAddress = new PublicKey("11111111111111111111111111111111");
 
 const seeds = [Buffer.from("helloWorld")];
-const [pda, bump] = await PublicKey.findProgramAddressSync(
-  seeds,
-  programAddress
-);
+const [pda, bump] = await PublicKey.findProgramAddress(seeds, programAddress);
+
+console.log(`PDA: ${pda}`);
+console.log(`Bump: ${bump}`);
+```
+
+```ts !! title="Web3.js (legacy)"
+import { PublicKey } from "@solana/web3.js";
+
+const programAddress = new PublicKey("11111111111111111111111111111111");
+
+const seeds = [Buffer.from("helloWorld")];
+const [pda, bump] = PublicKey.findProgramAddressSync(seeds, programAddress);
 
 console.log(`PDA: ${pda}`);
 console.log(`Bump: ${bump}`);

--- a/apps/docs/content/docs/en/core/accounts/account-types.mdx
+++ b/apps/docs/content/docs/en/core/accounts/account-types.mdx
@@ -82,7 +82,37 @@ const accountInfo = await client.rpc
 console.log(accountInfo);
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
+import { Connection, PublicKey } from "@solana/web3.js";
+
+const connection = new Connection(
+  "https://api.mainnet.solana.com",
+  "confirmed"
+);
+
+const programId = new PublicKey("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+const accountInfo = await connection.getAccountInfo(programId);
+// !collapse(1:17) collapsed
+console.log(
+  JSON.stringify(
+    accountInfo,
+    (key, value) => {
+      if (key === "data" && value && value.length > 1) {
+        return [
+          value[0],
+          "...truncated, total bytes: " + value.length + "...",
+          value[value.length - 1]
+        ];
+      }
+      return typeof value === "bigint" ? value.toString() : value;
+    },
+    2
+  )
+);
+```
+
+```ts !! title="Web3.js (legacy)"
 import { Connection, PublicKey } from "@solana/web3.js";
 
 const connection = new Connection(
@@ -216,7 +246,7 @@ const mintAccount = await fetchMint(client.rpc, mint.address);
 console.log(mintAccount);
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js (legacy)"
 import {
   Connection,
   Keypair,
@@ -448,7 +478,28 @@ const accountInfo = await client.rpc.getAccountInfo(keypair.address).send();
 console.log(accountInfo);
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
+import { Keypair, Connection, LAMPORTS_PER_SOL } from "@solana/web3.js";
+
+// Generate a new keypair
+const keypair = await Keypair.generate();
+console.log(`Public Key: ${keypair.publicKey}`);
+
+// Create a connection to the Solana cluster
+const connection = new Connection("http://localhost:8899", "confirmed");
+
+// Funding an address with SOL automatically creates an account
+const signature = await connection.requestAirdrop(
+  keypair.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction(signature, "confirmed");
+
+const accountInfo = await connection.getAccountInfo(keypair.publicKey);
+console.log(accountInfo);
+```
+
+```ts !! title="Web3.js (legacy)"
 import { Keypair, Connection, LAMPORTS_PER_SOL } from "@solana/web3.js";
 
 // Generate a new keypair
@@ -557,7 +608,43 @@ const clock = await fetchSysvarClock(client.rpc);
 console.log(clock);
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
+import { Connection, SYSVAR_CLOCK_PUBKEY } from "@solana/web3.js";
+import { getSysvarClockCodec } from "@solana/sysvars";
+
+const connection = new Connection(
+  "https://api.mainnet.solana.com",
+  "confirmed"
+);
+
+const accountInfo = await connection.getAccountInfo(SYSVAR_CLOCK_PUBKEY);
+
+// Deserialize the account data
+const decodedClock = getSysvarClockCodec().decode(
+  new Uint8Array(accountInfo?.data ?? [])
+);
+
+console.log(decodedClock);
+// !collapse(1:16) collapsed
+console.log(
+  JSON.stringify(
+    accountInfo,
+    (key, value) => {
+      if (key === "data" && value && value.length > 1) {
+        return [
+          value[0],
+          "...truncated, total bytes: " + value.length + "...",
+          value[value.length - 1]
+        ];
+      }
+      return typeof value === "bigint" ? value.toString() : value;
+    },
+    2
+  )
+);
+```
+
+```ts !! title="Web3.js (legacy)"
 import { Connection, SYSVAR_CLOCK_PUBKEY } from "@solana/web3.js";
 import { getSysvarClockCodec } from "@solana/sysvars";
 

--- a/apps/docs/content/docs/en/core/cpi/cpi-with-pda.mdx
+++ b/apps/docs/content/docs/en/core/cpi/cpi-with-pda.mdx
@@ -355,7 +355,78 @@ pub fn process_instruction(
 }
 ```
 
-```ts !! title="Test"
+```ts !! title="Test (Web3.js v3)"
+import * as path from "path";
+import {
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction
+} from "@solana/web3.js";
+import { LiteSVM } from "litesvm";
+
+test("sol transfer cpi with pda signer", async () => {
+  const svm = new LiteSVM();
+
+  const programId = (await Keypair.generate()).publicKey;
+  const programPath = path.join(__dirname, "program.so");
+  svm.addProgramFromFile(programId, programPath);
+
+  // Create recipient
+  const recipient = await Keypair.generate();
+
+  // Derive PDA that will hold and send funds
+  const [pdaAddress] = await PublicKey.findProgramAddress(
+    [Buffer.from("pda"), recipient.publicKey.toBytes()],
+    programId
+  );
+
+  // Fund accounts
+  const amount = BigInt(LAMPORTS_PER_SOL);
+  svm.airdrop(recipient.publicKey, amount); // 1 SOL
+  svm.airdrop(pdaAddress, amount); // 1 SOL
+
+  // Create instruction data buffer
+  const transferAmount = amount / BigInt(2); // 0.5 SOL
+  const instructionIndex = 0; // instruction index 0 for SolTransfer enum
+
+  const data = Buffer.alloc(9); // 1 byte for instruction enum + 8 bytes for u64
+  data.writeUInt8(instructionIndex, 0); // first byte identifies the instruction
+  data.writeBigUInt64LE(transferAmount, 1); // remaining bytes are instruction arguments
+
+  // Create instruction
+  const instruction = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: pdaAddress, isSigner: false, isWritable: true },
+      { pubkey: recipient.publicKey, isSigner: false, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false }
+    ],
+    data
+  });
+
+  // Create and send transaction
+  const transaction = new Transaction().add(instruction);
+  transaction.recentBlockhash = svm.latestBlockhash();
+  await transaction.sign(recipient);
+
+  svm.sendTransaction(transaction);
+
+  // Check balances
+  const recipientBalance = svm.getBalance(recipient.publicKey);
+  const pdaBalance = svm.getBalance(pdaAddress);
+
+  const transactionFee = BigInt(5000);
+  // Recipient starts with 1 SOL, receives 0.5 SOL, pays tx fee
+  expect(recipientBalance).toBe(amount + transferAmount - transactionFee);
+  // PDA starts with 1 SOL, sends 0.5 SOL
+  expect(pdaBalance).toBe(amount - transferAmount);
+});
+```
+
+```ts !! title="Test (Web3.js legacy)"
 import * as path from "path";
 import {
   Keypair,

--- a/apps/docs/content/docs/en/core/cpi/cpi-without-pda.mdx
+++ b/apps/docs/content/docs/en/core/cpi/cpi-without-pda.mdx
@@ -285,7 +285,70 @@ pub fn process_instruction(
 }
 ```
 
-```ts !! title="Test"
+```ts !! title="Test (Web3.js v3)"
+import * as path from "path";
+import {
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  TransactionInstruction
+} from "@solana/web3.js";
+import { LiteSVM } from "litesvm";
+
+test("sol transfer cpi", async () => {
+  const svm = new LiteSVM();
+
+  const programId = (await Keypair.generate()).publicKey;
+  const programPath = path.join(__dirname, "program.so");
+  svm.addProgramFromFile(programId, programPath);
+
+  // Create sender and recipient
+  const sender = await Keypair.generate();
+  const recipient = await Keypair.generate();
+
+  // Fund sender
+  const amount = BigInt(LAMPORTS_PER_SOL);
+  svm.airdrop(sender.publicKey, amount); // 1 SOL
+
+  // Create instruction data buffer
+  const transferAmount = amount / BigInt(2); // 0.5 SOL
+  const instructionIndex = 0; // instruction index 0 for SolTransfer enum
+
+  const data = Buffer.alloc(9); // 1 byte for instruction enum + 8 bytes for u64
+  data.writeUInt8(instructionIndex, 0); // first byte identifies the instruction
+  data.writeBigUInt64LE(transferAmount, 1); // remaining bytes are instruction arguments
+
+  // Create instruction
+  const instruction = new TransactionInstruction({
+    programId,
+    keys: [
+      { pubkey: sender.publicKey, isSigner: true, isWritable: true },
+      { pubkey: recipient.publicKey, isSigner: false, isWritable: true },
+      { pubkey: SystemProgram.programId, isSigner: false, isWritable: false }
+    ],
+    data
+  });
+
+  // Create and send transaction
+  const transaction = new Transaction().add(instruction);
+  transaction.recentBlockhash = svm.latestBlockhash();
+  await transaction.sign(sender);
+
+  svm.sendTransaction(transaction);
+
+  // Check balances
+  const recipientBalance = svm.getBalance(recipient.publicKey);
+  const senderBalance = svm.getBalance(sender.publicKey);
+
+  const transactionFee = BigInt(5000);
+  expect(recipientBalance).toBe(transferAmount);
+  expect(senderBalance).toBe(amount - transferAmount - transactionFee);
+});
+```
+
+```ts !! title="Test (Web3.js legacy)"
 import * as path from "path";
 import {
   Keypair,

--- a/apps/docs/content/docs/en/core/fees/fee-structure.mdx
+++ b/apps/docs/content/docs/en/core/fees/fee-structure.mdx
@@ -198,7 +198,17 @@ using Solana SDKs.
 
 <CodeTabs storage="compute-budget">
 
-```ts !! title="Typescript"
+```ts !! title="Web3.js v3"
+const limitInstruction = ComputeBudgetProgram.setComputeUnitLimit({
+  units: 300_000
+});
+
+const priceInstruction = ComputeBudgetProgram.setComputeUnitPrice({
+  microLamports: 1
+});
+```
+
+```ts !! title="Web3.js (legacy)"
 const limitInstruction = ComputeBudgetProgram.setComputeUnitLimit({
   units: 300_000
 });
@@ -218,7 +228,56 @@ let price_instruction = ComputeBudgetInstruction::set_compute_unit_price(1);
 
 <CodeTabs storage="compute-budget" flags="r">
 
-```ts !! title="Typescript"
+```ts !! title="Web3.js v3"
+import {
+  LAMPORTS_PER_SOL,
+  SystemProgram,
+  Transaction,
+  Keypair,
+  Connection,
+  ComputeBudgetProgram,
+  sendAndConfirmTransaction
+} from "@solana/web3.js";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+
+const sender = await Keypair.generate();
+const recipient = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  sender.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction(airdropSignature, "confirmed");
+
+// Create compute budget instructions
+const limitInstruction = ComputeBudgetProgram.setComputeUnitLimit({
+  units: 300_000
+});
+const priceInstruction = ComputeBudgetProgram.setComputeUnitPrice({
+  microLamports: 1
+});
+
+const transferInstruction = SystemProgram.transfer({
+  fromPubkey: sender.publicKey,
+  toPubkey: recipient.publicKey,
+  lamports: 0.01 * LAMPORTS_PER_SOL
+});
+
+// Add the compute budget and transfer instructions to a new transaction
+const transaction = new Transaction()
+  .add(limitInstruction)
+  .add(priceInstruction)
+  .add(transferInstruction);
+
+const signature = await sendAndConfirmTransaction(connection, transaction, [
+  sender
+]);
+
+console.log("Transaction Signature:", signature);
+```
+
+```ts !! title="Web3.js (legacy)"
 import {
   LAMPORTS_PER_SOL,
   SystemProgram,

--- a/apps/docs/content/docs/en/core/instructions/instruction-structure.mdx
+++ b/apps/docs/content/docs/en/core/instructions/instruction-structure.mdx
@@ -172,7 +172,32 @@ const transferInstruction = client.system.instructions.transferSol({
 console.log(JSON.stringify(transferInstruction, null, 2));
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
+import {
+  LAMPORTS_PER_SOL,
+  SystemProgram,
+  Transaction,
+  Keypair
+} from "@solana/web3.js";
+
+// Generate sender and recipient keypairs
+const sender = await Keypair.generate();
+const recipient = await Keypair.generate();
+
+// Define the amount to transfer
+const transferAmount = 0.01; // 0.01 SOL
+
+// Create a transfer instruction for transferring SOL from sender to recipient
+const transferInstruction = SystemProgram.transfer({
+  fromPubkey: sender.publicKey,
+  toPubkey: recipient.publicKey,
+  lamports: transferAmount * LAMPORTS_PER_SOL // Convert transferAmount to lamports
+});
+
+console.log(JSON.stringify(transferInstruction, null, 2));
+```
+
+```ts !! title="Web3.js (legacy)"
 import {
   LAMPORTS_PER_SOL,
   SystemProgram,
@@ -271,7 +296,42 @@ pieces of required information: [`program_id`](mention:program-id),
 }
 ```
 
-```json !! title="Legacy"
+```json !! title="Web3.js v3"
+{
+  // !mention(1:12) accounts
+  "keys": [
+    {
+      "pubkey": "3z9vL1zjN6qyAFHhHQdWYRTFAcy69pJydkZmSFBKHg1R",
+      "isSigner": true,
+      "isWritable": true
+    },
+    {
+      "pubkey": "BpvxsLYKQZTH42jjtWHZpsVSa7s6JVwLKwBptPSHXuZc",
+      "isSigner": false,
+      "isWritable": true
+    }
+  ],
+  // !mention program-id
+  "programId": "11111111111111111111111111111111",
+  // !mention(1:14) data
+  "data": {
+    "0": 2,
+    "1": 0,
+    "2": 0,
+    "3": 0,
+    "4": 128,
+    "5": 150,
+    "6": 152,
+    "7": 0,
+    "8": 0,
+    "9": 0,
+    "10": 0,
+    "11": 0
+  }
+}
+```
+
+```json !! title="Web3.js (legacy)"
 {
   // !mention(1:12) accounts
   "keys": [
@@ -329,7 +389,7 @@ The examples below show how to manually build the transfer instruction. (The
   manually build the instruction.
 </Callout>
 
-<Tabs items={['Kit', 'Legacy', 'Rust']}>
+<Tabs items={['Kit', 'Web3.js v3', 'Web3.js (legacy)', 'Rust']}>
 
 <Tab value="Kit">
 
@@ -359,7 +419,7 @@ instructionData.writeBigUInt64LE(transferAmount * LAMPORTS_PER_SOL, 4);
 const SYSTEM_PROGRAM_ADDRESS = "11111111111111111111111111111111" as Address;
 
 // Manually create the transfer instruction
-const transferInstruction: IInstruction = {
+const transferInstruction: Instruction = {
   programAddress: SYSTEM_PROGRAM_ADDRESS,
   accounts: [
     {
@@ -379,7 +439,47 @@ const transferInstruction: IInstruction = {
 
 </Tab>
 
-<Tab value="Legacy">
+<Tab value="Web3.js v3">
+
+<CodeTabs>
+
+```ts !! title="Instruction"
+const transferAmount = 0.01; // 0.01 SOL
+
+const transferInstruction = SystemProgram.transfer({
+  fromPubkey: sender.publicKey,
+  toPubkey: receiver.publicKey,
+  lamports: transferAmount * LAMPORTS_PER_SOL
+});
+```
+
+```ts !! title="Expanded Instruction"
+const transferAmount = 0.01; // 0.01 SOL
+
+// Instruction index for the System Program's transfer instruction
+const transferInstructionIndex = 2;
+
+// Create a buffer for the data to include in the instruction
+const instructionData = Buffer.alloc(4 + 8); // uint32 + uint64
+instructionData.writeUInt32LE(transferInstructionIndex, 0);
+instructionData.writeBigUInt64LE(BigInt(transferAmount * LAMPORTS_PER_SOL), 4);
+
+// Manually create a transfer instruction
+const transferInstruction = new TransactionInstruction({
+  keys: [
+    { pubkey: sender.publicKey, isSigner: true, isWritable: true }, // from account, is signer and is writable
+    { pubkey: receiver.publicKey, isSigner: false, isWritable: true } // to account, is not signer but is writable
+  ],
+  programId: SystemProgram.programId,
+  data: instructionData
+});
+```
+
+</CodeTabs>
+
+</Tab>
+
+<Tab value="Web3.js (legacy)">
 
 <CodeTabs>
 

--- a/apps/docs/content/docs/en/core/pda/pda-derivation.mdx
+++ b/apps/docs/content/docs/en/core/pda/pda-derivation.mdx
@@ -173,16 +173,25 @@ console.log(`PDA: ${pda}`);
 console.log(`Bump: ${bump}`);
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
 import { PublicKey } from "@solana/web3.js";
 
 const programAddress = new PublicKey("11111111111111111111111111111111");
 // !focus
 const seeds = [Buffer.from("helloWorld")];
-const [pda, bump] = await PublicKey.findProgramAddressSync(
-  seeds,
-  programAddress
-);
+const [pda, bump] = await PublicKey.findProgramAddress(seeds, programAddress);
+
+console.log(`PDA: ${pda}`);
+console.log(`Bump: ${bump}`);
+```
+
+```ts !! title="Web3.js (legacy)"
+import { PublicKey } from "@solana/web3.js";
+
+const programAddress = new PublicKey("11111111111111111111111111111111");
+// !focus
+const seeds = [Buffer.from("helloWorld")];
+const [pda, bump] = PublicKey.findProgramAddressSync(seeds, programAddress);
 
 console.log(`PDA: ${pda}`);
 console.log(`Bump: ${bump}`);
@@ -236,7 +245,23 @@ console.log(`PDA: ${pda}`);
 console.log(`Bump: ${bump}`);
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
+import { PublicKey } from "@solana/web3.js";
+
+const programAddress = new PublicKey("11111111111111111111111111111111");
+
+// !focus(1:3)
+const optionalSeedAddress = new PublicKey(
+  "B9Lf9z5BfNPT4d5KMeaBFx8x1G4CULZYR1jA2kmxRDka"
+);
+const seeds = [optionalSeedAddress.toBytes()];
+const [pda, bump] = await PublicKey.findProgramAddress(seeds, programAddress);
+
+console.log(`PDA: ${pda}`);
+console.log(`Bump: ${bump}`);
+```
+
+```ts !! title="Web3.js (legacy)"
 import { PublicKey } from "@solana/web3.js";
 
 const programAddress = new PublicKey("11111111111111111111111111111111");
@@ -246,10 +271,7 @@ const optionalSeedAddress = new PublicKey(
   "B9Lf9z5BfNPT4d5KMeaBFx8x1G4CULZYR1jA2kmxRDka"
 );
 const seeds = [optionalSeedAddress.toBuffer()];
-const [pda, bump] = await PublicKey.findProgramAddressSync(
-  seeds,
-  programAddress
-);
+const [pda, bump] = PublicKey.findProgramAddressSync(seeds, programAddress);
 
 console.log(`PDA: ${pda}`);
 console.log(`Bump: ${bump}`);
@@ -305,7 +327,23 @@ console.log(`PDA: ${pda}`);
 console.log(`Bump: ${bump}`);
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
+import { PublicKey } from "@solana/web3.js";
+
+const programAddress = new PublicKey("11111111111111111111111111111111");
+// !focus(1:4)
+const optionalSeedString = "helloWorld";
+const optionalSeedAddress = new PublicKey(
+  "B9Lf9z5BfNPT4d5KMeaBFx8x1G4CULZYR1jA2kmxRDka"
+);
+const seeds = [Buffer.from(optionalSeedString), optionalSeedAddress.toBytes()];
+const [pda, bump] = await PublicKey.findProgramAddress(seeds, programAddress);
+
+console.log(`PDA: ${pda}`);
+console.log(`Bump: ${bump}`);
+```
+
+```ts !! title="Web3.js (legacy)"
 import { PublicKey } from "@solana/web3.js";
 
 const programAddress = new PublicKey("11111111111111111111111111111111");
@@ -315,10 +353,7 @@ const optionalSeedAddress = new PublicKey(
   "B9Lf9z5BfNPT4d5KMeaBFx8x1G4CULZYR1jA2kmxRDka"
 );
 const seeds = [Buffer.from(optionalSeedString), optionalSeedAddress.toBuffer()];
-const [pda, bump] = await PublicKey.findProgramAddressSync(
-  seeds,
-  programAddress
-);
+const [pda, bump] = PublicKey.findProgramAddressSync(seeds, programAddress);
 
 console.log(`PDA: ${pda}`);
 console.log(`Bump: ${bump}`);
@@ -364,7 +399,27 @@ The following examples show PDA derivation using all possible bump seeds (255 to
 
 <CodeTabs storage="pda-examples" flags="r">
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
+import { PublicKey } from "@solana/web3.js";
+
+const programId = new PublicKey("11111111111111111111111111111111");
+const optionalSeed = "helloWorld";
+
+// Loop through all bump seeds (255 down to 0)
+for (let bump = 255; bump >= 0; bump--) {
+  try {
+    const PDA = await PublicKey.createProgramAddress(
+      [Buffer.from(optionalSeed), Buffer.from([bump])],
+      programId
+    );
+    console.log("bump " + bump + ": " + PDA);
+  } catch (error) {
+    console.log("bump " + bump + ": " + error);
+  }
+}
+```
+
+```ts !! title="Web3.js (legacy)"
 import { PublicKey } from "@solana/web3.js";
 
 const programId = new PublicKey("11111111111111111111111111111111");

--- a/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
+++ b/apps/docs/content/docs/en/core/transactions/transaction-structure.mdx
@@ -426,7 +426,67 @@ console.log(
 console.log("Transaction Signature:", transactionSignature.context.signature);
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
+import {
+  LAMPORTS_PER_SOL,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction,
+  Keypair,
+  Connection
+} from "@solana/web3.js";
+
+// Create a connection to cluster
+const connection = new Connection("http://localhost:8899", "confirmed");
+
+// Generate sender and recipient keypairs
+const sender = await Keypair.generate();
+const recipient = await Keypair.generate();
+
+// Fund sender with airdrop
+const airdropSignature = await connection.requestAirdrop(
+  sender.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction(airdropSignature, "confirmed");
+
+// Check balance before transfer
+const preBalance1 = await connection.getBalance(sender.publicKey);
+const preBalance2 = await connection.getBalance(recipient.publicKey);
+
+// Define the amount to transfer
+const transferAmount = 0.01; // 0.01 SOL
+
+// !mark(1:6)
+// Create a transfer instruction for transferring SOL from sender to recipient
+const transferInstruction = SystemProgram.transfer({
+  fromPubkey: sender.publicKey,
+  toPubkey: recipient.publicKey,
+  lamports: transferAmount * LAMPORTS_PER_SOL // Convert transferAmount to lamports
+});
+
+// Add the transfer instruction to a new transaction
+const transaction = new Transaction().add(transferInstruction);
+
+// Send the transaction to the network
+const transactionSignature = await sendAndConfirmTransaction(
+  connection,
+  transaction,
+  [sender] // signer
+);
+
+// Check balance after transfer
+const postBalance1 = await connection.getBalance(sender.publicKey);
+const postBalance2 = await connection.getBalance(recipient.publicKey);
+
+console.log("Sender prebalance:", preBalance1 / LAMPORTS_PER_SOL);
+console.log("Recipient prebalance:", preBalance2 / LAMPORTS_PER_SOL);
+console.log("Sender postbalance:", postBalance1 / LAMPORTS_PER_SOL);
+console.log("Recipient postbalance:", postBalance2 / LAMPORTS_PER_SOL);
+console.log("Transaction Signature:", transactionSignature);
+```
+
+```ts !! title="Web3.js (legacy)"
 import {
   LAMPORTS_PER_SOL,
   SystemProgram,
@@ -636,7 +696,45 @@ const compiledTransactionMessage =
 console.log(JSON.stringify(compiledTransactionMessage, null, 2));
 ```
 
-```ts !! title="Legacy"
+```ts !! title="Web3.js v3"
+import {
+  LAMPORTS_PER_SOL,
+  SystemProgram,
+  Transaction,
+  Keypair,
+  Connection
+} from "@solana/web3.js";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const { blockhash, lastValidBlockHeight } =
+  await connection.getLatestBlockhash();
+
+// Generate sender and recipient keypairs
+const sender = await Keypair.generate();
+const recipient = await Keypair.generate();
+
+// Define the amount to transfer
+const transferAmount = 0.01; // 0.01 SOL
+
+// Create a transfer instruction for transferring SOL from sender to recipient
+const transferInstruction = SystemProgram.transfer({
+  fromPubkey: sender.publicKey,
+  toPubkey: recipient.publicKey,
+  lamports: transferAmount * LAMPORTS_PER_SOL // Convert transferAmount to lamports
+});
+
+const transaction = new Transaction({
+  blockhash,
+  lastValidBlockHeight,
+  feePayer: sender.publicKey
+}).add(transferInstruction);
+await transaction.sign(sender);
+
+const compiledMessage = transaction.compileMessage();
+console.log(JSON.stringify(compiledMessage, null, 2));
+```
+
+```ts !! title="Web3.js (legacy)"
 import {
   LAMPORTS_PER_SOL,
   SystemProgram,
@@ -765,7 +863,7 @@ but notice that each instruction contains the same required information.
 }
 ```
 
-```json !! title="Legacy"
+```json !! title="Web3.js (legacy)"
 {
   // !mention header
   "header": {


### PR DESCRIPTION
## Problem

The core concept pages only offer Kit and web3.js v1 code tabs. web3.js v3 is a
separate, source-incompatible API (async `Keypair.generate`, async PDA
derivation, `Uint8Array`/`bigint` types), so readers on v3 have no working
snippet to copy. Several v1 blocks also `await` the synchronous
`PublicKey.findProgramAddressSync`, and the Kit tab in `instruction-structure`
still uses the removed `IInstruction` type name.

## Changes

- Added a `Web3.js v3` code tab before each web3.js v1 tab and renamed the v1
  tabs to `Web3.js (legacy)` on: `account-structure`, `account-types`,
  `instruction-structure`, `pda-derivation`, `transaction-structure`,
  `fee-structure`, `cpi-with-pda`, `cpi-without-pda`.
- v3 tabs apply `await Keypair.generate()`, `await PublicKey.findProgramAddress`
  / `createProgramAddress`, `.toBytes()` instead of `.toBuffer()`,
  `await transaction.sign()`, and drop the removed `PublicKey.unique()`.
- `instruction-structure`: outer tab list is now
  `['Kit', 'Web3.js v3', 'Web3.js (legacy)', 'Rust']`; Kit tab uses
  `Instruction` instead of `IInstruction`.
- Output blocks got a v3 variant only where the printed shape actually differs:
  instruction JSON (`data` is a `Uint8Array`, so it serializes as an object) and
  the `getAccountInfo` logs (`lamports`/`rentEpoch` are `bigint`, which
  `JSON.stringify` cannot serialize).
- `fee-structure`: the two `storage="compute-budget"` groups keep matching tab
  titles so tab-selection persistence still works.

Snippets were typechecked: every v3 code path in this PR was compiled in a
scratch project against `@solana/web3.js@rc` (3.0.0-rc.3) with `tsc --strict`,
exit 0. `pnpm --filter solana-docs lint` is green.

Skipped, with reasons:

- `core/pda/pda-accounts.mdx` and the Anchor test tabs in both CPI pages —
  `@coral-xyz/anchor` peer-depends on web3.js v1, so a v3 variant would not
  resolve.
- The `@solana/spl-token` mint block in `account-types.mdx` — `spl-token` does
  not run on v3; that port belongs to the token-page phase. Its tab was renamed
  only.
- `programs/idls.mdx` — out of scope for this PR.
- The source-link tables in `fee-structure` / `pda-derivation` are owned by the
  Phase 1 PR.

Note: the LiteSVM test tabs in the CPI pages are titled `Test (Web3.js v3)` /
`Test (Web3.js legacy)` rather than the bare convention, because their sibling
tabs are project files (`Example 1`, `Example 2`), not SDK alternatives.

Fixes DEV-1039
