### PR TITLE
docs(tokens): add Web3.js v3 tabs to long-form token guides (DEV-1041)

### DIFF
--- a/apps/docs/content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/scaled-ui-amount/integration-guide.mdx
@@ -60,7 +60,9 @@ amounts in the program.
 - If you need to know the UI Amount for an arbitrary amount you can get this
   calculation by calling the
   [`amountToUiAmountForMintWithoutSimulation`](https://github.com/solana-program/token-2022/blob/main/clients/js-legacy/src/actions/amountToUiAmount.ts#L164)
-  (web3.js v1) function or simulating a transaction using amountToUiAmount.
+  function or simulating a transaction using amountToUiAmount. The same function
+  is exported by `@solana-program/token-2022` (taking a Kit RPC) and by
+  `@solana/spl-token` (taking a web3.js v1 `Connection`).
   - Note: amountToUiAmount requires a transaction simulation which means it also
     needs a valid fee payer with balance. Because of this, this should not be
     the default way to get a balance.
@@ -94,7 +96,7 @@ $ curl http://localhost:8899 -s -X POST -H "Content-Type: application/json" -d '
 }
 ```
 
-```ts !! title="Kit-getTokenAccountBalance.ts"
+```ts !! title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
 const rpc_url = "https://api.devnet.solana.com";
 const rpc = createSolanaRpc(rpc_url);
@@ -115,8 +117,9 @@ console.log("Token Balance:", tokenBalance);
 } */
 ```
 
