### PR TITLE
docs(cookbook): describe transaction v1 in the present tense

### DIFF
--- a/apps/docs/content/cookbook/transactions/add-priority-fees.mdx
+++ b/apps/docs/content/cookbook/transactions/add-priority-fees.mdx
@@ -10,8 +10,8 @@ leader processes your transaction.
 To add a priority fee to a transaction, invoke instructions from the
 [Compute Budget Program](https://github.com/solana-program/compute-budget).
 
-> The upcoming
-> [v1 transaction format](/docs/core/transactions/versioned-transactions#v1-message-format)
+> The
+> [v1 transaction format](/docs/core/transactions/versioned-transactions#v1-format)
 > handles this differently: ComputeBudget instructions are ignored (they execute
 > as no-ops), and the priority fee is set directly in the message config as a
 > **total in lamports** rather than a price in micro-lamports per compute unit.

--- a/apps/docs/content/cookbook/transactions/lookup-tables.mdx
+++ b/apps/docs/content/cookbook/transactions/lookup-tables.mdx
@@ -15,8 +15,8 @@ address that is interacted with as part of the transaction, this listing would
 effectively be capped at 32 addresses per transaction. With the help of Address
 Lookup Tables, a transaction can raise that limit to 64 addresses.
 
-> Address Lookup Tables are supported by v0 transactions only. The upcoming
-> [v1 transaction format](/docs/core/transactions/versioned-transactions#v1-message-format)
+> Address Lookup Tables are supported by v0 transactions only. The
+> [v1 transaction format](/docs/core/transactions/versioned-transactions#v1-format)
 > does not support them — its 4,096-byte size limit fits up to 64 addresses
 > inline instead.
 

--- a/apps/docs/content/cookbook/transactions/optimize-compute.mdx
+++ b/apps/docs/content/cookbook/transactions/optimize-compute.mdx
@@ -6,8 +6,8 @@ Optimizing the Compute Requested on a transaction is important to ensure that
 the transaction is both processed in a timely manner as well as to avoid paying
 too much in priority fees.
 
-> In the upcoming
-> [v1 transaction format](/docs/core/transactions/versioned-transactions#v1-message-format),
+> In the
+> [v1 transaction format](/docs/core/transactions/versioned-transactions#v1-format),
 > the compute unit limit is set in the message config instead of a ComputeBudget
 > instruction — and an unset limit defaults to **zero**, not 200k per
 > instruction, so setting it explicitly becomes mandatory.

--- a/apps/docs/content/cookbook/transactions/versions.mdx
+++ b/apps/docs/content/cookbook/transactions/versions.mdx
@@ -22,10 +22,9 @@ The Solana runtime supports three transaction versions:
 - `legacy` - older transaction format with no additional benefit
 - `0` - added support for
   [Address Lookup Tables](/developers/cookbook/transactions/lookup-tables)
-- `1` - upcoming format that raises the size limit to 4,096 bytes, moves
-  resource limits into the message, and removes Address Lookup Tables. Not yet
-  active on any cluster; see
-  [versioned transactions](/docs/core/transactions/versioned-transactions#v1-message-format)
+- `1` - raises the size limit to 4,096 bytes, moves resource limits into the
+  message, and removes Address Lookup Tables. See
+  [versioned transactions](/docs/core/transactions/versioned-transactions#v1-format)
 
 ## Max supported transaction version
 
@@ -41,10 +40,9 @@ transaction is returned when `legacy` is selected)
 
 > WARNING: If no `maxSupportedTransactionVersion` value is set, then only
 > `legacy` transactions will be allowed in the RPC response. Therefore, your RPC
-> requests **WILL** fail if any version `0` transactions are returned. Once the
-> v1 format activates, the same applies one version up: requests that set `0`
-> will fail on version `1` transactions. Set the value to the integer `1` to be
-> ready.
+> requests **WILL** fail if any version `0` transactions are returned. The same
+> applies one version up: requests that set `0` fail on version `1`
+> transactions. Set the value to the integer `1`.
 
 ## How to set max supported version
 


### PR DESCRIPTION
Stack 3/4, on top of #2095.

- Drops the "upcoming" framing from the four cookbook transaction pages.
- Fixes the same dead `#v1-message-format` anchor → `#v1-format`.

Hold until v1 activates on mainnet.