### PR TITLE
[DO NOT MERGE] chore(content): mark the larger transaction sizes upgrade live

### DIFF
--- a/apps/media/content/upgrades/larger-transaction-sizes.mdx
+++ b/apps/media/content/upgrades/larger-transaction-sizes.mdx
@@ -1,21 +1,21 @@
 ---
 title: Larger Transaction Sizes
 description: >-
-  Solana raises the maximum transaction size from 1232 bytes to 4096 bytes at
-  the start of mainnet epoch 1035, expected September 15, 2026 at approximately
-  01:20 UTC. SIMD-0296 and the v1 transaction format unlock ZK proofs, large
-  multisigs, and onchain signature schemes in a single atomic transaction. v1 is
-  opt-in for sending but mandatory for reading transactions.
+  Solana has raised the maximum transaction size from 1232 bytes to 4096 bytes,
+  live on mainnet since the start of epoch 1035 on September 15, 2026.
+  SIMD-0296 and the v1 transaction format unlock ZK proofs, large multisigs, and
+  onchain signature schemes in a single atomic transaction. v1 is opt-in for
+  sending but mandatory for reading transactions.
 subtitle: Raising the maximum transaction size from 1232 to 4096 bytes
 publishedAt: 2026-06-09T00:00:00.000Z
 status: published
 author: solana-foundation
-stage: pending_activation
+stage: live
 release: agave-4-2
 order: 3
 metrics:
   - value: Epoch 1035
-    label: Mainnet activation, Sept 15 @ 01:20 UTC
+    label: Live on mainnet since Sept 15, 2026
   - value: "4096"
     label: Bytes per transaction, up from 1232
   - value: 3.3x
@@ -28,10 +28,10 @@ tags:
 
 **Updated September 2026** • Solana Foundation
 
-A major upcoming upgrade to Solana raises the maximum transaction size from 1232
-bytes to 4096 bytes. The feature has been activated on Testnet and Devnet and
-will be activated on Mainnet at the **start of mainnet epoch 1035**,
-expected on **September 15, 2026 at approximately 01:20 UTC**. The size
+A major upgrade to Solana raises the maximum transaction size from 1232 bytes to
+4096 bytes. The feature is active on Mainnet, Testnet, and Devnet; it activated
+on Mainnet at the **start of epoch 1035** on
+**September 15, 2026 at approximately 01:20 UTC**. The size
 increase is defined in
 [SIMD-0296](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0296-larger-transactions.md)
 and delivered through the v1 transaction format introduced in
@@ -39,10 +39,10 @@ and delivered through the v1 transaction format introduced in
 It unlocks workloads that previously could not fit inside a single transaction,
 including ZK proofs, large multisigs, and some onchain signature schemes.
 
-The existing `v0` and `legacy` transaction formats continue to work as they do
-today, so applications and wallets that don't need the larger size will be
-unaffected. Applications that want to take advantage of it will need to update
-to `v1` transactions.
+The existing `v0` and `legacy` transaction formats continue to work as they
+always have, so applications and wallets that don't need the larger size are
+unaffected. Applications that want to take advantage of it need to update to
+`v1` transactions.
 
 **Breaking Changes:**
 
@@ -55,16 +55,16 @@ to `v1` transactions.
 
 ## Mainnet Activation: Epoch 1035
 
-The `txv1` feature gate activates at the **start of mainnet epoch 1035**,
-expected on **September 15, 2026 at approximately 01:20 UTC**.
+The `txv1` feature gate activated at the **start of mainnet epoch 1035**, on
+**September 15, 2026 at approximately 01:20 UTC**.
 
-|                                  |                                                             |
-| -------------------------------- | ----------------------------------------------------------- |
-| Expected Mainnet Activation Date | Start of epoch 1035 — September 15, 2026, approx. 01:20 UTC |
-| Devnet Activation                | Live                                                        |
-| Breaking Change?                 | Yes, for reading, indexing, and sponsoring transactions     |
-| Indexing Changes Required?       | Yes, read limits from `transactionConfig`                   |
-| Feature Gate                     | `txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL`               |
+|                               |                                                         |
+| ----------------------------- | ------------------------------------------------------- |
+| Mainnet Activation            | Live since the start of epoch 1035 — September 15, 2026 |
+| Devnet and Testnet Activation | Live                                                    |
+| Breaking Change?              | Yes, for reading, indexing, and sponsoring transactions |
+| Indexing Changes Required?    | Yes, read limits from `transactionConfig`               |
+| Feature Gate                  | `txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL`           |
 
 Current feature gate activation status:
 