-```ts !! title="web3js-getTokenAccountBalance.ts"
+```ts !! title="Web3.js v3"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
+
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
 
 let tokenAddress = new PublicKey(
@@ -128,6 +131,28 @@ let tokenBalance = await connection.getTokenAccountBalance(tokenAddress);
 console.log("Token Balance:", tokenBalance);
 /* Token Balance: {
   context: { apiVersion: '2.2.14', slot: 381132711n },
+  value: {
+    amount: '10000000',
+    decimals: 6,
+    uiAmount: 20,
+    uiAmountString: '20'
+  }
+} */
+```
+
+```ts !! title="Web3.js (legacy)"
+import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
+const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+
+let tokenAddress = new PublicKey(
+  "2uuvxpnEKw52aTqNerHiQ3WeSqZriCMNVt8LhWfrkbPk"
+);
+
+let tokenBalance = await connection.getTokenAccountBalance(tokenAddress);
+
+console.log("Token Balance:", tokenBalance);
+/* Token Balance: {
+  context: { apiVersion: '2.2.14', slot: 381132711 },
   value: {
     amount: '10000000',
     decimals: 6,
@@ -194,7 +219,7 @@ $ curl http://localhost:8899 -s -X POST -H "Content-Type: application/json" -d '
 }
 ```
 
-```ts !! title="Kit-getAccountInfo.ts"
+```ts !! title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
 
 const rpc_url = "https://api.devnet.solana.com";
@@ -253,7 +278,64 @@ console.log(
 } */
 ```
 
-```ts !! title="web3js-getAccountInfo.ts"
+```ts !! title="Web3.js v3"
+import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
+
+const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+const publicKey = new PublicKey("2uuvxpnEKw52aTqNerHiQ3WeSqZriCMNVt8LhWfrkbPk");
+const accountInfo = await connection.getParsedAccountInfo(publicKey);
+
+console.log(
+  "Account Info:",
+  JSON.stringify(
+    accountInfo,
+    (key, value) => (typeof value === "bigint" ? value.toString() : value),
+    2
+  )
+);
+/* Account Info: {
+  "context": {
+    "apiVersion": "2.2.14",
+    "slot": "381133640"
+  },
+  "value": {
+    "data": {
+      "parsed": {
+        "info": {
+          "extensions": [
+            {
+              "extension": "immutableOwner"
+            },
+            {
+              "extension": "pausableAccount"
+            }
+          ],
+          "isNative": false,
+          "mint": "BZCd6HfTbb5ZYJ8hQsm8282tG4QzLyeqFR6tdgQA9EAG",
+          "owner": "G7ARQSUCwNrfvTDUCZvM5xdiRdBJiN3qVw2PryD8Wnib",
+          "state": "initialized",
+          "tokenAmount": {
+            "amount": "10000000",
+            "decimals": 6,
+            "uiAmount": 20,
+            "uiAmountString": "20"
+          }
+        },
+        "type": "account"
+      },
+      "program": "spl-token-2022",
+      "space": "174"
+    },
+    "executable": false,
+    "lamports": "2101920",
+    "owner": "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",
+    "rentEpoch": "18446744073709551615",
+    "space": "174"
+  }
+} */
+```
+
+```ts !! title="Web3.js (legacy)"
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
@@ -328,12 +410,50 @@ set for a future date, you can automatically poll at this update time
     dust rather than risk the transaction failing
   - To do this conversion you can use the
     [`uiAmountToAmountForMintWithoutSimulation`](https://github.com/solana-program/token-2022/blob/main/clients/js-legacy/src/actions/amountToUiAmount.ts#L312C23-L312C63)
-    (web3.js v1) function or simulating a transaction using amountToUiAmount.
+    function or simulating a transaction using amountToUiAmount. On web3.js v3
+    you can also read the multiplier off the decoded mint and convert locally
+    with `uiAmountToAmountForScaledUiAmountMintWithoutSimulation`, as below.
 
 <CodeTabs>
 
-```ts !! title="web3js-uiAmountToAmountForMintWithoutSimulation.ts"
-import { uiAmountToAmountForMintWithoutSimulation } from "@solana/web3.js";
+```ts !! title="Web3.js v3"
+import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import {
+  getMintDecoder,
+  uiAmountToAmountForScaledUiAmountMintWithoutSimulation
+} from "@solana-program/token-2022";
+
+const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+const mint = new PublicKey("BZCd6HfTbb5ZYJ8hQsm8282tG4QzLyeqFR6tdgQA9EAG");
+const uiAmount = "20.2";
+
+const mintAccountInfo = await connection.getAccountInfo(mint, "confirmed");
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+const scaledUiAmountConfig = (unwrapOption(mintAccount.extensions) ?? []).find(
+  (extension) => extension.__kind === "ScaledUiAmountConfig"
+);
+if (!scaledUiAmountConfig) {
+  throw new Error("ScaledUiAmountConfig not found");
+}
+
+const multiplier =
+  Date.now() / 1000 >=
+  Number(scaledUiAmountConfig.newMultiplierEffectiveTimestamp)
+    ? scaledUiAmountConfig.newMultiplier
+    : scaledUiAmountConfig.multiplier;
+
+const rawAmount = uiAmountToAmountForScaledUiAmountMintWithoutSimulation(
+  uiAmount,
+  mintAccount.decimals,
+  multiplier
+);
+console.log("Raw Amount:", rawAmount);
+/* Raw Amount: 20200000n */
+```
+
+```ts !! title="Web3.js (legacy)"
+import { uiAmountToAmountForMintWithoutSimulation } from "@solana/spl-token";
 import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
 
 const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
@@ -373,7 +493,7 @@ console.log("Raw Amount:", rawAmount);
 
 <CodeTabs>
 
-```ts !! title="Kit-getAccountInfo.ts"
+```ts !! title="Kit"
 import { address, createSolanaRpc } from "@solana/kit";
 
 const rpc_url = "https://api.devnet.solana.com";
@@ -431,7 +551,43 @@ Current Multiplier: 2
 */
 ```
 
-```ts !! title="web3js-getAccountInfo.ts"
+```ts !! title="Web3.js v3"
+import { Connection, PublicKey, clusterApiUrl } from "@solana/web3.js";
+import { unwrapOption } from "@solana/kit";
+import { getMintDecoder } from "@solana-program/token-2022";
+
+const connection = new Connection(clusterApiUrl("devnet"), "confirmed");
+const mint = new PublicKey("BZCd6HfTbb5ZYJ8hQsm8282tG4QzLyeqFR6tdgQA9EAG");
+
+const mintAccountInfo = await connection.getAccountInfo(mint, "confirmed");
+const mintAccount = getMintDecoder().decode(mintAccountInfo!.data);
+
+const scaledUiAmountConfig = (unwrapOption(mintAccount.extensions) ?? []).find(
+  (extension) => extension.__kind === "ScaledUiAmountConfig"
+);
+
+const currentMultiplier =
+  scaledUiAmountConfig &&
+  Date.now() / 1000 >=
+    Number(scaledUiAmountConfig.newMultiplierEffectiveTimestamp)
+    ? scaledUiAmountConfig.newMultiplier
+    : scaledUiAmountConfig?.multiplier;
+
+console.log("Scaled UI Amount Config:", scaledUiAmountConfig);
+console.log("Current Multiplier:", currentMultiplier);
+/*
+Scaled UI Amount Config: {
+  __kind: 'ScaledUiAmountConfig',
+  authority: 'G7ARQSUCwNrfvTDUCZvM5xdiRdBJiN3qVw2PryD8Wnib',
+  multiplier: 2,
+  newMultiplier: 2,
+  newMultiplierEffectiveTimestamp: 1743000000n
+}
+Current Multiplier: 2
+*/
+```
+
+```ts !! title="Web3.js (legacy)"
 import {
   type AccountInfo,
   Connection,

--- a/apps/docs/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/scaled-ui-amount/issuer-guide.mdx
@@ -11,6 +11,10 @@ To use the Scaled UI Amount extension, you need to enable it on a token mint or
 token account. Note that once a token is created, you cannot modify which
 extensions are enabled.
 
+The TypeScript examples come in two variants. `Web3.js v3` uses the class-based
+`@solana/web3.js` v3 API with `@solana-program/token-2022` instruction builders;
+`Web3.js (legacy)` uses `@solana/web3.js` v1 with `@solana/spl-token`.
+
 ### Enable the Scaled UI Amount extension on a token mint
 
 To enable the Scaled UI Amount extension on a token mint, you need to set the
@@ -30,7 +34,104 @@ Decimals:  9
 Signature: 2sPziXu9M3duTCvsDvxQE9UKC9nBiLayi8muDvnjhA2qYvfXSZuaUieoq39MFjg4kf8xFrw6crmYSkPyV59dvudF
 ```
 
-```ts !! title="create-token.ts"
+```ts !! title="Web3.js v3"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  SystemProgram,
+  Transaction,
+  sendAndConfirmTransaction
+} from "@solana/web3.js";
+import {
+  getInitializeMint2Instruction,
+  getInitializeScaledUiAmountMintInstruction,
+  getMintSize,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+/**
+ * Creates a new SPL-Token 2022 mint with the Scaled UI extension enabled
+ * and a UI multiplier of 1.1.
+ *
+ * @param connection – An initialized Solana Connection.
+ * @param payer      – Signer paying for fees and rent.
+ * @returns The newly created mint PublicKey.
+ */
+export async function createScaledUiMint(
+  connection: Connection,
+  payer: Keypair
+): Promise<PublicKey> {
+  // 1) Generate a new mint Keypair
+  const mint = await Keypair.generate();
+  const mintLen = getMintSize([
+    {
+      __kind: "ScaledUiAmountConfig",
+      authority: payer.publicKey.toBase58(),
+      multiplier: 1.1,
+      newMultiplierEffectiveTimestamp: 0n,
+      newMultiplier: 1.1
+    }
+  ]);
+  const mintLamports =
+    await connection.getMinimumBalanceForRentExemption(mintLen);
+  const mintTransaction = new Transaction().add(
+    SystemProgram.createAccount({
+      fromPubkey: payer.publicKey,
+      newAccountPubkey: mint.publicKey,
+      space: mintLen,
+      lamports: mintLamports,
+      programId: new PublicKey(TOKEN_2022_PROGRAM_ADDRESS)
+    }),
+    getInitializeScaledUiAmountMintInstruction({
+      mint: mint.publicKey.toBase58(),
+      authority: payer.publicKey.toBase58(),
+      multiplier: 1.1
+    }),
+    getInitializeMint2Instruction({
+      mint: mint.publicKey.toBase58(),
+      decimals: 0,
+      mintAuthority: payer.publicKey.toBase58(),
+      freezeAuthority: null
+    })
+  );
+  await sendAndConfirmTransaction(
+    connection,
+    mintTransaction,
+    [payer, mint],
+    undefined
+  );
+
+  console.log(
+    "✅ Created mint w/ scaled-UI extension:",
+    mint.publicKey.toBase58()
+  );
+  return mint.publicKey;
+}
+(async () => {
+  // 1) Establish a connection to the Solana devnet
+  const connection = new Connection(
+    "https://api.devnet.solana.com",
+    "confirmed"
+  );
+
+  // 2) Generate a new fee-payer Keypair
+  const payer = await Keypair.generate();
+
+  // 3) Airdrop 1 SOL to the fee-payer so it has funds for transactions
+  const airdropSignature = await connection.requestAirdrop(
+    payer.publicKey,
+    1_000_000_000 // 1 SOL in lamports
+  );
+
+  // 4) Create the scaled-UI mint using our helper
+  const mintPubkey = await createScaledUiMint(connection, payer);
+})().catch((err) => {
+  console.error("Error running example:", err);
+});
+```
+
+```ts !! title="Web3.js (legacy)"
 import {
   Connection,
   Keypair,
@@ -161,7 +262,77 @@ $ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XN
 $ spl-token update-ui-amount-multiplier 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM 1.5 -- 1746471400
 ```
 
-```ts !! title="update-ui-amount-multiplier.ts"
+```ts !! title="Web3.js v3"
+import { getUpdateMultiplierScaledUiMintInstruction } from "@solana-program/token-2022";
+
+/**
+ * Updates the scaled UI multiplier for an existing SPL-Token 2022 mint.
+ *
+ * @param connection – An initialized Solana Connection.
+ * @param payer      – Signer paying for fees and rent.
+ * @param mint       – PublicKey of the mint to update.
+ * @param multiplier – New multiplier value to set.
+ * @returns The transaction signature.
+ */
+export async function updateScaledUiMultiplier(
+  connection: Connection,
+  payer: Keypair,
+  mint: PublicKey,
+  multiplier: number,
+  effectiveTimestamp: bigint,
+  previousMultiplier: number,
+  previousEffectiveTimestamp: bigint
+): Promise<string> {
+  const transaction = new Transaction()
+    .add(
+      // Set the previous multiplier to the current multiplier
+      // This is temporarily needed until PR 522 is deployed to mainnet
+      getUpdateMultiplierScaledUiMintInstruction({
+        mint: mint.toBase58(),
+        authority: payer,
+        multiplier: previousMultiplier,
+        effectiveTimestamp: previousEffectiveTimestamp
+      })
+    )
+    .add(
+      getUpdateMultiplierScaledUiMintInstruction({
+        mint: mint.toBase58(),
+        authority: payer,
+        multiplier,
+        effectiveTimestamp
+      })
+    );
+
+  const signature = await sendAndConfirmTransaction(
+    connection,
+    transaction,
+    [payer],
+    undefined
+  );
+
+  console.log(
+    `✅ Updated scaled-UI multiplier to ${multiplier} for mint:`,
+    mint.toBase58()
+  );
+  return signature;
+}
+const multiplier = 1.5;
+const effectiveTimestamp = BigInt(Math.floor(Date.now() / 1000));
+const previousMultiplier = 1.2;
+const previousEffectiveTimestamp = BigInt(1746470000);
+const updateSignature = await updateScaledUiMultiplier(
+  connection,
+  payer,
+  mintPubkey,
+  multiplier,
+  effectiveTimestamp,
+  previousMultiplier,
+  previousEffectiveTimestamp
+);
+console.log("Update signature:", updateSignature);
+```
+
+```ts !! title="Web3.js (legacy)"
 /**
  * Updates the scaled UI multiplier for an existing SPL-Token 2022 mint.
  *
@@ -245,7 +416,51 @@ To fetch the balance, you need to use the `balance` command.
 $ spl-token balance 66EV4CaihdqyQ1fbsr51wBsoqKLgAG5KiYz7r5XNrxUM
 ```
 
-```ts !! title="balance.ts"
+```ts !! title="Web3.js v3"
+import {
+  findAssociatedTokenPda,
+  TOKEN_2022_PROGRAM_ADDRESS
+} from "@solana-program/token-2022";
+
+/**
+ * Gets the scaled UI amount balance for a token holder.
+ *
+ * @param connection – An initialized Solana Connection.
+ * @param mint       – PublicKey of the mint to check.
+ * @param owner      – PublicKey of the token holder.
+ * @returns The scaled UI amount balance.
+ */
+export async function getScaledUiAmountBalance(
+  connection: Connection,
+  mint: PublicKey,
+  owner: PublicKey
+): Promise<number> {
+  // Get the token account for this mint/owner pair
+  const [tokenAccount] = await findAssociatedTokenPda({
+    mint: mint.toBase58(),
+    owner: owner.toBase58(),
+    tokenProgram: TOKEN_2022_PROGRAM_ADDRESS
+  });
+
+  // Get the token account info
+  const accountInfo = await connection.getAccountInfo(
+    new PublicKey(tokenAccount)
+  );
+  if (!accountInfo) {
+    throw new Error("Token account not found");
+  }
+
+  const info = await connection.getTokenAccountBalance(
+    new PublicKey(tokenAccount)
+  );
+  if (info.value.uiAmount == null) throw new Error("No balance found");
+  console.log("Balance: ", info.value.uiAmount);
+  return info.value.uiAmount;
+}
+const balance = await getScaledUiAmountBalance(connection, mint, owner);
+```
+
+```ts !! title="Web3.js (legacy)"
 /**
  * Gets the scaled UI amount balance for a token holder.
  *

--- a/apps/docs/content/docs/en/tokens/extensions/transfer-hook-integration.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/transfer-hook-integration.mdx
@@ -38,23 +38,23 @@ does anything with the hook's logic. A client that doesn't resolve those
 accounts can't send the token at all; the transfer instruction fails onchain, it
 doesn't silently skip the hook. The complete functions to drop into your send
 path for this are under
-[Sending a transfer-hook token](#sending-a-transfer-hook-token) below, for both
-Kit and Web3.js.
+[Sending a transfer-hook token](#sending-a-transfer-hook-token) below, for Kit,
+web3.js v3, and web3.js v1.
 
 ### Resources
 
 - [Transfer Hook Interface reference](https://www.solana-program.com/docs/transfer-hook-interface)
 - [Extension Rust code](https://github.com/solana-program/token-2022/tree/main/program/src/extension/transfer_hook)
 - [`@solana-program/token-2022` JS client](https://github.com/solana-program/token-2022/tree/main/clients/js)
-  the Kit-based client, recommended for new integrations. Native transfer hook
-  resolution via `getTransferCheckedWithTransferHookInstructionAsync` plus the
-  lower-level `resolveExtraAccountMetasForExecute` /
-  `findExtraAccountMetaListPda` helpers.
+  the Kit-based client, recommended for new integrations and also the client
+  web3.js v3 code uses. Native transfer hook resolution via
+  `getTransferCheckedWithTransferHookInstructionAsync` plus the lower-level
+  `resolveExtraAccountMetasForExecute` / `findExtraAccountMetaListPda` helpers.
 - [`@solana/spl-token` JS client](https://github.com/solana-program/token-2022/tree/main/clients/js-legacy)
-  the legacy client for the deprecated `@solana/web3.js` library. Covers the
-  same ground (extension detection, extra account resolution, the high-level
+  the legacy client for `@solana/web3.js` v1. Covers the same ground (extension
+  detection, extra account resolution, the high-level
   `createTransferCheckedWithTransferHookInstruction` helper) for teams still on
-  web3.js.
+  web3.js v1.
 - [Transfer Hook extension guide](/docs/tokens/extensions/transfer-hook)
   (writing a hook program, for context on what issuers configure)
 
@@ -70,12 +70,13 @@ Kit and Web3.js.
 - **Resolution isn't optional.** If the extra accounts are missing or stale, the
   transfer instruction fails onchain. There's no fallback that silently sends
   the token without the hook.
-- **Both Kit (`@solana-program/token-2022`) and Web3.js (`@solana/spl-token`)
-  can send a hook-enabled transfer end-to-end** — see the complete functions
-  under [Sending a transfer-hook token](#sending-a-transfer-hook-token). Each
-  resolves the `ExtraAccountMetaList` natively: Kit via
-  `getTransferCheckedWithTransferHookInstructionAsync`, Web3.js via
-  `createTransferCheckedWithTransferHookInstruction`.
+- **Kit, web3.js v3, and web3.js v1 can all send a hook-enabled transfer
+  end-to-end** — see the complete functions under
+  [Sending a transfer-hook token](#sending-a-transfer-hook-token). Each resolves
+  the `ExtraAccountMetaList` natively: Kit and web3.js v3 via
+  `@solana-program/token-2022`'s
+  `getTransferCheckedWithTransferHookInstructionAsync`, web3.js v1 via
+  `@solana/spl-token`'s `createTransferCheckedWithTransferHookInstruction`.
 - **Always simulate before sending.** A hook program can fail the transfer for
   any reason it defines (an allowlist check, a paused state, a missing
   delegation), and the set of extra accounts can change if the issuer updates
@@ -106,7 +107,7 @@ Kit and Web3.js.
 
 Every hook-enabled transfer has to do four things: detect that the mint has a
 transfer hook, resolve the extra accounts the hook's CPI needs, simulate, and
-only then send. Both functions below do all four and are meant to be dropped in
+only then send. Each function below does all four and is meant to be dropped in
 wherever your app currently builds a Token-2022 transfer.
 
 ### Kit
@@ -229,10 +230,96 @@ export async function sendTokenTransfer({
 
 ### Web3.js
 
-The legacy `@solana/spl-token` client resolves everything natively — no bridging
-required.
+Both web3.js generations resolve everything natively. On v3, keep using
+`Connection` to build and send, and pass a Kit RPC for the same endpoint to
+`@solana-program/token-2022`'s
+`getTransferCheckedWithTransferHookInstructionAsync`, which returns an
+instruction a v3 `Transaction` accepts directly. On v1, `@solana/spl-token`'s
+`createTransferCheckedWithTransferHookInstruction` covers the same ground.
 
-```ts title="send-transfer-hook-token.ts"
+<CodeTabs>
+
+```ts !! title="Web3.js v3"
+import {
+  Connection,
+  Keypair,
+  PublicKey,
+  Transaction,
+  sendAndConfirmTransaction
+} from "@solana/web3.js";
+import type { GetAccountInfoApi, Rpc } from "@solana/kit";
+import { getTransferCheckedWithTransferHookInstructionAsync } from "@solana-program/token-2022";
+
+/**
+ * Builds, simulates, and sends a Token-2022 transfer, resolving transfer
+ * hook extra accounts when the mint requires them. Drop this in wherever
+ * your app currently builds a Token-2022 transfer instruction directly.
+ */
+export async function sendTokenTransfer({
+  connection,
+  rpc,
+  payer,
+  source,
+  mint,
+  destination,
+  owner,
+  amount,
+  decimals
+}: {
+  connection: Connection;
+  rpc: Rpc<GetAccountInfoApi>; // Kit RPC for the same endpoint, used to resolve hook accounts.
+  payer: Keypair; // Fee payer; can be the same signer as `owner`.
+  source: PublicKey;
+  mint: PublicKey;
+  destination: PublicKey;
+  owner: Keypair; // Authority over the source token account.
+  amount: bigint;
+  decimals: number;
+}) {
+  // 1. Build the transfer instruction. When the mint has a transfer hook this
+  // fetches it, resolves the ExtraAccountMetaList, and appends the accounts the
+  // hook's CPI needs; when it doesn't, you get a plain transferChecked. Because
+  // it re-fetches the mint on every call, don't cache the result across sends
+  // -- the hook program and its extra accounts can both change.
+  const instruction = await getTransferCheckedWithTransferHookInstructionAsync(
+    { rpc },
+    {
+      source: source.toBase58(),
+      mint: mint.toBase58(),
+      destination: destination.toBase58(),
+      authority: owner,
+      amount,
+      decimals
+    }
+  );
+
+  const { blockhash, lastValidBlockHeight } =
+    await connection.getLatestBlockhash();
+  const transaction = new Transaction({
+    feePayer: payer.publicKey,
+    blockhash,
+    lastValidBlockHeight
+  }).add(instruction);
+
+  // 2. Simulate before signing, so the user is never prompted to authorize a
+  // transfer the hook would reject. Simulating without signers runs the
+  // transaction unsigned, which catches a hook rejecting the transfer (an
+  // allowlist check, a paused mint, ...) or a stale ExtraAccountMetaList before
+  // anyone signs or pays a fee.
+  const simulation = await connection.simulateTransaction(transaction);
+  if (simulation.value.err) {
+    throw new Error(
+      `Transfer simulation failed: ${JSON.stringify(simulation.value.err)}\n` +
+        simulation.value.logs?.join("\n")
+    );
+  }
+
+  // 3. Sign and send only after a successful simulation.
+  return sendAndConfirmTransaction(connection, transaction, [payer, owner]);
+}
+```
+
+```ts !! title="Web3.js (legacy)"
 import {
   Connection,
   PublicKey,
@@ -335,10 +422,12 @@ export async function sendTokenTransfer({
 }
 ```
 
+</CodeTabs>
+
 ## Detecting the extension
 
-Both functions above re-fetch the mint and check for the hook on every send:
-Web3.js explicitly via `getMint`, Kit inside
+All three functions above re-fetch the mint and check for the hook on every
+send: web3.js v1 explicitly via `getMint`, Kit and web3.js v3 inside
 `getTransferCheckedWithTransferHookInstructionAsync`, which fetches the mint
 before it resolves anything.
 
@@ -363,7 +452,7 @@ account for that mint specifies. The list is a PDA derived from the hook
 program:
 
 ```ts title="derive-extra-account-meta-list.ts"
-// Kit (@solana-program/token-2022)
+// Kit and web3.js v3 (@solana-program/token-2022)
 import { findExtraAccountMetaListPda } from "@solana-program/token-2022";
 
 const [extraAccountMetaListPda] = await findExtraAccountMetaListPda(
@@ -371,7 +460,7 @@ const [extraAccountMetaListPda] = await findExtraAccountMetaListPda(
   { programAddress: transferHook.programId }
 );
 
-// Web3.js (@solana/spl-token)
+// Web3.js v1 (@solana/spl-token)
 import { getExtraAccountMetaAddress } from "@solana/spl-token";
 
 const extraAccountMetaListPda = getExtraAccountMetaAddress(
@@ -393,7 +482,7 @@ If you're assembling the instruction yourself rather than using the functions
 above, both clients expose the lower-level pieces those functions are built
 from.
 
-**Kit (`@solana-program/token-2022`)**
+**Kit and web3.js v3 (`@solana-program/token-2022`)**
 
 - `findExtraAccountMetaListPda({ mint }, { programAddress })`: derives the
   `ExtraAccountMetaList` validation account's PDA.
@@ -408,7 +497,7 @@ from.
   it returns the metas for you to spread onto the instruction rather than
   mutating it in place.
 
-**Web3.js (`@solana/spl-token`)**
+**Web3.js v1 (`@solana/spl-token`)**
 
 - `getExtraAccountMetas(account)`: decodes the raw `ExtraAccountMetaList`
   account data into a list of `ExtraAccountMeta` entries.
@@ -420,7 +509,7 @@ from.
 
 ## Simulating before sending
 
-The simulate step in both functions above is why this matters: two things can go
+The simulate step in the functions above is why this matters: two things can go
 wrong that only show up at execution time.
 
 - **The hook rejects the transfer.** A hook program can encode arbitrary

--- a/apps/docs/content/docs/en/tokens/extensions/transfer-hook.mdx
+++ b/apps/docs/content/docs/en/tokens/extensions/transfer-hook.mdx
@@ -79,12 +79,23 @@ the following seeds:
 - The Mint Account address
 - The Transfer Hook program ID
 
-```js
+<CodeTabs>
+
+```js !! title="Web3.js v3"
+const [pda] = await PublicKey.findProgramAddress(
+  [Buffer.from("extra-account-metas"), mint.publicKey.toBytes()],
+  program.programId // transfer hook program ID
+);
+```
+
+```js !! title="Web3.js (legacy)"
 const [pda] = PublicKey.findProgramAddressSync(
   [Buffer.from("extra-account-metas"), mint.publicKey.toBuffer()],
   program.programId // transfer hook program ID
 );
 ```
+
+</CodeTabs>
 
 By storing the extra accounts required by the `Execute` instruction in the
 predefined PDA, these accounts can be automatically added to a token transfer
@@ -285,10 +296,30 @@ pub fn transfer_hook(ctx: Context<TransferHook>, amount: u64) -> Result<()> {
 }
 ```
 
-In the client these additional accounts are added automatically by the helper
-function createTransferCheckedWithTransferHookInstruction:
+In the client these additional accounts are added automatically by a helper
+function: `getTransferCheckedWithTransferHookInstructionAsync` from
+`@solana-program/token-2022` on web3.js v3, or
+`createTransferCheckedWithTransferHookInstruction` from `@solana/spl-token` on
+web3.js v1.
 
-```js
+<CodeTabs>
+
+```js !! title="Web3.js v3"
+let transferInstructionWithHelper =
+  await getTransferCheckedWithTransferHookInstructionAsync(
+    { rpc },
+    {
+      source: sourceTokenAccount.toBase58(),
+      mint: mint.publicKey.toBase58(),
+      destination: destinationTokenAccount.toBase58(),
+      authority: wallet.publicKey.toBase58(),
+      amount: amountBigInt,
+      decimals
+    }
+  );
+```
+
+```js !! title="Web3.js (legacy)"
 let transferInstructionWithHelper =
   await createTransferCheckedWithTransferHookInstruction(
     connection,
@@ -303,6 +334,8 @@ let transferInstructionWithHelper =
     TOKEN_2022_PROGRAM_ID
   );
 ```
+
+</CodeTabs>
 
 To run the example in Solana Playground follow this link:
 [link](https://beta.solpg.io/github.com/solana-developers/anchor-transfer-hook/tree/counter)
@@ -1062,6 +1095,15 @@ deploy
 Next, let's test the program. Open the `transfer-hook.test.ts` file, and you
 should see the following starter code:
 
+<Callout type="info">
+  The test file below uses `@solana/web3.js` v1 and `@solana/spl-token`, because
+  Anchor's TypeScript client (`AnchorProvider`, `program.methods`, and the
+  `Wallet` it exposes) is built on web3.js v1 types. For a client-side send path
+  written against web3.js v3 and `@solana-program/token-2022`, see the [Transfer
+  Hook Integration
+  Guide](/docs/tokens/extensions/transfer-hook-integration#sending-a-transfer-hook-token).
+</Callout>
+
 ```js
 import * as anchor from "@coral-xyz/anchor";
 import { Program } from "@coral-xyz/anchor";
@@ -1694,12 +1736,23 @@ The helper function is resolving the account automatically from the
 ExtraAccounts data account. How the account would be resolved in the client is
 like this:
 
-```js
+<CodeTabs>
+
+```js !! title="Web3.js v3"
+const [counterPDA] = await PublicKey.findProgramAddress(
+  [Buffer.from("counter"), wallet.publicKey.toBytes()],
+  program.programId
+);
+```
+
+```js !! title="Web3.js (legacy)"
 const [counterPDA] = PublicKey.findProgramAddressSync(
   [Buffer.from("counter"), wallet.publicKey.toBuffer()],
   program.programId
 );
 ```
+
+</CodeTabs>
 
 Note that the counter account is derived from the owner of the token account and
 needs to be initialized before doing a transfer. In the case of this example we


### PR DESCRIPTION
## Problem

The four long-form token extension guides (transfer hook, transfer hook integration, scaled UI amount issuer and integration) only carried `@solana/web3.js` v1 + `@solana/spl-token` snippets. `@solana/spl-token` peers on web3.js `^1.x` and does not run on v3, so readers on v3 had no working path. Stacked on the token extensions PR; retarget to `docs/DEV-17-web3js-v3` once that merges.

## Changes

- Added `Web3.js v3` code tabs alongside the existing v1 snippets in all four guides, using `@solana-program/token-2022` instruction builders with the class-based `@solana/web3.js` v3 API. Existing v1 blocks are retitled `Web3.js (legacy)`; Kit blocks are unchanged.
- `transfer-hook-integration.mdx`: the Web3.js send-path function is now a two-tab block; v3 resolves `ExtraAccountMetaList` via `getTransferCheckedWithTransferHookInstructionAsync`. Prose updated to distinguish v3 from v1 throughout.
- `transfer-hook.mdx`: tabbed the three standalone client snippets. The Anchor test-file walkthrough stays on v1 because Anchor's TS client is built on web3.js v1 types; a callout explains this and links to the v3 send path.
- Drive-by fixes: legacy `uiAmountToAmountForMintWithoutSimulation` was imported from `@solana/web3.js` instead of `@solana/spl-token`; a legacy `getTokenAccountBalance` output comment showed a bigint slot.

Every new v3 snippet was typechecked under `tsc --strict` against web3.js `3.0.0-rc.3`, kit `8.3.0`, and `@solana-program/token-2022` `0.17.0`. `pnpm --filter solana-docs lint` is green.

Part of DEV-1041