### PR TITLE
docs(tokens): add Web3.js v3 sections to token extensions (DEV-1041)

### DIFF
--- a/apps/docs/content/docs/en/tokens/extensions/close-mint.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/close-mint.mdx
@@ -383,7 +383,125 @@ console.log("Mint Closed:", mintInfo.value === null);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import {
+  getCloseAccountInstruction,
+  getInitializeMint2Instruction,
+  getInitializeMintCloseAuthorityInstruction,
+  getMintSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const destination = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  5 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+const mintLength = getMintSize([
+  {
+    __kind: "MintCloseAuthority",
+    closeAuthority: feePayer.publicKey.toBase58()
+  }
+]);
+
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintLength);
+
+const createAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: feePayer.publicKey,
+  newAccountPubkey: mint.publicKey,
+  space: mintLength,
+  lamports: mintRent,
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS)
+});
+
+// !mark(1:5)
+const initializeMintCloseAuthorityInstruction =
+  getInitializeMintCloseAuthorityInstruction({
+    mint: mint.publicKey.toBase58(), // Mint account that stores the MintCloseAuthority extension.
+    closeAuthority: feePayer.publicKey.toBase58() // Authority allowed to close the mint.
+  });
+
+const initializeMintInstruction = getInitializeMint2Instruction({
+  mint: mint.publicKey.toBase58(), // mint pubkey
+  decimals: 9, // decimals
+  mintAuthority: feePayer.publicKey.toBase58(), // mint authority
+  freezeAuthority: feePayer.publicKey.toBase58() // freeze authority
+});
+
+const transaction = new Transaction({
+  feePayer: feePayer.publicKey,
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+}).add(
+  createAccountInstruction,
+  initializeMintCloseAuthorityInstruction,
+  initializeMintInstruction
+);
+
+const transactionSignature = await sendAndConfirmTransaction(
+  connection,
+  transaction,
+  [feePayer, mint]
+);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Transaction Signature:", transactionSignature);
+
+const latestBlockhash2 = await connection.getLatestBlockhash();
+
+// !mark(1:5)
+const closeMintInstruction = getCloseAccountInstruction({
+  account: mint.publicKey.toBase58(), // Mint account to close.
+  destination: destination.publicKey.toBase58(), // Account receiving the reclaimed lamports.
+  owner: feePayer // Close authority signing the instruction.
+});
+
+const closeMintTransaction = new Transaction({
+  feePayer: feePayer.publicKey,
+  blockhash: latestBlockhash2.blockhash,
+  lastValidBlockHeight: latestBlockhash2.lastValidBlockHeight
+}).add(closeMintInstruction);
+
+const transactionSignature3 = await sendAndConfirmTransaction(
+  connection,
+  closeMintTransaction,
+  [feePayer]
+);
+
+console.log("\nDestination Address:", destination.publicKey.toBase58());
+console.log("Transaction Signature:", transactionSignature3);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/cpi-guard.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/cpi-guard.mdx
@@ -570,7 +570,154 @@ console.log("\nDisabled CPI Guard:", disabledCpiGuard);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  getDisableCpiGuardInstruction,
+  getEnableCpiGuardInstruction,
+  getInitializeAccountInstruction,
+  getInitializeMint2Instruction,
+  getMintSize,
+  getTokenDecoder,
+  getTokenSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const mint = await Keypair.generate();
+const tokenAccount = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  5 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mintSpace = getMintSize();
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintSpace);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey, // Account funding account creation.
+      newAccountPubkey: mint.publicKey, // New mint account to create.
+      space: mintSpace, // Account size in bytes for the mint account.
+      lamports: mintRent, // Lamports funding the mint account rent.
+      programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+    }),
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(), // Mint account to initialize.
+      decimals: 0, // Number of decimals for the token.
+      mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+      freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+    })
+  ),
+  [feePayer, mint],
+  { commitment: "confirmed" }
+);
+
+const tokenAccountSpace = getTokenSize([
+  { __kind: "CpiGuard", lockCpi: false }
+]);
+const tokenAccountRent =
+  await connection.getMinimumBalanceForRentExemption(tokenAccountSpace);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey, // Account funding account creation.
+      newAccountPubkey: tokenAccount.publicKey, // New token account to create.
+      space: tokenAccountSpace, // Account size in bytes for the token account plus CpiGuard.
+      lamports: tokenAccountRent, // Lamports funding the token account rent.
+      programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the token account.
+    }),
+    getInitializeAccountInstruction({
+      account: tokenAccount.publicKey.toBase58(), // Token account to initialize.
+      mint: mint.publicKey.toBase58(), // Mint for the token account.
+      owner: feePayer.publicKey.toBase58() // Owner allowed to control the token account.
+    })
+  ),
+  [feePayer, tokenAccount],
+  { commitment: "confirmed" }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:4)
+    getEnableCpiGuardInstruction({
+      token: tokenAccount.publicKey.toBase58(), // Token account that stores the CpiGuard extension.
+      owner: feePayer // Token account owner authorized to enable CPI guard.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+const enabledAccountInfo = await connection.getAccountInfo(
+  tokenAccount.publicKey,
+  "confirmed"
+);
+const enabledTokenAccount = getTokenDecoder().decode(enabledAccountInfo!.data);
+const enabledCpiGuard = (
+  unwrapOption(enabledTokenAccount.extensions) ?? []
+).find((extension) => extension.__kind === "CpiGuard");
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:4)
+    getDisableCpiGuardInstruction({
+      token: tokenAccount.publicKey.toBase58(), // Token account that stores the CpiGuard extension.
+      owner: feePayer // Token account owner authorized to disable CPI guard.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+const disabledAccountInfo = await connection.getAccountInfo(
+  tokenAccount.publicKey,
+  "confirmed"
+);
+const disabledTokenAccount = getTokenDecoder().decode(
+  disabledAccountInfo!.data
+);
+const disabledCpiGuard = (
+  unwrapOption(disabledTokenAccount.extensions) ?? []
+).find((extension) => extension.__kind === "CpiGuard");
+
+console.log("\nMint Address:", mint.publicKey.toBase58());
+console.log("\nToken Account:", tokenAccount.publicKey.toBase58());
+console.log("\nEnabled CPI Guard:", enabledCpiGuard);
+console.log("\nDisabled CPI Guard:", disabledCpiGuard);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/default-state.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/default-state.mdx
@@ -553,7 +553,178 @@ console.log(
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  AccountState,
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstruction,
+  getInitializeDefaultAccountStateInstruction,
+  getInitializeMint2Instruction,
+  getMintDecoder,
+  getMintSize,
+  getTokenDecoder,
+  getUpdateDefaultAccountStateInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+
+const getTokenAccountStateLabel = (state: AccountState) => AccountState[state];
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  5 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+const mintLength = getMintSize([
+  { __kind: "DefaultAccountState", state: AccountState.Frozen }
+]);
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintLength);
+
+const createMintAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: feePayer.publicKey, // Account funding the new mint account.
+  newAccountPubkey: mint.publicKey, // New mint account to create.
+  space: mintLength, // Account size in bytes for the mint plus DefaultAccountState.
+  lamports: mintRent, // Lamports funding the mint account rent.
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+});
+
+// !mark(1:5)
+const initializeDefaultStateInstruction =
+  getInitializeDefaultAccountStateInstruction({
+    mint: mint.publicKey.toBase58(), // Mint account that stores the DefaultAccountState extension.
+    state: AccountState.Frozen // Default state assigned to new token accounts.
+  });
+
+const initializeMintInstruction = getInitializeMint2Instruction({
+  mint: mint.publicKey.toBase58(), // Mint account to initialize.
+  decimals: 0, // Number of decimals for the token.
+  mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+  freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    createMintAccountInstruction,
+    initializeDefaultStateInstruction,
+    initializeMintInstruction
+  ),
+  [feePayer, mint]
+);
+
+const [tokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    getCreateAssociatedTokenInstruction({
+      payer: feePayer, // Account funding the associated token account creation.
+      ata: tokenAccount, // Associated token account address to create.
+      owner: feePayer.publicKey.toBase58(), // Owner of the token account.
+      mint: mint.publicKey.toBase58() // Mint for the associated token account.
+    })
+  ),
+  [feePayer],
+  {
+    commitment: "confirmed"
+  }
+);
+
+const readDefaultAccountState = async () => {
+  const mintAccountInfo = await connection.getAccountInfo(
+    mint.publicKey,
+    "confirmed"
+  );
+  const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+  return (unwrapOption(mintAccount.extensions) ?? []).find(
+    (extension) => extension.__kind === "DefaultAccountState"
+  );
+};
+
+const readTokenAccountState = async () => {
+  const tokenAccountInfo = await connection.getAccountInfo(
+    new PublicKey(tokenAccount),
+    "confirmed"
+  );
+  return getTokenDecoder().decode(tokenAccountInfo!.data).state;
+};
+
+const tokenAccountStateBeforeUpdate = await readTokenAccountState();
+const defaultAccountStateBeforeUpdate = await readDefaultAccountState();
+
+// !mark(1:5)
+const updateDefaultStateInstruction = getUpdateDefaultAccountStateInstruction({
+  mint: mint.publicKey.toBase58(), // Mint account that stores the DefaultAccountState extension.
+  state: AccountState.Initialized, // New default state assigned to later token accounts.
+  freezeAuthority: feePayer // Freeze authority authorized to update the default state.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(updateDefaultStateInstruction),
+  [feePayer],
+  {
+    commitment: "confirmed"
+  }
+);
+
+const tokenAccountStateAfterUpdate = await readTokenAccountState();
+const defaultAccountStateAfterUpdate = await readDefaultAccountState();
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log(
+  "Default Account State Before Update:",
+  defaultAccountStateBeforeUpdate
+);
+console.log(
+  "Token Account State Before Update:",
+  getTokenAccountStateLabel(tokenAccountStateBeforeUpdate)
+);
+console.log(
+  "Default Account State After Update:",
+  defaultAccountStateAfterUpdate
+);
+console.log(
+  "Token Account State After Update:",
+  getTokenAccountStateLabel(tokenAccountStateAfterUpdate)
+);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/group-member.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/group-member.mdx
@@ -589,7 +589,251 @@ console.log(
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  Transaction,
+  SystemProgram,
+  PublicKey,
+  LAMPORTS_PER_SOL,
+  sendAndConfirmTransaction
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  TOKEN_2022_PROGRAM_ADDRESS,
+  getMintSize,
+  getMintDecoder,
+  getInitializeMint2Instruction,
+  getInitializeGroupPointerInstruction,
+  getInitializeTokenGroupInstruction,
+  getInitializeGroupMemberPointerInstruction,
+  getInitializeTokenGroupMemberInstruction
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+
+const authority = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  authority.publicKey,
+  5 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction(airdropSignature, "confirmed");
+
+const groupMint = await Keypair.generate();
+
+const spaceWithGroupPointerExtensions = getMintSize([
+  {
+    __kind: "GroupPointer",
+    authority: authority.publicKey.toBase58(),
+    groupAddress: groupMint.publicKey.toBase58()
+  }
+]);
+
+const spaceWithGroupAndGroupPointerExtensions = getMintSize([
+  {
+    __kind: "GroupPointer",
+    authority: authority.publicKey.toBase58(),
+    groupAddress: groupMint.publicKey.toBase58()
+  },
+  {
+    __kind: "TokenGroup",
+    updateAuthority: authority.publicKey.toBase58(),
+    mint: groupMint.publicKey.toBase58(),
+    size: 0n,
+    maxSize: 10n
+  }
+]);
+
+const groupMintRent = await connection.getMinimumBalanceForRentExemption(
+  spaceWithGroupAndGroupPointerExtensions
+);
+
+const { blockhash: latestBlockhash } = await connection.getLatestBlockhash();
+
+const createGroupMintAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: authority.publicKey, // Account funding the new mint account.
+  newAccountPubkey: groupMint.publicKey, // New group mint account to create.
+  lamports: groupMintRent, // Lamports funding the mint account rent.
+  space: spaceWithGroupPointerExtensions, // Account size in bytes for the mint plus GroupPointer.
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+});
+
+// !mark(1:5)
+const initializeGroupPointerInstruction = getInitializeGroupPointerInstruction({
+  mint: groupMint.publicKey.toBase58(), // Mint account that stores the GroupPointer extension.
+  authority: authority.publicKey.toBase58(), // Authority allowed to update the group pointer later.
+  groupAddress: groupMint.publicKey.toBase58() // Account address that stores the group data.
+});
+
+const initializeGroupMintInstruction = getInitializeMint2Instruction({
+  mint: groupMint.publicKey.toBase58(), // Mint account to initialize.
+  decimals: 0, // Number of decimals for the token.
+  mintAuthority: authority.publicKey.toBase58(), // Authority allowed to mint new tokens.
+  freezeAuthority: authority.publicKey.toBase58() // Authority allowed to freeze token accounts.
+});
+
+// !mark(1:7)
+const initializeGroupInstruction = getInitializeTokenGroupInstruction({
+  group: groupMint.publicKey.toBase58(), // Mint account that stores the group data.
+  mint: groupMint.publicKey.toBase58(), // Mint that the group data describes.
+  mintAuthority: authority, // Signer authorizing group initialization for the mint.
+  updateAuthority: authority.publicKey.toBase58(), // Authority allowed to update the group later.
+  maxSize: 10n // Maximum number of members allowed in the group.
+});
+
+const groupTransaction = new Transaction({
+  feePayer: authority.publicKey,
+  recentBlockhash: latestBlockhash
+}).add(
+  createGroupMintAccountInstruction,
+  initializeGroupPointerInstruction,
+  initializeGroupMintInstruction,
+  initializeGroupInstruction
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  groupTransaction,
+  [authority, groupMint],
+  {
+    commitment: "confirmed",
+    skipPreflight: true
+  }
+);
+
+const memberMint = await Keypair.generate();
+
+const spaceWithMemberPointerExtension = getMintSize([
+  {
+    __kind: "GroupMemberPointer",
+    authority: authority.publicKey.toBase58(),
+    memberAddress: memberMint.publicKey.toBase58()
+  }
+]);
+
+const spaceWithMemberAndMemberPointerExtensions = getMintSize([
+  {
+    __kind: "GroupMemberPointer",
+    authority: authority.publicKey.toBase58(),
+    memberAddress: memberMint.publicKey.toBase58()
+  },
+  {
+    __kind: "TokenGroupMember",
+    mint: memberMint.publicKey.toBase58(),
+    group: groupMint.publicKey.toBase58(),
+    memberNumber: 1n
+  }
+]);
+
+const memberMintRent = await connection.getMinimumBalanceForRentExemption(
+  spaceWithMemberAndMemberPointerExtensions
+);
+
+const { blockhash: memberLatestBlockhash } =
+  await connection.getLatestBlockhash();
+
+const createMemberMintAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: authority.publicKey, // Account funding the new mint account.
+  newAccountPubkey: memberMint.publicKey, // New member mint account to create.
+  lamports: memberMintRent, // Lamports funding the mint account rent.
+  space: spaceWithMemberPointerExtension, // Account size in bytes for the mint plus GroupMemberPointer.
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+});
+
+// !mark(1:6)
+const initializeMemberPointerInstruction =
+  getInitializeGroupMemberPointerInstruction({
+    mint: memberMint.publicKey.toBase58(), // Mint account that stores the GroupMemberPointer extension.
+    authority: authority.publicKey.toBase58(), // Authority allowed to update the member pointer later.
+    memberAddress: memberMint.publicKey.toBase58() // Account address that stores the member data.
+  });
+
+const initializeMemberMintInstruction = getInitializeMint2Instruction({
+  mint: memberMint.publicKey.toBase58(), // Mint account to initialize.
+  decimals: 0, // Number of decimals for the token.
+  mintAuthority: authority.publicKey.toBase58(), // Authority allowed to mint new tokens.
+  freezeAuthority: authority.publicKey.toBase58() // Authority allowed to freeze token accounts.
+});
+
+// !mark(1:7)
+const initializeMemberInstruction = getInitializeTokenGroupMemberInstruction({
+  member: memberMint.publicKey.toBase58(), // Mint account that stores the member data.
+  memberMint: memberMint.publicKey.toBase58(), // Mint that the member data describes.
+  memberMintAuthority: authority, // Signer authorizing member initialization for the mint.
+  group: groupMint.publicKey.toBase58(), // Group mint that this member belongs to.
+  groupUpdateAuthority: authority // Signer matching the group's update authority.
+});
+
+const memberTransaction = new Transaction({
+  feePayer: authority.publicKey,
+  recentBlockhash: memberLatestBlockhash
+}).add(
+  createMemberMintAccountInstruction,
+  initializeMemberPointerInstruction,
+  initializeMemberMintInstruction,
+  initializeMemberInstruction
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  memberTransaction,
+  [authority, memberMint],
+  {
+    commitment: "confirmed",
+    skipPreflight: true
+  }
+);
+
+const groupMintAccountInfo = await connection.getAccountInfo(
+  groupMint.publicKey,
+  "confirmed"
+);
+const groupMintExtensions =
+  unwrapOption(
+    getMintDecoder().decode(groupMintAccountInfo!.data).extensions
+  ) ?? [];
+const memberMintAccountInfo = await connection.getAccountInfo(
+  memberMint.publicKey,
+  "confirmed"
+);
+const memberMintExtensions =
+  unwrapOption(
+    getMintDecoder().decode(memberMintAccountInfo!.data).extensions
+  ) ?? [];
+
+console.log(
+  JSON.stringify(
+    {
+      groupMint: groupMint.publicKey,
+      groupPointer: groupMintExtensions.find(
+        (extension) => extension.__kind === "GroupPointer"
+      ),
+      group: groupMintExtensions.find(
+        (extension) => extension.__kind === "TokenGroup"
+      ),
+      memberMint: memberMint.publicKey,
+      memberPointer: memberMintExtensions.find(
+        (extension) => extension.__kind === "GroupMemberPointer"
+      ),
+      member: memberMintExtensions.find(
+        (extension) => extension.__kind === "TokenGroupMember"
+      )
+    },
+    (_, value) => (typeof value === "bigint" ? value.toString() : value),
+    2
+  )
+);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/immutable-owner.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/immutable-owner.mdx
@@ -484,7 +484,153 @@ console.log("SetAuthority Failure:", failure);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  AuthorityType,
+  getInitializeAccountInstruction,
+  getInitializeImmutableOwnerInstruction,
+  getInitializeMint2Instruction,
+  getMintSize,
+  getSetAuthorityInstruction,
+  getTokenDecoder,
+  getTokenSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const feePayer = await Keypair.generate();
+const newOwner = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  5 * LAMPORTS_PER_SOL
+);
+const latestBlockhash = await connection.getLatestBlockhash();
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+const mintLength = getMintSize();
+
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintLength);
+
+const tokenAccount = await Keypair.generate();
+const tokenAccountLen = getTokenSize([{ __kind: "ImmutableOwner" }]);
+const tokenAccountRent =
+  await connection.getMinimumBalanceForRentExemption(tokenAccountLen);
+
+const createMintAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: feePayer.publicKey, // Account funding the new mint account.
+  newAccountPubkey: mint.publicKey, // New mint account to create.
+  space: mintLength, // Account size in bytes for the mint.
+  lamports: mintRent, // Lamports funding the mint account rent.
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+});
+
+const initializeMintInstruction = getInitializeMint2Instruction({
+  mint: mint.publicKey.toBase58(), // Mint account to initialize.
+  decimals: 0, // Number of decimals for the token.
+  mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+  freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+});
+
+const createTokenAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: feePayer.publicKey, // Account funding the new token account.
+  newAccountPubkey: tokenAccount.publicKey, // New token account to create.
+  space: tokenAccountLen, // Account size in bytes for the token account plus ImmutableOwner.
+  lamports: tokenAccountRent, // Lamports funding the token account rent.
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the token account.
+});
+
+// !mark(1:4)
+const initializeImmutableOwnerInstruction =
+  getInitializeImmutableOwnerInstruction({
+    account: tokenAccount.publicKey.toBase58() // Token account that stores the ImmutableOwner extension.
+  });
+
+const initializeTokenAccountInstruction = getInitializeAccountInstruction({
+  account: tokenAccount.publicKey.toBase58(), // Token account to initialize.
+  mint: mint.publicKey.toBase58(), // Mint for the token account.
+  owner: feePayer.publicKey.toBase58() // Owner of the token account.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    createMintAccountInstruction,
+    initializeMintInstruction
+  ),
+  [feePayer, mint]
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    createTokenAccountInstruction,
+    initializeImmutableOwnerInstruction,
+    initializeTokenAccountInstruction
+  ),
+  [feePayer, tokenAccount]
+);
+
+let failure: string | undefined;
+try {
+  await sendAndConfirmTransaction(
+    connection,
+    new Transaction().add(
+      // !mark(1:6)
+      getSetAuthorityInstruction({
+        owned: tokenAccount.publicKey.toBase58(), // Token account whose authority is being updated.
+        owner: feePayer, // Current token account owner signing the instruction.
+        authorityType: AuthorityType.AccountOwner, // Account authority field to change.
+        newAuthority: newOwner.publicKey.toBase58() // New token account owner to set.
+      })
+    ),
+    [feePayer]
+  );
+} catch (error) {
+  failure = String(error);
+}
+if (!failure) {
+  throw new Error("Expected the owner change to fail");
+}
+
+const tokenAccountInfo = await connection.getAccountInfo(
+  tokenAccount.publicKey,
+  "confirmed"
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+const immutableOwnerExtension = (
+  unwrapOption(tokenAccountData.extensions) ?? []
+).find((extension) => extension.__kind === "ImmutableOwner");
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Token Account:", tokenAccount.publicKey.toBase58());
+console.log("ImmutableOwner Extension:", immutableOwnerExtension);
+console.log("SetAuthority Failure:", failure);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/interest-bearing-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/interest-bearing-tokens.mdx
@@ -660,7 +660,182 @@ console.log("InterestBearingConfig:", interestBearingConfig);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  findAssociatedTokenPda,
+  getAmountToUiAmountInstruction,
+  getCreateAssociatedTokenInstruction,
+  getInitializeInterestBearingMintInstruction,
+  getInitializeMint2Instruction,
+  getMintDecoder,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getUpdateRateInterestBearingMintInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const recipient = await Keypair.generate();
+const tokenAmount = 1_000_000_000_000n;
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  5 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+
+const mintLength = getMintSize([
+  {
+    __kind: "InterestBearingConfig",
+    rateAuthority: feePayer.publicKey.toBase58(),
+    initializationTimestamp: 0n,
+    preUpdateAverageRate: 0,
+    lastUpdateTimestamp: 0n,
+    currentRate: 30000
+  }
+]);
+
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintLength);
+
+const [tokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: recipient.publicKey.toBase58(),
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+const createMintAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: feePayer.publicKey, // Account funding the new mint account.
+  newAccountPubkey: mint.publicKey, // New mint account to create.
+  space: mintLength, // Account size in bytes for the mint plus InterestBearingConfig.
+  lamports: mintRent, // Lamports funding the mint account rent.
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+});
+
+// !mark(1:6)
+const initializeInterestBearingInstruction =
+  getInitializeInterestBearingMintInstruction({
+    mint: mint.publicKey.toBase58(), // Mint account that stores the InterestBearingConfig extension.
+    rateAuthority: feePayer.publicKey.toBase58(), // Authority allowed to update the interest rate later.
+    rate: 30000 // Interest rate in basis points.
+  });
+
+const initializeMintInstruction = getInitializeMint2Instruction({
+  mint: mint.publicKey.toBase58(), // Mint account to initialize.
+  decimals: 0, // Number of decimals for the token.
+  mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+  freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+});
+
+const createTokenAccountInstruction = getCreateAssociatedTokenInstruction({
+  payer: feePayer, // Account funding the associated token account creation.
+  ata: tokenAccount, // Associated token account address to create.
+  owner: recipient.publicKey.toBase58(), // Owner of the token account.
+  mint: mint.publicKey.toBase58() // Mint for the associated token account.
+});
+
+const mintToTokenAccountInstruction = getMintToCheckedInstruction({
+  mint: mint.publicKey.toBase58(), // Mint account that issues the tokens.
+  token: tokenAccount, // Token account receiving the newly minted tokens.
+  mintAuthority: feePayer, // Signer authorized to mint new tokens.
+  amount: tokenAmount, // Token amount in base units.
+  decimals: 0 // Decimals defined on the mint.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    createMintAccountInstruction,
+    initializeInterestBearingInstruction,
+    initializeMintInstruction
+  ),
+  [feePayer, mint]
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    createTokenAccountInstruction,
+    mintToTokenAccountInstruction
+  ),
+  [feePayer]
+);
+
+await new Promise((resolve) => setTimeout(resolve, 2_000));
+
+// !mark(1:4)
+const amountToUiInstruction = getAmountToUiAmountInstruction({
+  mint: mint.publicKey.toBase58(), // Mint whose UI amount conversion is being simulated.
+  amount: tokenAmount // Token amount in base units.
+});
+
+const amountToUiSimulation = await connection.simulateTransaction(
+  new Transaction().add(amountToUiInstruction),
+  [feePayer],
+  false
+);
+const simulatedUiAmount = Buffer.from(
+  amountToUiSimulation.value.returnData?.data?.[0] ?? "",
+  "base64"
+).toString("utf8");
+
+// !mark(1:5)
+const updateRateInstruction = getUpdateRateInterestBearingMintInstruction({
+  mint: mint.publicKey.toBase58(), // Mint account that stores the InterestBearingConfig extension.
+  rateAuthority: feePayer, // Signer authorized to update the interest rate.
+  rate: 15000 // New interest rate in basis points.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(updateRateInstruction),
+  [feePayer]
+);
+
+const mintAccountInfo = await connection.getAccountInfo(
+  mint.publicKey,
+  "confirmed"
+);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+const interestBearingConfig = (unwrapOption(mintAccount.extensions) ?? []).find(
+  (extension) => extension.__kind === "InterestBearingConfig"
+);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Token Account:", tokenAccount);
+console.log("Simulated UI Amount:", simulatedUiAmount);
+console.log("InterestBearingConfig:", interestBearingConfig);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/memo-transfer.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/memo-transfer.mdx
@@ -502,7 +502,195 @@ console.log("MemoTransfer Extension:", memoTransferExtension);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  PublicKey,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstruction,
+  getDisableMemoTransfersInstruction,
+  getEnableMemoTransfersInstruction,
+  getInitializeAccountInstruction,
+  getInitializeMint2Instruction,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getTokenDecoder,
+  getTokenSize,
+  getTransferCheckedInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+import { getAddMemoInstruction } from "@solana-program/memo";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+
+const feePayer = await Keypair.generate();
+const tokenOwner = await Keypair.generate();
+const tokenAmount = 1;
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  5 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction(airdropSignature, "confirmed");
+
+const mint = await Keypair.generate();
+
+const mintLength = getMintSize();
+
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintLength);
+const tokenAccount = await Keypair.generate();
+const tokenAccountLen = getTokenSize([
+  { __kind: "MemoTransfer", requireIncomingTransferMemos: true }
+]);
+const tokenAccountRent =
+  await connection.getMinimumBalanceForRentExemption(tokenAccountLen);
+
+const createMintAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: feePayer.publicKey, // Account funding the new mint account.
+  newAccountPubkey: mint.publicKey, // New mint account to create.
+  space: mintLength, // Account size in bytes for the mint.
+  lamports: mintRent, // Lamports funding the mint account rent.
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+});
+
+const initializeMintInstruction = getInitializeMint2Instruction({
+  mint: mint.publicKey.toBase58(), // Mint account to initialize.
+  decimals: 0, // Number of decimals for the token.
+  mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+  freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+});
+
+const [sourceToken] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(), // Mint for the source token account.
+  owner: feePayer.publicKey.toBase58(), // Owner of the source token account.
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS // Token program that owns the token account.
+});
+
+const createSourceTokenInstruction = getCreateAssociatedTokenInstruction({
+  payer: feePayer, // Account funding the associated token account creation.
+  ata: sourceToken, // Associated token account address to create.
+  owner: feePayer.publicKey.toBase58(), // Owner of the associated token account.
+  mint: mint.publicKey.toBase58() // Mint for the associated token account.
+});
+
+const mintToInstruction = getMintToCheckedInstruction({
+  mint: mint.publicKey.toBase58(), // Mint account that issues the tokens.
+  token: sourceToken, // Token account receiving the newly minted tokens.
+  mintAuthority: feePayer, // Signer authorized to mint new tokens.
+  amount: tokenAmount, // Token amount in base units.
+  decimals: 0 // Decimals defined on the mint.
+});
+
+const createTokenAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: feePayer.publicKey, // Account funding the new token account.
+  newAccountPubkey: tokenAccount.publicKey, // New token account to create.
+  space: tokenAccountLen, // Account size in bytes for the token account plus MemoTransfer.
+  lamports: tokenAccountRent, // Lamports funding the token account rent.
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the token account.
+});
+
+const initializeTokenAccountInstruction = getInitializeAccountInstruction({
+  account: tokenAccount.publicKey.toBase58(), // Token account to initialize.
+  mint: mint.publicKey.toBase58(), // Mint for the token account.
+  owner: tokenOwner.publicKey.toBase58() // Owner of the token account.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    createMintAccountInstruction,
+    initializeMintInstruction
+  ),
+  [feePayer, mint]
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    createSourceTokenInstruction,
+    mintToInstruction,
+    createTokenAccountInstruction,
+    initializeTokenAccountInstruction
+  ),
+  [feePayer, tokenAccount]
+);
+
+// !mark(1:5)
+const enableMemoTransferExtensionInstruction =
+  getEnableMemoTransfersInstruction({
+    token: tokenAccount.publicKey.toBase58(), // Token account that stores the MemoTransfer extension.
+    owner: tokenOwner // Token account owner authorized to toggle memo requirements.
+  });
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(enableMemoTransferExtensionInstruction),
+  [feePayer, tokenOwner]
+);
+
+const memoIx = getAddMemoInstruction({
+  memo: "memo required", // Memo string required by the destination token account.
+  signers: [feePayer] // Signers to include in the memo instruction.
+});
+
+const transferInstruction = getTransferCheckedInstruction({
+  source: sourceToken, // Token account sending the transfer.
+  mint: mint.publicKey.toBase58(), // Mint for the transfer.
+  destination: tokenAccount.publicKey.toBase58(), // Token account receiving the transfer.
+  authority: feePayer, // Owner of the source token account.
+  amount: tokenAmount, // Token amount in base units.
+  decimals: 0 // Decimals defined on the mint.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(memoIx, transferInstruction),
+  [feePayer]
+);
+
+// !mark(1:5)
+const disableMemoTransferExtensionInstruction =
+  getDisableMemoTransfersInstruction({
+    token: tokenAccount.publicKey.toBase58(), // Token account that stores the MemoTransfer extension.
+    owner: tokenOwner // Token account owner authorized to toggle memo requirements.
+  });
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(disableMemoTransferExtensionInstruction),
+  [feePayer, tokenOwner]
+);
+
+const tokenAccountInfo = await connection.getAccountInfo(
+  tokenAccount.publicKey,
+  "confirmed"
+);
+const tokenAccountData = getTokenDecoder().decode(tokenAccountInfo!.data);
+const memoTransferExtension = (
+  unwrapOption(tokenAccountData.extensions) ?? []
+).find((extension) => extension.__kind === "MemoTransfer");
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Token Account:", tokenAccount.publicKey.toBase58());
+console.log("Destination Amount:", tokenAccountData.amount.toString());
+console.log("MemoTransfer Extension:", memoTransferExtension);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/metadata.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/metadata.mdx
@@ -762,7 +762,224 @@ console.dir(
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  getEmitTokenMetadataInstruction,
+  getInitializeMetadataPointerInstruction,
+  getInitializeMint2Instruction,
+  getInitializeTokenMetadataInstruction,
+  getMintDecoder,
+  getMintSize,
+  getRemoveTokenMetadataKeyInstruction,
+  getUpdateMetadataPointerInstruction,
+  getUpdateTokenMetadataFieldInstruction,
+  getUpdateTokenMetadataUpdateAuthorityInstruction,
+  tokenMetadataField,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const mint = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const metadataPointerExtension = {
+  __kind: "MetadataPointer" as const,
+  authority: feePayer.publicKey.toBase58(),
+  metadataAddress: mint.publicKey.toBase58()
+};
+
+const mintSpace = getMintSize([metadataPointerExtension]);
+const mintRent = await connection.getMinimumBalanceForRentExemption(
+  getMintSize([
+    metadataPointerExtension,
+    {
+      __kind: "TokenMetadata",
+      updateAuthority: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58(),
+      name: "Example Token v2",
+      symbol: "EXMPL",
+      uri: "https://example.com/token.json",
+      additionalMetadata: new Map([
+        ["description", "Metadata stored on mint account"]
+      ])
+    }
+  ])
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:7)
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey, // Account funding account creation.
+      newAccountPubkey: mint.publicKey, // New mint account to create.
+      lamports: mintRent, // Lamports funding the mint account rent.
+      space: mintSpace, // Account size in bytes for the mint plus MetadataPointer.
+      programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+    }),
+    // !mark(1:5)
+    getInitializeMetadataPointerInstruction({
+      mint: mint.publicKey.toBase58(), // Mint account that stores the MetadataPointer extension.
+      authority: feePayer.publicKey.toBase58(), // Authority allowed to update the metadata pointer later.
+      metadataAddress: mint.publicKey.toBase58() // Account address that stores the metadata.
+    }),
+    // !mark(1:6)
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(), // Mint account to initialize.
+      decimals: 0, // Number of decimals for the token.
+      mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+      freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+    }),
+    // !mark(1:9)
+    getInitializeTokenMetadataInstruction({
+      metadata: mint.publicKey.toBase58(), // Mint account that stores the metadata.
+      updateAuthority: feePayer.publicKey.toBase58(), // Authority allowed to update metadata later.
+      mint: mint.publicKey.toBase58(), // Mint that the metadata describes.
+      mintAuthority: feePayer, // Signer authorizing metadata initialization for the mint.
+      name: "Example Token", // Token name stored in metadata.
+      symbol: "EXMPL", // Token symbol stored in metadata.
+      uri: "https://example.com/token.json" // URI pointing to off-chain JSON metadata.
+    }),
+    // !mark(1:6)
+    getUpdateTokenMetadataFieldInstruction({
+      metadata: mint.publicKey.toBase58(), // Mint account that stores the metadata.
+      updateAuthority: feePayer, // Authority allowed to update metadata fields.
+      field: tokenMetadataField("Key", ["description"]), // Custom metadata field to add.
+      value: "Metadata stored on mint account" // Value stored for the custom metadata field.
+    })
+  ),
+  [feePayer, mint],
+  { commitment: "confirmed" }
+);
+
+const readTokenMetadata = async () => {
+  const mintAccountInfo = await connection.getAccountInfo(
+    mint.publicKey,
+    "confirmed"
+  );
+  const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+  return (unwrapOption(mintAccount.extensions) ?? []).find(
+    (extension) => extension.__kind === "TokenMetadata"
+  );
+};
+
+const initialTokenMetadata = await readTokenMetadata();
+
+console.log(
+  JSON.stringify(
+    {
+      mint: mint.publicKey,
+      tokenMetadata: initialTokenMetadata
+    },
+    (_, value) => (value instanceof Map ? Object.fromEntries(value) : value),
+    2
+  )
+);
+
+const updateMetadataSignature = await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:6)
+    getUpdateTokenMetadataFieldInstruction({
+      metadata: mint.publicKey.toBase58(), // Mint account that stores the metadata.
+      updateAuthority: feePayer, // Authority allowed to update metadata fields.
+      field: tokenMetadataField("Name"), // Base metadata field to update.
+      value: "Example Token v2" // Updated value for the token name.
+    }),
+    // !mark(1:5)
+    getUpdateMetadataPointerInstruction({
+      mint: mint.publicKey.toBase58(), // Mint account that stores the MetadataPointer extension.
+      metadataPointerAuthority: feePayer, // Authority allowed to update the metadata pointer.
+      metadataAddress: mint.publicKey.toBase58() // Account address that stores the metadata.
+    }),
+    // !mark(1:6)
+    getRemoveTokenMetadataKeyInstruction({
+      metadata: mint.publicKey.toBase58(), // Mint account that stores the metadata.
+      updateAuthority: feePayer, // Authority allowed to remove custom metadata.
+      key: "description", // Custom metadata key to remove.
+      idempotent: false // Fail if the custom metadata key does not exist.
+    }),
+    // !mark(1:5)
+    getUpdateTokenMetadataUpdateAuthorityInstruction({
+      metadata: mint.publicKey.toBase58(), // Mint account that stores the metadata.
+      updateAuthority: feePayer, // Current authority allowed to change the update authority.
+      newUpdateAuthority: null // Clear the update authority so metadata can no longer be changed.
+    }),
+    // !mark(1:3)
+    getEmitTokenMetadataInstruction({
+      metadata: mint.publicKey.toBase58() // Mint account that stores the metadata to emit.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+const updateMetadataTransaction = (await connection.getTransaction(
+  updateMetadataSignature,
+  {
+    maxSupportedTransactionVersion: 0
+  }
+)) as any;
+const emittedDataBase64 =
+  updateMetadataTransaction?.meta?.returnData?.data?.[0];
+if (!emittedDataBase64) {
+  throw new Error("Expected token metadata return data");
+}
+const emittedTokenMetadataBytes = Buffer.from(emittedDataBase64, "base64");
+
+const mintAccountInfo = await connection.getAccountInfo(
+  mint.publicKey,
+  "confirmed"
+);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+const metadataPointer = (unwrapOption(mintAccount.extensions) ?? []).find(
+  (extension) => extension.__kind === "MetadataPointer"
+);
+const tokenMetadata = await readTokenMetadata();
+
+console.log(
+  JSON.stringify(
+    {
+      mint: mint.publicKey,
+      metadataPointer,
+      tokenMetadata,
+      emittedTokenMetadataLength: emittedTokenMetadataBytes.length
+    },
+    (_, value) => (value instanceof Map ? Object.fromEntries(value) : value),
+    2
+  )
+);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/non-transferrable-tokens.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/non-transferrable-tokens.mdx
@@ -399,7 +399,165 @@ console.log("Destination ATA:", destinationToken);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenIdempotentInstruction,
+  getInitializeMint2Instruction,
+  getInitializeNonTransferableMintInstruction,
+  getMintDecoder,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getTokenDecoder,
+  getTransferCheckedInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const recipient = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+const mintSpace = getMintSize([{ __kind: "NonTransferable" }]);
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintSpace);
+
+const [sourceToken] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+const [destinationToken] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: recipient.publicKey.toBase58(),
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction({
+    feePayer: feePayer.publicKey,
+    blockhash: latestBlockhash.blockhash,
+    lastValidBlockHeight: latestBlockhash.lastValidBlockHeight
+  }).add(
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey,
+      newAccountPubkey: mint.publicKey,
+      lamports: mintRent,
+      space: mintSpace,
+      programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS)
+    }),
+    // !mark(1:3)
+    getInitializeNonTransferableMintInstruction({
+      mint: mint.publicKey.toBase58() // Mint account that stores the NonTransferable extension.
+    }),
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(),
+      decimals: 0,
+      mintAuthority: feePayer.publicKey.toBase58(),
+      freezeAuthority: feePayer.publicKey.toBase58()
+    })
+  ),
+  [feePayer, mint],
+  { commitment: "confirmed" }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer: feePayer,
+      ata: sourceToken,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58()
+    }),
+    getCreateAssociatedTokenIdempotentInstruction({
+      payer: feePayer,
+      ata: destinationToken,
+      owner: recipient.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58()
+    }),
+    getMintToCheckedInstruction({
+      mint: mint.publicKey.toBase58(),
+      token: sourceToken,
+      mintAuthority: feePayer,
+      amount: 1,
+      decimals: 0
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+try {
+  await sendAndConfirmTransaction(
+    connection,
+    new Transaction().add(
+      // !mark(1:8)
+      getTransferCheckedInstruction({
+        source: sourceToken, // Token account sending the transfer.
+        mint: mint.publicKey.toBase58(), // Mint with the non-transferable configuration.
+        destination: destinationToken, // Token account receiving the transfer.
+        authority: feePayer, // Signer approving the transfer.
+        amount: 1, // Token amount in base units.
+        decimals: 0 // Decimals defined on the mint.
+      })
+    ),
+    [feePayer],
+    { commitment: "confirmed" }
+  );
+} catch (error) {
+  console.error("Transfer failed as expected:", error);
+}
+
+const mintAccountInfo = await connection.getAccountInfo(mint.publicKey);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+const sourceAccountInfo = await connection.getAccountInfo(
+  new PublicKey(sourceToken)
+);
+const sourceTokenAccount = getTokenDecoder().decode(sourceAccountInfo!.data);
+
+const extensions = unwrapOption(mintAccount.extensions) ?? [];
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log(
+  "Has NonTransferable:",
+  extensions.some((extension) => extension.__kind === "NonTransferable")
+);
+console.log("\nSource ATA:", sourceToken);
+console.log("Source Token Account:", sourceTokenAccount);
+console.log("Destination ATA:", destinationToken);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/pausable.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/pausable.mdx
@@ -577,7 +577,216 @@ console.log("\nConfig After Resume:", configAfterResume);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstruction,
+  getInitializeMint2Instruction,
+  getInitializePausableConfigInstruction,
+  getMintDecoder,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getPauseInstruction,
+  getResumeInstruction,
+  getTransferCheckedInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const mint = await Keypair.generate();
+const recipient = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  5 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mintSpace = getMintSize([
+  {
+    __kind: "PausableConfig",
+    authority: feePayer.publicKey.toBase58(),
+    paused: false
+  }
+]);
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintSpace);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey, // Account funding account creation.
+      newAccountPubkey: mint.publicKey, // New mint account to create.
+      space: mintSpace, // Account size in bytes for the mint plus PausableConfig.
+      lamports: mintRent, // Lamports funding the mint account rent.
+      programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+    }),
+    // !mark(1:4)
+    getInitializePausableConfigInstruction({
+      mint: mint.publicKey.toBase58(), // Mint account that stores the PausableConfig extension.
+      authority: feePayer.publicKey.toBase58() // Authority allowed to pause and resume the mint.
+    }),
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(), // Mint account to initialize.
+      decimals: 0, // Number of decimals for the token.
+      mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+      freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+    })
+  ),
+  [feePayer, mint],
+  { commitment: "confirmed" }
+);
+
+const [sourceToken] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: feePayer.publicKey.toBase58(),
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+const [destinationToken] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: recipient.publicKey.toBase58(),
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    getCreateAssociatedTokenInstruction({
+      payer: feePayer, // Account funding the associated token account creation.
+      ata: sourceToken, // Associated token account address to create.
+      owner: feePayer.publicKey.toBase58(), // Owner of the associated token account.
+      mint: mint.publicKey.toBase58() // Mint for the associated token account.
+    }),
+    getCreateAssociatedTokenInstruction({
+      payer: feePayer, // Account funding the associated token account creation.
+      ata: destinationToken, // Associated token account address to create.
+      owner: recipient.publicKey.toBase58(), // Owner of the associated token account.
+      mint: mint.publicKey.toBase58() // Mint for the associated token account.
+    }),
+    getMintToCheckedInstruction({
+      mint: mint.publicKey.toBase58(), // Mint account that issues the tokens.
+      token: sourceToken, // Token account receiving the newly minted tokens.
+      mintAuthority: feePayer, // Signer authorized to mint new tokens.
+      amount: 1, // Token amount in base units.
+      decimals: 0 // Decimals defined on the mint.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:4)
+    getPauseInstruction({
+      mint: mint.publicKey.toBase58(), // Mint account to pause.
+      authority: feePayer // Authority allowed to pause the mint.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+const readPausableConfig = async () => {
+  const mintAccountInfo = await connection.getAccountInfo(
+    mint.publicKey,
+    "confirmed"
+  );
+  const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+  return (unwrapOption(mintAccount.extensions) ?? []).find(
+    (extension) => extension.__kind === "PausableConfig"
+  );
+};
+
+const configAfterPause = await readPausableConfig();
+
+let pausedTransferFailure: string | undefined;
+try {
+  await sendAndConfirmTransaction(
+    connection,
+    new Transaction().add(
+      getTransferCheckedInstruction({
+        source: sourceToken, // Token account sending the transfer.
+        mint: mint.publicKey.toBase58(), // Mint with the pausable configuration.
+        destination: destinationToken, // Token account receiving the transfer.
+        authority: feePayer, // Signer approving the transfer.
+        amount: 1, // Token amount in base units.
+        decimals: 0 // Decimals defined on the mint.
+      })
+    ),
+    [feePayer],
+    { commitment: "confirmed" }
+  );
+} catch (error) {
+  pausedTransferFailure =
+    error instanceof Error ? error.message : String(error);
+}
+if (!pausedTransferFailure) {
+  throw new Error("Expected the paused transfer to fail");
+}
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:4)
+    getResumeInstruction({
+      mint: mint.publicKey.toBase58(), // Mint account to resume.
+      authority: feePayer // Authority allowed to resume the mint.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    getTransferCheckedInstruction({
+      source: sourceToken, // Token account sending the transfer.
+      mint: mint.publicKey.toBase58(), // Mint with the pausable configuration.
+      destination: destinationToken, // Token account receiving the transfer.
+      authority: feePayer, // Signer approving the transfer.
+      amount: 1, // Token amount in base units.
+      decimals: 0 // Decimals defined on the mint.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+const configAfterResume = await readPausableConfig();
+
+console.log("\nMint Address:", mint.publicKey.toBase58());
+console.log("\nConfig After Pause:", configAfterPause);
+console.log("\nError From Failed Transaction:", pausedTransferFailure);
+console.log("\nConfig After Resume:", configAfterResume);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/permanent-delegate.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/permanent-delegate.mdx
@@ -598,7 +598,176 @@ console.log("Permanent Delegate Extension:", permanentDelegate);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstruction,
+  getInitializeMint2Instruction,
+  getInitializePermanentDelegateInstruction,
+  getMintDecoder,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getTokenDecoder,
+  getTransferCheckedInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const owner = await Keypair.generate();
+const delegate = await Keypair.generate();
+const recipient = await Keypair.generate();
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  5 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+const mintLength = getMintSize([
+  { __kind: "PermanentDelegate", delegate: delegate.publicKey.toBase58() }
+]);
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintLength);
+
+const [sourceToken] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: owner.publicKey.toBase58(),
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+const [destinationToken] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: recipient.publicKey.toBase58(),
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+const createMintAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: feePayer.publicKey, // Account funding the new mint account.
+  newAccountPubkey: mint.publicKey, // New mint account to create.
+  space: mintLength, // Account size in bytes for the mint plus PermanentDelegate.
+  lamports: mintRent, // Lamports funding the mint account rent.
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+});
+
+// !mark(1:5)
+const initializePermanentDelegateInstruction =
+  getInitializePermanentDelegateInstruction({
+    mint: mint.publicKey.toBase58(), // Mint account that stores the PermanentDelegate extension.
+    delegate: delegate.publicKey.toBase58() // Permanent delegate authorized for all token accounts for the mint.
+  });
+
+const initializeMintInstruction = getInitializeMint2Instruction({
+  mint: mint.publicKey.toBase58(), // Mint account to initialize.
+  decimals: 0, // Number of decimals for the token.
+  mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+  freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    createMintAccountInstruction,
+    initializePermanentDelegateInstruction,
+    initializeMintInstruction
+  ),
+  [feePayer, mint],
+  {
+    commitment: "confirmed"
+  }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    getCreateAssociatedTokenInstruction({
+      payer: feePayer, // Account funding the associated token account creation.
+      ata: sourceToken, // Associated token account address to create.
+      owner: owner.publicKey.toBase58(), // Owner of the source token account.
+      mint: mint.publicKey.toBase58() // Mint for the associated token account.
+    }),
+    getCreateAssociatedTokenInstruction({
+      payer: feePayer, // Account funding the associated token account creation.
+      ata: destinationToken, // Associated token account address to create.
+      owner: recipient.publicKey.toBase58(), // Owner of the destination token account.
+      mint: mint.publicKey.toBase58() // Mint for the associated token account.
+    }),
+    getMintToCheckedInstruction({
+      mint: mint.publicKey.toBase58(), // Mint account that issues the tokens.
+      token: sourceToken, // Token account receiving the newly minted tokens.
+      mintAuthority: feePayer, // Signer authorized to mint new tokens.
+      amount: 1, // Token amount in base units.
+      decimals: 0 // Decimals defined on the mint.
+    })
+  ),
+  [feePayer],
+  {
+    commitment: "confirmed"
+  }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:8)
+    getTransferCheckedInstruction({
+      source: sourceToken, // Token account sending the transfer.
+      mint: mint.publicKey.toBase58(), // Mint with the permanent delegate configuration.
+      destination: destinationToken, // Token account receiving the transfer.
+      authority: delegate, // Permanent delegate signing the transfer.
+      amount: 1, // Token amount in base units.
+      decimals: 0 // Decimals defined on the mint.
+    })
+  ),
+  [feePayer, delegate],
+  {
+    commitment: "confirmed"
+  }
+);
+
+const destinationAccountInfo = await connection.getAccountInfo(
+  new PublicKey(destinationToken),
+  "confirmed"
+);
+const destinationAccount = getTokenDecoder().decode(
+  destinationAccountInfo!.data
+);
+const mintAccountInfo = await connection.getAccountInfo(
+  mint.publicKey,
+  "confirmed"
+);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+const permanentDelegate = (unwrapOption(mintAccount.extensions) ?? []).find(
+  (extension) => extension.__kind === "PermanentDelegate"
+);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Destination Amount:", destinationAccount.amount.toString());
+console.log("Permanent Delegate Extension:", permanentDelegate);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/scaled-ui-amount/index.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/scaled-ui-amount/index.mdx
@@ -251,7 +251,205 @@ console.log("ScaledUiAmountConfig:", scaledUiAmountConfig);
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction,
+  LAMPORTS_PER_SOL
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstruction,
+  getInitializeMint2Instruction,
+  getInitializeScaledUiAmountMintInstruction,
+  getMintDecoder,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getUpdateMultiplierScaledUiMintInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+async function calculateScaledUiAmount(
+  connection: Connection,
+  mintPublicKey: PublicKey,
+  tokenAmount: bigint
+) {
+  const mintAccountInfo = await connection.getAccountInfo(
+    mintPublicKey,
+    "confirmed"
+  );
+  const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+  const scaledUiAmountConfig = (
+    unwrapOption(mintAccount.extensions) ?? []
+  ).find((extension) => extension.__kind === "ScaledUiAmountConfig");
+  if (!scaledUiAmountConfig) {
+    throw new Error("ScaledUiAmountConfig not found");
+  }
+
+  const clockAccount = await connection.getParsedAccountInfo(
+    new PublicKey("SysvarC1ock11111111111111111111111111111111")
+  );
+  if (
+    !clockAccount.value ||
+    typeof clockAccount.value.data !== "object" ||
+    !("parsed" in clockAccount.value.data)
+  ) {
+    throw new Error("Failed to fetch clock sysvar");
+  }
+
+  const unixTimestamp = Number(
+    clockAccount.value.data.parsed.info.unixTimestamp
+  );
+  const multiplier =
+    unixTimestamp >=
+    Number(scaledUiAmountConfig.newMultiplierEffectiveTimestamp)
+      ? scaledUiAmountConfig.newMultiplier
+      : scaledUiAmountConfig.multiplier;
+  const scaledAmount = Math.trunc(Number(tokenAmount) * multiplier);
+  const calculatedUiAmount = scaledAmount / 10 ** mintAccount.decimals;
+
+  return {
+    calculatedUiAmount: calculatedUiAmount.toString(),
+    scaledUiAmountConfig
+  };
+}
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+
+const feePayer = await Keypair.generate();
+const recipient = await Keypair.generate();
+const initialMultiplier = 5.0;
+const updatedMultiplier = 10.0;
+const tokenAmount = 1_000n;
+
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  2 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction(airdropSignature, "confirmed");
+
+const mint = await Keypair.generate();
+const mintLength = getMintSize([
+  {
+    __kind: "ScaledUiAmountConfig",
+    authority: feePayer.publicKey.toBase58(),
+    multiplier: initialMultiplier,
+    newMultiplierEffectiveTimestamp: 0n,
+    newMultiplier: initialMultiplier
+  }
+]);
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintLength);
+
+const [tokenAccount] = await findAssociatedTokenPda({
+  mint: mint.publicKey.toBase58(),
+  owner: recipient.publicKey.toBase58(),
+  tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+});
+
+const createMintAccountInstruction = SystemProgram.createAccount({
+  fromPubkey: feePayer.publicKey, // Account funding the new mint account.
+  newAccountPubkey: mint.publicKey, // New mint account to create.
+  space: mintLength, // Account size in bytes for the mint plus ScaledUiAmountConfig.
+  lamports: mintRent, // Lamports funding the mint account rent.
+  programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+});
+
+// !mark(1:6)
+const initializeScaledUiAmountInstruction =
+  getInitializeScaledUiAmountMintInstruction({
+    mint: mint.publicKey.toBase58(), // Mint account that stores the ScaledUiAmountConfig extension.
+    authority: feePayer.publicKey.toBase58(), // Authority allowed to update the multiplier later.
+    multiplier: initialMultiplier // Initial multiplier used for displayed UI amounts.
+  });
+
+const initializeMintInstruction = getInitializeMint2Instruction({
+  mint: mint.publicKey.toBase58(), // Mint account to initialize.
+  decimals: 0, // Number of decimals for the token.
+  mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+  freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    createMintAccountInstruction,
+    initializeScaledUiAmountInstruction,
+    initializeMintInstruction
+  ),
+  [feePayer, mint]
+);
+
+const createTokenAccountInstruction = getCreateAssociatedTokenInstruction({
+  payer: feePayer, // Account funding the associated token account creation.
+  ata: tokenAccount, // Associated token account address to create.
+  owner: recipient.publicKey.toBase58(), // Owner of the token account.
+  mint: mint.publicKey.toBase58() // Mint for the associated token account.
+});
+
+const mintToTokenAccountInstruction = getMintToCheckedInstruction({
+  mint: mint.publicKey.toBase58(), // Mint account that issues the tokens.
+  token: tokenAccount, // Token account receiving the newly minted tokens.
+  mintAuthority: feePayer, // Signer authorized to mint new tokens.
+  amount: tokenAmount, // Token amount in base units.
+  decimals: 0 // Decimals defined on the mint.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    createTokenAccountInstruction,
+    mintToTokenAccountInstruction
+  ),
+  [feePayer]
+);
+
+const { calculatedUiAmount: calculatedUiAmountBeforeUpdate } =
+  await calculateScaledUiAmount(connection, mint.publicKey, tokenAmount);
+
+// !mark(1:6)
+const updateMultiplierInstruction = getUpdateMultiplierScaledUiMintInstruction({
+  mint: mint.publicKey.toBase58(), // Mint account that stores the ScaledUiAmountConfig extension.
+  authority: feePayer, // Signer authorized to update the multiplier.
+  multiplier: updatedMultiplier, // New multiplier used for displayed UI amounts.
+  effectiveTimestamp: 0n // Unix timestamp when the new multiplier takes effect.
+});
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(updateMultiplierInstruction),
+  [feePayer]
+);
+
+const {
+  calculatedUiAmount: calculatedUiAmountAfterUpdate,
+  scaledUiAmountConfig
+} = await calculateScaledUiAmount(connection, mint.publicKey, tokenAmount);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Token Account:", tokenAccount);
+console.log(
+  "Calculated UI Amount Before Update:",
+  calculatedUiAmountBeforeUpdate
+);
+console.log(
+  "Calculated UI Amount After Update:",
+  calculatedUiAmountAfterUpdate
+);
+console.log("ScaledUiAmountConfig:", scaledUiAmountConfig);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 

