### PR TITLE
docs(tokens): add Web3.js v3 sections to token basics (DEV-1041)

### DIFF
--- a/apps/docs/content/docs/en/tokens/basics/approve-delegate.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/approve-delegate.mdx
@@ -45,8 +45,10 @@ The token account owner signs the approval.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -199,7 +201,122 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getApproveCheckedInstruction,
+  getCreateMintInstructionPlan,
+  getMintToATAInstructionPlanAsync,
+  getTokenDecoder,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:57) collapsed
+// Setup: create a mint and fund the payer's ATA before approving a delegate.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const delegate = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer,
+        newMint: mint,
+        decimals: 2,
+        mintAuthority: feePayer.publicKey.toBase58(),
+        freezeAuthority: feePayer.publicKey.toBase58()
+      }
+    ),
+    await getMintToATAInstructionPlanAsync({
+      payer: feePayer,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58(),
+      mintAuthority: feePayer,
+      amount: 100,
+      decimals: 2
+    })
+  ),
+  [feePayer, mint]
+);
+
+const [associatedTokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+const approveBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: approveBlockhash.blockhash,
+    lastValidBlockHeight: approveBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:8)
+    getApproveCheckedInstruction({
+      source: associatedTokenAccount, // Token account whose delegate approval changes.
+      mint: mint.publicKey.toBase58(), // Mint for the token the delegate may spend.
+      delegate: delegate.publicKey.toBase58(), // Delegate allowed to spend from the token account.
+      owner: feePayer, // Owner approving this delegate change.
+      amount: 25, // Token amount in base units.
+      decimals: 2 // Decimals defined on the mint account.
+    })
+  ),
+  [feePayer]
+);
+
+const tokenAccountInfo = await connection.getAccountInfo(
+  new PublicKey(associatedTokenAccount)
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nAssociated Token Account Address:", associatedTokenAccount);
+console.log("Associated Token Account:", tokenAccountData);
+console.log("\nDelegate Address:", delegate.publicKey.toBase58());
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/burn-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/burn-tokens.mdx
@@ -47,8 +47,10 @@ if the mint has the permanent delegate extension enabled.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -200,7 +202,123 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getBurnCheckedInstruction,
+  getCreateMintInstructionPlan,
+  getMintDecoder,
+  getMintToATAInstructionPlanAsync,
+  getTokenDecoder,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:56) collapsed
+// Setup: create a mint and fund the payer's ATA before burning tokens.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer,
+        newMint: mint,
+        decimals: 2,
+        mintAuthority: feePayer.publicKey.toBase58(),
+        freezeAuthority: feePayer.publicKey.toBase58()
+      }
+    ),
+    await getMintToATAInstructionPlanAsync({
+      payer: feePayer,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58(),
+      mintAuthority: feePayer,
+      amount: 100,
+      decimals: 2
+    })
+  ),
+  [feePayer, mint]
+);
+
+const [associatedTokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+const burnBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: burnBlockhash.blockhash,
+    lastValidBlockHeight: burnBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:7)
+    getBurnCheckedInstruction({
+      account: associatedTokenAccount, // Token account holding the tokens to burn.
+      mint: mint.publicKey.toBase58(), // Mint for the token being burned.
+      authority: feePayer, // Owner or delegate approving the burn.
+      amount: 25, // Token amount in base units.
+      decimals: 2 // Decimals defined on the mint account.
+    })
+  ),
+  [feePayer]
+);
+
+const mintAccountInfo = await connection.getAccountInfo(mint.publicKey);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+const tokenAccountInfo = await connection.getAccountInfo(
+  new PublicKey(associatedTokenAccount)
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Mint Account:", mintAccount);
+console.log("\nAssociated Token Account Address:", associatedTokenAccount);
+console.log("Associated Token Account:", tokenAccountData);
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/close-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/close-account.mdx
@@ -44,8 +44,10 @@ extensions, but the base close flow is the same.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -189,7 +191,115 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getCloseAccountInstruction,
+  getCreateAssociatedTokenIdempotentInstructionAsync,
+  getCreateMintInstructionPlan,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:54) collapsed
+// Setup: create a mint and the payer's ATA before closing the token account.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer,
+        newMint: mint,
+        decimals: 2,
+        mintAuthority: feePayer.publicKey.toBase58(),
+        freezeAuthority: feePayer.publicKey.toBase58()
+      }
+    ),
+    await getCreateAssociatedTokenIdempotentInstructionAsync({
+      payer: feePayer,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58()
+    })
+  ),
+  [feePayer, mint]
+);
+
+const [associatedTokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+const destination = feePayer.publicKey;
+const closeBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: closeBlockhash.blockhash,
+    lastValidBlockHeight: closeBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:5)
+    getCloseAccountInstruction({
+      account: associatedTokenAccount, // Token account to close.
+      destination: destination.toBase58(), // Account receiving the reclaimed SOL.
+      owner: feePayer // Owner approving the account closure.
+    })
+  ),
+  [feePayer]
+);
+
+const tokenAccountData = await connection.getAccountInfo(
+  new PublicKey(associatedTokenAccount),
+  "confirmed"
+);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nAssociated Token Account Address:", associatedTokenAccount);
+console.log("Associated Token Account:", tokenAccountData);
+console.log("\nDestination Address:", destination.toBase58());
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/create-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/create-mint.mdx
@@ -81,8 +81,10 @@ the mint account data.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -222,7 +224,149 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Helper Function"
+import {
+  Connection,
+  Keypair,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  getCreateMintInstructionPlan,
+  getMintDecoder
+} from "@solana-program/token";
+
+// !collapse(1:17) collapsed
+// Setup: create and fund the fee payer before creating the mint.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:13)
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer, // Account funding account creation.
+        newMint: mint, // New mint account to create.
+        decimals: 9, // Decimals to define on the mint account.
+        mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+        freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+      }
+    )
+  ),
+  [feePayer, mint]
+);
+
+const mintAccountInfo = await connection.getAccountInfo(mint.publicKey);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Mint Account:", mintAccount);
+console.log("\nTransaction Signature:", result);
+```
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  getInitializeMint2Instruction,
+  getMintDecoder,
+  getMintSize,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:19) collapsed
+// Setup: create and fund the fee payer before creating the mint.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+const space = getMintSize();
+const mintRent = await connection.getMinimumBalanceForRentExemption(space);
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:13)
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey, // Account funding account creation.
+      newAccountPubkey: mint.publicKey, // New mint account to create.
+      space, // Account size in bytes.
+      lamports: mintRent, // Lamports funding the new account rent.
+      programId: new PublicKey(TOKEN_PROGRAM_ADDRESS) // Program that owns the new account.
+    }),
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(), // Mint account to initialize.
+      decimals: 9, // Decimals to define on the mint account.
+      mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+      freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+    })
+  ),
+  [feePayer, mint]
+);
+
+const mintAccountInfo = await connection.getAccountInfo(mint.publicKey);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Mint Account:", mintAccount);
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/create-token-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/create-token-account.mdx
@@ -158,8 +158,10 @@ Program.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -301,7 +303,208 @@ console.log("\nTransaction Signature:", result.context.signature);
 ```
 
 </CodeTabs>
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Helper Function"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstructionAsync,
+  getCreateMintInstructionPlan,
+  getTokenDecoder,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:43) collapsed
+// Setup: create a mint before creating the associated token account.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer,
+        newMint: mint,
+        decimals: 2,
+        mintAuthority: feePayer.publicKey.toBase58(),
+        freezeAuthority: feePayer.publicKey.toBase58()
+      }
+    )
+  ),
+  [feePayer, mint]
+);
+
+const createBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: createBlockhash.blockhash,
+    lastValidBlockHeight: createBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:5)
+    await getCreateAssociatedTokenIdempotentInstructionAsync({
+      payer: feePayer, // Account funding account creation.
+      owner: feePayer.publicKey.toBase58(), // Account that owns the token account.
+      mint: mint.publicKey.toBase58() // Mint for the token this account holds.
+    })
+  ),
+  [feePayer]
+);
+
+const [associatedTokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+
+const tokenAccountInfo = await connection.getAccountInfo(
+  new PublicKey(associatedTokenAccount)
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nAssociated Token Account Address:", associatedTokenAccount);
+console.log("Associated Token Account:", tokenAccountData);
+console.log("\nTransaction Signature:", result);
+```
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstruction,
+  getInitializeMint2Instruction,
+  getMintSize,
+  getTokenDecoder,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:49) collapsed
+// Setup: create a mint before creating the associated token account.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+const space = getMintSize();
+const mintRent = await connection.getMinimumBalanceForRentExemption(space);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey,
+      newAccountPubkey: mint.publicKey,
+      space,
+      lamports: mintRent,
+      programId: new PublicKey(TOKEN_PROGRAM_ADDRESS)
+    }),
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(),
+      decimals: 2,
+      mintAuthority: feePayer.publicKey.toBase58(),
+      freezeAuthority: feePayer.publicKey.toBase58()
+    })
+  ),
+  [feePayer, mint]
+);
+
+const [associatedTokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:6)
+    getCreateAssociatedTokenInstruction({
+      payer: feePayer, // Account funding account creation.
+      ata: associatedTokenAccount, // Associated token account to create.
+      owner: feePayer.publicKey.toBase58(), // Account that owns the token account.
+      mint: mint.publicKey.toBase58() // Mint for the token this account holds.
+    })
+  ),
+  [feePayer]
+);
+
+const tokenAccountInfo = await connection.getAccountInfo(
+  new PublicKey(associatedTokenAccount)
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nAssociated Token Account Address:", associatedTokenAccount);
+console.log("Associated Token Account:", tokenAccountData);
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 
@@ -713,8 +916,10 @@ is not already initialized and is rent-exempt.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -870,7 +1075,117 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  getInitializeAccountInstruction,
+  getInitializeMint2Instruction,
+  getMintSize,
+  getTokenDecoder,
+  getTokenSize,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:48) collapsed
+// Setup: create a mint before creating the token account.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+const mintSpace = getMintSize();
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintSpace);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey,
+      newAccountPubkey: mint.publicKey,
+      space: mintSpace,
+      lamports: mintRent,
+      programId: new PublicKey(TOKEN_PROGRAM_ADDRESS)
+    }),
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(),
+      decimals: 2,
+      mintAuthority: feePayer.publicKey.toBase58(),
+      freezeAuthority: feePayer.publicKey.toBase58()
+    })
+  ),
+  [feePayer, mint]
+);
+
+const tokenAccount = await Keypair.generate();
+const tokenAccountSpace = getTokenSize();
+const tokenAccountRent =
+  await connection.getMinimumBalanceForRentExemption(tokenAccountSpace);
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:12)
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey, // Account funding account creation.
+      newAccountPubkey: tokenAccount.publicKey, // New token account to create.
+      space: tokenAccountSpace, // Account size in bytes.
+      lamports: tokenAccountRent, // Lamports funding the new account rent.
+      programId: new PublicKey(TOKEN_PROGRAM_ADDRESS) // Program that owns the new account.
+    }),
+    getInitializeAccountInstruction({
+      account: tokenAccount.publicKey.toBase58(), // Token account to initialize.
+      mint: mint.publicKey.toBase58(), // Mint for the token this account holds.
+      owner: feePayer.publicKey.toBase58() // Account that owns the token account.
+    })
+  ),
+  [feePayer, tokenAccount]
+);
+
+const tokenAccountInfo = await connection.getAccountInfo(
+  tokenAccount.publicKey
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nToken Account Address:", tokenAccount.publicKey.toBase58());
+console.log("Token Account:", tokenAccountData);
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/freeze-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/freeze-account.mdx
@@ -50,8 +50,10 @@ freezing.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -194,7 +196,117 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getCreateMintInstructionPlan,
+  getFreezeAccountInstruction,
+  getMintToATAInstructionPlanAsync,
+  getTokenDecoder,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:56) collapsed
+// Setup: create a mint and fund the payer's ATA before freezing it.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer,
+        newMint: mint,
+        decimals: 2,
+        mintAuthority: feePayer.publicKey.toBase58(),
+        freezeAuthority: feePayer.publicKey.toBase58()
+      }
+    ),
+    await getMintToATAInstructionPlanAsync({
+      payer: feePayer,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58(),
+      mintAuthority: feePayer,
+      amount: 100,
+      decimals: 2
+    })
+  ),
+  [feePayer, mint]
+);
+
+const [associatedTokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+const freezeBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: freezeBlockhash.blockhash,
+    lastValidBlockHeight: freezeBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:5)
+    getFreezeAccountInstruction({
+      account: associatedTokenAccount, // Token account to freeze.
+      mint: mint.publicKey.toBase58(), // Mint for the token account being frozen.
+      owner: feePayer // Freeze authority approving this change.
+    })
+  ),
+  [feePayer]
+);
+
+const tokenAccountInfo = await connection.getAccountInfo(
+  new PublicKey(associatedTokenAccount)
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nAssociated Token Account Address:", associatedTokenAccount);
+console.log("Associated Token Account:", tokenAccountData);
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/mint-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/mint-tokens.mdx
@@ -44,8 +44,10 @@ The [native mint](/docs/tokens/basics/sync-native) does not support minting.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -253,7 +255,228 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Helper Function"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getCreateMintInstructionPlan,
+  getMintDecoder,
+  getMintToATAInstructionPlanAsync,
+  getTokenDecoder,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:43) collapsed
+// Setup: create a mint before minting tokens.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer,
+        newMint: mint,
+        decimals: 2,
+        mintAuthority: feePayer.publicKey.toBase58(),
+        freezeAuthority: feePayer.publicKey.toBase58()
+      }
+    )
+  ),
+  [feePayer, mint]
+);
+
+const mintBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: mintBlockhash.blockhash,
+    lastValidBlockHeight: mintBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:8)
+    await getMintToATAInstructionPlanAsync({
+      payer: feePayer, // Account paying transaction fees and account creation.
+      owner: feePayer.publicKey.toBase58(), // Wallet owning the token account.
+      mint: mint.publicKey.toBase58(), // Mint for the token being minted.
+      mintAuthority: feePayer, // Authority allowed to mint new tokens.
+      amount: 100, // Token amount in base units.
+      decimals: 2 // Decimals defined on the mint account.
+    })
+  ),
+  [feePayer]
+);
+
+const [associatedTokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+
+const mintAccountInfo = await connection.getAccountInfo(mint.publicKey);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+const tokenAccountInfo = await connection.getAccountInfo(
+  new PublicKey(associatedTokenAccount)
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Mint Account:", mintAccount);
+console.log("\nAssociated Token Account Address:", associatedTokenAccount);
+console.log("Associated Token Account:", tokenAccountData);
+console.log("\nTransaction Signature:", result);
+```
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getInitializeMint2Instruction,
+  getMintDecoder,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getTokenDecoder,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:56) collapsed
+// Setup: create a mint and the payer's ATA before minting tokens.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+const space = getMintSize();
+const mintRent = await connection.getMinimumBalanceForRentExemption(space);
+const [associatedTokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey,
+      newAccountPubkey: mint.publicKey,
+      space,
+      lamports: mintRent,
+      programId: new PublicKey(TOKEN_PROGRAM_ADDRESS)
+    }),
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(),
+      decimals: 2,
+      mintAuthority: feePayer.publicKey.toBase58(),
+      freezeAuthority: feePayer.publicKey.toBase58()
+    }),
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer: feePayer,
+      ata: associatedTokenAccount,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58()
+    })
+  ),
+  [feePayer, mint]
+);
+
+const mintBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: mintBlockhash.blockhash,
+    lastValidBlockHeight: mintBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:7)
+    getMintToCheckedInstruction({
+      mint: mint.publicKey.toBase58(), // Mint for the token being minted.
+      token: associatedTokenAccount, // Token account receiving the minted tokens.
+      mintAuthority: feePayer, // Authority allowed to mint new tokens.
+      amount: 100, // Token amount in base units.
+      decimals: 2 // Decimals defined on the mint account.
+    })
+  ),
+  [feePayer]
+);
+
+const mintAccountInfo = await connection.getAccountInfo(mint.publicKey);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+const tokenAccountInfo = await connection.getAccountInfo(
+  new PublicKey(associatedTokenAccount)
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Mint Account:", mintAccount);
+console.log("\nAssociated Token Account Address:", associatedTokenAccount);
+console.log("Associated Token Account:", tokenAccountData);
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/revoke-delegate.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/revoke-delegate.mdx
@@ -41,8 +41,10 @@ delegation.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -204,7 +206,140 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getApproveCheckedInstruction,
+  getCreateMintInstructionPlan,
+  getMintToATAInstructionPlanAsync,
+  getRevokeInstruction,
+  getTokenDecoder,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:78) collapsed
+// Setup: create a mint, fund the payer's ATA, and approve a delegate first.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const delegate = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer,
+        newMint: mint,
+        decimals: 2,
+        mintAuthority: feePayer.publicKey.toBase58(),
+        freezeAuthority: feePayer.publicKey.toBase58()
+      }
+    ),
+    await getMintToATAInstructionPlanAsync({
+      payer: feePayer,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58(),
+      mintAuthority: feePayer,
+      amount: 100,
+      decimals: 2
+    })
+  ),
+  [feePayer, mint]
+);
+
+const [associatedTokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+const approveBlockhash = await connection.getLatestBlockhash();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: approveBlockhash.blockhash,
+    lastValidBlockHeight: approveBlockhash.lastValidBlockHeight
+  }).add(
+    getApproveCheckedInstruction({
+      source: associatedTokenAccount,
+      mint: mint.publicKey.toBase58(),
+      delegate: delegate.publicKey.toBase58(),
+      owner: feePayer,
+      amount: 25,
+      decimals: 2
+    })
+  ),
+  [feePayer]
+);
+
+const revokeBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: revokeBlockhash.blockhash,
+    lastValidBlockHeight: revokeBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:4)
+    getRevokeInstruction({
+      source: associatedTokenAccount, // Token account whose delegate approval changes.
+      owner: feePayer // Owner approving this delegate change.
+    })
+  ),
+  [feePayer]
+);
+
+const tokenAccountInfo = await connection.getAccountInfo(
+  new PublicKey(associatedTokenAccount)
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nAssociated Token Account Address:", associatedTokenAccount);
+console.log("Associated Token Account:", tokenAccountData);
+console.log("\nDelegate Address:", delegate.publicKey.toBase58());
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/set-authority.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/set-authority.mdx
@@ -48,8 +48,10 @@ _rs`None`_ to revoke the selected authority permanently.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -175,7 +177,107 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  AuthorityType,
+  getCreateMintInstructionPlan,
+  getMintDecoder,
+  getSetAuthorityInstruction
+} from "@solana-program/token";
+
+// !collapse(1:44) collapsed
+// Setup: create a mint before changing its authorities.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const newAuthority = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer,
+        newMint: mint,
+        decimals: 2,
+        mintAuthority: feePayer.publicKey.toBase58(),
+        freezeAuthority: feePayer.publicKey.toBase58()
+      }
+    )
+  ),
+  [feePayer, mint]
+);
+
+const authorityBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: authorityBlockhash.blockhash,
+    lastValidBlockHeight: authorityBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:12)
+    getSetAuthorityInstruction({
+      owned: mint.publicKey.toBase58(), // Mint whose authority changes.
+      owner: feePayer, // Current authority approving this change.
+      authorityType: AuthorityType.MintTokens, // Authority role to update on the mint.
+      newAuthority: newAuthority.publicKey.toBase58() // New authority to assign to this role.
+    }),
+    getSetAuthorityInstruction({
+      owned: mint.publicKey.toBase58(), // Mint whose authority changes.
+      owner: feePayer, // Current authority approving this change.
+      authorityType: AuthorityType.FreezeAccount, // Authority role to update on the mint.
+      newAuthority: newAuthority.publicKey.toBase58() // New authority to assign to this role.
+    })
+  ),
+  [feePayer]
+);
+
+const mintAccountInfo = await connection.getAccountInfo(mint.publicKey);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Mint Account:", mintAccount);
+console.log("\nNew Authority Address:", newAuthority.publicKey.toBase58());
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/sync-native.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/sync-native.mdx
@@ -49,8 +49,10 @@ rent-exempt reserve.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -183,7 +185,105 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstructionAsync,
+  getSyncNativeInstruction,
+  getTokenDecoder,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+const NATIVE_MINT = new PublicKey(
+  "So11111111111111111111111111111111111111112"
+).toBase58();
+
+// !collapse(1:38) collapsed
+// Setup: create a WSOL ATA before wrapping and syncing SOL.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  2 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateAssociatedTokenIdempotentInstructionAsync({
+      payer: feePayer,
+      owner: feePayer.publicKey.toBase58(),
+      mint: NATIVE_MINT
+    })
+  ),
+  [feePayer]
+);
+
+const [associatedTokenAccount] = await findAssociatedTokenPda({
+  mint: NATIVE_MINT,
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+const syncBlockhash = await connection.getLatestBlockhash();
+
+// !mark(1:18)
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: syncBlockhash.blockhash,
+    lastValidBlockHeight: syncBlockhash.lastValidBlockHeight
+  }).add(
+    SystemProgram.transfer({
+      fromPubkey: feePayer.publicKey, // Account sending the SOL to wrap.
+      toPubkey: new PublicKey(associatedTokenAccount), // WSOL token account receiving the SOL.
+      lamports: 1_000_000 // SOL amount in lamports.
+    }),
+    getSyncNativeInstruction({
+      account: associatedTokenAccount // WSOL token account to synchronize.
+    })
+  ),
+  [feePayer]
+);
+
+const tokenAccountInfo = await connection.getAccountInfo(
+  new PublicKey(associatedTokenAccount)
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("WSOL Token Account Address:", associatedTokenAccount);
+console.log("WSOL Token Account:", tokenAccountData);
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/thaw-account.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/thaw-account.mdx
@@ -42,8 +42,10 @@ account state from frozen back to initialized.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -197,7 +199,136 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getCreateMintInstructionPlan,
+  getFreezeAccountInstruction,
+  getMintToATAInstructionPlanAsync,
+  getThawAccountInstruction,
+  getTokenDecoder,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:74) collapsed
+// Setup: create a mint, fund the payer's ATA, and freeze the token account first.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer,
+        newMint: mint,
+        decimals: 2,
+        mintAuthority: feePayer.publicKey.toBase58(),
+        freezeAuthority: feePayer.publicKey.toBase58()
+      }
+    ),
+    await getMintToATAInstructionPlanAsync({
+      payer: feePayer,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58(),
+      mintAuthority: feePayer,
+      amount: 100,
+      decimals: 2
+    })
+  ),
+  [feePayer, mint]
+);
+
+const [tokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+const freezeBlockhash = await connection.getLatestBlockhash();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: freezeBlockhash.blockhash,
+    lastValidBlockHeight: freezeBlockhash.lastValidBlockHeight
+  }).add(
+    getFreezeAccountInstruction({
+      account: tokenAccount,
+      mint: mint.publicKey.toBase58(),
+      owner: feePayer
+    })
+  ),
+  [feePayer]
+);
+
+const thawBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: thawBlockhash.blockhash,
+    lastValidBlockHeight: thawBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:5)
+    getThawAccountInstruction({
+      account: tokenAccount, // Token account to thaw.
+      mint: mint.publicKey.toBase58(), // Mint for the token account being thawed.
+      owner: feePayer // Freeze authority approving this change.
+    })
+  ),
+  [feePayer]
+);
+
+const tokenAccountInfo = await connection.getAccountInfo(
+  new PublicKey(tokenAccount)
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nToken Account Address:", tokenAccount);
+console.log("Token Account:", tokenAccountData);
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/basics/transfer-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/basics/transfer-tokens.mdx
@@ -50,8 +50,10 @@ transfer if the mint has the permanent delegate extension enabled.
 
 ### Typescript
 
-The `Kit` examples below show the recommended approach using `@solana/kit`.
-Legacy examples using `@solana/web3.js` are included for reference.
+The `Kit` examples show the recommended approach. `Web3.js v3` examples use the
+class-based `@solana/web3.js` v3 API with `@solana-program` instruction
+builders; `Web3.js (legacy)` examples use `@solana/web3.js` v1 with
+`@solana/spl-token`.
 
 #### Kit
 
@@ -316,7 +318,272 @@ console.log("\nTransaction Signature:", result.context.signature);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Helper Function"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getCreateMintInstructionPlan,
+  getMintToATAInstructionPlanAsync,
+  getTokenDecoder,
+  getTransferToATAInstructionPlanAsync,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:52) collapsed
+// Setup: create a mint and fund the payer's ATA before transferring tokens.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const recipient = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    await getCreateMintInstructionPlan(
+      {
+        getMinimumBalance: (space: number) =>
+          connection.getMinimumBalanceForRentExemption(space)
+      },
+      {
+        payer: feePayer,
+        newMint: mint,
+        decimals: 2,
+        mintAuthority: feePayer.publicKey.toBase58(),
+        freezeAuthority: feePayer.publicKey.toBase58()
+      }
+    ),
+    await getMintToATAInstructionPlanAsync({
+      payer: feePayer,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58(),
+      mintAuthority: feePayer,
+      amount: 100,
+      decimals: 2
+    })
+  ),
+  [feePayer, mint]
+);
+
+const transferBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: transferBlockhash.blockhash,
+    lastValidBlockHeight: transferBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:8)
+    await getTransferToATAInstructionPlanAsync({
+      payer: feePayer, // Account paying transaction fees and account creation.
+      mint: mint.publicKey.toBase58(), // Mint for the token being transferred.
+      authority: feePayer, // Owner or delegate approving the transfer.
+      recipient: recipient.publicKey.toBase58(), // Wallet receiving the tokens.
+      amount: 25, // Token amount in base units.
+      decimals: 2 // Decimals defined on the mint account.
+    })
+  ),
+  [feePayer]
+);
+
+const [feePayerATA] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+const [recipientATA] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: recipient.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+
+const senderAccountInfo = await connection.getAccountInfo(
+  new PublicKey(feePayerATA)
+);
+const senderTokenAccount = getTokenDecoder().decode(senderAccountInfo!.data);
+const recipientAccountInfo = await connection.getAccountInfo(
+  new PublicKey(recipientATA)
+);
+const recipientTokenAccount = getTokenDecoder().decode(
+  recipientAccountInfo!.data
+);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nSource Token Account Address:", feePayerATA);
+console.log("Source Token Account:", senderTokenAccount);
+console.log("\nDestination Token Account Address:", recipientATA);
+console.log("Destination Token Account:", recipientTokenAccount);
+console.log("\nTransaction Signature:", result);
+```
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getInitializeMint2Instruction,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getTokenDecoder,
+  getTransferCheckedInstruction,
+  TOKEN_PROGRAM_ADDRESS
+} from "@solana-program/token";
+
+// !collapse(1:75) collapsed
+// Setup: create a mint, fund the payer's ATA, and create the recipient's ATA.
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const recipient = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+const space = getMintSize();
+const mintRent = await connection.getMinimumBalanceForRentExemption(space);
+const [feePayerATA] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+const [recipientATA] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: recipient.publicKey.toBase58(),
+  tokenProgram: TOKEN_PROGRAM_ADDRESS
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey,
+      newAccountPubkey: mint.publicKey,
+      space,
+      lamports: mintRent,
+      programId: new PublicKey(TOKEN_PROGRAM_ADDRESS)
+    }),
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(),
+      decimals: 2,
+      mintAuthority: feePayer.publicKey.toBase58(),
+      freezeAuthority: feePayer.publicKey.toBase58()
+    }),
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer: feePayer,
+      ata: feePayerATA,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58()
+    }),
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer: feePayer,
+      ata: recipientATA,
+      owner: recipient.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58()
+    }),
+    getMintToCheckedInstruction({
+      mint: mint.publicKey.toBase58(),
+      token: feePayerATA,
+      mintAuthority: feePayer,
+      amount: 100,
+      decimals: 2
+    })
+  ),
+  [feePayer, mint]
+);
+
+const transferBlockhash = await connection.getLatestBlockhash();
+
+const result = await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: transferBlockhash.blockhash,
+    lastValidBlockHeight: transferBlockhash.lastValidBlockHeight
+  }).add(
+    // !mark(1:8)
+    getTransferCheckedInstruction({
+      source: feePayerATA, // Token account sending the tokens.
+      mint: mint.publicKey.toBase58(), // Mint for the token being transferred.
+      destination: recipientATA, // Token account receiving the tokens.
+      authority: feePayer, // Owner or delegate approving the transfer.
+      amount: 25, // Token amount in base units.
+      decimals: 2 // Decimals defined on the mint account.
+    })
+  ),
+  [feePayer]
+);
+
+const senderAccountInfo = await connection.getAccountInfo(
+  new PublicKey(feePayerATA)
+);
+const senderTokenAccount = getTokenDecoder().decode(senderAccountInfo!.data);
+const recipientAccountInfo = await connection.getAccountInfo(
+  new PublicKey(recipientATA)
+);
+const recipientTokenAccount = getTokenDecoder().decode(
+  recipientAccountInfo!.data
+);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("\nSource Token Account Address:", feePayerATA);
+console.log("Source Token Account:", senderTokenAccount);
+console.log("\nDestination Token Account Address:", recipientATA);
+console.log("Destination Token Account:", recipientTokenAccount);
+console.log("\nTransaction Signature:", result);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 


### PR DESCRIPTION
## Problem

The 12 `tokens/basics` pages offer Kit and web3.js v1 TypeScript examples. `@solana/spl-token` does not run on web3.js v3 (it peer-depends on v1 and is Buffer-based), so v3 readers have no working sample.

## Changes

- Added a `#### Web3.js v3` section (`storage="token-ts-web3v3"`) between Kit and legacy on all 12 pages: approve-delegate, burn-tokens, close-account, create-mint, create-token-account (two sections), freeze-account, mint-tokens, revoke-delegate, set-authority, sync-native, thaw-account, transfer-tokens.
- v3 sections keep `Connection`, `Keypair`, `Transaction`, and `sendAndConfirmTransaction` from `@solana/web3.js` and build instructions with `@solana-program/token` builders and plan helpers, which v3 `Transaction.add()` accepts directly.
- Renamed `#### Web3.js` to `#### Web3.js (legacy)` and replaced the "Legacy examples ... for reference" sentence with wording that covers Kit, v3, and legacy.

Every v3 snippet was compiled with `tsc --noEmit --strict` against `@solana/web3.js@3.0.0-rc.3` and `@solana-program/token@0.16.1` before being added. `pnpm --filter solana-docs lint` is green.

Note for upstream: `getCreateMintInstructionPlan` is async and takes a client with `getMinimumBalance` as its first argument. The web3.js repo's spl-token migration guide shows it as a sync single-argument call, which does not compile. Snippets pass a one-line adapter over `connection.getMinimumBalanceForRentExemption`.

Part of the web3.js v3 docs rollout tracked in DEV-17. Targets the `docs/DEV-17-web3js-v3` integration branch.

Part of DEV-1041