@@ -77,10 +77,9 @@ you can do so with the Solana CLI (use `-u d` or `-u t` for devnet or testnet):
 solana -u m feature status txv1aq4pp281K9um3tnPgkfX8UqtFT6wcVW3hNezGLL
 ```
 
-You can test v1 transactions today, ahead of epoch 1035. They are
-enabled on:
+You can also test v1 transactions off mainnet. They are enabled on:
 
-- **Devnet**, where the feature gate is already active
+- **Devnet** and **Testnet**, where the feature gate is active
 - Local test validator in the [Solana CLI](https://solana.com/docs/intro/installation)
   (v4.2+)
 - [Surfpool](https://www.surfpool.run/) (v1.5+)
@@ -108,8 +107,8 @@ These are the first releases that handle v1 transactions. Upgrade your dependenc
 <AudienceGroup>
 <Audience title="For Users" summary="Update your wallets.">
 
-Wallets and applications keep working exactly as they do today. The `legacy` and
-`v0` transaction formats are unchanged, and nothing about how you approve, sign,
+Wallets and applications keep working exactly as they always have. The `legacy`
+and `v0` transaction formats are unchanged, and nothing about how you approve, sign,
 or send a transaction changes. To benefit from Dapps use of v1 transactions, you
 will want to make sure your wallets are up to date.
 
@@ -181,14 +180,13 @@ Sample code is available [here](https://github.com/solana-foundation/transaction
 
 </Audience>
 
-<Audience title="For Validator and RPC Operators" summary="Jito-Solana and RPC operators both need v4.2.2 before epoch 1035.">
+<Audience title="For Validator and RPC Operators" summary="Jito-Solana and RPC operators both need v4.2.2.">
 
 All v4.2.x validators support larger transactions at the consensus layer;
-however, there are two classes of nodes that need a specific release before
-epoch 1035.
+however, there are two classes of nodes that need a specific release.
 
 **Jito-Solana validators — v4.2.2 or later.** Earlier releases do not support v1
-transactions. This means a leader running an older jito-solana build will not
+transactions. This means a leader running an older jito-solana build does not
 build v1 transactions into its blocks. All jito-solana operators should upgrade
 to [v4.2.2](https://github.com/jito-foundation/jito-solana/releases/tag/v4.2.2-jito).
 
@@ -207,7 +205,7 @@ their node to [Agave v4.2.2](https://github.com/anza-xyz/agave/releases/tag/v4.2
 **[GitHub: Transaction V1 Example Code](https://github.com/solana-foundation/transaction-v1-examples)** has a runnable example in each of these languages — sending, decoding, reading blocks, and indexing over gRPC — against a local validator, plus a version matrix recording the first release of every dependency that handles v1, including the ones that drop the config silently rather than erroring. Details for all breaking changes are included below:
 
 <AudienceGroup>
-<Audience title="For Transaction Readers" summary="Opt in to v1 transactions before they appear onchain.">
+<Audience title="For Transaction Readers" summary="Opt in to v1 transactions — they are onchain now.">
 
 ### Breaking Change: Reading Transactions and Blocks
 
@@ -598,9 +596,8 @@ and one single confirmation rather than several chained transactions.
 
 This upgrade addresses a practical ceiling that application teams have had to
 design around since the early days of Solana, and brings a whole new class of
-capabilities that we're looking forward to support. It goes live on mainnet at
-the start of epoch 1035, expected on September 15, 2026 at approximately
-01:20 UTC.
+capabilities that we're looking forward to support. It has been live on mainnet
+since the start of epoch 1035, on September 15, 2026.
 
 The format details are specified in
 [SIMD-0385](https://github.com/solana-foundation/solana-improvement-documents/blob/main/proposals/0385-transaction-v1.md)


### PR DESCRIPTION
Stack 4/4, on top of #2096.

- Moves the upgrade page to `stage: live` and rewrites the activation framing, metrics label, and operator guidance now that the `txv1` gate has activated.

Note: the page hardcodes Sept 15 @ 01:20 UTC for epoch 1035 — needs a touch-up if that slips. Hold until v1 activates on mainnet.