--- a/apps/docs/content/docs/en/tokens/extensions/transfer-fees.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/transfer-fees.mdx
@@ -1689,7 +1689,292 @@ console.dir(
 
 </CodeTabs>
 
-#### Web3.js
+#### Web3.js v3
+
+<CodeTabs storage="token-ts-web3v3" flags="r">
+
+```ts !! title="Instructions"
+import {
+  Connection,
+  Keypair,
+  LAMPORTS_PER_SOL,
+  PublicKey,
+  sendAndConfirmTransaction,
+  SystemProgram,
+  Transaction
+} from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  findAssociatedTokenPda,
+  getCreateAssociatedTokenInstruction,
+  getHarvestWithheldTokensToMintInstruction,
+  getInitializeMint2Instruction,
+  getInitializeTransferFeeConfigInstruction,
+  getMintDecoder,
+  getMintSize,
+  getMintToCheckedInstruction,
+  getSetTransferFeeInstruction,
+  getTokenDecoder,
+  getTransferCheckedWithFeeInstruction,
+  getWithdrawWithheldTokensFromAccountsInstruction,
+  getWithdrawWithheldTokensFromMintInstruction,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+const connection = new Connection("http://localhost:8899", "confirmed");
+const latestBlockhash = await connection.getLatestBlockhash();
+
+const feePayer = await Keypair.generate();
+const recipientA = await Keypair.generate();
+const recipientB = await Keypair.generate();
+const feeReceiver = await Keypair.generate();
+const airdropSignature = await connection.requestAirdrop(
+  feePayer.publicKey,
+  5 * LAMPORTS_PER_SOL
+);
+await connection.confirmTransaction({
+  blockhash: latestBlockhash.blockhash,
+  lastValidBlockHeight: latestBlockhash.lastValidBlockHeight,
+  signature: airdropSignature
+});
+
+const mint = await Keypair.generate();
+const transferFee = {
+  epoch: 0n,
+  maximumFee: 10n,
+  transferFeeBasisPoints: 150
+};
+const mintLen = getMintSize([
+  {
+    __kind: "TransferFeeConfig",
+    transferFeeConfigAuthority: feePayer.publicKey.toBase58(),
+    withdrawWithheldAuthority: feePayer.publicKey.toBase58(),
+    withheldAmount: 0n,
+    olderTransferFee: transferFee,
+    newerTransferFee: transferFee
+  }
+]);
+const mintRent = await connection.getMinimumBalanceForRentExemption(mintLen);
+
+const deriveAta = async (owner: PublicKey) => {
+  const [ata] = await findAssociatedTokenPda({
+    mint: mint.publicKey.toBase58(),
+    owner: owner.toBase58(),
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  });
+  return ata;
+};
+
+const sourceToken = await deriveAta(feePayer.publicKey);
+const destinationAToken = await deriveAta(recipientA.publicKey);
+const destinationBToken = await deriveAta(recipientB.publicKey);
+const feeReceiverToken = await deriveAta(feeReceiver.publicKey);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: feePayer.publicKey, // Account funding account creation.
+      newAccountPubkey: mint.publicKey, // New mint account to create.
+      lamports: mintRent, // Lamports funding the mint account rent.
+      space: mintLen, // Account size in bytes for the mint plus TransferFeeConfig.
+      programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS) // Program that owns the mint account.
+    }),
+    // !mark(1:7)
+    getInitializeTransferFeeConfigInstruction({
+      mint: mint.publicKey.toBase58(), // Mint account that stores the TransferFeeConfig extension.
+      transferFeeConfigAuthority: feePayer.publicKey.toBase58(), // Authority allowed to update the transfer fee later.
+      withdrawWithheldAuthority: feePayer.publicKey.toBase58(), // Value stored in the mint's `withdraw_withheld_authority` field.
+      transferFeeBasisPoints: 150, // Transfer fee in basis points.
+      maximumFee: 10n // Maximum fee charged on each transfer.
+    }),
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(), // Mint account to initialize.
+      decimals: 2, // Number of decimals for the token.
+      mintAuthority: feePayer.publicKey.toBase58(), // Authority allowed to mint new tokens.
+      freezeAuthority: feePayer.publicKey.toBase58() // Authority allowed to freeze token accounts.
+    })
+  ),
+  [feePayer, mint],
+  { commitment: "confirmed" }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    getCreateAssociatedTokenInstruction({
+      payer: feePayer,
+      ata: sourceToken,
+      owner: feePayer.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58()
+    }),
+    getCreateAssociatedTokenInstruction({
+      payer: feePayer,
+      ata: destinationAToken,
+      owner: recipientA.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58()
+    }),
+    getCreateAssociatedTokenInstruction({
+      payer: feePayer,
+      ata: destinationBToken,
+      owner: recipientB.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58()
+    }),
+    getCreateAssociatedTokenInstruction({
+      payer: feePayer,
+      ata: feeReceiverToken,
+      owner: feeReceiver.publicKey.toBase58(),
+      mint: mint.publicKey.toBase58()
+    }),
+    getMintToCheckedInstruction({
+      mint: mint.publicKey.toBase58(),
+      token: sourceToken,
+      mintAuthority: feePayer,
+      amount: 1_000,
+      decimals: 2
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:9)
+    getTransferCheckedWithFeeInstruction({
+      source: sourceToken, // Token account sending the transfer.
+      mint: mint.publicKey.toBase58(), // Mint with the transfer fee configuration.
+      destination: destinationAToken, // Token account receiving the transfer.
+      authority: feePayer, // Signer approving the transfer.
+      amount: 200n, // Token amount in base units.
+      decimals: 2, // Decimals defined on the mint.
+      fee: 3n // Expected transfer fee for this transfer.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:7)
+    getWithdrawWithheldTokensFromAccountsInstruction({
+      mint: mint.publicKey.toBase58(), // Mint with the transfer fee configuration.
+      feeReceiver: feeReceiverToken, // Token account receiving the withdrawn fees.
+      withdrawWithheldAuthority: feePayer, // Signer matching the mint's `withdraw_withheld_authority`.
+      sources: [destinationAToken], // Token accounts to withdraw withheld fees from.
+      numTokenAccounts: 1 // Number of token accounts to withdraw from.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:9)
+    getTransferCheckedWithFeeInstruction({
+      source: sourceToken, // Token account sending the transfer.
+      mint: mint.publicKey.toBase58(), // Mint with the transfer fee configuration.
+      destination: destinationBToken, // Token account receiving the transfer.
+      authority: feePayer, // Signer approving the transfer.
+      amount: 200n, // Token amount in base units.
+      decimals: 2, // Decimals defined on the mint.
+      fee: 3n // Expected transfer fee for this transfer.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:4)
+    getHarvestWithheldTokensToMintInstruction({
+      mint: mint.publicKey.toBase58(), // Mint that collects harvested withheld fees.
+      sources: [destinationBToken] // Token accounts to harvest withheld fees from.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+await sendAndConfirmTransaction(
+  connection,
+  new Transaction().add(
+    // !mark(1:5)
+    getWithdrawWithheldTokensFromMintInstruction({
+      mint: mint.publicKey.toBase58(), // Mint storing harvested withheld fees.
+      feeReceiver: feeReceiverToken, // Token account receiving withdrawn fees.
+      withdrawWithheldAuthority: feePayer // Signer matching the mint's `withdraw_withheld_authority`.
+    }),
+    // !mark(1:6)
+    getSetTransferFeeInstruction({
+      mint: mint.publicKey.toBase58(), // Mint whose next transfer fee configuration is updated.
+      transferFeeConfigAuthority: feePayer, // Authority allowed to update the transfer fee later.
+      transferFeeBasisPoints: 250, // New transfer fee in basis points.
+      maximumFee: 25n // New maximum fee for the next transfer fee configuration.
+    })
+  ),
+  [feePayer],
+  { commitment: "confirmed" }
+);
+
+const readTokenAccount = async (address: string) => {
+  const info = await connection.getAccountInfo(
+    new PublicKey(address),
+    "confirmed"
+  );
+  return getTokenDecoder().decode(info!.data);
+};
+
+type TokenAccount = Awaited<ReturnType<typeof readTokenAccount>>;
+
+const withheldAmountOf = (account: TokenAccount) =>
+  (unwrapOption(account.extensions) ?? []).find(
+    (extension) => extension.__kind === "TransferFeeAmount"
+  );
+
+const destinationAAccount = await readTokenAccount(destinationAToken);
+const destinationBAccount = await readTokenAccount(destinationBToken);
+const feeReceiverAccount = await readTokenAccount(feeReceiverToken);
+const mintAccountInfo = await connection.getAccountInfo(
+  mint.publicKey,
+  "confirmed"
+);
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+
+console.log("Mint Address:", mint.publicKey.toBase58());
+console.log("Destination A Amount:", destinationAAccount.amount.toString());
+console.log(
+  "Destination A Transfer Fee Amount:",
+  withheldAmountOf(destinationAAccount)
+);
+console.log("Destination B Amount:", destinationBAccount.amount.toString());
+console.log(
+  "Destination B Transfer Fee Amount:",
+  withheldAmountOf(destinationBAccount)
+);
+console.log("Fee Receiver Amount:", feeReceiverAccount.amount.toString());
+console.log(
+  "Fee Receiver Transfer Fee Amount:",
+  withheldAmountOf(feeReceiverAccount)
+);
+console.log(
+  "Transfer Fee Config:",
+  (unwrapOption(mintAccount.extensions) ?? []).find(
+    (extension) => extension.__kind === "TransferFeeConfig"
+  )
+);
+```
+
+</CodeTabs>
+
+#### Web3.js (legacy)
 
 <CodeTabs storage="token-ts-legacy" flags="r">
 


### PR DESCRIPTION
## Problem

The 13 `tokens/extensions` pages with Kit and web3.js v1 sections have no web3.js v3 sample. Stacked on the token basics PR; retarget to `docs/DEV-17-web3js-v3` once that merges.

## Changes

- Added a `#### Web3.js v3` section on: close-mint, cpi-guard, default-state, group-member, immutable-owner, interest-bearing-tokens, memo-transfer, metadata, non-transferrable-tokens, pausable, permanent-delegate, transfer-fees, scaled-ui-amount/index.
- v3 sections use `@solana-program/token-2022` generated builders. `getMintSize` takes full extension args objects rather than v1's `ExtensionType` variants; extension state is read from `unwrapOption(decoded.extensions)` instead of v1's `getXState` helpers.
- Renamed `#### Web3.js` to `#### Web3.js (legacy)`.

Every v3 snippet was compiled with `tsc --noEmit --strict` against `@solana/web3.js@3.0.0-rc.3` and `@solana-program/token-2022@0.17.0`. `pnpm --filter solana-docs lint` is green.

Places where the port is not one to one:
- `metadata`: `@solana-program/token-2022` has no `getTokenMetadataDecoder`, so the v3 block reads metadata from the decoded mint extensions and reports the emitted payload length.
- `interest-bearing-tokens`: no equivalent of `amountToUiAmountForMintWithoutSimulation`; the v3 block keeps only the simulation-based UI amount.
- `transfer-fees`: `getWithdrawWithheldTokensFromAccountsInstruction` requires an explicit `numTokenAccounts`.

Not included: the four long-form guides (`transfer-hook`, `transfer-hook-integration`, `scaled-ui-amount/integration-guide`, `scaled-ui-amount/issuer-guide`). Those remain open on DEV-1041.

Part of DEV-1041